### PR TITLE
change for pandas dataframe .values to to_numpy() and ravel() on Seres to to_numpy()

### DIFF
--- a/process_improve/monitoring/control_charts.py
+++ b/process_improve/monitoring/control_charts.py
@@ -141,7 +141,7 @@ class ControlChart(object):
 
         # After whichever fit is completed, check which are outside +/- 3S:
         idx_bool = (self.df["y"] - self.target).abs() > 3.0 * self.s
-        self.idx_outside_3S = np.nonzero(idx_bool.ravel())[0].tolist()
+        self.idx_outside_3S = np.nonzero(idx_bool.to_numpy())[0].tolist()
 
     def _xbar_no_subgroup_fit(self):
         """

--- a/process_improve/regression/methods.py
+++ b/process_improve/regression/methods.py
@@ -298,7 +298,7 @@ def multiple_linear_regression(  # noqa: PLR0915, PLR0913
         out["x_ssq"] = np.sum(np.power(x_vector - mean_X, 2))[0]
 
         # Can be calculated before the model is even fit:
-        out["leverage"] = (1 / out["N"] + np.power(x_vector - mean_X, 2) / out["x_ssq"]).values.ravel()
+        out["leverage"] = (1 / out["N"] + np.power(x_vector - mean_X, 2) / out["x_ssq"]).to_numpy().ravel()
 
     # Do the work
     model = sm.OLS(y_, X_)


### PR DESCRIPTION
Basically title, in this way:
- we don't raise warnings
- we handle future deprecation and follow pandas conventions.

Test pass as before the change.