### PR TITLE
Add tool-call-first infrastructure for robust univariate statistics

### DIFF
--- a/process_improve/tool_spec.py
+++ b/process_improve/tool_spec.py
@@ -1,0 +1,168 @@
+"""(c) Kevin Dunn, 2010-2025. MIT License.
+
+Tool-call-first infrastructure for process-improve.
+
+Provides the ``@tool_spec`` decorator, a global registry of all decorated
+functions, and helpers for Anthropic-compatible tool-use integrations.
+
+Quick start
+-----------
+
+Import the decorated tools and pass the specs to the Anthropic client::
+
+    import anthropic
+    from process_improve.tool_spec import get_tool_specs, execute_tool_call
+
+    client = anthropic.Anthropic()
+    response = client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=1024,
+        tools=get_tool_specs(),
+        messages=[{"role": "user", "content": "Are there outliers in [1,2,3,100]?"}],
+    )
+
+    # Dispatch tool calls from the response
+    for block in response.content:
+        if block.type == "tool_use":
+            result = execute_tool_call(block.name, block.input)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+#: Maps tool name -> decorated callable.  Populated by ``@tool_spec``.
+_TOOL_REGISTRY: dict[str, Callable[..., Any]] = {}
+
+
+# ---------------------------------------------------------------------------
+# Decorator
+# ---------------------------------------------------------------------------
+
+
+def tool_spec(
+    name: str,
+    description: str,
+    input_schema: dict[str, Any],
+    examples: str = "",
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Mark a function as an agent-callable tool.
+
+    Parameters
+    ----------
+    name:
+        Unique tool name exposed to the LLM (snake_case).
+    description:
+        Natural-language description of what the tool does and when to use it.
+        Good descriptions contain:
+        * What the tool computes.
+        * What the inputs represent.
+        * When *not* to use it (if applicable).
+    input_schema:
+        A dict with a single key ``"json"`` whose value is a valid `JSON Schema
+        <https://json-schema.org>`_ object describing the tool's parameters.
+        This mirrors the Anthropic ``input_schema`` field directly.
+    examples:
+        Optional string with one or more natural-language → tool-call mappings
+        (plain text, no special format required).  Appended to ``description``
+        so the LLM can see worked examples inside the tool spec.
+
+    Returns
+    -------
+    Callable
+        The original function, unchanged except for an attached ``_tool_spec``
+        attribute and registration in :data:`_TOOL_REGISTRY`.
+
+    Examples
+    --------
+    ::
+
+        @tool_spec(
+            name="add_numbers",
+            description="Add two numbers together.",
+            input_schema={"json": {
+                "type": "object",
+                "properties": {
+                    "a": {"type": "number"},
+                    "b": {"type": "number"},
+                },
+                "required": ["a", "b"],
+            }},
+            examples='# "What is 2 + 3?" -> ``add_numbers(a=2, b=3)``',
+        )
+        def add_numbers(*, a: float, b: float) -> dict:
+            return {"result": a + b}
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        full_description = description
+        if examples:
+            full_description = f"{description}\n\nExamples\n--------\n{examples}"
+
+        spec: dict[str, Any] = {
+            "name": name,
+            "description": full_description,
+            "input_schema": input_schema["json"],
+        }
+        func._tool_spec = spec  # type: ignore[attr-defined]
+        _TOOL_REGISTRY[name] = func
+        return func
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def get_tool_specs(names: list[str] | None = None) -> list[dict[str, Any]]:
+    """Return tool specs in the format expected by the Anthropic ``tools=`` parameter.
+
+    Parameters
+    ----------
+    names:
+        Optional allow-list of tool names to include.  When *None* (default)
+        all registered tools are returned.
+
+    Returns
+    -------
+    list[dict]
+        Each dict has keys ``"name"``, ``"description"``, and
+        ``"input_schema"`` as required by the Anthropic API.
+    """
+    registry = _TOOL_REGISTRY
+    if names is not None:
+        registry = {k: v for k, v in registry.items() if k in names}
+    return [func._tool_spec for func in registry.values()]  # type: ignore[attr-defined]
+
+
+def execute_tool_call(tool_name: str, tool_input: dict[str, Any]) -> Any:
+    """Dispatch a single tool call from an Anthropic ``tool_use`` content block.
+
+    Parameters
+    ----------
+    tool_name:
+        The ``name`` field from the ``tool_use`` block.
+    tool_input:
+        The ``input`` dict from the ``tool_use`` block.
+
+    Returns
+    -------
+    Any
+        Whatever the tool function returns (typically a JSON-serialisable
+        ``dict``).
+
+    Raises
+    ------
+    ValueError
+        If *tool_name* is not in the registry.
+    """
+    if tool_name not in _TOOL_REGISTRY:
+        available = sorted(_TOOL_REGISTRY)
+        raise ValueError(f"Unknown tool {tool_name!r}. Available tools: {available}")
+    return _TOOL_REGISTRY[tool_name](**tool_input)

--- a/process_improve/univariate/__init__.py
+++ b/process_improve/univariate/__init__.py
@@ -1,0 +1,29 @@
+"""(c) Kevin Dunn, 2010-2025. MIT License."""
+
+from process_improve.univariate.metrics import (  # noqa: F401
+    Sn,
+    confidence_interval,
+    median_abs_deviation,
+    normality_check,
+    outlier_detection_multiple,
+    summary_stats,
+    t_value,
+    t_value_cdf,
+    ttest_difference,
+    ttest_difference_calculate,
+    ttest_paired_difference,
+    ttest_paired_difference_calculate,
+    within_between_standard_deviation,
+)
+from process_improve.univariate.tools import (  # noqa: F401
+    confidence_interval as confidence_interval_tool,
+    detect_outliers,
+    get_univariate_tool_specs,
+    median_absolute_deviation,
+    normality_test,
+    robust_scale_sn,
+    robust_summary_stats,
+    ttest_paired_samples,
+    ttest_two_samples,
+    within_between_variance,
+)

--- a/process_improve/univariate/tools.py
+++ b/process_improve/univariate/tools.py
@@ -1,0 +1,663 @@
+"""(c) Kevin Dunn, 2010-2025. MIT License.
+
+Agent-callable tool wrappers for robust univariate statistics.
+
+Each function in this module is decorated with ``@tool_spec`` so it can be
+passed directly to an LLM tool-use API (e.g. Anthropic ``tools=``).
+The wrappers accept plain JSON-serialisable inputs (lists of numbers, strings,
+booleans) and always return JSON-serialisable ``dict`` results.
+
+Import all specs at once::
+
+    from process_improve.univariate.tools import get_univariate_tool_specs
+    # or get everything registered so far
+    from process_improve.tool_spec import get_tool_specs
+
+Dispatch a tool call returned by the model::
+
+    from process_improve.tool_spec import execute_tool_call
+    result = execute_tool_call(block.name, block.input)
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+from process_improve.tool_spec import _TOOL_REGISTRY, get_tool_specs, tool_spec
+from process_improve.univariate.metrics import (
+    Sn,
+    median_abs_deviation,
+    normality_check,
+    outlier_detection_multiple,
+    summary_stats,
+    t_value,
+    t_value_cdf,
+    ttest_difference_calculate,
+    ttest_paired_difference_calculate,
+    within_between_standard_deviation,
+)
+
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_UNIVARIATE_TOOL_NAMES: list[str] = []
+
+
+def _register(name: str) -> None:
+    _UNIVARIATE_TOOL_NAMES.append(name)
+
+
+def _clean(value: Any) -> Any:
+    """Recursively convert numpy scalars / arrays to plain Python types."""
+    if isinstance(value, dict):
+        return {k: _clean(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_clean(v) for v in value]
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, np.floating):
+        v = float(value)
+        return None if math.isnan(v) or math.isinf(v) else v
+    if isinstance(value, float):
+        return None if math.isnan(value) or math.isinf(value) else value
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@tool_spec(
+    name="robust_summary_stats",
+    description=(
+        "Compute comprehensive summary statistics for a list of numeric values. "
+        "Returns both classical (mean, std) and robust (median, Sn scale estimator) measures "
+        "of location and spread, along with percentiles, IQR, and relative standard deviation. "
+        "Use the 'robust' method (default) when data may contain outliers. "
+        "Use 'classical' only when you are certain the data are clean and normally distributed."
+    ),
+    input_schema={
+        "json": {
+            "type": "object",
+            "properties": {
+                "values": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "List of numeric observations. Missing values should be omitted.",
+                    "minItems": 2,
+                },
+                "method": {
+                    "type": "string",
+                    "enum": ["robust", "classical"],
+                    "description": (
+                        "Which method to use for the primary 'center' and 'spread' outputs. "
+                        "'robust' uses the median and Sn scale estimator (default). "
+                        "'classical' uses the mean and standard deviation."
+                    ),
+                },
+            },
+            "required": ["values"],
+        }
+    },
+    examples="""
+    # "Give me summary statistics for [10, 12, 11, 9, 100]"
+        -> ``robust_summary_stats(values=[10, 12, 11, 9, 100])``
+
+    # "Summarise this batch result using classical statistics: [5.1, 4.9, 5.0, 5.2]"
+        -> ``robust_summary_stats(values=[5.1, 4.9, 5.0, 5.2], method="classical")``
+    """,
+)
+def robust_summary_stats(*, values: list[float], method: str = "robust") -> dict:
+    """Compute summary statistics; see tool spec for parameter details."""
+    arr = np.asarray(values, dtype=float)
+    result = summary_stats(arr, method=method)
+    return _clean(result)
+
+
+_register("robust_summary_stats")
+
+
+@tool_spec(
+    name="detect_outliers",
+    description=(
+        "Detect outliers in a list of numeric values using the Generalised ESD (Extreme Studentised "
+        "Deviate) test. "
+        "Returns the zero-based indices and values of any detected outliers. "
+        "The robust variant (default) uses the median and MAD instead of mean and std, making the "
+        "test itself resistant to the influence of the very outliers it is trying to detect. "
+        "Set max_outliers_to_detect to at least the number of outliers you suspect; the algorithm "
+        "will find the actual count up to that limit."
+    ),
+    input_schema={
+        "json": {
+            "type": "object",
+            "properties": {
+                "values": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "List of numeric observations to test.",
+                    "minItems": 3,
+                },
+                "max_outliers_to_detect": {
+                    "type": "integer",
+                    "description": (
+                        "Upper bound on the number of outliers to search for "
+                        "(default 5, must be < len(values))."
+                    ),
+                    "minimum": 1,
+                },
+                "alpha": {
+                    "type": "number",
+                    "description": "Significance level for each individual test (default 0.05).",
+                    "exclusiveMinimum": 0,
+                    "exclusiveMaximum": 1,
+                },
+                "robust_variant": {
+                    "type": "boolean",
+                    "description": (
+                        "When true (default), use median and MAD instead of mean and std. "
+                        "Recommended when outliers may already be present."
+                    ),
+                },
+            },
+            "required": ["values"],
+        }
+    },
+    examples="""
+    # "Are there outliers in [1, 2, 2, 3, 2, 100]?"
+        -> ``detect_outliers(values=[1, 2, 2, 3, 2, 100])``
+
+    # "Find up to 3 outliers at the 1% level in my data"
+        -> ``detect_outliers(values=[...], max_outliers_to_detect=3, alpha=0.01)``
+
+    # "Run a classical (non-robust) outlier test"
+        -> ``detect_outliers(values=[...], robust_variant=False)``
+    """,
+)
+def detect_outliers(
+    *,
+    values: list[float],
+    max_outliers_to_detect: int = 5,
+    alpha: float = 0.05,
+    robust_variant: bool = True,
+) -> dict:
+    """Detect outliers using the Generalised ESD test; see tool spec for details."""
+    arr = np.asarray(values, dtype=float)
+    max_k = min(max_outliers_to_detect, len(arr) - 1)
+    outlier_indices, details = outlier_detection_multiple(
+        arr,
+        algorithm="esd",
+        max_outliers_detected=max_k,
+        alpha=alpha,
+        robust_variant=robust_variant,
+    )
+    outlier_values = [float(values[i]) for i in outlier_indices]
+    return {
+        "outlier_indices": list(outlier_indices),
+        "outlier_values": outlier_values,
+        "n_outliers_found": len(outlier_indices),
+        "alpha": alpha,
+        "robust_variant": robust_variant,
+    }
+
+
+_register("detect_outliers")
+
+
+@tool_spec(
+    name="robust_scale_sn",
+    description=(
+        "Compute the Sn robust scale estimator for a list of numeric values. "
+        "Sn is an alternative to the standard deviation that is highly resistant to outliers "
+        "and does not assume symmetry around the median, unlike MAD. "
+        "For normally distributed data with no outliers, Sn ≈ std. "
+        "A large Sn relative to the mean suggests high variability or outliers. "
+        "Reference: Rousseeuw & Croux (1993)."
+    ),
+    input_schema={
+        "json": {
+            "type": "object",
+            "properties": {
+                "values": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "List of numeric observations.",
+                    "minItems": 2,
+                },
+            },
+            "required": ["values"],
+        }
+    },
+    examples="""
+    # "What is the robust spread of [5, 6, 5, 7, 5, 6, 100]?"
+        -> ``robust_scale_sn(values=[5, 6, 5, 7, 5, 6, 100])``
+    """,
+)
+def robust_scale_sn(*, values: list[float]) -> dict:
+    """Compute Sn robust scale estimator; see tool spec for details."""
+    arr = np.asarray(values, dtype=float)
+    sn_value = float(Sn(arr))
+    mean = float(np.nanmean(arr))
+    rsd = (sn_value / mean) if mean != 0 else None
+    return _clean({"sn": sn_value, "rsd": rsd, "n": int(np.sum(~np.isnan(arr)))})
+
+
+_register("robust_scale_sn")
+
+
+@tool_spec(
+    name="median_absolute_deviation",
+    description=(
+        "Compute the Median Absolute Deviation (MAD) for a list of numeric values. "
+        "MAD = median(|x_i - median(x)|). "
+        "With scale='normal' (default) the result is normalised to be consistent with the "
+        "standard deviation for normally distributed data (divide by ~0.6745). "
+        "MAD is more robust than the standard deviation but assumes approximate symmetry. "
+        "Prefer Sn (robust_scale_sn) when symmetry cannot be assumed."
+    ),
+    input_schema={
+        "json": {
+            "type": "object",
+            "properties": {
+                "values": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "List of numeric observations.",
+                    "minItems": 2,
+                },
+                "scale": {
+                    "type": "string",
+                    "enum": ["normal", "raw"],
+                    "description": (
+                        "'normal' (default): normalise so MAD ≈ std for Gaussian data. "
+                        "'raw': return the raw median of absolute deviations."
+                    ),
+                },
+            },
+            "required": ["values"],
+        }
+    },
+    examples="""
+    # "What is the MAD of [10, 11, 12, 10, 9, 10, 50]?"
+        -> ``median_absolute_deviation(values=[10, 11, 12, 10, 9, 10, 50])``
+
+    # "Give me the raw (un-normalised) MAD"
+        -> ``median_absolute_deviation(values=[...], scale="raw")``
+    """,
+)
+def median_absolute_deviation(*, values: list[float], scale: str = "normal") -> dict:
+    """Compute Median Absolute Deviation; see tool spec for details."""
+    arr = np.asarray(values, dtype=float)
+    scale_arg = "normal" if scale == "normal" else 1.0
+    mad_value = float(median_abs_deviation(arr, scale=scale_arg))
+    return _clean({"mad": mad_value, "scale": scale, "n": int(np.sum(~np.isnan(arr)))})
+
+
+_register("median_absolute_deviation")
+
+
+@tool_spec(
+    name="normality_test",
+    description=(
+        "Test whether a list of numeric values is consistent with a normal (Gaussian) distribution "
+        "using the Shapiro-Wilk test. "
+        "Returns the test statistic, p-value, and a plain-language interpretation. "
+        "A p-value below the significance threshold (default 0.05) provides evidence AGAINST "
+        "normality. Failure to reject does not prove normality — it merely means the data are "
+        "not inconsistent with it. "
+        "Use this to decide whether robust or classical statistics are more appropriate."
+    ),
+    input_schema={
+        "json": {
+            "type": "object",
+            "properties": {
+                "values": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "List of numeric observations (3 to ~5000 values).",
+                    "minItems": 3,
+                },
+                "alpha": {
+                    "type": "number",
+                    "description": "Significance level for the decision (default 0.05).",
+                    "exclusiveMinimum": 0,
+                    "exclusiveMaximum": 1,
+                },
+            },
+            "required": ["values"],
+        }
+    },
+    examples="""
+    # "Is this data normally distributed? [10.1, 9.8, 10.2, 9.9, 10.0]"
+        -> ``normality_test(values=[10.1, 9.8, 10.2, 9.9, 10.0])``
+
+    # "Test for normality at the 1% level"
+        -> ``normality_test(values=[...], alpha=0.01)``
+    """,
+)
+def normality_test(*, values: list[float], alpha: float = 0.05) -> dict:
+    """Shapiro-Wilk normality test; see tool spec for details."""
+    from scipy.stats import shapiro
+
+    arr = np.asarray(values, dtype=float)
+    arr_clean = arr[~np.isnan(arr)]
+    stat, p_value = shapiro(arr_clean)
+    is_normal = bool(p_value >= alpha)
+    return _clean(
+        {
+            "statistic": float(stat),
+            "p_value": float(p_value),
+            "alpha": alpha,
+            "is_normal": is_normal,
+            "interpretation": (
+                f"At the {alpha:.0%} significance level, the data appear consistent with "
+                "a normal distribution."
+                if is_normal
+                else f"At the {alpha:.0%} significance level, there is evidence that the data "
+                "are NOT normally distributed (p={p_value:.4f}). Consider using robust methods."
+            ),
+        }
+    )
+
+
+_register("normality_test")
+
+
+@tool_spec(
+    name="confidence_interval",
+    description=(
+        "Calculate a confidence interval for the center of a list of numeric values. "
+        "The 'robust' method (default) uses the median as center and MAD as spread estimate, "
+        "making it resistant to outliers. "
+        "The 'classical' method uses the mean and standard deviation. "
+        "The interval is computed using the t-distribution to account for small samples."
+    ),
+    input_schema={
+        "json": {
+            "type": "object",
+            "properties": {
+                "values": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "List of numeric observations.",
+                    "minItems": 3,
+                },
+                "confidence_level": {
+                    "type": "number",
+                    "description": "Confidence level between 0 and 1 (default 0.95 → 95% CI).",
+                    "exclusiveMinimum": 0,
+                    "exclusiveMaximum": 1,
+                },
+                "method": {
+                    "type": "string",
+                    "enum": ["robust", "classical"],
+                    "description": (
+                        "'robust' (default): use median ± t * MAD / √n. "
+                        "'classical': use mean ± t * std / √n."
+                    ),
+                },
+            },
+            "required": ["values"],
+        }
+    },
+    examples="""
+    # "What is the 95% confidence interval for [10, 11, 12, 10, 9, 10]?"
+        -> ``confidence_interval(values=[10, 11, 12, 10, 9, 10])``
+
+    # "Give me a 99% classical confidence interval"
+        -> ``confidence_interval(values=[...], confidence_level=0.99, method="classical")``
+    """,
+)
+def confidence_interval(
+    *,
+    values: list[float],
+    confidence_level: float = 0.95,
+    method: str = "robust",
+) -> dict:
+    """Compute a confidence interval; see tool spec for details."""
+    arr = np.asarray(values, dtype=float)
+    arr_clean = arr[~np.isnan(arr)]
+    n = len(arr_clean)
+    if method == "robust":
+        center = float(np.median(arr_clean))
+        spread = float(median_abs_deviation(arr_clean))
+    else:
+        center = float(np.mean(arr_clean))
+        spread = float(np.std(arr_clean, ddof=1))
+    ct = float(t_value(1 - (1 - confidence_level) / 2, n - 1))
+    margin = ct * spread / np.sqrt(n)
+    return _clean(
+        {
+            "lower": center - margin,
+            "center": center,
+            "upper": center + margin,
+            "margin_of_error": margin,
+            "confidence_level": confidence_level,
+            "method": method,
+            "n": n,
+        }
+    )
+
+
+_register("confidence_interval")
+
+
+@tool_spec(
+    name="ttest_two_samples",
+    description=(
+        "Perform an unpaired (independent samples) two-sided t-test to determine whether the "
+        "means of two groups differ significantly. "
+        "Returns the z/t statistic, p-value, confidence interval for the difference "
+        "(group_b_mean − group_a_mean), and degrees of freedom. "
+        "The groups must be independent (different subjects/items). "
+        "Use ttest_paired_samples instead when each observation in group A is matched to one in B."
+    ),
+    input_schema={
+        "json": {
+            "type": "object",
+            "properties": {
+                "group_a": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "Observations for group A (the reference / baseline group).",
+                    "minItems": 2,
+                },
+                "group_b": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "Observations for group B (the comparison group).",
+                    "minItems": 2,
+                },
+                "confidence_level": {
+                    "type": "number",
+                    "description": "Confidence level for the interval (default 0.95).",
+                    "exclusiveMinimum": 0,
+                    "exclusiveMaximum": 1,
+                },
+            },
+            "required": ["group_a", "group_b"],
+        }
+    },
+    examples="""
+    # "Is the average yield different between process A [102,98,100] and process B [110,112,108]?"
+        -> ``ttest_two_samples(group_a=[102,98,100], group_b=[110,112,108])``
+
+    # "t-test at 99% confidence level"
+        -> ``ttest_two_samples(group_a=[...], group_b=[...], confidence_level=0.99)``
+    """,
+)
+def ttest_two_samples(
+    *,
+    group_a: list[float],
+    group_b: list[float],
+    confidence_level: float = 0.95,
+) -> dict:
+    """Unpaired t-test for two independent samples; see tool spec for details."""
+    a = pd.Series(np.asarray(group_a, dtype=float)).dropna()
+    b = pd.Series(np.asarray(group_b, dtype=float)).dropna()
+    result = ttest_difference_calculate(a, b, conflevel=confidence_level)
+    result["confidence_level"] = confidence_level
+    significant = bool(result["p value"] < (1 - confidence_level))
+    result["significant"] = significant
+    result["interpretation"] = (
+        f"The difference (B − A = {result['Group B average'] - result['Group A average']:.4g}) "
+        + (
+            f"IS statistically significant (p={result['p value']:.4f} < {1-confidence_level:.2f})."
+            if significant
+            else f"is NOT statistically significant (p={result['p value']:.4f} ≥ {1-confidence_level:.2f})."
+        )
+    )
+    return _clean(result)
+
+
+_register("ttest_two_samples")
+
+
+@tool_spec(
+    name="ttest_paired_samples",
+    description=(
+        "Perform a paired (repeated-measures) two-sided t-test to determine whether the "
+        "mean of the differences between matched pairs is significantly different from zero. "
+        "The difference is defined as before − after (group_a − group_b). "
+        "Each position i in group_a must correspond to the same subject/unit as position i in "
+        "group_b (e.g. before/after measurements on the same individual). "
+        "Use ttest_two_samples instead for independent groups."
+    ),
+    input_schema={
+        "json": {
+            "type": "object",
+            "properties": {
+                "group_a": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "Before / reference measurements (one per subject).",
+                    "minItems": 2,
+                },
+                "group_b": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "After / comparison measurements (same order as group_a).",
+                    "minItems": 2,
+                },
+                "confidence_level": {
+                    "type": "number",
+                    "description": "Confidence level for the interval (default 0.95).",
+                    "exclusiveMinimum": 0,
+                    "exclusiveMaximum": 1,
+                },
+            },
+            "required": ["group_a", "group_b"],
+        }
+    },
+    examples="""
+    # "Did the treatment improve scores? Before: [70,65,80], After: [75,70,82]"
+        -> ``ttest_paired_samples(group_a=[70,65,80], group_b=[75,70,82])``
+    """,
+)
+def ttest_paired_samples(
+    *,
+    group_a: list[float],
+    group_b: list[float],
+    confidence_level: float = 0.95,
+) -> dict:
+    """Paired t-test; see tool spec for details."""
+    a = pd.Series(np.asarray(group_a, dtype=float))
+    b = pd.Series(np.asarray(group_b, dtype=float))
+    assert len(a) == len(b), "group_a and group_b must have the same length for a paired test."
+    differences = a - b.values
+    differences = differences.dropna()
+    result = ttest_paired_difference_calculate(differences, conflevel=confidence_level)
+    result["Group A average"] = float(a.mean())
+    result["Group B average"] = float(b.mean())
+    result["Group A number"] = int(a.count())
+    result["Group B number"] = int(b.count())
+    result["confidence_level"] = confidence_level
+    significant = bool(result["p value"] < (1 - confidence_level))
+    result["significant"] = significant
+    result["interpretation"] = (
+        f"The mean paired difference (A − B = {result['Differences mean']:.4g}) "
+        + (
+            f"IS statistically significant (p={result['p value']:.4f} < {1-confidence_level:.2f})."
+            if significant
+            else f"is NOT statistically significant (p={result['p value']:.4f} ≥ {1-confidence_level:.2f})."
+        )
+    )
+    return _clean(result)
+
+
+_register("ttest_paired_samples")
+
+
+@tool_spec(
+    name="within_between_variance",
+    description=(
+        "Decompose the total variability of a numeric variable into within-group and between-group "
+        "components using one-way ANOVA variance decomposition. "
+        "Useful for gauge R&R studies, reproducibility analysis, or any situation where you want "
+        "to understand whether variation is mainly due to differences within repeated measurements "
+        "of the same condition, or due to differences between conditions. "
+        "Supply two parallel lists: 'values' (the measurements) and 'groups' (a group label for "
+        "each measurement)."
+    ),
+    input_schema={
+        "json": {
+            "type": "object",
+            "properties": {
+                "values": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "Numeric measurement for each observation.",
+                    "minItems": 3,
+                },
+                "groups": {
+                    "type": "array",
+                    "items": {},
+                    "description": (
+                        "Group label for each observation (same length as values). "
+                        "Can be strings, integers, or any hashable type."
+                    ),
+                    "minItems": 3,
+                },
+            },
+            "required": ["values", "groups"],
+        }
+    },
+    examples="""
+    # "Measurements on day 1: [101,102] and day 2: [94,95]. How much variation is within vs between days?"
+        -> ``within_between_variance(values=[101,102,94,95], groups=[1,1,2,2])``
+
+    # "Operator study: Alice measured [10.1,10.2,10.0], Bob measured [10.5,10.4,10.6]"
+        -> ``within_between_variance(values=[10.1,10.2,10.0,10.5,10.4,10.6], groups=["Alice","Alice","Alice","Bob","Bob","Bob"])``
+    """,
+)
+def within_between_variance(
+    *,
+    values: list[float],
+    groups: list[Any],
+) -> dict:
+    """Within- and between-group variance decomposition; see tool spec for details."""
+    assert len(values) == len(groups), "'values' and 'groups' must have the same length."
+    df = pd.DataFrame({"measured": values, "repeat": groups})
+    result = within_between_standard_deviation(df, measured="measured", repeat="repeat")
+    return _clean(result)
+
+
+_register("within_between_variance")
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience
+# ---------------------------------------------------------------------------
+
+
+def get_univariate_tool_specs() -> list[dict]:
+    """Return tool specs for all univariate tools registered in this module."""
+    return get_tool_specs(names=_UNIVARIATE_TOOL_NAMES)

--- a/tests/test_tool_spec.py
+++ b/tests/test_tool_spec.py
@@ -1,0 +1,400 @@
+"""Tests for the tool_spec decorator, registry, and univariate tool wrappers."""
+
+from __future__ import annotations
+
+import pytest
+
+# Importing the univariate tools module triggers @tool_spec registration.
+import process_improve.univariate.tools  # noqa: F401
+from process_improve.tool_spec import (
+    _TOOL_REGISTRY,
+    execute_tool_call,
+    get_tool_specs,
+    tool_spec,
+)
+from process_improve.univariate.tools import get_univariate_tool_specs
+
+
+# ---------------------------------------------------------------------------
+# tool_spec decorator and registry
+# ---------------------------------------------------------------------------
+
+
+class TestToolSpecDecorator:
+    def test_attaches_tool_spec_attribute(self):
+        @tool_spec(
+            name="test_dummy_add",
+            description="Add two numbers.",
+            input_schema={"json": {"type": "object", "properties": {"a": {"type": "number"}, "b": {"type": "number"}}, "required": ["a", "b"]}},
+        )
+        def _dummy(*, a: float, b: float) -> dict:
+            return {"result": a + b}
+
+        assert hasattr(_dummy, "_tool_spec")
+        assert _dummy._tool_spec["name"] == "test_dummy_add"
+
+    def test_function_still_callable(self):
+        @tool_spec(
+            name="test_dummy_mul",
+            description="Multiply.",
+            input_schema={"json": {"type": "object", "properties": {"a": {"type": "number"}, "b": {"type": "number"}}, "required": ["a", "b"]}},
+        )
+        def _mul(*, a: float, b: float) -> dict:
+            return {"result": a * b}
+
+        assert _mul(a=3, b=4)["result"] == 12
+
+    def test_examples_appended_to_description(self):
+        @tool_spec(
+            name="test_dummy_examples",
+            description="A tool.",
+            input_schema={"json": {"type": "object", "properties": {}, "required": []}},
+            examples="# example -> call()",
+        )
+        def _ex() -> dict:
+            return {}
+
+        assert "Examples" in _ex._tool_spec["description"]
+        assert "example -> call()" in _ex._tool_spec["description"]
+
+    def test_no_examples_no_extra_text(self):
+        @tool_spec(
+            name="test_dummy_no_examples",
+            description="Plain description.",
+            input_schema={"json": {"type": "object", "properties": {}, "required": []}},
+        )
+        def _plain() -> dict:
+            return {}
+
+        assert _plain._tool_spec["description"] == "Plain description."
+
+    def test_registered_in_registry(self):
+        assert "test_dummy_add" in _TOOL_REGISTRY
+        assert "test_dummy_mul" in _TOOL_REGISTRY
+
+
+class TestGetToolSpecs:
+    def test_returns_list_of_dicts(self):
+        specs = get_tool_specs()
+        assert isinstance(specs, list)
+        assert all(isinstance(s, dict) for s in specs)
+
+    def test_each_spec_has_required_keys(self):
+        for spec in get_tool_specs():
+            assert "name" in spec
+            assert "description" in spec
+            assert "input_schema" in spec
+
+    def test_name_filter(self):
+        specs = get_tool_specs(names=["robust_summary_stats"])
+        assert len(specs) == 1
+        assert specs[0]["name"] == "robust_summary_stats"
+
+    def test_empty_filter_returns_empty(self):
+        specs = get_tool_specs(names=[])
+        assert specs == []
+
+
+class TestExecuteToolCall:
+    def test_dispatches_by_name(self):
+        result = execute_tool_call("robust_summary_stats", {"values": [1, 2, 3]})
+        assert "mean" in result
+
+    def test_raises_on_unknown_tool(self):
+        with pytest.raises(ValueError, match="Unknown tool"):
+            execute_tool_call("nonexistent_tool_xyz", {})
+
+
+# ---------------------------------------------------------------------------
+# get_univariate_tool_specs
+# ---------------------------------------------------------------------------
+
+
+class TestGetUnivariateToolSpecs:
+    def test_returns_all_nine_tools(self):
+        specs = get_univariate_tool_specs()
+        names = {s["name"] for s in specs}
+        expected = {
+            "robust_summary_stats",
+            "detect_outliers",
+            "robust_scale_sn",
+            "median_absolute_deviation",
+            "normality_test",
+            "confidence_interval",
+            "ttest_two_samples",
+            "ttest_paired_samples",
+            "within_between_variance",
+        }
+        assert expected == names
+
+
+# ---------------------------------------------------------------------------
+# robust_summary_stats
+# ---------------------------------------------------------------------------
+
+
+class TestRobustSummaryStats:
+    def test_basic_keys_present(self):
+        result = execute_tool_call("robust_summary_stats", {"values": [1, 2, 3, 4, 5]})
+        for key in ("mean", "median", "std_ddof1", "center", "spread", "N_non_missing"):
+            assert key in result
+
+    def test_robust_method_center_is_median(self):
+        result = execute_tool_call("robust_summary_stats", {"values": [1, 2, 3, 4, 5]})
+        assert result["center"] == result["median"]
+
+    def test_classical_method_center_is_mean(self):
+        result = execute_tool_call("robust_summary_stats", {"values": [1, 2, 3, 4, 5], "method": "classical"})
+        assert result["center"] == result["mean"]
+
+    def test_outlier_does_not_dominate_robust_center(self):
+        # Use data with natural spread so Sn > 0 and the robust path is taken
+        result = execute_tool_call("robust_summary_stats", {"values": [9, 10, 11, 10, 9, 11, 10, 200]})
+        # Robust center (median) should be near 10, not pulled toward 200
+        assert result["center"] == pytest.approx(10.0)
+
+    def test_n_non_missing(self):
+        result = execute_tool_call("robust_summary_stats", {"values": [1, 2, 3]})
+        assert result["N_non_missing"] == 3
+
+    def test_all_values_json_serialisable(self):
+        import json
+        result = execute_tool_call("robust_summary_stats", {"values": [1.0, 2.0, 3.0]})
+        json.dumps(result)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# detect_outliers
+# ---------------------------------------------------------------------------
+
+
+class TestDetectOutliers:
+    def test_detects_obvious_outlier(self):
+        result = execute_tool_call("detect_outliers", {"values": [1, 2, 2, 3, 2, 100]})
+        assert result["n_outliers_found"] == 1
+        assert 5 in result["outlier_indices"]
+        assert 100.0 in result["outlier_values"]
+
+    def test_clean_data_no_outliers(self):
+        # Uniformly spaced data: ESD finds no outliers
+        result = execute_tool_call("detect_outliers", {"values": list(range(1, 15))})
+        assert result["n_outliers_found"] == 0
+
+    def test_respects_max_outliers_param(self):
+        result = execute_tool_call(
+            "detect_outliers",
+            {"values": [1, 2, 3, 4, 5, 1000, 2000], "max_outliers_to_detect": 1},
+        )
+        assert result["n_outliers_found"] <= 1
+
+    def test_result_json_serialisable(self):
+        import json
+        result = execute_tool_call("detect_outliers", {"values": [1, 2, 3, 100]})
+        json.dumps(result)
+
+
+# ---------------------------------------------------------------------------
+# robust_scale_sn
+# ---------------------------------------------------------------------------
+
+
+class TestRobustScaleSn:
+    def test_returns_sn_key(self):
+        result = execute_tool_call("robust_scale_sn", {"values": [1, 2, 3, 4, 5]})
+        assert "sn" in result
+
+    def test_sn_approximately_matches_std_for_normal_data(self):
+        import numpy as np
+        rng = np.random.default_rng(42)
+        data = rng.normal(loc=0, scale=1, size=200).tolist()
+        result = execute_tool_call("robust_scale_sn", {"values": data})
+        # For large normal samples, Sn ≈ std
+        assert pytest.approx(1.0, abs=0.2) == result["sn"]
+
+    def test_outlier_does_not_inflate_sn(self):
+        # Without outlier: data ~[10..15], with: add 10000
+        clean = list(range(10, 16))
+        dirty = clean + [10000]
+        clean_result = execute_tool_call("robust_scale_sn", {"values": clean})
+        dirty_result = execute_tool_call("robust_scale_sn", {"values": dirty})
+        # Sn should be much more stable than std
+        assert dirty_result["sn"] < 10 * clean_result["sn"]
+
+
+# ---------------------------------------------------------------------------
+# median_absolute_deviation
+# ---------------------------------------------------------------------------
+
+
+class TestMedianAbsoluteDeviation:
+    def test_returns_mad_key(self):
+        result = execute_tool_call("median_absolute_deviation", {"values": [1, 2, 3, 4, 5]})
+        assert "mad" in result
+
+    def test_normal_scale_approx_std(self):
+        import numpy as np
+        rng = np.random.default_rng(0)
+        data = rng.normal(0, 1, 1000).tolist()
+        result = execute_tool_call("median_absolute_deviation", {"values": data, "scale": "normal"})
+        assert pytest.approx(1.0, abs=0.1) == result["mad"]
+
+    def test_raw_scale_smaller_than_normal(self):
+        data = list(range(1, 11))
+        raw = execute_tool_call("median_absolute_deviation", {"values": data, "scale": "raw"})
+        normal = execute_tool_call("median_absolute_deviation", {"values": data, "scale": "normal"})
+        assert raw["mad"] < normal["mad"]
+
+
+# ---------------------------------------------------------------------------
+# normality_test
+# ---------------------------------------------------------------------------
+
+
+class TestNormalityTest:
+    def test_clearly_normal_data(self):
+        import numpy as np
+        rng = np.random.default_rng(1)
+        data = rng.normal(10, 1, 100).tolist()
+        result = execute_tool_call("normality_test", {"values": data})
+        assert result["is_normal"] is True
+        assert "p_value" in result
+        assert "statistic" in result
+        assert "interpretation" in result
+
+    def test_clearly_non_normal_data(self):
+        # Exponential distribution is highly skewed
+        import numpy as np
+        rng = np.random.default_rng(2)
+        data = rng.exponential(scale=1, size=100).tolist()
+        result = execute_tool_call("normality_test", {"values": data})
+        # Not guaranteed but very likely to reject normality for exponential
+        assert "is_normal" in result
+
+    def test_returns_json_serialisable(self):
+        import json
+        result = execute_tool_call("normality_test", {"values": [1.0, 2.0, 1.5, 1.8, 2.1]})
+        json.dumps(result)
+
+
+# ---------------------------------------------------------------------------
+# confidence_interval
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceInterval:
+    def test_returns_lower_center_upper(self):
+        result = execute_tool_call("confidence_interval", {"values": [10, 11, 12, 10, 9, 10]})
+        assert result["lower"] < result["center"] < result["upper"]
+
+    def test_wider_at_higher_confidence(self):
+        values = list(range(1, 20))
+        ci95 = execute_tool_call("confidence_interval", {"values": values, "confidence_level": 0.95})
+        ci99 = execute_tool_call("confidence_interval", {"values": values, "confidence_level": 0.99})
+        width95 = ci95["upper"] - ci95["lower"]
+        width99 = ci99["upper"] - ci99["lower"]
+        assert width99 > width95
+
+    def test_robust_center_is_median(self):
+        values = [10, 10, 10, 10, 10]
+        result = execute_tool_call("confidence_interval", {"values": values, "method": "robust"})
+        assert result["center"] == pytest.approx(10.0)
+
+    def test_classical_center_is_mean(self):
+        values = [1.0, 2.0, 3.0, 4.0, 5.0]
+        result = execute_tool_call("confidence_interval", {"values": values, "method": "classical"})
+        assert result["center"] == pytest.approx(3.0)
+
+
+# ---------------------------------------------------------------------------
+# ttest_two_samples
+# ---------------------------------------------------------------------------
+
+
+class TestTtestTwoSamples:
+    def test_obvious_difference_is_significant(self):
+        result = execute_tool_call(
+            "ttest_two_samples",
+            {"group_a": [100, 101, 99, 100, 101], "group_b": [200, 201, 199, 200, 201]},
+        )
+        assert result["significant"] is True
+        assert result["p value"] < 0.05
+
+    def test_same_groups_not_significant(self):
+        data = [10.0, 10.0, 10.0, 10.0, 10.0]
+        result = execute_tool_call("ttest_two_samples", {"group_a": data, "group_b": data})
+        assert result["significant"] is False
+
+    def test_output_keys_present(self):
+        result = execute_tool_call(
+            "ttest_two_samples",
+            {"group_a": [1, 2, 3], "group_b": [4, 5, 6]},
+        )
+        for key in ("p value", "z value", "ConfInt: Lo", "ConfInt: Hi", "interpretation"):
+            assert key in result
+
+    def test_result_json_serialisable(self):
+        import json
+        result = execute_tool_call("ttest_two_samples", {"group_a": [1, 2, 3], "group_b": [4, 5, 6]})
+        json.dumps(result)
+
+
+# ---------------------------------------------------------------------------
+# ttest_paired_samples
+# ---------------------------------------------------------------------------
+
+
+class TestTtestPairedSamples:
+    def test_before_after_no_effect(self):
+        values = [10, 11, 9, 10, 11]
+        result = execute_tool_call("ttest_paired_samples", {"group_a": values, "group_b": values})
+        # identical before/after: differences all zero
+        assert result["Differences mean"] == pytest.approx(0.0)
+
+    def test_output_keys_present(self):
+        result = execute_tool_call(
+            "ttest_paired_samples",
+            {"group_a": [70, 65, 80], "group_b": [75, 70, 82]},
+        )
+        for key in ("Differences mean", "p value", "z value", "significant", "interpretation"):
+            assert key in result
+
+    def test_result_json_serialisable(self):
+        import json
+        result = execute_tool_call(
+            "ttest_paired_samples", {"group_a": [1, 2, 3], "group_b": [1, 2, 3]}
+        )
+        json.dumps(result)
+
+
+# ---------------------------------------------------------------------------
+# within_between_variance
+# ---------------------------------------------------------------------------
+
+
+class TestWithinBetweenVariance:
+    def test_day_example_matches_docs(self):
+        result = execute_tool_call(
+            "within_between_variance",
+            {"values": [101, 102, 94, 95], "groups": [1, 1, 2, 2]},
+        )
+        assert result["within_stddev"] == pytest.approx(0.70711, abs=1e-4)
+        assert result["between_stddev"] == pytest.approx(7.0, abs=1e-4)
+
+    def test_output_keys_present(self):
+        result = execute_tool_call(
+            "within_between_variance",
+            {"values": [1, 2, 3, 4], "groups": ["A", "A", "B", "B"]},
+        )
+        for key in ("within_ms", "within_stddev", "between_ms", "between_stddev"):
+            assert key in result
+
+    def test_string_group_labels(self):
+        result = execute_tool_call(
+            "within_between_variance",
+            {
+                "values": [10.1, 10.2, 10.0, 10.5, 10.4, 10.6],
+                "groups": ["Alice", "Alice", "Alice", "Bob", "Bob", "Bob"],
+            },
+        )
+        assert result["within_stddev"] is not None
+        assert result["between_stddev"] is not None


### PR DESCRIPTION
Introduces @tool_spec decorator, a global tool registry, and nine
agent-callable wrappers around the existing robust univariate functions.

New files
---------
process_improve/tool_spec.py
  - @tool_spec decorator: attaches name/description/input_schema/examples
    to any function and registers it in _TOOL_REGISTRY.
  - get_tool_specs(names=None) -> list[dict]: returns specs in the exact
    format expected by the Anthropic tools= API parameter.
  - execute_tool_call(name, input_dict): dispatches a tool_use block by name.

process_improve/univariate/tools.py
  Nine JSON-in / JSON-out wrappers, each decorated with @tool_spec:
  - robust_summary_stats   – mean, median, Sn, percentiles, IQR, RSD
  - detect_outliers        – Generalised ESD test (robust variant default)
  - robust_scale_sn        – Rousseeuw & Croux Sn scale estimator
  - median_absolute_deviation – MAD with normal or raw scaling
  - normality_test         – Shapiro-Wilk test with plain-English verdict
  - confidence_interval    – robust (median/MAD) or classical (mean/std)
  - ttest_two_samples      – unpaired t-test with significance flag
  - ttest_paired_samples   – paired t-test with significance flag
  - within_between_variance – ANOVA variance decomposition (gauge R&R)
  Also exposes get_univariate_tool_specs() for module-scoped spec retrieval.

tests/test_tool_spec.py
  45 tests covering decorator behaviour, registry, get_tool_specs,
  execute_tool_call dispatch, and each of the nine tool functions.

Updated
-------
process_improve/univariate/__init__.py
  Re-exports both the existing metrics functions and all nine new tool
  wrappers so they are accessible from process_improve.univariate directly.

https://claude.ai/code/session_01KcYNKM5uVCfPRqA4mVCZL9