### PR TITLE
Add PLS cross_validate() for beta coefficient error bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ from process_improve.multivariate.methods import PLS, MCUVScaler
 # Scale X and Y separately
 scaler_x = MCUVScaler().fit(X)
 scaler_y = MCUVScaler().fit(Y)
+X_s, Y_s = scaler_x.transform(X), scaler_y.transform(Y)
 
 # Fit a PLS model
-pls = PLS(n_components=3).fit(scaler_x.transform(X), scaler_y.transform(Y))
+pls = PLS(n_components=3).fit(X_s, Y_s)
 
 # Inspect results
 print(pls.scores_)  # X scores (N x A)
@@ -72,6 +73,18 @@ print(result.hotellings_t2)  # Hotelling's T² for new data
 # Detect outliers and analyze contributions
 outliers = pls.detect_outliers(conf_level=0.95)
 contrib = pls.score_contributions(pls.scores_.iloc[0].values)
+
+# Variable importance
+print(pls.vip())  # VIP scores per X variable
+
+# Cross-validation with beta coefficient error bars
+cv = pls.cross_validate(X_s, Y_s, cv="loo")
+print(cv.beta_mean)       # Mean beta across LOO resamples
+print(cv.beta_ci_lower)   # Lower 95% CI for each beta
+print(cv.beta_ci_upper)   # Upper 95% CI for each beta
+print(cv.significant)     # Which betas are significantly != 0
+print(cv.q_squared)       # Cross-validated R² (Q²)
+print(cv.rmse_cv)         # Cross-validated RMSE per Y variable
 ```
 
 ## Features
@@ -82,7 +95,9 @@ contrib = pls.score_contributions(pls.scores_.iloc[0].values)
 - **Missing data handling** via TSR and NIPALS algorithms
 - **Outlier detection** combining Hotelling's T² and SPE with robust ESD test
 - **Score contributions** for variable-level diagnostics
-- **Cross-validation** for component selection (PRESS with Wold's criterion)
+- **VIP** (Variable Importance in Projection) scores for PCA and PLS
+- **Cross-validation** for PCA component selection (PRESS with Wold's criterion)
+- **PLS cross-validation** with beta coefficient error bars (jackknife, K-fold, bootstrap), Q², and RMSE
 - **Interactive plots** (Plotly) for scores, loadings, SPE, and T²
 - **Designed experiments** — full factorial, fractional factorial, response surface
 - **Process monitoring** — Shewhart, CUSUM, EWMA control charts

--- a/docs/api/multivariate.rst
+++ b/docs/api/multivariate.rst
@@ -10,7 +10,7 @@ PCA
 ~~~
 
 .. autoclass:: PCA
-   :members: fit, predict, score, select_n_components, score_contributions, detect_outliers
+   :members: fit, transform, fit_transform, predict, score, select_n_components, score_contributions, detect_outliers
    :undoc-members:
    :show-inheritance:
 
@@ -18,7 +18,7 @@ PLS
 ~~~
 
 .. autoclass:: PLS
-   :members: fit, predict, score_contributions, detect_outliers
+   :members: fit, transform, fit_transform, predict, score, score_contributions, detect_outliers, cross_validate
    :undoc-members:
    :show-inheritance:
 
@@ -29,6 +29,11 @@ TPLS
    :members:
    :undoc-members:
    :show-inheritance:
+
+Analysis
+--------
+
+.. autofunction:: vip
 
 Preprocessing
 -------------

--- a/docs/user_guide/cross_validation.rst
+++ b/docs/user_guide/cross_validation.rst
@@ -1,5 +1,14 @@
+Cross-Validation
+=================
+
+Cross-validation is used for two purposes in multivariate analysis:
+
+1. **Component selection** — choosing the right number of components (PCA).
+2. **Coefficient uncertainty** — obtaining error bars for PLS beta
+   coefficients.
+
 Selecting the Number of Components
-===================================
+-----------------------------------
 
 Choosing the right number of components is critical. Too few components
 underfit (miss important structure), too many overfit (model noise).
@@ -50,3 +59,51 @@ improves prediction — it is likely fitting noise.
 
 Lower thresholds (e.g., 0.90) are more conservative (fewer components).
 Higher thresholds (e.g., 0.98) are more liberal (more components).
+
+PLS Beta Coefficient Error Bars
+--------------------------------
+
+For PLS models, ``model.cross_validate()`` refits the model on data subsets
+and computes confidence intervals for the regression coefficients. This answers
+the question: *"How reliable is each beta coefficient?"*
+
+Three resampling strategies are supported:
+
+- **Jackknife** (``cv="loo"``, default) — leave-one-out resampling. Uses the
+  jackknife variance formula with t-distribution critical values.
+- **K-fold** (``cv=5``) — K-fold cross-validation. Faster for large datasets.
+- **Bootstrap** (``n_bootstrap=200``) — resample with replacement. Uses
+  percentile confidence intervals.
+
+.. code-block:: python
+
+   from process_improve.multivariate.methods import PLS, MCUVScaler
+
+   scaler_x = MCUVScaler().fit(X)
+   scaler_y = MCUVScaler().fit(Y)
+   X_s, Y_s = scaler_x.transform(X), scaler_y.transform(Y)
+
+   pls = PLS(n_components=2).fit(X_s, Y_s)
+
+   # Jackknife (leave-one-out) cross-validation
+   cv = pls.cross_validate(X_s, Y_s, cv="loo")
+
+   print(cv.significant)      # Which betas have CIs excluding zero
+   print(cv.beta_ci_lower)    # Lower 95% CI
+   print(cv.beta_ci_upper)    # Upper 95% CI
+   print(cv.q_squared)        # Cross-validated R² (Q²)
+   print(cv.rmse_cv)          # Cross-validated RMSE
+
+The result is a ``Bunch`` with:
+
+- ``beta_mean``, ``beta_std``: mean and standard error of betas across
+  resamples
+- ``beta_ci_lower``, ``beta_ci_upper``: confidence interval bounds
+- ``significant``: boolean mask — ``True`` where the CI excludes zero
+- ``beta_samples``: raw betas from every resample (n_resamples × K × M)
+- ``y_hat_cv``: out-of-fold Y predictions (jackknife / K-fold only)
+- ``press``: Prediction Error Sum of Squares
+- ``rmse_cv``: cross-validated RMSE per Y variable
+- ``q_squared``: cross-validated R² (Q²) per Y variable
+
+See :doc:`pls` for detailed documentation and additional examples.

--- a/docs/user_guide/pca.rst
+++ b/docs/user_guide/pca.rst
@@ -183,6 +183,33 @@ first):
    for o in outliers:
        print(f"{o['observation']}: {o['outlier_types']} (severity={o['severity']})")
 
+Variable Importance in Projection (VIP)
+---------------------------------------
+
+VIP scores quantify how much each variable contributes to the PCA model. For
+PCA, the loadings matrix is used as the weight matrix:
+
+.. math::
+
+   \text{VIP}_j = \sqrt{K \cdot
+       \frac{\sum_{a=1}^{A} r2_a \cdot p_{ja}^2}{\sum_{a=1}^{A} r2_a}}
+
+where :math:`p_{ja}` is the loading for feature :math:`j` on component
+:math:`a`, and :math:`r2_a` is the fraction of variance explained by that
+component.
+
+- Variables with **VIP > 1** contribute more than average to the model.
+- Variables with **VIP < 0.5** contribute very little.
+
+.. code-block:: python
+
+   model = PCA(n_components=3).fit(X_scaled)
+   vip_scores = model.vip()
+   print(vip_scores.sort_values(ascending=False))
+
+   # Compute VIP using only the first 2 components
+   vip_2 = model.vip(n_components=2)
+
 Model Selection
 ---------------
 

--- a/docs/user_guide/pls.rst
+++ b/docs/user_guide/pls.rst
@@ -109,15 +109,49 @@ These diagnostics work identically to PCA (see :doc:`pca`):
   variables.
 - ``model.detect_outliers()`` — combined statistical + robust ESD detection.
 
+Variable Importance in Projection (VIP)
+---------------------------------------
+
+VIP scores quantify how much each X variable contributes to the PLS model's
+ability to explain Y. The formula weights each variable's loading by the
+variance explained by each component:
+
+.. math::
+
+   \text{VIP}_j = \sqrt{K \cdot
+       \frac{\sum_{a=1}^{A} r2_a \cdot w_{ja}^2}{\sum_{a=1}^{A} r2_a}}
+
+where :math:`K` is the number of features, :math:`A` the number of
+components, :math:`r2_a` the fraction of Y variance explained by component
+:math:`a`, and :math:`w_{ja}` the PLS weight for feature :math:`j` in
+component :math:`a`.
+
+- Variables with **VIP > 1** are considered important (above average
+  contribution).
+- Variables with **VIP < 0.5** contribute very little and may be candidates
+  for removal.
+
+.. code-block:: python
+
+   pls = PLS(n_components=3).fit(X_scaled, Y_scaled)
+   vip_scores = pls.vip()
+   print(vip_scores.sort_values(ascending=False))
+
+   # Use fewer components for VIP calculation
+   vip_2 = pls.vip(n_components=2)
+
+VIP is also available for PCA models (using loadings instead of weights),
+accessed the same way via ``pca.vip()``.
+
 Predictions
 -----------
 
 After fitting, ``model.predict(X_new)`` returns a ``Bunch`` with:
 
-- ``predictions_`` — the predicted Y values.
-- ``scores_`` — the X-scores for the new observations.
-- ``spe_`` — SPE values for the new observations.
-- ``hotellings_t2_`` — T² values for the new observations.
+- ``y_hat`` — the predicted Y values.
+- ``scores`` — the X-scores for the new observations.
+- ``spe`` — SPE values for the new observations.
+- ``hotellings_t2`` — T² values for the new observations.
 
 The underlying regression relationship is captured in
 ``model.beta_coefficients_``, which maps directly from (preprocessed) X to
@@ -135,6 +169,86 @@ The same PRESS / Wold's criterion approach described in
 :doc:`cross_validation` applies. A practical check: if the training R² is
 much higher than the test-set R² (gap > 0.15–0.20), overfitting is likely
 and you should reduce the number of components.
+
+Cross-Validation and Beta Coefficient Error Bars
+-------------------------------------------------
+
+PLS regression coefficients (``model.beta_coefficients_``) represent the best
+point estimate from the training data, but they do not convey how certain
+those estimates are. The ``cross_validate()`` method provides uncertainty
+quantification by refitting the model on data subsets and computing confidence
+intervals.
+
+**Three resampling strategies are available:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Strategy
+     - Parameter
+     - Description
+   * - Jackknife (LOO)
+     - ``cv="loo"``
+     - Leave-one-out: N resamples. Uses the jackknife variance formula
+       :math:`\hat{\text{var}}(\beta_j) = \frac{N-1}{N} \sum_{i=1}^{N}
+       (\beta_{j,i} - \bar{\beta}_j)^2` with a t-distribution CI. This is
+       the default and most common choice in chemometrics.
+   * - K-fold
+     - ``cv=5``
+     - K-fold cross-validation: K resamples. Faster than LOO for large
+       datasets.
+   * - Bootstrap
+     - ``n_bootstrap=200``
+     - Resample with replacement B times. CI from percentiles of the
+       distribution.
+
+**Basic usage:**
+
+.. code-block:: python
+
+   from process_improve.multivariate.methods import PLS, MCUVScaler
+
+   scaler_x = MCUVScaler().fit(X)
+   scaler_y = MCUVScaler().fit(Y)
+   X_s, Y_s = scaler_x.transform(X), scaler_y.transform(Y)
+
+   pls = PLS(n_components=2).fit(X_s, Y_s)
+   cv = pls.cross_validate(X_s, Y_s, cv="loo")
+
+   # Beta coefficient uncertainty
+   print(cv.beta_mean)        # Mean beta across resamples
+   print(cv.beta_std)         # Standard error
+   print(cv.beta_ci_lower)    # Lower 95% CI bound
+   print(cv.beta_ci_upper)    # Upper 95% CI bound
+   print(cv.significant)      # True where CI excludes zero
+
+   # Prediction metrics
+   print(cv.q_squared)        # Cross-validated R² (Q²) per Y variable
+   print(cv.rmse_cv)          # Cross-validated RMSE per Y variable
+   print(cv.press)            # Total PRESS
+
+**Interpreting the results:**
+
+- ``significant`` flags which beta coefficients have confidence intervals that
+  do not contain zero — these are the X variables with a statistically
+  meaningful relationship to Y at the chosen confidence level.
+- ``q_squared`` (Q²) is the cross-validated R². A large gap between training
+  R² (``model.r2_cumulative_``) and Q² indicates overfitting.
+- ``beta_samples`` (shape: n_resamples × K × M) contains the raw beta
+  coefficients from every resample, useful for custom analyses or plotting
+  distributions.
+
+**Bootstrap example with custom confidence level:**
+
+.. code-block:: python
+
+   cv = pls.cross_validate(
+       X_s, Y_s,
+       n_bootstrap=200,
+       conf_level=0.99,
+       random_state=42,
+   )
 
 Missing Data and Troubleshooting
 --------------------------------

--- a/process_improve/multivariate/methods.py
+++ b/process_improve/multivariate/methods.py
@@ -14,9 +14,10 @@ import plotly.graph_objects as go
 import pytest
 import ridgeplot
 from scipy.stats import chi2, f
+from scipy.stats import t as t_dist
 from sklearn.base import BaseEstimator, RegressorMixin, TransformerMixin, _fit_context, clone
 from sklearn.metrics import r2_score
-from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import KFold, cross_val_score
 from sklearn.utils import Bunch
 from sklearn.utils.validation import check_array, check_is_fitted
 from tqdm import tqdm
@@ -1521,6 +1522,232 @@ class PLS(RegressorMixin, TransformerMixin, BaseEstimator):
 
         results.sort(key=lambda d: d["severity"], reverse=True)
         return results
+
+    def cross_validate(  # noqa: PLR0912, PLR0913, PLR0915, C901
+        self,
+        X: DataMatrix,
+        Y: DataMatrix,
+        *,
+        cv: int | str = "loo",
+        n_bootstrap: int = 0,
+        conf_level: float = 0.95,
+        random_state: int | None = None,
+        show_progress: bool = True,
+    ) -> Bunch:
+        """Cross-validate the PLS model and compute error bars for beta coefficients.
+
+        Refits the model on data subsets (jackknife, K-fold, or bootstrap),
+        collects ``beta_coefficients_`` from each refit, and computes
+        confidence intervals. Also returns cross-validated predictions
+        and prediction-error metrics (RMSE, Q²).
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Predictor matrix (same data used for ``fit``).
+        Y : array-like of shape (n_samples, n_targets)
+            Response matrix (same data used for ``fit``).
+        cv : int or ``"loo"``, default ``"loo"``
+            Cross-validation strategy:
+
+            * ``"loo"`` — leave-one-out (jackknife). Produces N resamples.
+            * ``int`` — number of folds for K-fold CV.
+        n_bootstrap : int, default 0
+            If > 0, use bootstrap resampling instead of CV folds.
+            The value specifies the number of bootstrap rounds.
+            Overrides the ``cv`` parameter when set.
+        conf_level : float, default 0.95
+            Confidence level for the beta-coefficient intervals, in (0, 1).
+        random_state : int or None, default None
+            Random seed for reproducibility (K-fold shuffle and bootstrap).
+        show_progress : bool, default True
+            Whether to display a ``tqdm`` progress bar.
+
+        Returns
+        -------
+        result : :class:`~sklearn.utils.Bunch`
+            Dictionary-like object with the following keys:
+
+            **Beta-coefficient uncertainty**
+
+            beta_samples : np.ndarray of shape (n_resamples, n_features, n_targets)
+                Raw beta coefficients from every resample.
+            beta_mean : pd.DataFrame of shape (n_features, n_targets)
+                Mean beta across resamples.
+            beta_std : pd.DataFrame of shape (n_features, n_targets)
+                Standard error of the beta coefficients.
+            beta_ci_lower : pd.DataFrame of shape (n_features, n_targets)
+                Lower bound of the confidence interval.
+            beta_ci_upper : pd.DataFrame of shape (n_features, n_targets)
+                Upper bound of the confidence interval.
+            significant : pd.DataFrame of shape (n_features, n_targets)
+                ``True`` where the confidence interval excludes zero.
+
+            **Prediction metrics**
+
+            y_hat_cv : pd.DataFrame of shape (n_samples, n_targets)
+                Cross-validated predictions (out-of-fold). Only available for
+                jackknife and K-fold; ``None`` for bootstrap.
+            press : float
+                Prediction Error Sum of Squares (sum over all Y elements).
+                Only for jackknife / K-fold.
+            rmse_cv : pd.Series of length n_targets
+                Root-mean-square error per Y variable (cross-validated).
+                Only for jackknife / K-fold.
+            q_squared : pd.Series of length n_targets
+                Cross-validated R² (Q²) per Y variable.
+                Only for jackknife / K-fold.
+
+            **Metadata**
+
+            n_resamples : int
+                Number of resamples performed.
+            method : str
+                ``"jackknife"``, ``"kfold"``, or ``"bootstrap"``.
+            conf_level : float
+                The confidence level used.
+
+        Examples
+        --------
+        >>> from process_improve.multivariate import PLS, MCUVScaler
+        >>> scaler_x = MCUVScaler().fit(X)
+        >>> scaler_y = MCUVScaler().fit(Y)
+        >>> X_s, Y_s = scaler_x.transform(X), scaler_y.transform(Y)
+        >>> pls = PLS(n_components=2).fit(X_s, Y_s)
+        >>> cv_results = pls.cross_validate(X_s, Y_s, cv="loo")
+        >>> cv_results.beta_mean          # mean beta across LOO resamples
+        >>> cv_results.significant        # which betas are significantly != 0
+        >>> cv_results.q_squared          # cross-validated R²
+        """
+        check_is_fitted(self, "beta_coefficients_")
+
+        X = pd.DataFrame(X) if not isinstance(X, pd.DataFrame) else X
+        Y = pd.DataFrame(Y) if not isinstance(Y, pd.DataFrame) else Y
+
+        N, _K = X.shape
+        M = Y.shape[1]
+
+        if X.shape[0] != Y.shape[0]:
+            raise ValueError(f"X and Y must have the same number of rows, got {X.shape[0]} and {Y.shape[0]}.")
+        if not (0.5 < conf_level < 1.0):
+            raise ValueError(f"conf_level must be between 0.5 and 1.0, got {conf_level}.")
+
+        # --- Determine resampling strategy ---
+        use_bootstrap = n_bootstrap > 0
+        if use_bootstrap:
+            method = "bootstrap"
+            n_resamples = n_bootstrap
+        elif cv == "loo":
+            method = "jackknife"
+            n_resamples = N
+        else:
+            method = "kfold"
+            n_resamples = int(cv)
+
+        # --- Collect beta coefficients (and out-of-fold predictions for CV) ---
+        beta_collection: list[np.ndarray] = []
+        y_hat_cv = np.full((N, M), np.nan) if not use_bootstrap else None
+        rng = np.random.default_rng(random_state)
+
+        if use_bootstrap:
+            iterator = tqdm(range(n_bootstrap), desc="Bootstrap", disable=not show_progress)
+            for _ in iterator:
+                train_idx = rng.choice(N, size=N, replace=True)
+                sub_model = clone(self).fit(X.iloc[train_idx], Y.iloc[train_idx])
+                beta_collection.append(sub_model.beta_coefficients_.values)
+
+        elif method == "jackknife":
+            iterator = tqdm(range(N), desc="Jackknife (LOO)", disable=not show_progress)
+            for i in iterator:
+                train_idx = np.concatenate([np.arange(i), np.arange(i + 1, N)])
+                sub_model = clone(self).fit(X.iloc[train_idx], Y.iloc[train_idx])
+                beta_collection.append(sub_model.beta_coefficients_.values)
+                pred = sub_model.predict(X.iloc[[i]])
+                y_hat_cv[i, :] = pred.y_hat.values.ravel()
+
+        else:  # K-fold
+            kf = KFold(n_splits=n_resamples, shuffle=True, random_state=random_state)
+            desc = f"{n_resamples}-Fold CV"
+            for train_idx, test_idx in tqdm(kf.split(X), total=n_resamples, desc=desc, disable=not show_progress):
+                sub_model = clone(self).fit(X.iloc[train_idx], Y.iloc[train_idx])
+                beta_collection.append(sub_model.beta_coefficients_.values)
+                pred = sub_model.predict(X.iloc[test_idx])
+                y_hat_cv[test_idx, :] = pred.y_hat.values
+
+        beta_samples = np.array(beta_collection)  # (n_resamples, K, M)
+        actual_n_resamples = beta_samples.shape[0]
+
+        # --- Beta-coefficient statistics ---
+        beta_mean_arr = beta_samples.mean(axis=0)
+
+        if method == "jackknife":
+            # Jackknife variance: var = (N-1)/N * sum_i (beta_i - beta_mean)^2
+            jackknife_var = (N - 1) / N * np.sum((beta_samples - beta_mean_arr) ** 2, axis=0)
+            beta_std_arr = np.sqrt(jackknife_var)
+            # CI via t-distribution
+            alpha = 1 - conf_level
+            t_crit = t_dist.ppf(1 - alpha / 2, df=N - 1)
+            beta_ci_lower_arr = beta_mean_arr - t_crit * beta_std_arr
+            beta_ci_upper_arr = beta_mean_arr + t_crit * beta_std_arr
+        elif method == "kfold":
+            # For K-fold, use sample std of the K beta estimates
+            beta_std_arr = beta_samples.std(axis=0, ddof=1)
+            alpha = 1 - conf_level
+            t_crit = t_dist.ppf(1 - alpha / 2, df=actual_n_resamples - 1)
+            beta_ci_lower_arr = beta_mean_arr - t_crit * beta_std_arr
+            beta_ci_upper_arr = beta_mean_arr + t_crit * beta_std_arr
+        else:  # bootstrap percentile CI
+            beta_std_arr = beta_samples.std(axis=0, ddof=1)
+            alpha = 1 - conf_level
+            beta_ci_lower_arr = np.percentile(beta_samples, 100 * alpha / 2, axis=0)
+            beta_ci_upper_arr = np.percentile(beta_samples, 100 * (1 - alpha / 2), axis=0)
+
+        # Significance: CI does not contain zero
+        significant_arr = (beta_ci_lower_arr > 0) | (beta_ci_upper_arr < 0)
+
+        x_cols = self.beta_coefficients_.index
+        y_cols = self.beta_coefficients_.columns
+
+        beta_mean_df = pd.DataFrame(beta_mean_arr, index=x_cols, columns=y_cols)
+        beta_std_df = pd.DataFrame(beta_std_arr, index=x_cols, columns=y_cols)
+        beta_ci_lower_df = pd.DataFrame(beta_ci_lower_arr, index=x_cols, columns=y_cols)
+        beta_ci_upper_df = pd.DataFrame(beta_ci_upper_arr, index=x_cols, columns=y_cols)
+        significant_df = pd.DataFrame(significant_arr, index=x_cols, columns=y_cols)
+
+        # --- Cross-validated prediction metrics ---
+        press_val = None
+        rmse_cv_series = None
+        q_squared_series = None
+        y_hat_cv_df = None
+
+        if y_hat_cv is not None:
+            y_hat_cv_df = pd.DataFrame(y_hat_cv, index=Y.index, columns=Y.columns)
+            residuals = Y.values - y_hat_cv
+            press_val = float(np.nansum(residuals**2))
+            ss_total = np.nansum((Y.values - Y.values.mean(axis=0)) ** 2, axis=0)
+            ss_res = np.nansum(residuals**2, axis=0)
+
+            rmse_vals = np.sqrt(np.nanmean(residuals**2, axis=0))
+            rmse_cv_series = pd.Series(rmse_vals, index=Y.columns, name="RMSE_CV")
+
+            q2_vals = 1.0 - ss_res / ss_total
+            q_squared_series = pd.Series(q2_vals, index=Y.columns, name="Q_squared")
+
+        return Bunch(
+            beta_samples=beta_samples,
+            beta_mean=beta_mean_df,
+            beta_std=beta_std_df,
+            beta_ci_lower=beta_ci_lower_df,
+            beta_ci_upper=beta_ci_upper_df,
+            significant=significant_df,
+            y_hat_cv=y_hat_cv_df,
+            press=press_val,
+            rmse_cv=rmse_cv_series,
+            q_squared=q_squared_series,
+            n_resamples=actual_n_resamples,
+            method=method,
+            conf_level=conf_level,
+        )
 
     def __getattr__(self, name: str):
         """Provide helpful error messages for old attribute names."""

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -1848,6 +1848,128 @@ def test_pls_detect_outliers_ldpe(
         assert severities == sorted(severities, reverse=True)
 
 
+def test_pls_cross_validate_jackknife() -> None:
+    """Test PLS cross-validation with jackknife (leave-one-out)."""
+    rng = np.random.default_rng(42)
+    N, K, M = 30, 5, 2
+    beta_true = np.array([[3.0, 0.0], [0.0, 2.5], [-2.0, 0.0], [0.0, 0.0], [1.5, -1.0]])
+    X = pd.DataFrame(rng.standard_normal((N, K)), columns=[f"X{i}" for i in range(1, K + 1)])
+    Y = pd.DataFrame(X.values @ beta_true + rng.standard_normal((N, M)) * 0.5, columns=["Y1", "Y2"])
+
+    scaler_x = MCUVScaler().fit(X)
+    scaler_y = MCUVScaler().fit(Y)
+    X_s, Y_s = scaler_x.transform(X), scaler_y.transform(Y)
+
+    pls = PLS(n_components=2).fit(X_s, Y_s)
+    cv_result = pls.cross_validate(X_s, Y_s, cv="loo", show_progress=False)
+
+    assert cv_result.method == "jackknife"
+    assert cv_result.n_resamples == N
+    assert cv_result.conf_level == 0.95
+    assert cv_result.beta_samples.shape == (N, K, M)
+    assert cv_result.beta_mean.shape == (K, M)
+    assert cv_result.beta_std.shape == (K, M)
+    assert cv_result.beta_ci_lower.shape == (K, M)
+    assert cv_result.beta_ci_upper.shape == (K, M)
+    assert cv_result.significant.shape == (K, M)
+
+    # CI lower < mean < CI upper everywhere
+    assert (cv_result.beta_ci_lower.values <= cv_result.beta_mean.values + 1e-10).all()
+    assert (cv_result.beta_ci_upper.values >= cv_result.beta_mean.values - 1e-10).all()
+
+    # Prediction metrics should be present for LOO
+    assert cv_result.y_hat_cv is not None
+    assert cv_result.y_hat_cv.shape == (N, M)
+    assert cv_result.press is not None
+    assert cv_result.press > 0
+    assert cv_result.rmse_cv is not None
+    assert len(cv_result.rmse_cv) == M
+    assert cv_result.q_squared is not None
+    assert len(cv_result.q_squared) == M
+    # Q² should be positive for this well-conditioned problem
+    assert (cv_result.q_squared.values > 0).all()
+
+
+def test_pls_cross_validate_kfold() -> None:
+    """Test PLS cross-validation with K-fold."""
+    rng = np.random.default_rng(123)
+    N, K = 40, 4
+    X = pd.DataFrame(rng.standard_normal((N, K)), columns=[f"X{i}" for i in range(1, K + 1)])
+    beta_true = np.array([[2.0], [-1.5], [0.0], [1.0]])
+    Y = pd.DataFrame(X.values @ beta_true + rng.standard_normal((N, 1)) * 0.3, columns=["Y1"])
+
+    scaler_x = MCUVScaler().fit(X)
+    scaler_y = MCUVScaler().fit(Y)
+    X_s, Y_s = scaler_x.transform(X), scaler_y.transform(Y)
+
+    pls = PLS(n_components=2).fit(X_s, Y_s)
+    cv_result = pls.cross_validate(X_s, Y_s, cv=5, random_state=42, show_progress=False)
+
+    assert cv_result.method == "kfold"
+    assert cv_result.n_resamples == 5
+    assert cv_result.beta_samples.shape == (5, K, 1)
+    assert cv_result.y_hat_cv is not None
+    assert cv_result.y_hat_cv.shape == (N, 1)
+    assert cv_result.q_squared is not None
+    assert cv_result.q_squared.values[0] > 0
+
+
+def test_pls_cross_validate_bootstrap() -> None:
+    """Test PLS cross-validation with bootstrap."""
+    rng = np.random.default_rng(99)
+    N, K = 30, 3
+    X = pd.DataFrame(rng.standard_normal((N, K)), columns=[f"X{i}" for i in range(1, K + 1)])
+    Y = pd.DataFrame(X.values @ np.array([[1.0], [0.0], [-1.0]]) + rng.standard_normal((N, 1)) * 0.5, columns=["Y1"])
+
+    scaler_x = MCUVScaler().fit(X)
+    scaler_y = MCUVScaler().fit(Y)
+    X_s, Y_s = scaler_x.transform(X), scaler_y.transform(Y)
+
+    pls = PLS(n_components=2).fit(X_s, Y_s)
+    cv_result = pls.cross_validate(X_s, Y_s, n_bootstrap=50, random_state=42, show_progress=False)
+
+    assert cv_result.method == "bootstrap"
+    assert cv_result.n_resamples == 50
+    assert cv_result.beta_samples.shape == (50, K, 1)
+    # Bootstrap uses percentile CI
+    assert (cv_result.beta_ci_lower.values <= cv_result.beta_ci_upper.values).all()
+    # No cross-validated predictions for bootstrap
+    assert cv_result.y_hat_cv is None
+    assert cv_result.press is None
+    assert cv_result.q_squared is None
+
+
+def test_pls_cross_validate_significance() -> None:
+    """Test that significant betas are correctly identified with strong signal."""
+    rng = np.random.default_rng(7)
+    N, K = 50, 4
+    # Strong signal for X1 and X3, zero for X2 and X4
+    beta_true = np.array([[5.0], [0.0], [-5.0], [0.0]])
+    X = pd.DataFrame(rng.standard_normal((N, K)), columns=[f"X{i}" for i in range(1, K + 1)])
+    Y = pd.DataFrame(X.values @ beta_true + rng.standard_normal((N, 1)) * 0.1, columns=["Y1"])
+
+    scaler_x = MCUVScaler().fit(X)
+    scaler_y = MCUVScaler().fit(Y)
+    X_s, Y_s = scaler_x.transform(X), scaler_y.transform(Y)
+
+    pls = PLS(n_components=2).fit(X_s, Y_s)
+    cv_result = pls.cross_validate(X_s, Y_s, cv=5, random_state=0, show_progress=False)
+
+    # With very strong signal and low noise, the significant variables (X1, X3) should be flagged
+    sig = cv_result.significant
+    assert sig.loc["X1", "Y1"]  # strong positive
+    assert sig.loc["X3", "Y1"]  # strong negative
+
+
+def test_pls_cross_validate_not_fitted() -> None:
+    """Test that cross_validate raises error on unfitted model."""
+    pls = PLS(n_components=2)
+    X = pd.DataFrame(np.random.default_rng(0).standard_normal((20, 3)))
+    Y = pd.DataFrame(np.random.default_rng(0).standard_normal((20, 1)))
+    with pytest.raises(Exception):  # noqa: B017
+        pls.cross_validate(X, Y)
+
+
 def test_pls_old_attribute_names_raise() -> None:
     """Test that old PLS attribute names raise helpful errors."""
     rng = np.random.default_rng(42)


### PR DESCRIPTION
## Summary

- Adds `cross_validate()` method to the PLS class that refits the model on data subsets and computes confidence intervals for beta coefficients
- Supports three resampling strategies: **jackknife** (LOO, default), **K-fold**, and **bootstrap**
- Returns cross-validated prediction metrics: Y predictions, PRESS, RMSE_CV, and Q² (cross-validated R²)
- Returns beta uncertainty: `beta_mean`, `beta_std`, `beta_ci_lower`, `beta_ci_upper`, and `significant` (whether CI excludes zero)
- Jackknife CI uses the standard formula: `var = (N-1)/N * Σ(β_i - β̄)²` with t-distribution critical values
- Bootstrap CI uses the percentile method
- Includes 5 new tests covering all CV strategies, significance detection, and error handling

## Test plan

- [x] `test_pls_cross_validate_jackknife` — LOO CV with shape/metric validation and Q² > 0
- [x] `test_pls_cross_validate_kfold` — 5-fold CV with correct resample count
- [x] `test_pls_cross_validate_bootstrap` — Bootstrap with 50 rounds, no CV predictions
- [x] `test_pls_cross_validate_significance` — Strong-signal synthetic data correctly flags significant betas
- [x] `test_pls_cross_validate_not_fitted` — Raises error on unfitted model
- [x] All 26 existing PLS tests still pass

https://claude.ai/code/session_01YRiMPdabnGwiK9K62MpZB8