### PR TITLE
Add evaluate_design() tool for design quality metrics (Tool 2)

### DIFF
--- a/docs/api/experiments.rst
+++ b/docs/api/experiments.rst
@@ -10,3 +10,8 @@ Designed Experiments
    :members:
    :undoc-members:
    :show-inheritance:
+
+.. automodule:: process_improve.experiments.evaluate
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/process_improve/experiments/__init__.py
+++ b/process_improve/experiments/__init__.py
@@ -2,6 +2,7 @@
 
 from process_improve.experiments.designs import generate_design
 from process_improve.experiments.designs_factorial import full_factorial
+from process_improve.experiments.evaluate import evaluate_design
 from process_improve.experiments.factor import Constraint, DesignResult, Factor
 from process_improve.experiments.models import Model, lm, predict, summary
 from process_improve.experiments.structures import (
@@ -21,6 +22,7 @@ __all__ = [
     "Factor",
     "Model",
     "c",
+    "evaluate_design",
     "expand_grid",
     "full_factorial",
     "gather",

--- a/process_improve/experiments/evaluate.py
+++ b/process_improve/experiments/evaluate.py
@@ -1,0 +1,801 @@
+# (c) Kevin Dunn, 2010-2026. MIT License.
+
+"""Design evaluation: quality metrics for experimental designs.
+
+Provides :func:`evaluate_design`, which computes properties and quality metrics
+of an existing design matrix.  Supported metrics include efficiency values
+(D/I/G), prediction variance, VIF, condition number, power analysis, alias
+structure, confounding, resolution, defining relation, clear effects, minimum
+aberration, and degrees of freedom.
+
+Example
+-------
+>>> from process_improve.experiments import evaluate_design, generate_design, Factor
+>>> factors = [Factor(name="A", low=0, high=10), Factor(name="B", low=0, high=10)]
+>>> result = generate_design(factors, design_type="full_factorial", center_points=0)
+>>> metrics = evaluate_design(result, model="interactions", metric=["d_efficiency", "vif"])
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from patsy import dmatrix
+from scipy import stats
+from scipy.stats import qmc
+from statsmodels.stats.outliers_influence import variance_inflation_factor
+
+from process_improve.experiments.factor import DesignResult
+
+# ---------------------------------------------------------------------------
+# Internal context shared across metric computations
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _EvalContext:
+    """Shared evaluation context, computed once and reused by all metrics."""
+
+    X: np.ndarray
+    column_names: list[str]
+    factor_names: list[str]
+    design_df: pd.DataFrame
+    N: int
+    p: int
+    XtX: np.ndarray
+    XtX_inv: np.ndarray | None  # None when X'X is singular
+    is_singular: bool
+    generators: list[str] | None
+    defining_relation: list[str] | None
+    resolution: int | None
+    effect_size: float | None
+    alpha: float
+    sigma: float | None
+
+
+# ---------------------------------------------------------------------------
+# Model matrix construction
+# ---------------------------------------------------------------------------
+
+_ROMAN = {3: "III", 4: "IV", 5: "V", 6: "VI", 7: "VII", 8: "VIII"}
+
+
+def _build_model_matrix(
+    design_df: pd.DataFrame,
+    model: str | None,
+    factor_names: list[str],
+) -> tuple[np.ndarray, list[str]]:
+    """Build the expanded model matrix *X* using patsy.
+
+    Parameters
+    ----------
+    design_df : DataFrame
+        Design matrix with one column per factor (coded units).
+    model : str or None
+        ``"main_effects"``, ``"interactions"``, ``"quadratic"``, an explicit
+        patsy formula, or *None* (defaults to ``"interactions"``).
+    factor_names : list[str]
+        Ordered factor names.
+
+    Returns
+    -------
+    X : ndarray of shape (N, p)
+        The model matrix including the intercept column.
+    column_names : list[str]
+        Human-readable names for each column of *X*.
+    """
+    if model is None:
+        model = "interactions"
+
+    # Map shorthand names to patsy right-hand-side formulas
+    joined = " + ".join(factor_names)
+    if model == "main_effects":
+        rhs = joined
+    elif model == "interactions":
+        rhs = f"({joined}) ** 2"
+    elif model == "quadratic":
+        squared = " + ".join(f"I({f} ** 2)" for f in factor_names)
+        rhs = f"({joined}) ** 2 + {squared}"
+    elif "~" in model:
+        # Explicit formula with response side — strip LHS
+        rhs = model.split("~", 1)[1].strip()
+    else:
+        # Assume it is already a valid RHS formula
+        rhs = model
+
+    dm = dmatrix(rhs, design_df, return_type="dataframe")
+    X = np.asarray(dm, dtype=float)
+    column_names = list(dm.columns)
+    return X, column_names
+
+
+def _build_context(  # noqa: PLR0913
+    design_df: pd.DataFrame,
+    factor_names: list[str],
+    model: str | None,
+    generators: list[str] | None,
+    defining_relation: list[str] | None,
+    resolution: int | None,
+    effect_size: float | None,
+    alpha: float,
+    sigma: float | None,
+) -> _EvalContext:
+    """Build the shared evaluation context."""
+    X, column_names = _build_model_matrix(design_df, model, factor_names)
+    N, p = X.shape
+    XtX = X.T @ X
+
+    rank = np.linalg.matrix_rank(XtX)
+    is_singular = rank < p
+    XtX_inv: np.ndarray | None = None
+    if not is_singular:
+        XtX_inv = np.linalg.inv(XtX)
+
+    return _EvalContext(
+        X=X,
+        column_names=column_names,
+        factor_names=factor_names,
+        design_df=design_df,
+        N=N,
+        p=p,
+        XtX=XtX,
+        XtX_inv=XtX_inv,
+        is_singular=is_singular,
+        generators=generators,
+        defining_relation=defining_relation,
+        resolution=resolution,
+        effect_size=effect_size,
+        alpha=alpha,
+        sigma=sigma,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Metric implementations
+# ---------------------------------------------------------------------------
+
+
+def _compute_d_efficiency(ctx: _EvalContext) -> dict[str, Any]:
+    """D-efficiency: 100 * det(X'X)^(1/p) / N."""
+    if ctx.is_singular:
+        return {"d_efficiency": None, "note": "Design is rank-deficient for the specified model."}
+    sign, logdet = np.linalg.slogdet(ctx.XtX)
+    if sign <= 0:
+        return {"d_efficiency": None, "note": "X'X has non-positive determinant."}
+    d_eff = 100.0 * np.exp(logdet / ctx.p) / ctx.N
+    return {"d_efficiency": float(d_eff)}
+
+
+def _prediction_variance_at_points(X_points: np.ndarray, XtX_inv: np.ndarray) -> np.ndarray:
+    """Compute d(x) = x' (X'X)^-1 x for each row of X_points."""
+    # (X_points @ XtX_inv) element-wise * X_points, summed per row
+    return np.sum((X_points @ XtX_inv) * X_points, axis=1)
+
+
+def _generate_evaluation_grid(factor_names: list[str], n_points: int = 5000) -> np.ndarray:
+    """Generate points in [-1, 1]^k for evaluating prediction variance.
+
+    Uses Sobol sequences for efficient space-filling coverage.
+    """
+    k = len(factor_names)
+    sampler = qmc.Sobol(d=k, scramble=True, seed=42)
+    # Power-of-2 samples for Sobol balance
+    m = max(10, int(np.ceil(np.log2(n_points))))
+    points_01 = sampler.random_base2(m)  # in [0, 1]^k
+    return points_01 * 2.0 - 1.0  # scale to [-1, 1]^k
+
+
+def _expand_grid_points(grid_raw: np.ndarray, factor_names: list[str], model: str | None) -> np.ndarray:
+    """Expand raw grid points through the model formula to get X_grid."""
+    df_grid = pd.DataFrame(grid_raw, columns=factor_names)
+    X_grid, _ = _build_model_matrix(df_grid, model, factor_names)
+    return X_grid
+
+
+def _compute_g_efficiency(ctx: _EvalContext) -> dict[str, Any]:
+    """G-efficiency: 100 * p / (N * max prediction variance over design region)."""
+    if ctx.is_singular:
+        return {"g_efficiency": None, "note": "Design is rank-deficient for the specified model."}
+
+    grid_raw = _generate_evaluation_grid(ctx.factor_names)
+    # Determine the model string to rebuild for grid points
+    model_str = _infer_model_string(ctx)
+    X_grid = _expand_grid_points(grid_raw, ctx.factor_names, model_str)
+    pv = _prediction_variance_at_points(X_grid, ctx.XtX_inv)
+    max_pv = float(np.max(pv))
+
+    g_eff = 100.0 * ctx.p / (ctx.N * max_pv) if max_pv > 0 else None
+    return {
+        "g_efficiency": float(g_eff) if g_eff is not None else None,
+        "max_prediction_variance": max_pv,
+    }
+
+
+def _compute_i_efficiency(ctx: _EvalContext) -> dict[str, Any]:
+    """I-efficiency: 100 * p / (N * average prediction variance over design region)."""
+    if ctx.is_singular:
+        return {"i_efficiency": None, "note": "Design is rank-deficient for the specified model."}
+
+    grid_raw = _generate_evaluation_grid(ctx.factor_names)
+    model_str = _infer_model_string(ctx)
+    X_grid = _expand_grid_points(grid_raw, ctx.factor_names, model_str)
+    pv = _prediction_variance_at_points(X_grid, ctx.XtX_inv)
+    avg_pv = float(np.mean(pv))
+
+    i_eff = 100.0 * ctx.p / (ctx.N * avg_pv) if avg_pv > 0 else None
+    return {
+        "i_efficiency": float(i_eff) if i_eff is not None else None,
+        "average_prediction_variance": avg_pv,
+    }
+
+
+def _infer_model_string(ctx: _EvalContext) -> str | None:
+    """Reconstruct the model string from the context for grid expansion.
+
+    We need to re-apply the same model transformation to grid points.  Since
+    the context stores only the expanded column names, we reconstruct the
+    model shorthand by checking the column structure.
+    """
+    cols = set(ctx.column_names)
+    has_interactions = any(":" in c for c in cols)
+    has_squared = any("**" in c or c.startswith("I(") for c in cols)
+
+    if has_squared:
+        return "quadratic"
+    if has_interactions:
+        return "interactions"
+    return "main_effects"
+
+
+def _compute_prediction_variance(ctx: _EvalContext) -> dict[str, Any]:
+    """Prediction variance d(x_i) = x_i' (X'X)^-1 x_i at each design point."""
+    if ctx.is_singular:
+        return {"prediction_variance": None, "note": "Design is rank-deficient for the specified model."}
+
+    pv = _prediction_variance_at_points(ctx.X, ctx.XtX_inv)
+    pv_list = [float(v) for v in pv]
+    return {
+        "prediction_variance": pv_list,
+        "mean": float(np.mean(pv)),
+        "max": float(np.max(pv)),
+        "min": float(np.min(pv)),
+    }
+
+
+def _compute_vif(ctx: _EvalContext) -> dict[str, Any]:
+    """Variance Inflation Factor for each model term (excluding intercept)."""
+    if ctx.is_singular:
+        return {"vif": None, "note": "Design is rank-deficient for the specified model."}
+
+    vif_dict: dict[str, float] = {}
+    for i, name in enumerate(ctx.column_names):
+        if name.lower() == "intercept" or name == "1":
+            continue
+        vif_val = variance_inflation_factor(ctx.X, i)
+        vif_dict[name] = float(vif_val)
+    return {"vif": vif_dict}
+
+
+def _compute_condition_number(ctx: _EvalContext) -> dict[str, float]:
+    """Condition number of the model matrix X."""
+    cn = float(np.linalg.cond(ctx.X))
+    return {"condition_number": cn}
+
+
+def _compute_power(ctx: _EvalContext) -> dict[str, Any]:
+    """Statistical power for detecting each model term."""
+    if ctx.is_singular:
+        return {"power": None, "note": "Design is rank-deficient for the specified model."}
+
+    sigma = ctx.sigma if ctx.sigma is not None else 1.0
+    df_resid = ctx.N - ctx.p
+
+    if df_resid <= 0:
+        return {"power": None, "note": "No residual degrees of freedom (saturated model)."}
+
+    assert ctx.XtX_inv is not None  # guaranteed by not is_singular
+    diag_inv = np.diag(ctx.XtX_inv)
+
+    if ctx.effect_size is not None:
+        # Single power value per term
+        power_dict: dict[str, float] = {}
+        for i, name in enumerate(ctx.column_names):
+            if name.lower() == "intercept" or name == "1":
+                continue
+            ncp = (ctx.effect_size**2) / (sigma**2 * diag_inv[i])
+            f_crit = stats.f.ppf(1.0 - ctx.alpha, dfn=1, dfd=df_resid)
+            pwr = 1.0 - stats.ncf.cdf(f_crit, dfn=1, dfd=df_resid, nc=ncp)
+            power_dict[name] = float(pwr)
+        return {"power": power_dict}
+
+    # No effect_size: generate power curves over a range of effect sizes
+    effect_sizes = np.linspace(0.5 * sigma, 3.0 * sigma, 20)
+    power_curves: dict[str, list[dict[str, float]]] = {}
+    for i, name in enumerate(ctx.column_names):
+        if name.lower() == "intercept" or name == "1":
+            continue
+        curve = []
+        for es in effect_sizes:
+            ncp = (es**2) / (sigma**2 * diag_inv[i])
+            f_crit = stats.f.ppf(1.0 - ctx.alpha, dfn=1, dfd=df_resid)
+            pwr = 1.0 - stats.ncf.cdf(f_crit, dfn=1, dfd=df_resid, nc=ncp)
+            curve.append({"effect_size": float(es), "power": float(pwr)})
+        power_curves[name] = curve
+    return {"power_curves": power_curves, "sigma": float(sigma)}
+
+
+def _compute_degrees_of_freedom(ctx: _EvalContext) -> dict[str, Any]:
+    """Degrees of freedom breakdown."""
+    df_model = ctx.p - 1  # excluding intercept
+    df_residual = ctx.N - ctx.p
+    df_total = ctx.N - 1
+
+    # Detect replicates by counting distinct rows
+    design_rounded = np.round(ctx.design_df[ctx.factor_names].values, decimals=10)
+    n_distinct = len(set(map(tuple, design_rounded)))
+    has_replicates = n_distinct < ctx.N
+
+    result: dict[str, Any] = {
+        "degrees_of_freedom": {
+            "model": df_model,
+            "residual": df_residual,
+            "total": df_total,
+        }
+    }
+    if has_replicates:
+        df_pure_error = ctx.N - n_distinct
+        df_lack_of_fit = n_distinct - ctx.p if n_distinct > ctx.p else 0
+        result["degrees_of_freedom"]["pure_error"] = df_pure_error
+        result["degrees_of_freedom"]["lack_of_fit"] = df_lack_of_fit
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Alias / confounding metrics (GF(2) arithmetic on generator words)
+# ---------------------------------------------------------------------------
+
+
+def _parse_word(word: str, factor_names: list[str]) -> frozenset[int]:
+    """Parse a word like ``"ABCE"`` into a frozenset of factor indices.
+
+    Also handles ``"I=ABCE"`` format (strips the ``I=`` prefix).
+    """
+    word = word.strip().removeprefix("I=")
+    if word == "I":
+        return frozenset()
+
+    # Try multi-char factor names first (when names are longer than 1 char)
+    name_to_idx = {name: i for i, name in enumerate(factor_names)}
+
+    # If all factor names are single chars, parse character-by-character
+    if all(len(n) == 1 for n in factor_names):
+        indices = set()
+        for ch in word:
+            if ch in name_to_idx:
+                indices.add(name_to_idx[ch])
+        return frozenset(indices)
+
+    # Multi-char names: try to match greedily (longest first)
+    remaining = word
+    indices = set()
+    sorted_names = sorted(name_to_idx.keys(), key=len, reverse=True)
+    while remaining:
+        matched = False
+        for name in sorted_names:
+            if remaining.startswith(name):
+                indices.add(name_to_idx[name])
+                remaining = remaining[len(name) :]
+                matched = True
+                break
+        if not matched:
+            remaining = remaining[1:]  # skip unrecognized character
+    return frozenset(indices)
+
+
+def _word_to_str(indices: frozenset[int], factor_names: list[str]) -> str:
+    """Convert factor indices back to a word string."""
+    if not indices:
+        return "I"
+    sorted_indices = sorted(indices)
+    return "".join(factor_names[i] for i in sorted_indices)
+
+
+def _multiply_words(w1: frozenset[int], w2: frozenset[int]) -> frozenset[int]:
+    """Multiply two words in GF(2) — symmetric difference of factor sets."""
+    return w1.symmetric_difference(w2)
+
+
+def _defining_relation_from_generators(
+    generators: list[str], factor_names: list[str]
+) -> list[frozenset[int]]:
+    """Compute the full defining relation from generator strings.
+
+    Each generator like ``"D=ABC"`` produces the word ``ABCD``.  The full
+    defining relation is the closure under GF(2) multiplication of all
+    generator words and their products (all non-empty subsets).
+    """
+    # Parse each generator into a defining word
+    base_words: list[frozenset[int]] = []
+    for gen in generators:
+        parts = gen.split("=")
+        lhs = parts[0].strip()
+        rhs = parts[1].strip() if len(parts) > 1 else ""
+        lhs_idx = _parse_word(lhs, factor_names)
+        rhs_idx = _parse_word(rhs, factor_names)
+        word = _multiply_words(lhs_idx, rhs_idx)
+        base_words.append(word)
+
+    # Generate all non-empty subsets and their products
+    all_words: set[frozenset[int]] = set()
+    for r in range(1, len(base_words) + 1):
+        for subset in itertools.combinations(base_words, r):
+            product = frozenset()
+            for w in subset:
+                product = _multiply_words(product, w)
+            if product:  # exclude identity
+                all_words.add(product)
+
+    return sorted(all_words, key=lambda w: (len(w), sorted(w)))
+
+
+def _compute_defining_relation(ctx: _EvalContext) -> dict[str, Any]:
+    """Compute or return the defining relation."""
+    if ctx.defining_relation:
+        return {"defining_relation": ctx.defining_relation}
+
+    if not ctx.generators:
+        return {"defining_relation": None, "note": "No generators available. Not a fractional factorial design."}
+
+    words = _defining_relation_from_generators(ctx.generators, ctx.factor_names)
+    relation = [f"I={_word_to_str(w, ctx.factor_names)}" for w in words]
+    return {"defining_relation": relation}
+
+
+def _compute_resolution(ctx: _EvalContext) -> dict[str, Any]:
+    """Design resolution = minimum word length in the defining relation."""
+    if ctx.resolution is not None:
+        roman = _ROMAN.get(ctx.resolution, str(ctx.resolution))
+        return {"resolution": ctx.resolution, "roman": roman}
+
+    if not ctx.generators:
+        return {"resolution": None, "roman": None, "note": "Not a fractional factorial design."}
+
+    words = _defining_relation_from_generators(ctx.generators, ctx.factor_names)
+    if not words:
+        return {"resolution": None, "roman": None, "note": "No defining relation words found."}
+
+    res = min(len(w) for w in words)
+    roman = _ROMAN.get(res, str(res))
+    return {"resolution": res, "roman": roman}
+
+
+def _compute_alias_structure(ctx: _EvalContext) -> dict[str, Any]:
+    """Alias structure: which effects are aliased with which others.
+
+    Uses GF(2) arithmetic when generators are available; falls back to
+    correlation-based detection otherwise.
+    """
+    if ctx.generators:
+        return _alias_structure_from_generators(ctx)
+    return _alias_structure_from_correlation(ctx)
+
+
+def _alias_structure_from_generators(ctx: _EvalContext) -> dict[str, Any]:
+    """Compute alias chains using GF(2) multiplication against the defining relation."""
+    words = _defining_relation_from_generators(ctx.generators, ctx.factor_names)
+    if not words:
+        return {"alias_structure": []}
+
+    # Build alias chains for main effects and 2-factor interactions
+    alias_chains: list[str] = []
+    k = len(ctx.factor_names)
+
+    # Main effects
+    for i in range(k):
+        effect = frozenset([i])
+        effect_name = ctx.factor_names[i]
+        aliases = []
+        for w in words:
+            alias = _multiply_words(effect, w)
+            alias_name = _word_to_str(alias, ctx.factor_names)
+            aliases.append(alias_name)
+        # Sort by word length
+        aliases.sort(key=lambda s: (len(s), s))
+        chain = f"{effect_name} = " + " + ".join(aliases)
+        alias_chains.append(chain)
+
+    # 2-factor interactions
+    for i, j in itertools.combinations(range(k), 2):
+        effect = frozenset([i, j])
+        effect_name = _word_to_str(effect, ctx.factor_names)
+        aliases = []
+        for w in words:
+            alias = _multiply_words(effect, w)
+            alias_name = _word_to_str(alias, ctx.factor_names)
+            aliases.append(alias_name)
+        aliases.sort(key=lambda s: (len(s), s))
+        chain = f"{effect_name} = " + " + ".join(aliases)
+        alias_chains.append(chain)
+
+    return {"alias_structure": alias_chains}
+
+
+def _is_intercept_col(name: str) -> bool:
+    """Check if a column name represents the intercept."""
+    return name.lower() == "intercept" or name == "1"
+
+
+def _find_correlated_aliases(
+    X_full: np.ndarray, col_names: list[str], col_idx: int, nonzero: np.ndarray, threshold: float
+) -> list[tuple[str, str]]:
+    """Find columns highly correlated with column *col_idx*."""
+    aliases: list[tuple[str, str]] = []
+    for j in range(X_full.shape[1]):
+        if j == col_idx or not nonzero[j] or _is_intercept_col(col_names[j]):
+            continue
+        corr = np.corrcoef(X_full[:, col_idx], X_full[:, j])[0, 1]
+        if abs(corr) > threshold:
+            sign = "+" if corr > 0 else "-"
+            aliases.append((sign, col_names[j]))
+    return aliases
+
+
+def _alias_structure_from_correlation(ctx: _EvalContext) -> dict[str, Any]:
+    """Detect aliasing via correlation of model matrix columns."""
+    if ctx.p <= 1:
+        return {"alias_structure": []}
+
+    # Build an expanded model matrix with higher-order terms for alias detection
+    factor_str = " + ".join(ctx.factor_names)
+    k = len(ctx.factor_names)
+    max_order = min(k, 3)
+    rhs = f"({factor_str}) ** {max_order}" if max_order >= 3 else f"({factor_str}) ** 2"
+
+    dm = dmatrix(rhs, ctx.design_df, return_type="dataframe")
+    X_full = np.asarray(dm, dtype=float)
+    col_names = list(dm.columns)
+
+    stddevs = X_full.std(axis=0)
+    nonzero = stddevs > np.sqrt(np.finfo(float).eps)
+
+    alias_chains: list[str] = []
+    for i in range(X_full.shape[1]):
+        if _is_intercept_col(col_names[i]) or not nonzero[i]:
+            continue
+        aliases = _find_correlated_aliases(X_full, col_names, i, nonzero, threshold=0.995)
+        if aliases:
+            alias_parts = [f"{sign}{name}" for sign, name in aliases]
+            alias_chains.append(f"{col_names[i]} = " + " + ".join(alias_parts))
+
+    return {"alias_structure": alias_chains}
+
+
+def _compute_confounding(ctx: _EvalContext) -> dict[str, Any]:
+    """Confounding structure: pairs of effects that cannot be distinguished."""
+    alias_result = _compute_alias_structure(ctx)
+    alias_chains = alias_result.get("alias_structure", [])
+    if not alias_chains:
+        return {"confounding": [], "note": "No confounding detected."}
+
+    confounding_list: list[dict[str, Any]] = []
+    for chain in alias_chains:
+        if " = " not in chain:
+            continue
+        parts = chain.split(" = ", 1)
+        effect = parts[0].strip()
+        aliases_str = parts[1].strip()
+        confounded = [a.strip().lstrip("+-") for a in aliases_str.split(" + ")]
+        confounding_list.append({
+            "effect": effect,
+            "confounded_with": confounded,
+        })
+    return {"confounding": confounding_list}
+
+
+def _effect_order(term: str, factor_names: list[str]) -> int:
+    """Determine the order of an effect term (1=main, 2=2FI, etc.)."""
+    if ":" in term:
+        return term.count(":") + 1
+    if term in factor_names:
+        return 1
+    return len(term)  # approximate for single-char factor names
+
+
+def _compute_clear_effects(ctx: _EvalContext) -> dict[str, Any]:
+    """Identify effects whose aliases are all of higher order."""
+    alias_result = _compute_alias_structure(ctx)
+    alias_chains = alias_result.get("alias_structure", [])
+
+    clear_main: list[str] = []
+    clear_2fi: list[str] = []
+
+    for chain in alias_chains:
+        if " = " not in chain:
+            continue
+        effect, aliases_str = chain.split(" = ", 1)
+        effect = effect.strip()
+        order = _effect_order(effect, ctx.factor_names)
+
+        alias_terms = [a.strip().lstrip("+-") for a in aliases_str.strip().split(" + ")]
+        all_higher = all(_effect_order(a, ctx.factor_names) > order for a in alias_terms)
+
+        if all_higher and order == 1:
+            clear_main.append(effect)
+        elif all_higher and order == 2:
+            clear_2fi.append(effect)
+
+    return {
+        "clear_effects": {
+            "main_effects": clear_main,
+            "two_factor_interactions": clear_2fi,
+        }
+    }
+
+
+def _compute_minimum_aberration(ctx: _EvalContext) -> dict[str, Any]:
+    """Wordlength pattern (A_3, A_4, ...) from the defining relation."""
+    if not ctx.generators:
+        return {
+            "minimum_aberration": {
+                "wordlength_pattern": [],
+                "note": "Not a fractional factorial design.",
+            }
+        }
+
+    words = _defining_relation_from_generators(ctx.generators, ctx.factor_names)
+    if not words:
+        return {
+            "minimum_aberration": {
+                "wordlength_pattern": [],
+                "note": "No defining relation words found.",
+            }
+        }
+
+    lengths = [len(w) for w in words]
+    max_len = max(lengths) if lengths else 0
+    # Wordlength pattern: A_i = number of words of length i, starting at i=3
+    pattern = [lengths.count(i) for i in range(3, max_len + 1)]
+
+    return {
+        "minimum_aberration": {
+            "wordlength_pattern": pattern,
+            "wordlength_pattern_labels": [f"A_{i}" for i in range(3, max_len + 1)],
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Metric dispatch registry
+# ---------------------------------------------------------------------------
+
+_METRIC_REGISTRY: dict[str, Callable[[_EvalContext], Any]] = {
+    "d_efficiency": _compute_d_efficiency,
+    "i_efficiency": _compute_i_efficiency,
+    "g_efficiency": _compute_g_efficiency,
+    "prediction_variance": _compute_prediction_variance,
+    "vif": _compute_vif,
+    "condition_number": _compute_condition_number,
+    "power": _compute_power,
+    "degrees_of_freedom": _compute_degrees_of_freedom,
+    "alias_structure": _compute_alias_structure,
+    "confounding": _compute_confounding,
+    "resolution": _compute_resolution,
+    "defining_relation": _compute_defining_relation,
+    "clear_effects": _compute_clear_effects,
+    "minimum_aberration": _compute_minimum_aberration,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def evaluate_design(  # noqa: PLR0913
+    design_matrix: pd.DataFrame | DesignResult,
+    model: str | None = None,
+    metric: str | list[str] = "d_efficiency",
+    effect_size: float | None = None,
+    alpha: float = 0.05,
+    sigma: float | None = None,
+) -> dict[str, Any]:
+    """Compute quality metrics for an experimental design.
+
+    Parameters
+    ----------
+    design_matrix : DataFrame or DesignResult
+        The design to evaluate.  If a :class:`DesignResult` is passed, the
+        coded design matrix and any generator / defining-relation metadata
+        are extracted automatically.
+    model : str or None
+        Model type: ``"main_effects"``, ``"interactions"``, ``"quadratic"``,
+        or an explicit patsy formula.  ``None`` defaults to ``"interactions"``.
+    metric : str or list[str]
+        One or more metric names to compute.  Valid names:
+        ``"alias_structure"``, ``"confounding"``, ``"resolution"``,
+        ``"defining_relation"``, ``"power"``, ``"d_efficiency"``,
+        ``"i_efficiency"``, ``"g_efficiency"``, ``"prediction_variance"``,
+        ``"degrees_of_freedom"``, ``"vif"``, ``"condition_number"``,
+        ``"clear_effects"``, ``"minimum_aberration"``.
+    effect_size : float or None
+        Expected effect size for power calculation.  When *None*, a power
+        curve over a range of effect sizes is returned instead.
+    alpha : float
+        Significance level for power calculation (default 0.05).
+    sigma : float or None
+        Estimated noise standard deviation.  Defaults to 1.0 when needed
+        but not provided.
+
+    Returns
+    -------
+    dict[str, Any]
+        Results keyed by metric name.  The structure of each value depends
+        on the metric — see individual metric documentation.
+
+    Examples
+    --------
+    >>> from process_improve.experiments import evaluate_design, generate_design, Factor
+    >>> factors = [Factor(name="A", low=0, high=10), Factor(name="B", low=0, high=10)]
+    >>> result = generate_design(factors, design_type="full_factorial", center_points=0)
+    >>> metrics = evaluate_design(result, model="main_effects", metric="d_efficiency")
+    >>> metrics["d_efficiency"]  # doctest: +SKIP
+    100.0
+    """
+    # --- Unpack input ---
+    generators: list[str] | None = None
+    defining_relation: list[str] | None = None
+    resolution: int | None = None
+
+    if isinstance(design_matrix, DesignResult):
+        generators = design_matrix.generators
+        defining_relation = design_matrix.defining_relation
+        resolution = design_matrix.resolution
+        factor_names = list(design_matrix.factor_names)
+        design_df = pd.DataFrame(design_matrix.design)
+    else:
+        design_df = pd.DataFrame(design_matrix)
+        factor_names = list(design_df.columns)
+
+    # Drop non-factor columns
+    for col in ["RunOrder", "Block"]:
+        if col in design_df.columns and col not in factor_names:
+            design_df = design_df.drop(columns=[col])
+        elif col in factor_names:
+            factor_names.remove(col)
+            design_df = design_df.drop(columns=[col])
+
+    # --- Normalize metric to list ---
+    metrics = [metric] if isinstance(metric, str) else list(metric)
+
+    # Validate metric names
+    unknown = [m for m in metrics if m not in _METRIC_REGISTRY]
+    if unknown:
+        available = sorted(_METRIC_REGISTRY.keys())
+        raise ValueError(f"Unknown metric(s): {unknown}. Available metrics: {available}")
+
+    # --- Build context ---
+    ctx = _build_context(
+        design_df=design_df,
+        factor_names=factor_names,
+        model=model,
+        generators=generators,
+        defining_relation=defining_relation,
+        resolution=resolution,
+        effect_size=effect_size,
+        alpha=alpha,
+        sigma=sigma,
+    )
+
+    # --- Compute requested metrics ---
+    results: dict[str, Any] = {}
+    for m in metrics:
+        result = _METRIC_REGISTRY[m](ctx)
+        results.update(result)
+
+    return results

--- a/process_improve/experiments/tools.py
+++ b/process_improve/experiments/tools.py
@@ -381,6 +381,134 @@ def generate_design_tool(  # noqa: PLR0913
 _register("generate_design")
 
 
+@tool_spec(
+    name="evaluate_design",
+    description=(
+        "Evaluate the quality of an experimental design matrix by computing metrics such as "
+        "D-efficiency, G-efficiency, I-efficiency, VIF, condition number, alias structure, "
+        "confounding pattern, resolution, power, prediction variance, degrees of freedom, "
+        "clear effects, and minimum aberration. "
+        "The design_matrix should be a list of dictionaries with factor names as keys and "
+        "coded values (-1/+1) as values. "
+        "Use this after generating a design to check if it meets quality criteria, or to "
+        "compare alternative designs."
+    ),
+    input_schema={
+        "json": {
+            "type": "object",
+            "properties": {
+                "design_matrix": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {"type": "number"},
+                    },
+                    "description": (
+                        "List of dictionaries, one per experimental run. Each dict maps "
+                        "factor name to coded value. Example: [{'A': -1, 'B': -1}, ...]"
+                    ),
+                    "minItems": 2,
+                },
+                "model": {
+                    "type": "string",
+                    "enum": ["main_effects", "interactions", "quadratic"],
+                    "description": (
+                        "Model type to evaluate against. 'main_effects' = main effects only, "
+                        "'interactions' = main effects + 2-factor interactions (default), "
+                        "'quadratic' = interactions + squared terms."
+                    ),
+                },
+                "metric": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "enum": [
+                                "d_efficiency",
+                                "i_efficiency",
+                                "g_efficiency",
+                                "prediction_variance",
+                                "vif",
+                                "condition_number",
+                                "power",
+                                "degrees_of_freedom",
+                                "alias_structure",
+                                "confounding",
+                                "resolution",
+                                "defining_relation",
+                                "clear_effects",
+                                "minimum_aberration",
+                            ],
+                        },
+                        {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                    ],
+                    "description": (
+                        "One or more metric names to compute. Default: 'd_efficiency'."
+                    ),
+                },
+                "effect_size": {
+                    "type": "number",
+                    "description": "Expected effect size for power calculation.",
+                },
+                "alpha": {
+                    "type": "number",
+                    "description": "Significance level (default 0.05).",
+                },
+                "sigma": {
+                    "type": "number",
+                    "description": "Estimated noise standard deviation.",
+                },
+            },
+            "required": ["design_matrix", "metric"],
+        }
+    },
+    examples="""
+    # "What is the D-efficiency of my 2^3 factorial design?"
+        -> ``evaluate_design(design_matrix=[{"A":-1,"B":-1,"C":-1}, ...],
+                metric="d_efficiency", model="interactions")``
+
+    # "Check VIF and condition number"
+        -> ``evaluate_design(design_matrix=[...],
+                metric=["vif", "condition_number"], model="interactions")``
+
+    # "What is the power to detect an effect of size 2 with noise SD of 1?"
+        -> ``evaluate_design(design_matrix=[...],
+                metric="power", effect_size=2.0, sigma=1.0)``
+    """,
+    category="experiments",
+)
+def evaluate_design_tool(  # noqa: PLR0913
+    *,
+    design_matrix: list[dict[str, Any]],
+    model: str | None = None,
+    metric: str | list[str] = "d_efficiency",
+    effect_size: float | None = None,
+    alpha: float = 0.05,
+    sigma: float | None = None,
+) -> dict[str, Any]:
+    """Evaluate design quality; see tool spec for details."""
+    try:
+        from process_improve.experiments.evaluate import evaluate_design  # noqa: PLC0415
+
+        df = pd.DataFrame(design_matrix)
+        result = evaluate_design(
+            df,
+            model=model,
+            metric=metric,
+            effect_size=effect_size,
+            alpha=alpha,
+            sigma=sigma,
+        )
+        return clean(result)
+    except Exception as e:  # noqa: BLE001
+        return {"error": str(e)}
+
+
+_register("evaluate_design")
+
+
 # ---------------------------------------------------------------------------
 # Module-level convenience
 # ---------------------------------------------------------------------------

--- a/tests/test_evaluate_design.py
+++ b/tests/test_evaluate_design.py
@@ -1,0 +1,784 @@
+"""Tests for the evaluate_design() design quality metrics API."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from process_improve.experiments.designs import generate_design
+from process_improve.experiments.evaluate import (
+    _build_model_matrix,
+    _defining_relation_from_generators,
+    _multiply_words,
+    _parse_word,
+    _word_to_str,
+    evaluate_design,
+)
+from process_improve.experiments.factor import Factor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _continuous_factors(n: int, names: str | None = None) -> list[Factor]:
+    """Create n continuous factors with default ranges."""
+    if names and len(names) >= n:
+        return [Factor(name=names[i], low=0, high=10) for i in range(n)]
+    return [Factor(name=f"X{i + 1}", low=0, high=10) for i in range(n)]
+
+
+def _full_factorial_df(k: int, names: str = "ABCDEFGHIJ") -> pd.DataFrame:
+    """Create a 2^k full factorial design as a DataFrame of -1/+1 coded values."""
+    n = 2**k
+    cols = {}
+    for i in range(k):
+        cols[names[i]] = [1 if (j >> (k - 1 - i)) & 1 else -1 for j in range(n)]
+    return pd.DataFrame(cols)
+
+
+# ---------------------------------------------------------------------------
+# Model matrix construction
+# ---------------------------------------------------------------------------
+
+
+class TestModelMatrix:
+    """Test _build_model_matrix."""
+
+    def test_main_effects_shape(self) -> None:
+        """2^3 factorial with main_effects produces (8, 4) matrix."""
+        df = _full_factorial_df(3)
+        X, cols = _build_model_matrix(df, "main_effects", ["A", "B", "C"])
+        assert X.shape == (8, 4)  # intercept + 3 main effects
+        assert "Intercept" in cols
+
+    def test_interactions_shape(self) -> None:
+        """2^3 factorial with interactions produces (8, 7+1) columns."""
+        df = _full_factorial_df(3)
+        X, _cols = _build_model_matrix(df, "interactions", ["A", "B", "C"])
+        # intercept + 3 main + 3 two-factor interactions = 7
+        assert X.shape == (8, 7)
+
+    def test_quadratic_shape(self) -> None:
+        """Design with quadratic model includes squared terms."""
+        # CCD has 3 levels per factor, so squared terms are estimable
+        factors = _continuous_factors(2, "AB")
+        result = generate_design(factors, design_type="ccd", alpha="face_centered")
+        df = pd.DataFrame(result.design[["A", "B"]])
+        X, _cols = _build_model_matrix(df, "quadratic", ["A", "B"])
+        # intercept + 2 main + 1 interaction + 2 squared = 6
+        assert X.shape[1] == 6
+
+    def test_none_defaults_to_interactions(self) -> None:
+        """model=None should default to interactions."""
+        df = _full_factorial_df(3)
+        X_none, _cols_none = _build_model_matrix(df, None, ["A", "B", "C"])
+        X_int, _cols_int = _build_model_matrix(df, "interactions", ["A", "B", "C"])
+        np.testing.assert_array_equal(X_none, X_int)
+
+    def test_explicit_formula_with_tilde(self) -> None:
+        """Explicit formula with ~ should strip the LHS."""
+        df = _full_factorial_df(2)
+        X, _cols = _build_model_matrix(df, "y ~ A + B", ["A", "B"])
+        assert X.shape == (4, 3)  # intercept + 2 main
+
+    def test_explicit_rhs_formula(self) -> None:
+        """Explicit RHS formula (no ~) should work directly."""
+        df = _full_factorial_df(2)
+        X, _cols = _build_model_matrix(df, "A * B", ["A", "B"])
+        assert X.shape[1] == 4  # intercept + A + B + A:B
+
+
+# ---------------------------------------------------------------------------
+# D-efficiency
+# ---------------------------------------------------------------------------
+
+
+class TestDEfficiency:
+    """Test D-efficiency metric."""
+
+    def test_orthogonal_full_factorial(self) -> None:
+        """Orthogonal 2^2 factorial with main-effects model has D-eff = 100%."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="main_effects", metric="d_efficiency")
+        assert result["d_efficiency"] == pytest.approx(100.0, abs=0.5)
+
+    def test_full_factorial_interactions(self) -> None:
+        """2^3 full factorial with full interaction model has D-eff = 100%."""
+        df = _full_factorial_df(3)
+        result = evaluate_design(df, model="interactions", metric="d_efficiency")
+        # 2^3 design evaluating main + 2FI is 7 terms for 8 runs; D-eff should be high
+        assert result["d_efficiency"] is not None
+        assert result["d_efficiency"] > 50.0
+
+    def test_singular_returns_none(self) -> None:
+        """Rank-deficient design returns None for D-efficiency."""
+        # 2^2 factorial trying to fit quadratic is rank-deficient
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="quadratic", metric="d_efficiency")
+        assert result["d_efficiency"] is None
+
+    def test_fractional_less_than_full(self) -> None:
+        """Fractional factorial should have lower D-eff than full factorial for same model."""
+        factors = _continuous_factors(4, "ABCD")
+        frac = generate_design(
+            factors, design_type="fractional_factorial", generators=["D=ABC"], center_points=0
+        )
+        full = generate_design(factors, design_type="full_factorial", center_points=0)
+        d_frac = evaluate_design(frac, model="main_effects", metric="d_efficiency")["d_efficiency"]
+        d_full = evaluate_design(full, model="main_effects", metric="d_efficiency")["d_efficiency"]
+        assert d_frac is not None
+        assert d_full is not None
+        # Both should be valid; full factorial should be at least as good
+        assert d_full >= d_frac - 1.0  # small tolerance
+
+
+# ---------------------------------------------------------------------------
+# G-efficiency
+# ---------------------------------------------------------------------------
+
+
+class TestGEfficiency:
+    """Test G-efficiency metric."""
+
+    def test_orthogonal_design(self) -> None:
+        """Orthogonal design should have high G-efficiency."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="main_effects", metric="g_efficiency")
+        assert result["g_efficiency"] is not None
+        assert result["g_efficiency"] > 80.0
+
+    def test_returns_max_prediction_variance(self) -> None:
+        """G-efficiency result should include max_prediction_variance."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="main_effects", metric="g_efficiency")
+        assert "max_prediction_variance" in result
+
+    def test_singular_returns_none(self) -> None:
+        """Singular design returns None for G-efficiency."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="quadratic", metric="g_efficiency")
+        assert result["g_efficiency"] is None
+
+
+# ---------------------------------------------------------------------------
+# I-efficiency
+# ---------------------------------------------------------------------------
+
+
+class TestIEfficiency:
+    """Test I-efficiency metric."""
+
+    def test_orthogonal_design(self) -> None:
+        """Orthogonal design should have high I-efficiency."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="main_effects", metric="i_efficiency")
+        assert result["i_efficiency"] is not None
+        assert result["i_efficiency"] > 80.0
+
+    def test_returns_average_prediction_variance(self) -> None:
+        """I-efficiency result should include average_prediction_variance."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="main_effects", metric="i_efficiency")
+        assert "average_prediction_variance" in result
+
+
+# ---------------------------------------------------------------------------
+# Prediction variance
+# ---------------------------------------------------------------------------
+
+
+class TestPredictionVariance:
+    """Test prediction variance metric."""
+
+    def test_returns_list(self) -> None:
+        """Prediction variance returns a list of values, one per design point."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="main_effects", metric="prediction_variance")
+        assert len(result["prediction_variance"]) == 4
+
+    def test_hat_matrix_diagonal(self) -> None:
+        """For orthogonal 2^k with full model, hat diagonal = p/N at every point."""
+        df = _full_factorial_df(3)
+        result = evaluate_design(df, model="main_effects", metric="prediction_variance")
+        # p = 4 (intercept + 3 main), N = 8; h_ii = p/N = 0.5
+        for v in result["prediction_variance"]:
+            assert v == pytest.approx(0.5, abs=1e-10)
+
+    def test_includes_summary_stats(self) -> None:
+        """Result should include mean, max, min."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="main_effects", metric="prediction_variance")
+        assert "mean" in result
+        assert "max" in result
+        assert "min" in result
+
+    def test_singular_returns_none(self) -> None:
+        """Singular design returns None for prediction variance."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="quadratic", metric="prediction_variance")
+        assert result["prediction_variance"] is None
+
+
+# ---------------------------------------------------------------------------
+# VIF
+# ---------------------------------------------------------------------------
+
+
+class TestVIF:
+    """Test VIF metric."""
+
+    def test_orthogonal_all_ones(self) -> None:
+        """Orthogonal 2^k design has VIF = 1 for all terms."""
+        df = _full_factorial_df(3)
+        result = evaluate_design(df, model="main_effects", metric="vif")
+        vif = result["vif"]
+        for name, value in vif.items():
+            assert value == pytest.approx(1.0, abs=0.01), f"VIF for {name} should be 1.0"
+
+    def test_returns_dict_keyed_by_term(self) -> None:
+        """VIF returns a dict mapping term names to VIF values."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="main_effects", metric="vif")
+        vif = result["vif"]
+        assert isinstance(vif, dict)
+        assert "A" in vif
+        assert "B" in vif
+
+    def test_excludes_intercept(self) -> None:
+        """VIF should not include the intercept term."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="main_effects", metric="vif")
+        vif = result["vif"]
+        assert "Intercept" not in vif
+
+    def test_singular_returns_none(self) -> None:
+        """Singular design returns None for VIF."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="quadratic", metric="vif")
+        assert result["vif"] is None
+
+
+# ---------------------------------------------------------------------------
+# Condition number
+# ---------------------------------------------------------------------------
+
+
+class TestConditionNumber:
+    """Test condition number metric."""
+
+    def test_orthogonal_low(self) -> None:
+        """Orthogonal design should have low condition number."""
+        df = _full_factorial_df(3)
+        result = evaluate_design(df, model="main_effects", metric="condition_number")
+        assert result["condition_number"] < 5.0
+
+    def test_always_positive(self) -> None:
+        """Condition number should always be positive."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="main_effects", metric="condition_number")
+        assert result["condition_number"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Power
+# ---------------------------------------------------------------------------
+
+
+class TestPower:
+    """Test power analysis metric."""
+
+    def test_large_effect_near_one(self) -> None:
+        """Large effect size produces power near 1.0."""
+        df = _full_factorial_df(3)
+        result = evaluate_design(
+            df, model="main_effects", metric="power", effect_size=10.0, sigma=1.0
+        )
+        power = result["power"]
+        for name, pwr in power.items():
+            assert pwr > 0.99, f"Power for {name} should be near 1.0 for large effect"
+
+    def test_small_effect_low(self) -> None:
+        """Small effect size produces low power."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(
+            df, model="main_effects", metric="power", effect_size=0.01, sigma=1.0
+        )
+        power = result["power"]
+        for name, pwr in power.items():
+            assert pwr < 0.5, f"Power for {name} should be low for small effect"
+
+    def test_more_runs_more_power(self) -> None:
+        """More runs (replicated design) should yield higher power."""
+        factors = _continuous_factors(3, "ABC")
+        single = generate_design(factors, design_type="full_factorial", center_points=0, replicates=1)
+        double = generate_design(factors, design_type="full_factorial", center_points=0, replicates=2)
+        p1 = evaluate_design(single, model="main_effects", metric="power", effect_size=2.0, sigma=1.0)
+        p2 = evaluate_design(double, model="main_effects", metric="power", effect_size=2.0, sigma=1.0)
+        # Pick any factor — power should be higher with 2x runs
+        assert p2["power"]["A"] >= p1["power"]["A"] - 0.01
+
+    def test_power_curve_when_no_effect_size(self) -> None:
+        """When effect_size is None, return power curves."""
+        df = _full_factorial_df(3)
+        result = evaluate_design(df, model="main_effects", metric="power", sigma=1.0)
+        assert "power_curves" in result
+        # Each term should have a list of {effect_size, power} dicts
+        for curve in result["power_curves"].values():
+            assert len(curve) > 0
+            assert "effect_size" in curve[0]
+            assert "power" in curve[0]
+
+    def test_saturated_model_returns_none(self) -> None:
+        """Saturated model (0 residual DF) returns None for power."""
+        df = _full_factorial_df(3)
+        # 8 runs, interactions model = 7 params + intercept = 8 → not fully saturated
+        evaluate_design(df, model="interactions", metric="power", effect_size=2.0, sigma=1.0)
+        # With N=8, p=7 (intercept + 3 main + 3 2FI), df_resid = 1
+        # This should still compute (1 df_resid is nonzero)
+        # But a truly saturated case:
+        df2 = _full_factorial_df(2)  # 4 runs
+        # interactions: intercept + A + B + A:B = 4 params → 0 df_resid
+        result2 = evaluate_design(df2, model="interactions", metric="power", effect_size=2.0, sigma=1.0)
+        assert result2["power"] is None
+
+
+# ---------------------------------------------------------------------------
+# Degrees of freedom
+# ---------------------------------------------------------------------------
+
+
+class TestDegreesOfFreedom:
+    """Test degrees of freedom metric."""
+
+    def test_full_factorial_main_effects(self) -> None:
+        """2^3 full factorial, main effects model."""
+        df = _full_factorial_df(3)
+        result = evaluate_design(df, model="main_effects", metric="degrees_of_freedom")
+        dof = result["degrees_of_freedom"]
+        assert dof["model"] == 3  # 3 main effects
+        assert dof["residual"] == 4  # 8 - 4
+        assert dof["total"] == 7  # 8 - 1
+
+    def test_components_sum(self) -> None:
+        """df_model + df_residual + 1 (intercept) = df_total + 1 = N."""
+        df = _full_factorial_df(3)
+        result = evaluate_design(df, model="main_effects", metric="degrees_of_freedom")
+        dof = result["degrees_of_freedom"]
+        assert dof["model"] + dof["residual"] + 1 == len(df)
+
+    def test_saturated(self) -> None:
+        """Saturated design has 0 residual DF."""
+        df = _full_factorial_df(2)  # 4 runs
+        result = evaluate_design(df, model="interactions", metric="degrees_of_freedom")
+        dof = result["degrees_of_freedom"]
+        assert dof["residual"] == 0
+
+    def test_replicated_has_pure_error(self) -> None:
+        """Replicated design should report pure_error and lack_of_fit DF."""
+        factors = _continuous_factors(2, "AB")
+        result = generate_design(factors, design_type="full_factorial", center_points=0, replicates=2)
+        metrics = evaluate_design(result, model="main_effects", metric="degrees_of_freedom")
+        dof = metrics["degrees_of_freedom"]
+        assert "pure_error" in dof
+        assert dof["pure_error"] == 4  # 8 - 4 distinct points
+
+
+# ---------------------------------------------------------------------------
+# Alias structure
+# ---------------------------------------------------------------------------
+
+
+class TestAliasStructure:
+    """Test alias structure metric."""
+
+    def test_half_fraction(self) -> None:
+        """2^(4-1) with D=ABC: main effects are aliased with 3FI."""
+        factors = [Factor(name=n, low=0, high=10) for n in ["A", "B", "C", "D"]]
+        result = generate_design(
+            factors, design_type="fractional_factorial", generators=["D=ABC"], center_points=0
+        )
+        metrics = evaluate_design(result, metric="alias_structure")
+        aliases = metrics["alias_structure"]
+        assert len(aliases) > 0
+        # A should be aliased with BCD
+        a_alias = [a for a in aliases if a.startswith("A ")]
+        assert len(a_alias) == 1
+        assert "BCD" in a_alias[0]
+
+    def test_full_factorial_no_aliases_from_generators(self) -> None:
+        """Full factorial has no generators, so generator-based aliasing is empty."""
+        factors = _continuous_factors(3, "ABC")
+        result = generate_design(factors, design_type="full_factorial", center_points=0)
+        metrics = evaluate_design(result, metric="alias_structure")
+        # No generators → falls back to correlation-based, which should find none
+        aliases = metrics["alias_structure"]
+        assert len(aliases) == 0
+
+    def test_raw_dataframe_correlation_fallback(self) -> None:
+        """Raw DataFrame without generators should use correlation fallback."""
+        # Create a fractional factorial manually: 2^(3-1) with C=AB
+        df = pd.DataFrame(
+            {"A": [-1, 1, -1, 1], "B": [-1, -1, 1, 1], "C": [1, -1, -1, 1]}
+        )
+        # C = A*B, so aliasing should be detected
+        metrics = evaluate_design(df, metric="alias_structure")
+        aliases = metrics["alias_structure"]
+        assert len(aliases) > 0
+
+
+# ---------------------------------------------------------------------------
+# Confounding
+# ---------------------------------------------------------------------------
+
+
+class TestConfounding:
+    """Test confounding metric."""
+
+    def test_res_iii(self) -> None:
+        """Resolution III design has main effects confounded with 2FI."""
+        # 2^(3-1) with C=AB is resolution III
+        factors = [Factor(name=n, low=0, high=10) for n in ["A", "B", "C"]]
+        result = generate_design(
+            factors, design_type="fractional_factorial", generators=["C=AB"], center_points=0
+        )
+        metrics = evaluate_design(result, metric="confounding")
+        confounding = metrics["confounding"]
+        assert len(confounding) > 0
+        # A is confounded with BC
+        a_conf = [c for c in confounding if c["effect"] == "A"]
+        assert len(a_conf) == 1
+        assert "BC" in a_conf[0]["confounded_with"]
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolution:
+    """Test resolution metric."""
+
+    def test_from_design_result(self) -> None:
+        """Resolution should be passed through from DesignResult metadata."""
+        factors = [Factor(name=n, low=0, high=10) for n in ["A", "B", "C", "D", "E"]]
+        result = generate_design(
+            factors, design_type="fractional_factorial", resolution=3, center_points=0
+        )
+        metrics = evaluate_design(result, metric="resolution")
+        assert metrics["resolution"] is not None
+
+    def test_from_generators(self) -> None:
+        """Resolution computed from generators."""
+        factors = [Factor(name=n, low=0, high=10) for n in ["A", "B", "C", "D"]]
+        result = generate_design(
+            factors, design_type="fractional_factorial", generators=["D=ABC"], center_points=0
+        )
+        # D=ABC → I=ABCD → resolution IV
+        metrics = evaluate_design(result, metric="resolution")
+        res = metrics["resolution"]
+        assert res == 4
+        assert metrics["roman"] == "IV"
+
+    def test_none_for_full_factorial(self) -> None:
+        """Full factorial has no resolution."""
+        factors = _continuous_factors(3, "ABC")
+        result = generate_design(factors, design_type="full_factorial", center_points=0)
+        metrics = evaluate_design(result, metric="resolution")
+        assert metrics["resolution"] is None
+
+
+# ---------------------------------------------------------------------------
+# Defining relation
+# ---------------------------------------------------------------------------
+
+
+class TestDefiningRelation:
+    """Test defining relation metric."""
+
+    def test_single_generator(self) -> None:
+        """D=ABC gives I=ABCD."""
+        factors = [Factor(name=n, low=0, high=10) for n in ["A", "B", "C", "D"]]
+        result = generate_design(
+            factors, design_type="fractional_factorial", generators=["D=ABC"], center_points=0
+        )
+        metrics = evaluate_design(result, metric="defining_relation")
+        dr = metrics["defining_relation"]
+        assert dr is not None
+        assert any("ABCD" in word for word in dr)
+
+    def test_two_generators(self) -> None:
+        """D=AB, E=AC gives 3 defining words."""
+        factors = [Factor(name=n, low=0, high=10) for n in ["A", "B", "C", "D", "E"]]
+        result = generate_design(
+            factors,
+            design_type="fractional_factorial",
+            generators=["D=AB", "E=AC"],
+            center_points=0,
+        )
+        metrics = evaluate_design(result, metric="defining_relation")
+        dr = metrics["defining_relation"]
+        assert dr is not None
+        assert len(dr) == 3  # ABD, ACE, and BCDE
+
+    def test_none_for_non_fractional(self) -> None:
+        """Full factorial returns None for defining relation."""
+        df = _full_factorial_df(2)
+        metrics = evaluate_design(df, metric="defining_relation")
+        assert metrics["defining_relation"] is None
+
+
+# ---------------------------------------------------------------------------
+# Clear effects
+# ---------------------------------------------------------------------------
+
+
+class TestClearEffects:
+    """Test clear effects metric."""
+
+    def test_res_iv_clear_main_effects(self) -> None:
+        """In a Resolution IV design, all main effects should be clear."""
+        factors = [Factor(name=n, low=0, high=10) for n in ["A", "B", "C", "D"]]
+        result = generate_design(
+            factors, design_type="fractional_factorial", generators=["D=ABC"], center_points=0
+        )
+        metrics = evaluate_design(result, metric="clear_effects")
+        clear = metrics["clear_effects"]
+        # Resolution IV: main effects aliased only with 3FI → all main effects clear
+        assert set(clear["main_effects"]) == {"A", "B", "C", "D"}
+
+
+# ---------------------------------------------------------------------------
+# Minimum aberration
+# ---------------------------------------------------------------------------
+
+
+class TestMinimumAberration:
+    """Test minimum aberration metric."""
+
+    def test_wordlength_pattern(self) -> None:
+        """D=ABC gives I=ABCD (length 4), so WLP = [0, 1] for A_3=0, A_4=1."""
+        factors = [Factor(name=n, low=0, high=10) for n in ["A", "B", "C", "D"]]
+        result = generate_design(
+            factors, design_type="fractional_factorial", generators=["D=ABC"], center_points=0
+        )
+        metrics = evaluate_design(result, metric="minimum_aberration")
+        ma = metrics["minimum_aberration"]
+        wlp = ma["wordlength_pattern"]
+        # I=ABCD has length 4; WLP starts at A_3: A_3=0, A_4=1
+        assert wlp == [0, 1]
+
+    def test_non_fractional(self) -> None:
+        """Non-fractional design returns empty WLP."""
+        df = _full_factorial_df(2)
+        metrics = evaluate_design(df, metric="minimum_aberration")
+        assert metrics["minimum_aberration"]["wordlength_pattern"] == []
+
+
+# ---------------------------------------------------------------------------
+# GF(2) word arithmetic internals
+# ---------------------------------------------------------------------------
+
+
+class TestWordArithmetic:
+    """Test internal GF(2) word parsing and multiplication."""
+
+    def test_parse_single_char_word(self) -> None:
+        """Parse 'ABC' into factor indices {0, 1, 2}."""
+        result = _parse_word("ABC", ["A", "B", "C", "D"])
+        assert result == frozenset({0, 1, 2})
+
+    def test_parse_with_i_prefix(self) -> None:
+        """Parse 'I=ABCD' stripping the I= prefix."""
+        result = _parse_word("I=ABCD", ["A", "B", "C", "D"])
+        assert result == frozenset({0, 1, 2, 3})
+
+    def test_parse_identity(self) -> None:
+        """Parse 'I' returns empty set."""
+        result = _parse_word("I", ["A", "B", "C"])
+        assert result == frozenset()
+
+    def test_multiply_words(self) -> None:
+        """Multiplying {0,1} and {1,2} gives {0,2} (symmetric difference)."""
+        w1 = frozenset({0, 1})
+        w2 = frozenset({1, 2})
+        assert _multiply_words(w1, w2) == frozenset({0, 2})
+
+    def test_word_to_str(self) -> None:
+        """Convert indices back to string."""
+        result = _word_to_str(frozenset({0, 2, 3}), ["A", "B", "C", "D"])
+        assert result == "ACD"
+
+    def test_word_to_str_identity(self) -> None:
+        """Empty frozenset gives 'I'."""
+        result = _word_to_str(frozenset(), ["A", "B", "C"])
+        assert result == "I"
+
+    def test_defining_relation_single_generator(self) -> None:
+        """D=ABC → full relation is [ABCD]."""
+        words = _defining_relation_from_generators(["D=ABC"], ["A", "B", "C", "D"])
+        strs = [_word_to_str(w, ["A", "B", "C", "D"]) for w in words]
+        assert "ABCD" in strs
+        assert len(words) == 1
+
+    def test_defining_relation_two_generators(self) -> None:
+        """D=AB, E=AC → relations ABD, ACE, BCDE."""
+        words = _defining_relation_from_generators(["D=AB", "E=AC"], ["A", "B", "C", "D", "E"])
+        strs = [_word_to_str(w, ["A", "B", "C", "D", "E"]) for w in words]
+        assert len(words) == 3
+        assert "ABD" in strs
+        assert "ACE" in strs
+        assert "BCDE" in strs
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcher:
+    """Test the evaluate_design dispatcher."""
+
+    def test_single_metric_string(self) -> None:
+        """metric='d_efficiency' works."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="main_effects", metric="d_efficiency")
+        assert "d_efficiency" in result
+
+    def test_multiple_metrics_list(self) -> None:
+        """metric=['d_efficiency', 'vif'] returns both."""
+        df = _full_factorial_df(3)
+        result = evaluate_design(
+            df, model="main_effects", metric=["d_efficiency", "vif"]
+        )
+        assert "d_efficiency" in result
+        assert "vif" in result
+
+    def test_unknown_metric_raises(self) -> None:
+        """Unknown metric name raises ValueError."""
+        df = _full_factorial_df(2)
+        with pytest.raises(ValueError, match="Unknown metric"):
+            evaluate_design(df, model="main_effects", metric="nonexistent")
+
+    def test_accepts_design_result(self) -> None:
+        """evaluate_design accepts a DesignResult object."""
+        factors = _continuous_factors(2, "AB")
+        result = generate_design(factors, design_type="full_factorial", center_points=0)
+        metrics = evaluate_design(result, model="main_effects", metric="d_efficiency")
+        assert "d_efficiency" in metrics
+
+    def test_drops_run_order_column(self) -> None:
+        """RunOrder column in design should be ignored."""
+        factors = _continuous_factors(2, "AB")
+        result = generate_design(factors, design_type="full_factorial", center_points=0)
+        # DesignResult has RunOrder in the design
+        metrics = evaluate_design(result, model="main_effects", metric="degrees_of_freedom")
+        dof = metrics["degrees_of_freedom"]
+        assert dof["model"] == 2  # only A and B as factors
+
+
+# ---------------------------------------------------------------------------
+# Tool spec wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestToolSpec:
+    """Test the LLM tool spec wrapper."""
+
+    def test_basic_round_trip(self) -> None:
+        """Tool wrapper returns JSON-serializable output."""
+        from process_improve.experiments.tools import evaluate_design_tool  # noqa: PLC0415
+
+        result = evaluate_design_tool(
+            design_matrix=[
+                {"A": -1, "B": -1},
+                {"A": 1, "B": -1},
+                {"A": -1, "B": 1},
+                {"A": 1, "B": 1},
+            ],
+            model="main_effects",
+            metric="d_efficiency",
+        )
+        assert "error" not in result
+        assert "d_efficiency" in result
+
+    def test_multiple_metrics(self) -> None:
+        """Tool wrapper supports list of metrics."""
+        from process_improve.experiments.tools import evaluate_design_tool  # noqa: PLC0415
+
+        result = evaluate_design_tool(
+            design_matrix=[
+                {"A": -1, "B": -1},
+                {"A": 1, "B": -1},
+                {"A": -1, "B": 1},
+                {"A": 1, "B": 1},
+            ],
+            metric=["d_efficiency", "condition_number"],
+        )
+        assert "error" not in result
+        assert "d_efficiency" in result
+        assert "condition_number" in result
+
+    def test_error_handling(self) -> None:
+        """Bad metric name returns error dict."""
+        from process_improve.experiments.tools import evaluate_design_tool  # noqa: PLC0415
+
+        result = evaluate_design_tool(
+            design_matrix=[{"A": -1}, {"A": 1}],
+            metric="nonexistent",
+        )
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Integration
+# ---------------------------------------------------------------------------
+
+
+class TestIntegration:
+    """Integration tests: generate_design -> evaluate_design pipeline."""
+
+    def test_full_pipeline(self) -> None:
+        """Generate a design, evaluate multiple metrics."""
+        factors = [
+            Factor(name="Temperature", low=150, high=200, units="degC"),
+            Factor(name="Pressure", low=1, high=5, units="bar"),
+            Factor(name="Time", low=10, high=60, units="min"),
+        ]
+        result = generate_design(factors, design_type="full_factorial", center_points=3)
+        metrics = evaluate_design(
+            result,
+            model="main_effects",
+            metric=["d_efficiency", "vif", "degrees_of_freedom", "condition_number"],
+        )
+        assert metrics["d_efficiency"] is not None
+        assert all(v == pytest.approx(1.0, abs=0.1) for v in metrics["vif"].values())
+        assert metrics["degrees_of_freedom"]["residual"] > 0
+        assert metrics["condition_number"] > 0
+
+    def test_ccd_quadratic(self) -> None:
+        """CCD with quadratic model should have valid metrics."""
+        factors = _continuous_factors(3, "ABC")
+        result = generate_design(factors, design_type="ccd", alpha="face_centered", center_points=3)
+        metrics = evaluate_design(
+            result, model="quadratic", metric=["d_efficiency", "degrees_of_freedom"]
+        )
+        assert metrics["d_efficiency"] is not None
+        assert metrics["degrees_of_freedom"]["residual"] > 0
+
+    def test_fractional_factorial_aliases(self) -> None:
+        """Fractional factorial should report alias structure and resolution."""
+        factors = [Factor(name=n, low=0, high=10) for n in ["A", "B", "C", "D"]]
+        result = generate_design(
+            factors, design_type="fractional_factorial", generators=["D=ABC"], center_points=0
+        )
+        metrics = evaluate_design(
+            result,
+            metric=["alias_structure", "resolution", "defining_relation", "clear_effects", "minimum_aberration"],
+        )
+        assert len(metrics["alias_structure"]) > 0
+        assert metrics["resolution"] == 4
+        assert any("ABCD" in w for w in metrics["defining_relation"])
+        assert "A" in metrics["clear_effects"]["main_effects"]
+        assert metrics["minimum_aberration"]["wordlength_pattern"] == [0, 1]


### PR DESCRIPTION
Implements evaluate_design() which computes 14 quality metrics for
experimental designs: D/I/G-efficiency, prediction variance, VIF,
condition number, power analysis, alias structure, confounding,
resolution, defining relation, clear effects, minimum aberration,
and degrees of freedom. Includes LLM tool wrapper and 66 tests.

https://claude.ai/code/session_01MWFeDV4c9so2oTV9U2L2v3