### PR TITLE
Add return type annotations to Resampler methods

### DIFF
--- a/process_improve/multivariate/methods.py
+++ b/process_improve/multivariate/methods.py
@@ -3310,7 +3310,7 @@ class Resampler:
         self.parameters: list = []
         self.n_resamples = 0
 
-    def resample(self, show_progress: bool = True):
+    def resample(self, show_progress: bool = True) -> Resampler:
         """Perform the resampling."""
         if self.use_jackknife:
             return self.jackknife(show_progress=show_progress)
@@ -3321,7 +3321,7 @@ class Resampler:
         else:
             raise ValueError("Either use_jackknife or bootstrap_rounds must be set.")
 
-    def jackknife(self, show_progress: bool):
+    def jackknife(self, show_progress: bool) -> Resampler:
         """Perform jackknife resampling on the given estimator."""
         self.parameters = []
         indices = np.arange(len(self.x))
@@ -3336,7 +3336,7 @@ class Resampler:
             raise ValueError("No resamples were generated. Check your data and parameters.")
         return self
 
-    def bootstrap(self, show_progress: bool):
+    def bootstrap(self, show_progress: bool) -> Resampler:
         """Perform bootstrap resampling on the given estimator."""
         self.parameters = []
 
@@ -3356,7 +3356,7 @@ class Resampler:
 
         return self
 
-    def fractional(self, show_progress: bool):
+    def fractional(self, show_progress: bool) -> Resampler:
         """Perform fractional resampling on the given estimator.
 
         Will repeat N times (N = number of rows in x), each time leaving out a fraction of the data as specified by


### PR DESCRIPTION
## Summary
- Adds `Resampler` return type annotations to `resample`, `jackknife`, `bootstrap`, and `fractional` methods
- Fixes 4 ruff ANN201 lint errors that were failing CI

## Test plan
- [x] `ruff check .` passes
- [x] No runtime impact — uses forward reference via `from __future__ import annotations`

https://claude.ai/code/session_01PCoBNPYzZGAmzhSsFeJYm6