### PR TITLE
Fix DataFrame truth value error in PCA no-variance test

### DIFF
--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -440,8 +440,7 @@ def test_pca_columns_with_no_variance() -> None:
     )
 
     # Are scores orthogonal?
-    covmatrix = m.scores_.T @ m.scores_
-    # covmatrix - np.diag(np.diag(covmatrix))
+    covmatrix = m.scores_.values.T @ m.scores_.values
     assert (np.sum(np.abs(covmatrix - np.diag(np.diag(covmatrix))))) == pytest.approx(0, abs=1e-6)
 
 


### PR DESCRIPTION
## Summary
- `m.scores_` is a DataFrame, so `m.scores_.T @ m.scores_` produces a DataFrame covariance matrix
- Comparing that with `pytest.approx()` yields a Series of booleans, which raises `ValueError: The truth value of a Series is ambiguous`
- Fix: use `m.scores_.values` to stay in numpy land

## Test plan
- [x] `pytest tests/test_multivariate.py -k test_pca_columns_with_no_variance` passes

https://claude.ai/code/session_01PCoBNPYzZGAmzhSsFeJYm6