### PR TITLE
Add optimize_responses (Tool 4) for DOE response optimization

### DIFF
--- a/docs/doe/coverage.md
+++ b/docs/doe/coverage.md
@@ -9,7 +9,7 @@ Current implementation status and gap analysis.
 | `generate_design` | **Partial** | `create_factorial_design` in `tools.py` — 2^k full factorial only | No fractional, PB, BBD, CCD, DSD, D-optimal, mixture, or Taguchi |
 | `analyze_experiment` | **Implemented** | `analysis.py` — full dispatcher with 13 analysis types via statsmodels/scipy | Split-plot ANOVA (mixed model mapping) |
 | `evaluate_design` | Not started | — | Everything: alias structure, power, efficiency metrics, VIF |
-| `optimize_responses` | Not started | `optimization.py` has legacy MATLAB skeleton | Desirability, steepest ascent, stationary point, ridge analysis |
+| `optimize_responses` | **Partial** | `optimization.py` — desirability, steepest ascent/descent, stationary point, canonical analysis | Ridge analysis, Pareto front (stubs) |
 | `augment_design` | Not started | — | Foldover, semifold, axial points, optimal augmentation |
 | `visualize_doe` | Not started | — | All DOE plot types |
 | `doe_knowledge` | Not started | — | Knowledge graph, decision logic, interpretation guidance |
@@ -23,11 +23,11 @@ Current implementation status and gap analysis.
 | `models.py` | `Model`, `lm()`, `predict()`, `summary()` | `analyze_experiment` |
 | `designs_factorial.py` | `full_factorial()` | `generate_design` |
 | `optimal.py` | D-optimal point exchange | `generate_design` (future) |
-| `optimization.py` | Legacy MATLAB RSM code | `optimize_responses` (needs rewrite) |
+| `optimization.py` | `optimize_responses()`, desirability, stationary point, canonical analysis, steepest ascent/descent | `optimize_responses` |
 | `datasets.py` | Sample datasets | Testing / examples |
 | `simulations.py` | `popcorn()`, `grocery()` | Teaching / examples |
 | `analysis.py` | `analyze_experiment()`, formula builder, 13 analysis types | `analyze_experiment` |
-| `tools.py` | 4 tool specs registered | Agent interface |
+| `tools.py` | 5 tool specs registered | Agent interface |
 
 ## Usage Frequency
 

--- a/process_improve/experiments/__init__.py
+++ b/process_improve/experiments/__init__.py
@@ -6,6 +6,7 @@ from process_improve.experiments.designs_factorial import full_factorial
 from process_improve.experiments.evaluate import evaluate_design
 from process_improve.experiments.factor import Constraint, DesignResult, Factor
 from process_improve.experiments.models import Model, lm, predict, summary
+from process_improve.experiments.optimization import optimize_responses
 from process_improve.experiments.structures import (
     Column,
     Expt,
@@ -30,6 +31,7 @@ __all__ = [
     "gather",
     "generate_design",
     "lm",
+    "optimize_responses",
     "predict",
     "summary",
     "supplement",

--- a/process_improve/experiments/optimization.py
+++ b/process_improve/experiments/optimization.py
@@ -113,7 +113,7 @@ def _build_model_evaluator(
             elif len(components) == 1:
                 # Linear
                 y += coef * x[name_to_idx[components[0]]]
-            elif len(components) == 2:  # noqa: PLR2004
+            elif len(components) == 2:
                 # Interaction or quadratic
                 y += coef * x[name_to_idx[components[0]]] * x[name_to_idx[components[1]]]
             else:
@@ -183,7 +183,7 @@ def _extract_b_and_B(  # noqa: N802
             b0 = coef
         elif len(components) == 1:
             b[name_to_idx[components[0]]] = coef
-        elif len(components) == 2:  # noqa: PLR2004
+        elif len(components) == 2:
             i = name_to_idx[components[0]]
             j = name_to_idx[components[1]]
             if i == j:
@@ -337,7 +337,7 @@ def _canonical_analysis(
 # ---------------------------------------------------------------------------
 
 
-def _steepest_path(
+def _steepest_path(  # noqa: PLR0913
     coefficients: list[dict[str, Any]],
     factor_names: list[str],
     step_size: float = 0.5,
@@ -454,7 +454,7 @@ def _desirability_minimize(y: float, low: float, high: float, weight: float = 1.
     return ((high - y) / (high - low)) ** weight
 
 
-def _desirability_target(
+def _desirability_target(  # noqa: PLR0913
     y: float,
     low: float,
     target: float,
@@ -503,13 +503,13 @@ def _composite_desirability(d_values: list[float], importances: list[float] | No
     if not d_values:
         return 0.0
 
-    weights = importances if importances else [1.0] * len(d_values)
+    weights = importances or [1.0] * len(d_values)
 
     # If any desirability is zero, composite is zero
     if any(d == 0.0 for d in d_values):
         return 0.0
 
-    log_d = sum(w * np.log(d) for d, w in zip(d_values, weights))
+    log_d = sum(w * np.log(d) for d, w in zip(d_values, weights, strict=True))
     w_sum = sum(weights)
     if w_sum == 0:
         return 0.0
@@ -548,7 +548,7 @@ def _optimize_desirability(
 
     def neg_composite(x: np.ndarray) -> float:
         d_vals = []
-        for evaluator, goal in zip(evaluators, goals):
+        for evaluator, goal in zip(evaluators, goals, strict=True):
             y_pred = evaluator(x)
             d = _individual_desirability(y_pred, goal)
             d_vals.append(d)
@@ -562,9 +562,7 @@ def _optimize_desirability(
     best_result = None
     best_value = np.inf
 
-    starting_points = [np.zeros(k)]
-    for _ in range(9):
-        starting_points.append(rng.uniform(-1, 1, size=k))
+    starting_points = [np.zeros(k), *[rng.uniform(-1, 1, size=k) for _ in range(9)]]
 
     for x0 in starting_points:
         res = optimize.minimize(neg_composite, x0, method="SLSQP", bounds=bounds)
@@ -578,7 +576,7 @@ def _optimize_desirability(
     # Evaluate individual responses and desirabilities at optimum
     predictions = {}
     individual_d = {}
-    for evaluator, model_dict, goal in zip(evaluators, fitted_models, goals):
+    for evaluator, model_dict, goal in zip(evaluators, fitted_models, goals, strict=True):
         resp_name = model_dict.get("response_name", "response")
         y_pred = float(evaluator(x_opt))
         predictions[resp_name] = y_pred
@@ -682,7 +680,7 @@ def _coded_to_actual(coded: dict[str, float], factor_ranges: dict[str, dict[str,
 # ---------------------------------------------------------------------------
 
 
-def optimize_responses(  # noqa: PLR0912, PLR0913, C901
+def optimize_responses(  # noqa: PLR0913, C901
     fitted_models: list[dict[str, Any]],
     goals: list[dict[str, Any]] | None = None,
     method: str = "desirability",

--- a/process_improve/experiments/optimization.py
+++ b/process_improve/experiments/optimization.py
@@ -1,303 +1,818 @@
-r"""
-IDEAS from earlier code written in 2015/2016.
-RSM optimization.
+# (c) Kevin Dunn, 2010-2026. MIT License.
 
+"""Response optimization for designed experiments (Tool 4).
 
+Find optimal factor settings for one or multiple responses after fitting
+a model with :func:`analyze_experiment` (Tool 3).
 
-    function out = optimization_caller()
+Implemented methods
+-------------------
+- **desirability** — Derringer-Suich desirability functions (single and
+  multi-response) with ``scipy.optimize.minimize`` (SLSQP).
+- **steepest_ascent** / **steepest_descent** — Move along the gradient
+  of a first-order model from the design centre.
+- **stationary_point** — Locate the stationary point of a second-order
+  model via ``numpy.linalg.solve``.
+- **canonical_analysis** — Eigenvalue decomposition of the *B* matrix
+  to classify the stationary point (max / min / saddle).
 
-% Leave this part intact. Copy it, and paste it below, altering the values.
-% Repeat that once per factor.
-template = struct;
-template.descriptive_name = 'Parameter name';
-template.argument_name = 'Name as used in a function';
-template.parameter_type = 'Categorical | Numerical';
-template.default_value = 'Text or numeric value';
-template.levels = 'A cell array of level names, only for categorical factor. Numerical: ignored';
-template.level_mapping = 'A vector of numeric values used to map the levels, e.g. [1, 2, 3]. Numerical: ignored';
-template.starting_lower_bound = 'A numeric factor will be evaluated starting at this low value. Categorical: ignored';
-template.starting_upper_bound = 'A numeric factor will be evaluated starting at this upper value, Categorical: ignored';
-template.absolute_lower_bound = 'A numeric factor cannot go lower than this. Categorical: ignored';
-template.absolute_upper_bound = 'A numeric factor cannot go above this. Categorical: ignored';
-
-
-% 0. OVERALL settings
-% ========================
-settings = struct;
-
-% This is your function that will be called to run the optimization.
-% It will have only 1 input, a structure. That structure will have the names
-% of your factors. If you have specified ``factors`` (see below) as
-%   factors.A
-%   factors.my_variable
-%   etc
-%
-% that is what will be passed into the function.
-%
-% This will almost certainly mean that you must write another MATLAB file
-% function which receives this input, and translates it into the right form to
-% actually run the experiment/simulation.
-%
-% The function must return a single scalar value.
-settings.expt_function = @my_function_call;
-settings.expt_function__n_outputs = 3;
-
-% Number of starting runs to kick-off the D-optimal design
-settings.n_start_runs = 20;
-
-% If you start with a full factorial, then the above setting of
-% ``n_start_runs`` is ignored. It will run the full set of potentially many,
-% many runs
-settings.start_full_factorial = 0;
-
-
-
-% 1. SPECIFY parameters
-% ========================
-% Reference spectrum type
-A = template;
-A.descriptive_name = 'Reference type';
-A.argument_name = 'reference_type';
-A.parameter_type = 'Categorical';
-A.default_value = 'average';
-A.levels = {'average', 'median', 'max', 'average2'};
-A.level_mapping = [1, 2, 3, 4];
-
-% Number of intervals
-B = template;
-B.descriptive_name = 'Number of intervals';
-B.argument_name = 'number_intervals';
-B.parameter_type = 'Numerical';
-B.default_value = 50;
-B.starting_lower_bound = 60;
-B.starting_upper_bound = 120;
-B.absolute_lower_bound = 10;
-B.absolute_upper_bound = 100;
-
-% Number of intervals: as a categorical variable
-B = template;
-B.descriptive_name = 'Number of intervals';
-B.argument_name = 'number_intervals';
-B.parameter_type = 'Categorical';
-B.default_value = 50;
-B.levels = {50, 70, 90, 110};
-B.level_mapping = [50, 70, 90, 110];
-
-
-% Filling mode
-C = template;
-C.descriptive_name = 'Filling mode';
-C.argument_name = 'filling_mode';
-C.parameter_type = 'Categorical';
-C.default_value = 0;
-C.levels = {0, 1};
-C.level_mapping = [0, 1];
-
-
-% Coshift preprocessing
-D = template;
-D.descriptive_name = 'Coshift';
-D.argument_name = 'coshift_preprocessing';
-D.parameter_type = 'Categorical';
-D.default_value = 0;
-D.levels = {0, 1};
-D.level_mapping = [0, 1];
-
-% Max allowed shift for the Co-shift preprocessing
-E = template;
-E.descriptive_name = 'Maximum allowed shift';
-E.argument_name = 'max_coshift_allowed';
-E.parameter_type = 'Numerical';
-E.default_value = 50;
-E.starting_lower_bound = 40;
-E.starting_upper_bound = 100;
-E.absolute_lower_bound = 10;
-E.absolute_upper_bound = 100;
-
-% Alignment method
-F = template;
-F.descriptive_name = 'Alignment';
-F.argument_name = 'alignment_method';
-F.parameter_type = 'Categorical';
-F.default_value = 0;
-F.levels = {0, 1, 3};
-F.level_mapping = [0, 1, 3];
-
-
-% Maximum shift correction in data
-G = template;
-G.descriptive_name = 'Maxshift';
-G.argument_name = 'maxshift_type';
-G.parameter_type = 'Categorical';
-G.default_value = 'b';
-G.levels = {'b', 'f'};
-G.level_mapping = [0, 1];
-
-
-factors = struct;
-factors.A = A;
-factors.B = B;
-factors.C = C;
-factors.D = D;
-%factors.E = E;  % <-- not used anyway
-factors.F = F;
-%factors.G = G;
-
-fields = fieldnames(factors);
-n_factors = numel(fields);
-
-% 2. CALCULATE all combinations
-% ========================
-% Also, while do this, call the ``cordexch`` function, to see what that gives:
-
-
-type_of_experiment = 'interaction';
-
-
-starting_set = cell(1, numel(fields));
-categorical = zeros(1, n_factors);
-levels = zeros(1, n_factors);
-for p = 1 : n_factors
-    factor = factors.(fields{p});
-    if strcmp(factor.parameter_type, 'Numerical')
-        this_levels = [factor.starting_lower_bound, factor.starting_upper_bound];
-        factors.(fields{p}).current_mins_one = factor.starting_lower_bound;
-        factors.(fields{p}).current_plus_one = factor.starting_upper_bound;
-        levels(p) = 2;
-    elseif strcmp(factor.parameter_type, 'Categorical')
-        this_levels = factor.level_mapping;
-        levels(p) = numel(factor.level_mapping);
-        categorical(p) = 1;
-    end
-    starting_set{p} = this_levels;
-end
-
-% Based on code from https://nl.mathworks.com/matlabcentral/fileexchange/10064-allcomb-varargin
-% but modified for our situation.
-ii = 1 : 1 : numel(fields);
-A = zeros(0, numel(fields)) ;
-[A{ii}] = ndgrid(starting_set{ii});
-combinations = reshape(cat(numel(fields) + 1, A{:}), [], numel(fields));
-
-% Coordinate exchange experiments:
-coord_exch_full_set = cordexch(n_factors, size(combinations, 1), type_of_experiment, ...
-         'categorical', find(categorical), 'levels', levels, 'display', 'off');
-
-
-
-% 3. SELECT the subset to run
-% =========================
-
-% TODO: select a Plackett-Burham subset
-
-% Use the D-optimal approach to select a subset of the full set in
-% ``combinations`` as a starting candidate set.
-
-if settings.start_full_factorial
-    start_set = combinations;
-
-else
-    start_set = rowexch(n_factors, settings.n_start_runs, type_of_experiment, ...
-         'categorical', find(categorical), 'levels', levels, 'display', 'off');
-
-    % Original method: use "candexch" to select, but this ignores all the
-    % levels of a categorical factor, and only picks the extremes (first and
-    % last levels of such a factor).
-    %subset = candexch(coord_exch_full_set, settings.n_start_runs, 'display', 'off', ...
-    %              'tries', 100, 'maxiter', 1000);
-    %start_set = combinations(subset, :);
-end
-
-% Remove the duplicates
-start_set = unique(start_set, 'rows', 'stable');
-
-
-% 4. RUN the experiments
-n_runs = size(start_set, 1);
-outputs = zeros(n_runs, settings.expt_function__n_outputs);
-for k = 1:n_runs
-    disp(['Run number: ', num2str(k), ' of ', num2str(n_runs)])
-    fn_input = translate_coded_to_realworld_structure(start_set(k, :), factors);
-    fn_input
-    %try
-    outputs(k, :) = settings.expt_function(fn_input);
-    %catch
-    %
-    %    outputs(k, :) = NaN;
-    %end
-    outputs(k, :)
-end
-out = [start_set outputs];
-
-% 5. SHOW results
-%------------------------------
-figure;
-subplot(settings.expt_function__n_outputs, n_factors, 1)
-count = 1;
-for yout = 1:settings.expt_function__n_outputs
-    for p = 1:n_factors
-        factor = factors.(fields{p});
-        subplot(settings.expt_function__n_outputs, n_factors, count)
-        count = count + 1;
-        xs = start_set(:, p);
-        ys = outputs(:, yout);
-        plot(xs, ys, 'o')
-        hold on
-        b = regress(ys, [ones(size(xs, 1), 1), xs]);
-        plot(xs, b(1) + b(2) .* xs, 'k-', 'linewidth', 2)
-        grid on
-        title(factor.descriptive_name)
-    end
-
-    fprintf('For output %d: the highest and lowest values are:\n', yout)
-    [min_y, idx_min] = min(ys);
-    fprintf('Low : y = %f; settings=\n', min_y)
-    disp(translate_coded_to_realworld_structure(start_set(idx_min, :), factors))
-
-
-    [max_y, idx_max] = max(ys);
-    fprintf('High: y = %f; settings=\n', max_y)
-    disp(translate_coded_to_realworld_structure(start_set(idx_max, :), factors))
-end
-
-a=2;
-
-
-% 6. IDENTIFY next optimization
-%------------------------------
-
-function output = translate_coded_to_realworld_structure(input, factors)
-% Translates a numeric vector, ``input``, where each entry is the numeric
-% factor settings [which may include categorical values], back to the mixed
-% numeric and string representation. Returns a structure.
-%   range = upper_bound - lower_bound
-%   center_value = 0.5 * (upper_bound + lower_bound)
-%   coded_value = (actual_value - center_value) / (0.5 * range)
-%   actual_value = coded_value * (0.5 * range) + lower_bound
-fields = fieldnames(factors);
-output = struct;
-for p = 1 : numel(fields)
-    factor = factors.(fields{p});
-    if strcmp(factor.parameter_type, 'Numerical')
-
-        % To get exact matching, without roundoff
-        if input(p) == -1
-            value = factor.current_mins_one;
-        elseif input(p) == +1
-            value = factor.current_plus_one;
-        else
-            range = (factor.current_plus_one - factor.current_mins_one);
-            center_value = 0.5*(factor.current_plus_one + factor.current_mins_one);
-            value = input(p) * (0.5 * range) + center_value;
-        end
-
-    elseif strcmp(factor.parameter_type, 'Categorical')
-        value = factor.levels{input(p)};
-        % Do NOT remove the 'find' part here, or try to simplify it. It is
-        % correct as it is.
-        %temp = %(factor.levels(find(factor.level_mapping == input(p))));
-        %value = temp{1};
-    end
-    output.(factor.argument_name) = value;
-end
+Stubs (not yet implemented)
+---------------------------
+- **ridge_analysis** — Trace the optimum along increasing radii.
+- **pareto_front** — Multi-objective Pareto frontier (NSGA-II).
 """
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import numpy as np
+from scipy import optimize
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_METHODS = {
+    "desirability",
+    "steepest_ascent",
+    "steepest_descent",
+    "stationary_point",
+    "canonical_analysis",
+    "ridge_analysis",
+    "pareto_front",
+}
+
+# ---------------------------------------------------------------------------
+# Model evaluation layer
+# ---------------------------------------------------------------------------
+
+
+def _parse_term(term: str) -> tuple[str, ...]:
+    """Classify a coefficient term name into its components.
+
+    Returns
+    -------
+    tuple[str, ...]
+        Empty tuple for ``"Intercept"``, single-element for linear,
+        ``("A", "B")`` for interaction ``"A:B"``, ``("A", "A")`` for
+        quadratic ``"I(A ** 2)"``.
+    """
+    if term == "Intercept":
+        return ()
+
+    # Quadratic: I(A ** 2) or np.power(A, 2) patterns
+    m = re.match(r"I\((\w+)\s*\*\*\s*2\)", term)
+    if m:
+        name = m.group(1)
+        return (name, name)
+
+    # Interaction: A:B
+    if ":" in term:
+        parts = term.split(":")
+        return tuple(parts)
+
+    # Linear: plain factor name
+    return (term,)
+
+
+def _build_model_evaluator(
+    coefficients: list[dict[str, Any]],
+    factor_names: list[str],
+) -> callable:
+    """Return a function ``f(point) -> float`` that evaluates the model.
+
+    Parameters
+    ----------
+    coefficients : list[dict]
+        Each dict has ``"term"`` and ``"coefficient"`` keys, as returned
+        by ``analyze_experiment(..., analysis_type="coefficients")``.
+    factor_names : list[str]
+        Ordered factor names (e.g. ``["A", "B"]``).
+
+    Returns
+    -------
+    callable
+        ``f(x)`` where *x* is a 1-D array of coded factor values in the
+        same order as *factor_names*.
+    """
+    name_to_idx = {n: i for i, n in enumerate(factor_names)}
+    parsed: list[tuple[tuple[str, ...], float]] = []
+    for entry in coefficients:
+        term = entry["term"]
+        coef = float(entry["coefficient"])
+        parsed.append((_parse_term(term), coef))
+
+    def _eval(x: np.ndarray) -> float:
+        y = 0.0
+        for components, coef in parsed:
+            if len(components) == 0:
+                # Intercept
+                y += coef
+            elif len(components) == 1:
+                # Linear
+                y += coef * x[name_to_idx[components[0]]]
+            elif len(components) == 2:  # noqa: PLR2004
+                # Interaction or quadratic
+                y += coef * x[name_to_idx[components[0]]] * x[name_to_idx[components[1]]]
+            else:
+                # Higher-order (unusual but handle gracefully)
+                val = 1.0
+                for c in components:
+                    val *= x[name_to_idx[c]]
+                y += coef * val
+        return y
+
+    return _eval
+
+
+def evaluate_model(
+    coefficients: list[dict[str, Any]],
+    factor_names: list[str],
+    point: dict[str, float],
+) -> float:
+    """Evaluate predicted response at an arbitrary coded point.
+
+    Parameters
+    ----------
+    coefficients : list[dict]
+        Coefficient list from ``analyze_experiment``.
+    factor_names : list[str]
+        Ordered factor names.
+    point : dict[str, float]
+        Factor settings in coded units, e.g. ``{"A": 0.5, "B": -1.0}``.
+
+    Returns
+    -------
+    float
+        Predicted response value.
+    """
+    f = _build_model_evaluator(coefficients, factor_names)
+    x = np.array([point[n] for n in factor_names], dtype=float)
+    return float(f(x))
+
+
+# ---------------------------------------------------------------------------
+# Extract b vector and B matrix from second-order model
+# ---------------------------------------------------------------------------
+
+
+def _extract_b_and_B(  # noqa: N802
+    coefficients: list[dict[str, Any]],
+    factor_names: list[str],
+) -> tuple[float, np.ndarray, np.ndarray]:
+    """Extract intercept, linear vector *b* and quadratic matrix *B*.
+
+    For a second-order model ``y = b0 + b'x + x'Bx``, returns
+    ``(b0, b, B)`` where *B* is symmetric with off-diagonal elements
+    equal to half the interaction coefficients.
+    """
+    k = len(factor_names)
+    name_to_idx = {n: i for i, n in enumerate(factor_names)}
+    b0 = 0.0
+    b = np.zeros(k)
+    B = np.zeros((k, k))
+
+    for entry in coefficients:
+        term = entry["term"]
+        coef = float(entry["coefficient"])
+        components = _parse_term(term)
+
+        if len(components) == 0:
+            b0 = coef
+        elif len(components) == 1:
+            b[name_to_idx[components[0]]] = coef
+        elif len(components) == 2:  # noqa: PLR2004
+            i = name_to_idx[components[0]]
+            j = name_to_idx[components[1]]
+            if i == j:
+                # Quadratic term: coefficient is the diagonal of B
+                B[i, i] = coef
+            else:
+                # Interaction: split equally across B[i,j] and B[j,i]
+                B[i, j] = coef / 2.0
+                B[j, i] = coef / 2.0
+
+    return b0, b, B
+
+
+# ---------------------------------------------------------------------------
+# Stationary point
+# ---------------------------------------------------------------------------
+
+
+def _find_stationary_point(
+    coefficients: list[dict[str, Any]],
+    factor_names: list[str],
+    factor_ranges: dict[str, dict[str, float]] | None = None,
+) -> dict[str, Any]:
+    """Find the stationary point of a second-order response surface model.
+
+    Solves ``2*B*x_s + b = 0`` for ``x_s``.
+
+    Parameters
+    ----------
+    coefficients : list[dict]
+        Model coefficients.
+    factor_names : list[str]
+        Ordered factor names.
+    factor_ranges : dict or None
+        Maps factor name to ``{"low": float, "high": float}`` in actual
+        units.  Used to convert coded → actual.
+
+    Returns
+    -------
+    dict
+        ``stationary_point_coded``, ``stationary_point_actual``,
+        ``predicted_response``, ``classification``.
+    """
+    b0, b, B = _extract_b_and_B(coefficients, factor_names)
+
+    # Check that B has quadratic terms (not purely first-order)
+    if np.allclose(B, 0):
+        return {"error": "Model has no quadratic or interaction terms — cannot find stationary point."}
+
+    try:
+        # Solve 2*B*x_s = -b
+        x_s = np.linalg.solve(2.0 * B, -b)
+    except np.linalg.LinAlgError:
+        return {"error": "Singular B matrix — stationary point does not exist."}
+
+    # Predicted response at stationary point
+    y_s = float(b0 + b @ x_s + x_s @ B @ x_s)
+
+    # Classification from eigenvalues
+    eigenvalues = np.linalg.eigvalsh(B)
+    if np.all(eigenvalues < 0):
+        classification = "maximum"
+    elif np.all(eigenvalues > 0):
+        classification = "minimum"
+    else:
+        classification = "saddle_point"
+
+    # Check if stationary point is inside the design space (coded [-1, 1])
+    inside_design_space = bool(np.all(np.abs(x_s) <= 1.0))
+
+    result: dict[str, Any] = {
+        "stationary_point_coded": {n: float(x_s[i]) for i, n in enumerate(factor_names)},
+        "predicted_response": y_s,
+        "classification": classification,
+        "eigenvalues": [float(e) for e in eigenvalues],
+        "inside_design_space": inside_design_space,
+    }
+
+    if factor_ranges:
+        actual = {}
+        for i, name in enumerate(factor_names):
+            if name in factor_ranges:
+                lo = factor_ranges[name]["low"]
+                hi = factor_ranges[name]["high"]
+                center = (lo + hi) / 2.0
+                half_range = (hi - lo) / 2.0
+                actual[name] = center + x_s[i] * half_range
+            else:
+                actual[name] = float(x_s[i])
+        result["stationary_point_actual"] = actual
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Canonical analysis
+# ---------------------------------------------------------------------------
+
+
+def _canonical_analysis(
+    coefficients: list[dict[str, Any]],
+    factor_names: list[str],
+) -> dict[str, Any]:
+    """Canonical analysis of a second-order response surface model.
+
+    Computes eigenvalues and eigenvectors of the *B* matrix to determine
+    the shape and orientation of the response surface.
+
+    Returns
+    -------
+    dict
+        ``eigenvalues``, ``eigenvectors``, ``classification``,
+        ``canonical_form_description``.
+    """
+    _b0, _b, B = _extract_b_and_B(coefficients, factor_names)
+
+    if np.allclose(B, 0):
+        return {"error": "Model has no quadratic or interaction terms — canonical analysis not applicable."}
+
+    eigenvalues, eigenvectors = np.linalg.eigh(B)
+
+    # Sort by absolute value (largest first)
+    order = np.argsort(-np.abs(eigenvalues))
+    eigenvalues = eigenvalues[order]
+    eigenvectors = eigenvectors[:, order]
+
+    if np.all(eigenvalues < 0):
+        classification = "maximum"
+    elif np.all(eigenvalues > 0):
+        classification = "minimum"
+    else:
+        classification = "saddle_point"
+
+    desc_parts = []
+    for i, ev in enumerate(eigenvalues):
+        w_name = f"W{i + 1}"
+        direction = "concave" if ev < 0 else "convex"
+        desc_parts.append(f"{w_name}: eigenvalue={ev:.4f} ({direction})")
+
+    return {
+        "eigenvalues": [float(e) for e in eigenvalues],
+        "eigenvectors": [[float(v) for v in eigenvectors[:, i]] for i in range(len(eigenvalues))],
+        "classification": classification,
+        "canonical_form_description": desc_parts,
+        "factor_names": factor_names,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Steepest ascent / descent
+# ---------------------------------------------------------------------------
+
+
+def _steepest_path(
+    coefficients: list[dict[str, Any]],
+    factor_names: list[str],
+    step_size: float = 0.5,
+    n_steps: int = 10,
+    direction: str = "ascent",
+    factor_ranges: dict[str, dict[str, float]] | None = None,
+) -> dict[str, Any]:
+    """Generate a table of steps along the steepest ascent (or descent).
+
+    Uses only the first-order (linear) coefficients to determine
+    direction.  Steps start at the design centre (all coded = 0).
+
+    Parameters
+    ----------
+    coefficients : list[dict]
+        Model coefficients.
+    factor_names : list[str]
+        Ordered factor names.
+    step_size : float
+        Step magnitude in coded units (default 0.5).
+    n_steps : int
+        Number of steps to generate (default 10).
+    direction : str
+        ``"ascent"`` or ``"descent"``.
+    factor_ranges : dict or None
+        For coded → actual conversion.
+
+    Returns
+    -------
+    dict
+        ``steps`` list and ``direction_vector``.
+    """
+    evaluator = _build_model_evaluator(coefficients, factor_names)
+
+    # Extract linear coefficients only
+    name_to_idx = {n: i for i, n in enumerate(factor_names)}
+    b = np.zeros(len(factor_names))
+    for entry in coefficients:
+        components = _parse_term(entry["term"])
+        if len(components) == 1 and components[0] in name_to_idx:
+            b[name_to_idx[components[0]]] = float(entry["coefficient"])
+
+    if np.allclose(b, 0):
+        return {"error": "All linear coefficients are zero — no steepest direction."}
+
+    # Direction: normalize, then scale by step_size
+    norm = np.linalg.norm(b)
+    direction_vec = b / norm
+    if direction == "descent":
+        direction_vec = -direction_vec
+
+    steps = []
+    for step_num in range(n_steps + 1):
+        x_coded = direction_vec * step_size * step_num
+        predicted = float(evaluator(x_coded))
+
+        step_entry: dict[str, Any] = {
+            "step": step_num,
+            "coded": {n: float(x_coded[i]) for i, n in enumerate(factor_names)},
+            "predicted_response": predicted,
+        }
+
+        if factor_ranges:
+            actual = {}
+            for i, name in enumerate(factor_names):
+                if name in factor_ranges:
+                    lo = factor_ranges[name]["low"]
+                    hi = factor_ranges[name]["high"]
+                    center = (lo + hi) / 2.0
+                    half_range = (hi - lo) / 2.0
+                    actual[name] = center + x_coded[i] * half_range
+                else:
+                    actual[name] = float(x_coded[i])
+            step_entry["actual"] = actual
+
+        steps.append(step_entry)
+
+    return {
+        "direction": direction,
+        "direction_vector": {n: float(direction_vec[i]) for i, n in enumerate(factor_names)},
+        "step_size": step_size,
+        "steps": steps,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Derringer-Suich desirability functions
+# ---------------------------------------------------------------------------
+
+
+def _desirability_maximize(y: float, low: float, high: float, weight: float = 1.0) -> float:
+    """One-sided desirability for maximisation.
+
+    d = 0 if y <= low, d = ((y - low) / (high - low))^weight if
+    low < y < high, d = 1 if y >= high.
+    """
+    if y <= low:
+        return 0.0
+    if y >= high:
+        return 1.0
+    return ((y - low) / (high - low)) ** weight
+
+
+def _desirability_minimize(y: float, low: float, high: float, weight: float = 1.0) -> float:
+    """One-sided desirability for minimisation.
+
+    d = 1 if y <= low, d = ((high - y) / (high - low))^weight if
+    low < y < high, d = 0 if y >= high.
+    """
+    if y <= low:
+        return 1.0
+    if y >= high:
+        return 0.0
+    return ((high - y) / (high - low)) ** weight
+
+
+def _desirability_target(
+    y: float,
+    low: float,
+    target: float,
+    high: float,
+    weight_low: float = 1.0,
+    weight_high: float = 1.0,
+) -> float:
+    """Two-sided desirability for a target value.
+
+    Ramps up from *low* to *target*, then ramps down from *target* to
+    *high*.  Returns 0 outside ``[low, high]``.
+    """
+    if y <= low or y >= high:
+        return 0.0
+    if y <= target:
+        return ((y - low) / (target - low)) ** weight_low
+    return ((high - y) / (high - target)) ** weight_high
+
+
+def _individual_desirability(y: float, goal: dict[str, Any]) -> float:
+    """Compute individual desirability for a single response value."""
+    goal_type = goal["goal"]
+    low = goal.get("low", 0.0)
+    high = goal.get("high", 1.0)
+    weight = goal.get("weight", 1.0)
+
+    if goal_type == "maximize":
+        return _desirability_maximize(y, low, high, weight)
+    if goal_type == "minimize":
+        return _desirability_minimize(y, low, high, weight)
+    if goal_type == "target":
+        target = goal["target"]
+        return _desirability_target(y, low, target, high, weight, weight)
+
+    msg = f"Unknown goal type: {goal_type!r}. Use 'maximize', 'minimize', or 'target'."
+    raise ValueError(msg)
+
+
+def _composite_desirability(d_values: list[float], importances: list[float] | None = None) -> float:
+    """Weighted geometric mean of individual desirability values.
+
+    D = (d1^w1 * d2^w2 * ... * dk^wk) ^ (1 / sum(wi))
+
+    If any d_i is zero, the composite is zero.
+    """
+    if not d_values:
+        return 0.0
+
+    weights = importances if importances else [1.0] * len(d_values)
+
+    # If any desirability is zero, composite is zero
+    if any(d == 0.0 for d in d_values):
+        return 0.0
+
+    log_d = sum(w * np.log(d) for d, w in zip(d_values, weights))
+    w_sum = sum(weights)
+    if w_sum == 0:
+        return 0.0
+    return float(np.exp(log_d / w_sum))
+
+
+def _optimize_desirability(
+    fitted_models: list[dict[str, Any]],
+    goals: list[dict[str, Any]],
+    factor_names: list[str],
+    factor_ranges: dict[str, dict[str, float]] | None = None,
+    importances: list[float] | None = None,
+) -> dict[str, Any]:
+    """Optimise composite desirability using scipy SLSQP.
+
+    Parameters
+    ----------
+    fitted_models : list[dict]
+        Each has ``"coefficients"`` and ``"response_name"``.
+    goals : list[dict]
+        Per-response goals.
+    factor_names : list[str]
+        Ordered factor names.
+    factor_ranges : dict or None
+        Factor bounds in actual units.
+    importances : list[float] or None
+        Relative importance weights for composite desirability.
+
+    Returns
+    -------
+    dict
+        Optimal settings, predicted responses, individual and composite
+        desirability.
+    """
+    evaluators = [_build_model_evaluator(m["coefficients"], factor_names) for m in fitted_models]
+
+    def neg_composite(x: np.ndarray) -> float:
+        d_vals = []
+        for evaluator, goal in zip(evaluators, goals):
+            y_pred = evaluator(x)
+            d = _individual_desirability(y_pred, goal)
+            d_vals.append(d)
+        return -_composite_desirability(d_vals, importances)
+
+    k = len(factor_names)
+    bounds = [(-1.0, 1.0)] * k
+
+    # Multi-start: try centre + random points
+    rng = np.random.default_rng(42)
+    best_result = None
+    best_value = np.inf
+
+    starting_points = [np.zeros(k)]
+    for _ in range(9):
+        starting_points.append(rng.uniform(-1, 1, size=k))
+
+    for x0 in starting_points:
+        res = optimize.minimize(neg_composite, x0, method="SLSQP", bounds=bounds)
+        if res.fun < best_value:
+            best_value = res.fun
+            best_result = res
+
+    x_opt = best_result.x
+    composite_d = -best_value
+
+    # Evaluate individual responses and desirabilities at optimum
+    predictions = {}
+    individual_d = {}
+    for evaluator, model_dict, goal in zip(evaluators, fitted_models, goals):
+        resp_name = model_dict.get("response_name", "response")
+        y_pred = float(evaluator(x_opt))
+        predictions[resp_name] = y_pred
+        individual_d[resp_name] = _individual_desirability(y_pred, goal)
+
+    result: dict[str, Any] = {
+        "optimal_coded": {n: float(x_opt[i]) for i, n in enumerate(factor_names)},
+        "predicted_responses": predictions,
+        "individual_desirability": individual_d,
+        "composite_desirability": composite_d,
+        "optimizer_success": bool(best_result.success),
+    }
+
+    if factor_ranges:
+        actual = {}
+        for i, name in enumerate(factor_names):
+            if name in factor_ranges:
+                lo = factor_ranges[name]["low"]
+                hi = factor_ranges[name]["high"]
+                center = (lo + hi) / 2.0
+                half_range = (hi - lo) / 2.0
+                actual[name] = center + x_opt[i] * half_range
+            else:
+                actual[name] = float(x_opt[i])
+        result["optimal_actual"] = actual
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Stubs for future implementation
+# ---------------------------------------------------------------------------
+
+
+def _ridge_analysis(
+    coefficients: list[dict[str, Any]],
+    factor_names: list[str],
+    factor_ranges: dict[str, dict[str, float]] | None = None,
+) -> dict[str, Any]:
+    """Ridge analysis — trace the optimum along increasing radii.
+
+    .. note::
+        Not yet implemented.  Planned: constrained eigenvalue computation
+        tracing the optimum on spheres of increasing radius from the
+        design centre when the stationary point lies outside the design
+        space.
+    """
+    return {
+        "error": (
+            "Ridge analysis is not yet implemented. "
+            "Use 'stationary_point' or 'canonical_analysis' as alternatives."
+        ),
+        "status": "stub",
+    }
+
+
+def _pareto_front(
+    fitted_models: list[dict[str, Any]],
+    goals: list[dict[str, Any]],
+    factor_names: list[str],
+    factor_ranges: dict[str, dict[str, float]] | None = None,
+) -> dict[str, Any]:
+    """Multi-objective Pareto frontier.
+
+    .. note::
+        Not yet implemented.  Planned: multi-start ``scipy.optimize``
+        wrapper or ``pymoo`` NSGA-II for true Pareto frontiers with
+        many responses.
+    """
+    return {
+        "error": (
+            "Pareto front is not yet implemented. "
+            "Use 'desirability' for multi-response optimization instead."
+        ),
+        "status": "stub",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Coded ↔ actual conversion helpers
+# ---------------------------------------------------------------------------
+
+
+def _coded_to_actual(coded: dict[str, float], factor_ranges: dict[str, dict[str, float]]) -> dict[str, float]:
+    """Convert coded factor settings to actual units."""
+    actual = {}
+    for name, coded_val in coded.items():
+        if name in factor_ranges:
+            lo = factor_ranges[name]["low"]
+            hi = factor_ranges[name]["high"]
+            center = (lo + hi) / 2.0
+            half_range = (hi - lo) / 2.0
+            actual[name] = center + coded_val * half_range
+        else:
+            actual[name] = coded_val
+    return actual
+
+
+# ---------------------------------------------------------------------------
+# Public API — dispatcher
+# ---------------------------------------------------------------------------
+
+
+def optimize_responses(  # noqa: PLR0912, PLR0913, C901
+    fitted_models: list[dict[str, Any]],
+    goals: list[dict[str, Any]] | None = None,
+    method: str = "desirability",
+    factor_ranges: dict[str, dict[str, float]] | None = None,
+    step_size: float = 0.5,
+    n_steps: int = 10,
+    desirability_weights: list[float] | None = None,
+) -> dict[str, Any]:
+    """Find optimal factor settings for one or multiple responses.
+
+    Parameters
+    ----------
+    fitted_models : list[dict]
+        Each dict describes a fitted model with keys:
+
+        - ``"response_name"`` (str) — name of the response.
+        - ``"coefficients"`` (list[dict]) — coefficient list, each with
+          ``"term"`` and ``"coefficient"`` keys as returned by
+          ``analyze_experiment(..., analysis_type="coefficients")``.
+        - ``"factor_names"`` (list[str]) — ordered factor names.
+        - ``"mse_residual"`` (float, optional) — mean squared error.
+        - ``"r_squared"`` (float, optional) — model R-squared.
+
+    goals : list[dict] or None
+        Per-response optimisation goals.  Each dict has keys:
+
+        - ``"response"`` (str) — response name (must match a model).
+        - ``"goal"`` (str) — ``"maximize"``, ``"minimize"``, or
+          ``"target"``.
+        - ``"target"`` (float, optional) — target value (required when
+          ``goal="target"``).
+        - ``"low"`` (float) — lower acceptable bound.
+        - ``"high"`` (float) — upper acceptable bound.
+        - ``"weight"`` (float, default 1) — desirability shape parameter.
+        - ``"importance"`` (float, default 1) — relative importance for
+          composite desirability.
+
+    method : str
+        Optimisation method: ``"desirability"``,
+        ``"steepest_ascent"``, ``"steepest_descent"``,
+        ``"stationary_point"``, ``"canonical_analysis"``,
+        ``"ridge_analysis"`` (stub), ``"pareto_front"`` (stub).
+    factor_ranges : dict or None
+        Maps factor name to ``{"low": float, "high": float}`` in actual
+        units.  Used for coded ↔ actual conversion.
+    step_size : float
+        Step magnitude for steepest ascent/descent (coded units).
+    n_steps : int
+        Number of steps for steepest ascent/descent.
+    desirability_weights : list[float] or None
+        Importance weights for composite desirability (overrides per-goal
+        ``"importance"`` values).
+
+    Returns
+    -------
+    dict[str, Any]
+        Results keyed by method.  Always includes ``"method"`` and
+        ``"factor_names"``.
+
+    Examples
+    --------
+    >>> from process_improve.experiments.optimization import optimize_responses
+    >>> model = {
+    ...     "response_name": "yield",
+    ...     "coefficients": [
+    ...         {"term": "Intercept", "coefficient": 40.0},
+    ...         {"term": "A", "coefficient": 5.25},
+    ...         {"term": "B", "coefficient": -2.0},
+    ...         {"term": "I(A ** 2)", "coefficient": -3.0},
+    ...         {"term": "I(B ** 2)", "coefficient": -1.5},
+    ...         {"term": "A:B", "coefficient": 1.5},
+    ...     ],
+    ...     "factor_names": ["A", "B"],
+    ... }
+    >>> result = optimize_responses(
+    ...     fitted_models=[model],
+    ...     method="stationary_point",
+    ... )
+    >>> result["stationary_point"]["classification"]
+    'maximum'
+    """
+    if method not in _METHODS:
+        available = sorted(_METHODS)
+        msg = f"Unknown method {method!r}. Available: {available}"
+        raise ValueError(msg)
+
+    if not fitted_models:
+        msg = "At least one fitted model is required."
+        raise ValueError(msg)
+
+    # Use factor_names from the first model as the canonical ordering
+    factor_names = fitted_models[0]["factor_names"]
+    coefficients = fitted_models[0]["coefficients"]
+
+    result: dict[str, Any] = {"method": method, "factor_names": factor_names}
+
+    if method == "stationary_point":
+        result["stationary_point"] = _find_stationary_point(coefficients, factor_names, factor_ranges)
+
+    elif method == "canonical_analysis":
+        result["canonical_analysis"] = _canonical_analysis(coefficients, factor_names)
+        # Also include the stationary point for context
+        result["stationary_point"] = _find_stationary_point(coefficients, factor_names, factor_ranges)
+
+    elif method in ("steepest_ascent", "steepest_descent"):
+        direction = "ascent" if method == "steepest_ascent" else "descent"
+        result["steepest_path"] = _steepest_path(
+            coefficients, factor_names, step_size, n_steps, direction, factor_ranges
+        )
+
+    elif method == "desirability":
+        if goals is None:
+            msg = "Goals are required for desirability optimization."
+            raise ValueError(msg)
+
+        importances = desirability_weights
+        if importances is None:
+            importances = [g.get("importance", 1.0) for g in goals]
+
+        result["desirability"] = _optimize_desirability(
+            fitted_models, goals, factor_names, factor_ranges, importances
+        )
+
+    elif method == "ridge_analysis":
+        result["ridge_analysis"] = _ridge_analysis(coefficients, factor_names, factor_ranges)
+
+    elif method == "pareto_front":
+        if goals is None:
+            msg = "Goals are required for Pareto front optimization."
+            raise ValueError(msg)
+        result["pareto_front"] = _pareto_front(fitted_models, goals, factor_names, factor_ranges)
+
+    return result

--- a/process_improve/experiments/tools.py
+++ b/process_improve/experiments/tools.py
@@ -650,6 +650,210 @@ def analyze_experiment_tool(  # noqa: PLR0913
 _register("analyze_experiment")
 
 
+@tool_spec(
+    name="optimize_responses",
+    description=(
+        "Find optimal factor settings for one or multiple responses from fitted experimental models. "
+        "Supports several methods: 'desirability' (Derringer-Suich desirability functions for single or "
+        "multi-response optimisation), 'steepest_ascent' / 'steepest_descent' (move along the gradient "
+        "of a first-order model), 'stationary_point' (locate the optimum of a second-order model), "
+        "'canonical_analysis' (eigenvalue decomposition to classify the response surface shape). "
+        "Ridge analysis and Pareto front are planned but not yet implemented. "
+        "Each fitted_model must include coefficients (as returned by analyze_experiment with "
+        "analysis_type='coefficients'), factor_names, and response_name. "
+        "For desirability, each goal specifies whether to maximize, minimize, or target a value."
+    ),
+    input_schema={
+        "json": {
+            "type": "object",
+            "properties": {
+                "fitted_models": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "response_name": {
+                                "type": "string",
+                                "description": "Name of the response variable.",
+                            },
+                            "coefficients": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "term": {"type": "string"},
+                                        "coefficient": {"type": "number"},
+                                    },
+                                    "required": ["term", "coefficient"],
+                                },
+                                "description": (
+                                    "List of model coefficients as returned by "
+                                    "analyze_experiment(analysis_type='coefficients'). "
+                                    "Each entry has 'term' (e.g. 'Intercept', 'A', 'A:B', "
+                                    "'I(A ** 2)') and 'coefficient' (float)."
+                                ),
+                            },
+                            "factor_names": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Ordered list of factor names.",
+                            },
+                            "mse_residual": {
+                                "type": "number",
+                                "description": "Mean squared error of the model (optional).",
+                            },
+                            "r_squared": {
+                                "type": "number",
+                                "description": "R-squared of the model (optional).",
+                            },
+                        },
+                        "required": ["coefficients", "factor_names"],
+                    },
+                    "description": "One or more fitted models from analyze_experiment.",
+                    "minItems": 1,
+                },
+                "goals": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "response": {
+                                "type": "string",
+                                "description": "Response name (must match a fitted_model).",
+                            },
+                            "goal": {
+                                "type": "string",
+                                "enum": ["maximize", "minimize", "target"],
+                                "description": "Optimisation direction.",
+                            },
+                            "target": {
+                                "type": "number",
+                                "description": "Target value (required when goal='target').",
+                            },
+                            "low": {
+                                "type": "number",
+                                "description": "Lower acceptable bound for desirability.",
+                            },
+                            "high": {
+                                "type": "number",
+                                "description": "Upper acceptable bound for desirability.",
+                            },
+                            "weight": {
+                                "type": "number",
+                                "description": "Desirability shape parameter (default 1.0 = linear).",
+                            },
+                            "importance": {
+                                "type": "number",
+                                "description": "Relative importance for composite desirability.",
+                            },
+                        },
+                        "required": ["response", "goal", "low", "high"],
+                    },
+                    "description": (
+                        "Per-response optimisation goals. Required for 'desirability' method."
+                    ),
+                },
+                "method": {
+                    "type": "string",
+                    "enum": [
+                        "desirability",
+                        "steepest_ascent",
+                        "steepest_descent",
+                        "stationary_point",
+                        "canonical_analysis",
+                        "ridge_analysis",
+                        "pareto_front",
+                    ],
+                    "description": "Optimisation method (default: 'desirability').",
+                },
+                "factor_ranges": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                            "low": {"type": "number"},
+                            "high": {"type": "number"},
+                        },
+                        "required": ["low", "high"],
+                    },
+                    "description": (
+                        "Factor bounds in actual units, e.g. "
+                        '{"Temperature": {"low": 150, "high": 200}}. '
+                        "Used to convert coded settings to actual units in the output."
+                    ),
+                },
+                "step_size": {
+                    "type": "number",
+                    "description": "Step size in coded units for steepest ascent/descent (default 0.5).",
+                },
+                "n_steps": {
+                    "type": "integer",
+                    "description": "Number of steps for steepest ascent/descent (default 10).",
+                    "minimum": 1,
+                },
+                "desirability_weights": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "description": "Importance weights for composite desirability (overrides per-goal importance).",
+                },
+            },
+            "required": ["fitted_models"],
+        }
+    },
+    examples="""
+    # "Find the stationary point of my quadratic model"
+        -> ``optimize_responses(fitted_models=[{"response_name": "yield",
+                "coefficients": [{"term": "Intercept", "coefficient": 40},
+                    {"term": "A", "coefficient": 5.25}, {"term": "B", "coefficient": -2},
+                    {"term": "I(A ** 2)", "coefficient": -3}, {"term": "I(B ** 2)", "coefficient": -1.5},
+                    {"term": "A:B", "coefficient": 1.5}],
+                "factor_names": ["A", "B"]}],
+            method="stationary_point")``
+
+    # "Optimize two responses using desirability"
+        -> ``optimize_responses(fitted_models=[model1, model2],
+                goals=[{"response": "yield", "goal": "maximize", "low": 30, "high": 50},
+                       {"response": "cost", "goal": "minimize", "low": 10, "high": 40}],
+                method="desirability")``
+
+    # "Generate a steepest ascent path from a first-order model"
+        -> ``optimize_responses(fitted_models=[model],
+                method="steepest_ascent", step_size=0.5, n_steps=8,
+                factor_ranges={"Temperature": {"low": 150, "high": 200}})``
+    """,
+    category="experiments",
+)
+def optimize_responses_tool(  # noqa: PLR0913
+    *,
+    fitted_models: list[dict[str, Any]],
+    goals: list[dict[str, Any]] | None = None,
+    method: str = "desirability",
+    factor_ranges: dict[str, dict[str, float]] | None = None,
+    step_size: float = 0.5,
+    n_steps: int = 10,
+    desirability_weights: list[float] | None = None,
+) -> dict[str, Any]:
+    """Optimize experimental responses; see tool spec for details."""
+    try:
+        from process_improve.experiments.optimization import optimize_responses  # noqa: PLC0415
+
+        result = optimize_responses(
+            fitted_models=fitted_models,
+            goals=goals,
+            method=method,
+            factor_ranges=factor_ranges,
+            step_size=step_size,
+            n_steps=n_steps,
+            desirability_weights=desirability_weights,
+        )
+        return clean(result)
+    except Exception as e:  # noqa: BLE001
+        return {"error": str(e)}
+
+
+_register("optimize_responses")
+
+
 # ---------------------------------------------------------------------------
 # Module-level convenience
 # ---------------------------------------------------------------------------

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -399,3 +399,210 @@ class TestCompositeDesirability:
 
     def test_empty_list(self) -> None:
         assert _composite_desirability([]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Desirability optimisation (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+class TestOptimizeDesirability:
+    def test_single_response_maximize(self) -> None:
+        model = {
+            "response_name": "yield",
+            "coefficients": _quadratic_2f_coeffs(),
+            "factor_names": FACTOR_NAMES_2F,
+        }
+        goals = [{"response": "yield", "goal": "maximize", "low": 30.0, "high": 50.0}]
+        result = optimize_responses([model], goals=goals, method="desirability")
+        d_result = result["desirability"]
+        assert "optimal_coded" in d_result
+        assert "composite_desirability" in d_result
+        assert d_result["composite_desirability"] > 0.0
+
+    def test_two_response_desirability(self) -> None:
+        model1 = {
+            "response_name": "yield",
+            "coefficients": _quadratic_2f_coeffs(),
+            "factor_names": FACTOR_NAMES_2F,
+        }
+        model2 = {
+            "response_name": "purity",
+            "coefficients": [
+                {"term": "Intercept", "coefficient": 80.0},
+                {"term": "A", "coefficient": -3.0},
+                {"term": "B", "coefficient": 2.0},
+                {"term": "I(A ** 2)", "coefficient": -1.0},
+                {"term": "I(B ** 2)", "coefficient": -2.0},
+                {"term": "A:B", "coefficient": 0.5},
+            ],
+            "factor_names": FACTOR_NAMES_2F,
+        }
+        goals = [
+            {"response": "yield", "goal": "maximize", "low": 30.0, "high": 50.0},
+            {"response": "purity", "goal": "maximize", "low": 70.0, "high": 90.0},
+        ]
+        result = optimize_responses([model1, model2], goals=goals, method="desirability")
+        d_result = result["desirability"]
+        assert "predicted_responses" in d_result
+        assert "yield" in d_result["predicted_responses"]
+        assert "purity" in d_result["predicted_responses"]
+
+    def test_with_factor_ranges(self) -> None:
+        model = {
+            "response_name": "yield",
+            "coefficients": _quadratic_2f_coeffs(),
+            "factor_names": FACTOR_NAMES_2F,
+        }
+        goals = [{"response": "yield", "goal": "maximize", "low": 30.0, "high": 50.0}]
+        result = optimize_responses(
+            [model], goals=goals, method="desirability", factor_ranges=FACTOR_RANGES_2F
+        )
+        d_result = result["desirability"]
+        assert "optimal_actual" in d_result
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class TestStubs:
+    def test_ridge_analysis_stub(self) -> None:
+        model = {
+            "response_name": "yield",
+            "coefficients": _quadratic_2f_coeffs(),
+            "factor_names": FACTOR_NAMES_2F,
+        }
+        result = optimize_responses([model], method="ridge_analysis")
+        assert "error" in result["ridge_analysis"]
+        assert result["ridge_analysis"]["status"] == "stub"
+
+    def test_pareto_front_stub(self) -> None:
+        model = {
+            "response_name": "yield",
+            "coefficients": _quadratic_2f_coeffs(),
+            "factor_names": FACTOR_NAMES_2F,
+        }
+        goals = [{"response": "yield", "goal": "maximize", "low": 30.0, "high": 50.0}]
+        result = optimize_responses([model], goals=goals, method="pareto_front")
+        assert "error" in result["pareto_front"]
+        assert result["pareto_front"]["status"] == "stub"
+
+
+# ---------------------------------------------------------------------------
+# Public dispatcher
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcher:
+    def test_stationary_point_via_dispatcher(self) -> None:
+        model = {
+            "response_name": "yield",
+            "coefficients": _quadratic_2f_coeffs(),
+            "factor_names": FACTOR_NAMES_2F,
+        }
+        result = optimize_responses([model], method="stationary_point")
+        assert result["method"] == "stationary_point"
+        assert "stationary_point" in result
+
+    def test_canonical_via_dispatcher(self) -> None:
+        model = {
+            "response_name": "yield",
+            "coefficients": _quadratic_2f_coeffs(),
+            "factor_names": FACTOR_NAMES_2F,
+        }
+        result = optimize_responses([model], method="canonical_analysis")
+        assert "canonical_analysis" in result
+        assert "stationary_point" in result  # also included
+
+    def test_steepest_ascent_via_dispatcher(self) -> None:
+        model = {
+            "response_name": "yield",
+            "coefficients": _linear_2f_coeffs(),
+            "factor_names": FACTOR_NAMES_2F,
+        }
+        result = optimize_responses([model], method="steepest_ascent", step_size=0.5, n_steps=5)
+        assert "steepest_path" in result
+
+    def test_steepest_descent_via_dispatcher(self) -> None:
+        model = {
+            "response_name": "yield",
+            "coefficients": _linear_2f_coeffs(),
+            "factor_names": FACTOR_NAMES_2F,
+        }
+        result = optimize_responses([model], method="steepest_descent")
+        assert "steepest_path" in result
+        assert result["steepest_path"]["direction"] == "descent"
+
+    def test_unknown_method_raises(self) -> None:
+        model = {
+            "response_name": "y",
+            "coefficients": _linear_2f_coeffs(),
+            "factor_names": FACTOR_NAMES_2F,
+        }
+        with pytest.raises(ValueError, match="Unknown method"):
+            optimize_responses([model], method="bogus")
+
+    def test_empty_models_raises(self) -> None:
+        with pytest.raises(ValueError, match="At least one"):
+            optimize_responses([], method="stationary_point")
+
+    def test_desirability_without_goals_raises(self) -> None:
+        model = {
+            "response_name": "y",
+            "coefficients": _linear_2f_coeffs(),
+            "factor_names": FACTOR_NAMES_2F,
+        }
+        with pytest.raises(ValueError, match="Goals are required"):
+            optimize_responses([model], method="desirability")
+
+    def test_factor_names_in_result(self) -> None:
+        model = {
+            "response_name": "y",
+            "coefficients": _linear_2f_coeffs(),
+            "factor_names": FACTOR_NAMES_2F,
+        }
+        result = optimize_responses([model], method="steepest_ascent")
+        assert result["factor_names"] == FACTOR_NAMES_2F
+
+
+# ---------------------------------------------------------------------------
+# Tool wrapper (JSON round-trip)
+# ---------------------------------------------------------------------------
+
+
+class TestToolWrapper:
+    def test_tool_returns_dict(self) -> None:
+        from process_improve.experiments.tools import optimize_responses_tool
+
+        result = optimize_responses_tool(
+            fitted_models=[{
+                "response_name": "yield",
+                "coefficients": _quadratic_2f_coeffs(),
+                "factor_names": FACTOR_NAMES_2F,
+            }],
+            method="stationary_point",
+        )
+        assert isinstance(result, dict)
+        assert "method" in result
+
+    def test_tool_error_handling(self) -> None:
+        from process_improve.experiments.tools import optimize_responses_tool
+
+        result = optimize_responses_tool(
+            fitted_models=[{
+                "coefficients": _linear_2f_coeffs(),
+                "factor_names": FACTOR_NAMES_2F,
+            }],
+            method="desirability",
+            # Missing goals → should error
+        )
+        assert "error" in result
+
+    def test_tool_registered(self) -> None:
+        from process_improve.tool_spec import get_tool_specs
+
+        specs = get_tool_specs(category="experiments")
+        names = [s["name"] for s in specs]
+        assert "optimize_responses" in names

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -20,6 +20,8 @@ from process_improve.experiments.optimization import (
     evaluate_model,
     optimize_responses,
 )
+from process_improve.experiments.tools import optimize_responses_tool
+from process_improve.tool_spec import get_tool_specs
 
 # ---------------------------------------------------------------------------
 # Fixtures — reusable model coefficient dicts
@@ -27,10 +29,7 @@ from process_improve.experiments.optimization import (
 
 
 def _quadratic_2f_coeffs() -> list[dict]:
-    """Two-factor quadratic model: y = 40 + 5.25*A - 2*B - 3*A^2 - 1.5*B^2 + 1.5*A:B.
-
-    Stationary point is a maximum (both eigenvalues of B negative).
-    """
+    """Two-factor quadratic: y = 40 + 5.25*A - 2*B - 3*A^2 - 1.5*B^2 + 1.5*A:B."""
     return [
         {"term": "Intercept", "coefficient": 40.0},
         {"term": "A", "coefficient": 5.25},
@@ -82,20 +81,27 @@ FACTOR_RANGES_2F = {"A": {"low": 150, "high": 200}, "B": {"low": 1, "high": 5}}
 
 
 class TestParseTerm:
+    """Verify _parse_term classifies coefficient term names correctly."""
+
     def test_intercept(self) -> None:
+        """Intercept returns empty tuple."""
         assert _parse_term("Intercept") == ()
 
     def test_linear(self) -> None:
+        """Linear terms return single-element tuple."""
         assert _parse_term("A") == ("A",)
         assert _parse_term("Temperature") == ("Temperature",)
 
     def test_interaction(self) -> None:
+        """Interaction A:B returns two-element tuple."""
         assert _parse_term("A:B") == ("A", "B")
 
     def test_quadratic(self) -> None:
+        """Quadratic I(A ** 2) returns (A, A)."""
         assert _parse_term("I(A ** 2)") == ("A", "A")
 
     def test_three_way_interaction(self) -> None:
+        """Three-way interaction A:B:C returns three-element tuple."""
         assert _parse_term("A:B:C") == ("A", "B", "C")
 
 
@@ -105,35 +111,40 @@ class TestParseTerm:
 
 
 class TestModelEvaluator:
+    """Verify polynomial evaluation at known coded points."""
+
     def test_intercept_only(self) -> None:
+        """Intercept-only model returns constant."""
         coeffs = [{"term": "Intercept", "coefficient": 42.0}]
         val = evaluate_model(coeffs, ["A"], {"A": 0.0})
         assert val == pytest.approx(42.0)
 
     def test_linear_model_at_origin(self) -> None:
+        """Linear model at origin returns intercept."""
         coeffs = _linear_2f_coeffs()
         val = evaluate_model(coeffs, FACTOR_NAMES_2F, {"A": 0.0, "B": 0.0})
         assert val == pytest.approx(30.0)
 
     def test_linear_model_at_plus_one(self) -> None:
+        """Linear model at (1,1): y = 30 + 4 + 3 = 37."""
         coeffs = _linear_2f_coeffs()
-        # y = 30 + 4*1 + 3*1 = 37
         val = evaluate_model(coeffs, FACTOR_NAMES_2F, {"A": 1.0, "B": 1.0})
         assert val == pytest.approx(37.0)
 
     def test_quadratic_model_at_origin(self) -> None:
+        """Quadratic at origin returns intercept (all x=0)."""
         coeffs = _quadratic_2f_coeffs()
-        # At origin: y = 40 (intercept only, all x=0)
         val = evaluate_model(coeffs, FACTOR_NAMES_2F, {"A": 0.0, "B": 0.0})
         assert val == pytest.approx(40.0)
 
     def test_quadratic_model_at_corner(self) -> None:
+        """Quadratic at (1,1): 40 + 5.25 - 2 - 3 - 1.5 + 1.5 = 40.25."""
         coeffs = _quadratic_2f_coeffs()
-        # At (1,1): y = 40 + 5.25 - 2 - 3 - 1.5 + 1.5 = 40.25
         val = evaluate_model(coeffs, FACTOR_NAMES_2F, {"A": 1.0, "B": 1.0})
         assert val == pytest.approx(40.25)
 
     def test_build_evaluator_returns_callable(self) -> None:
+        """_build_model_evaluator returns a callable accepting numpy array."""
         f = _build_model_evaluator(_linear_2f_coeffs(), FACTOR_NAMES_2F)
         assert callable(f)
         assert f(np.array([0.0, 0.0])) == pytest.approx(30.0)
@@ -145,27 +156,32 @@ class TestModelEvaluator:
 
 
 class TestExtractBandB:
-    def test_linear_model_has_zero_B(self) -> None:
-        b0, b, B = _extract_b_and_B(_linear_2f_coeffs(), FACTOR_NAMES_2F)
+    """Verify extraction of intercept, linear vector b, and quadratic matrix B."""
+
+    def test_linear_model_has_zero_b_matrix(self) -> None:
+        """Linear model produces zero B matrix."""
+        b0, b, b_mat = _extract_b_and_B(_linear_2f_coeffs(), FACTOR_NAMES_2F)
         assert b0 == pytest.approx(30.0)
         assert b[0] == pytest.approx(4.0)
         assert b[1] == pytest.approx(3.0)
-        assert np.allclose(B, 0)
+        assert np.allclose(b_mat, 0)
 
-    def test_quadratic_model_B_is_symmetric(self) -> None:
-        _b0, _b, B = _extract_b_and_B(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
-        assert B[0, 1] == pytest.approx(B[1, 0])
+    def test_quadratic_model_b_matrix_is_symmetric(self) -> None:
+        """Quadratic B matrix is symmetric."""
+        _b0, _b, b_mat = _extract_b_and_B(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
+        assert b_mat[0, 1] == pytest.approx(b_mat[1, 0])
 
     def test_quadratic_diagonals(self) -> None:
-        _b0, _b, B = _extract_b_and_B(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
-        assert B[0, 0] == pytest.approx(-3.0)
-        assert B[1, 1] == pytest.approx(-1.5)
+        """Diagonal entries of B match quadratic coefficients."""
+        _b0, _b, b_mat = _extract_b_and_B(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
+        assert b_mat[0, 0] == pytest.approx(-3.0)
+        assert b_mat[1, 1] == pytest.approx(-1.5)
 
     def test_interaction_split(self) -> None:
-        _b0, _b, B = _extract_b_and_B(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
-        # Interaction coeff 1.5 is split: B[0,1] = B[1,0] = 0.75
-        assert B[0, 1] == pytest.approx(0.75)
-        assert B[1, 0] == pytest.approx(0.75)
+        """Interaction coeff 1.5 splits to B[0,1]=B[1,0]=0.75."""
+        _b0, _b, b_mat = _extract_b_and_B(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
+        assert b_mat[0, 1] == pytest.approx(0.75)
+        assert b_mat[1, 0] == pytest.approx(0.75)
 
 
 # ---------------------------------------------------------------------------
@@ -174,19 +190,25 @@ class TestExtractBandB:
 
 
 class TestStationaryPoint:
+    """Verify stationary point computation and classification."""
+
     def test_maximum_classification(self) -> None:
+        """Quadratic model with all-negative eigenvalues classified as maximum."""
         result = _find_stationary_point(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
         assert result["classification"] == "maximum"
 
     def test_saddle_classification(self) -> None:
+        """Model with mixed-sign eigenvalues classified as saddle point."""
         result = _find_stationary_point(_saddle_2f_coeffs(), FACTOR_NAMES_2F)
         assert result["classification"] == "saddle_point"
 
     def test_minimum_classification(self) -> None:
+        """Model with all-positive eigenvalues classified as minimum."""
         result = _find_stationary_point(_minimum_2f_coeffs(), FACTOR_NAMES_2F)
         assert result["classification"] == "minimum"
 
     def test_stationary_point_keys(self) -> None:
+        """Result contains all expected keys."""
         result = _find_stationary_point(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
         assert "stationary_point_coded" in result
         assert "predicted_response" in result
@@ -195,10 +217,12 @@ class TestStationaryPoint:
         assert "inside_design_space" in result
 
     def test_predicted_response_is_float(self) -> None:
+        """Predicted response at stationary point is a Python float."""
         result = _find_stationary_point(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
         assert isinstance(result["predicted_response"], float)
 
     def test_with_factor_ranges(self) -> None:
+        """Factor ranges trigger coded-to-actual conversion."""
         result = _find_stationary_point(_quadratic_2f_coeffs(), FACTOR_NAMES_2F, FACTOR_RANGES_2F)
         assert "stationary_point_actual" in result
         actual = result["stationary_point_actual"]
@@ -206,10 +230,12 @@ class TestStationaryPoint:
         assert "B" in actual
 
     def test_linear_model_errors(self) -> None:
+        """First-order model with no quadratic terms returns error."""
         result = _find_stationary_point(_linear_2f_coeffs(), FACTOR_NAMES_2F)
         assert "error" in result
 
     def test_eigenvalues_count(self) -> None:
+        """Number of eigenvalues matches number of factors."""
         result = _find_stationary_point(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
         assert len(result["eigenvalues"]) == 2
 
@@ -220,34 +246,43 @@ class TestStationaryPoint:
 
 
 class TestCanonicalAnalysis:
+    """Verify canonical analysis eigenvalue decomposition."""
+
     def test_maximum_classification(self) -> None:
+        """Quadratic with all-negative eigenvalues → maximum."""
         result = _canonical_analysis(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
         assert result["classification"] == "maximum"
 
     def test_saddle_classification(self) -> None:
+        """Mixed-sign eigenvalues → saddle point."""
         result = _canonical_analysis(_saddle_2f_coeffs(), FACTOR_NAMES_2F)
         assert result["classification"] == "saddle_point"
 
     def test_minimum_classification(self) -> None:
+        """All-positive eigenvalues → minimum."""
         result = _canonical_analysis(_minimum_2f_coeffs(), FACTOR_NAMES_2F)
         assert result["classification"] == "minimum"
 
     def test_eigenvalues_sorted_by_absolute(self) -> None:
+        """Eigenvalues are sorted largest-absolute first."""
         result = _canonical_analysis(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
         evs = result["eigenvalues"]
         assert abs(evs[0]) >= abs(evs[1])
 
     def test_eigenvectors_present(self) -> None:
+        """Result includes eigenvector list matching factor count."""
         result = _canonical_analysis(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
         assert "eigenvectors" in result
         assert len(result["eigenvectors"]) == 2
 
     def test_canonical_form_description(self) -> None:
+        """Canonical form description has one entry per eigenvalue."""
         result = _canonical_analysis(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
         assert "canonical_form_description" in result
         assert len(result["canonical_form_description"]) == 2
 
     def test_linear_model_errors(self) -> None:
+        """First-order model returns error for canonical analysis."""
         result = _canonical_analysis(_linear_2f_coeffs(), FACTOR_NAMES_2F)
         assert "error" in result
 
@@ -258,25 +293,29 @@ class TestCanonicalAnalysis:
 
 
 class TestSteepestPath:
+    """Verify steepest ascent/descent path generation."""
+
     def test_ascent_direction(self) -> None:
+        """For y=30+4A+3B, ascent direction is positive for both factors."""
         result = _steepest_path(_linear_2f_coeffs(), FACTOR_NAMES_2F, direction="ascent")
         dv = result["direction_vector"]
-        # For y = 30 + 4A + 3B, direction should be positive for both
         assert dv["A"] > 0
         assert dv["B"] > 0
 
     def test_descent_direction(self) -> None:
+        """Descent direction is negative for both factors."""
         result = _steepest_path(_linear_2f_coeffs(), FACTOR_NAMES_2F, direction="descent")
         dv = result["direction_vector"]
         assert dv["A"] < 0
         assert dv["B"] < 0
 
     def test_step_count(self) -> None:
+        """Steps list has n_steps+1 entries (including step 0 at centre)."""
         result = _steepest_path(_linear_2f_coeffs(), FACTOR_NAMES_2F, n_steps=5)
-        # n_steps + 1 because step 0 (center) is included
         assert len(result["steps"]) == 6
 
     def test_first_step_is_center(self) -> None:
+        """Step 0 is at the design centre (all coded values zero)."""
         result = _steepest_path(_linear_2f_coeffs(), FACTOR_NAMES_2F)
         step0 = result["steps"][0]
         assert step0["step"] == 0
@@ -284,13 +323,14 @@ class TestSteepestPath:
         assert step0["coded"]["B"] == pytest.approx(0.0)
 
     def test_predicted_response_increases_for_ascent(self) -> None:
+        """Each ascent step gives a higher predicted response."""
         result = _steepest_path(_linear_2f_coeffs(), FACTOR_NAMES_2F, direction="ascent")
         responses = [s["predicted_response"] for s in result["steps"]]
-        # Each step should give a higher predicted response
         for i in range(1, len(responses)):
             assert responses[i] > responses[i - 1]
 
     def test_actual_values_with_factor_ranges(self) -> None:
+        """Factor ranges trigger actual-unit conversion in step entries."""
         result = _steepest_path(
             _linear_2f_coeffs(), FACTOR_NAMES_2F, factor_ranges=FACTOR_RANGES_2F
         )
@@ -300,6 +340,7 @@ class TestSteepestPath:
         assert "B" in step1["actual"]
 
     def test_zero_coefficients_error(self) -> None:
+        """All-zero linear coefficients return an error."""
         coeffs = [
             {"term": "Intercept", "coefficient": 10.0},
             {"term": "A", "coefficient": 0.0},
@@ -315,89 +356,118 @@ class TestSteepestPath:
 
 
 class TestDesirabilityMaximize:
+    """Verify one-sided maximise desirability function."""
+
     def test_below_low(self) -> None:
+        """Value below low bound gives d=0."""
         assert _desirability_maximize(5.0, 10.0, 20.0) == 0.0
 
     def test_above_high(self) -> None:
+        """Value above high bound gives d=1."""
         assert _desirability_maximize(25.0, 10.0, 20.0) == 1.0
 
     def test_at_midpoint(self) -> None:
+        """Midpoint gives d=0.5 with linear weight."""
         assert _desirability_maximize(15.0, 10.0, 20.0) == pytest.approx(0.5)
 
     def test_weight_effect(self) -> None:
+        """Weight < 1 (concave) gives higher d at midpoint than linear."""
         d_linear = _desirability_maximize(15.0, 10.0, 20.0, weight=1.0)
         d_concave = _desirability_maximize(15.0, 10.0, 20.0, weight=0.5)
-        # weight < 1 → concave → higher d at midpoint
         assert d_concave > d_linear
 
 
 class TestDesirabilityMinimize:
+    """Verify one-sided minimise desirability function."""
+
     def test_below_low(self) -> None:
+        """Value below low bound gives d=1."""
         assert _desirability_minimize(5.0, 10.0, 20.0) == 1.0
 
     def test_above_high(self) -> None:
+        """Value above high bound gives d=0."""
         assert _desirability_minimize(25.0, 10.0, 20.0) == 0.0
 
     def test_at_midpoint(self) -> None:
+        """Midpoint gives d=0.5 with linear weight."""
         assert _desirability_minimize(15.0, 10.0, 20.0) == pytest.approx(0.5)
 
 
 class TestDesirabilityTarget:
+    """Verify two-sided target desirability function."""
+
     def test_at_target(self) -> None:
+        """At target value, d=1."""
         assert _desirability_target(15.0, 10.0, 15.0, 20.0) == pytest.approx(1.0)
 
     def test_below_low(self) -> None:
+        """Below low bound, d=0."""
         assert _desirability_target(5.0, 10.0, 15.0, 20.0) == 0.0
 
     def test_above_high(self) -> None:
+        """Above high bound, d=0."""
         assert _desirability_target(25.0, 10.0, 15.0, 20.0) == 0.0
 
     def test_between_low_and_target(self) -> None:
+        """Between low and target, 0 < d < 1."""
         d = _desirability_target(12.5, 10.0, 15.0, 20.0)
         assert 0.0 < d < 1.0
 
     def test_between_target_and_high(self) -> None:
+        """Between target and high, 0 < d < 1."""
         d = _desirability_target(17.5, 10.0, 15.0, 20.0)
         assert 0.0 < d < 1.0
 
 
 class TestIndividualDesirability:
+    """Verify _individual_desirability dispatch to correct function."""
+
     def test_maximize_goal(self) -> None:
+        """Maximize goal above high gives d=1."""
         goal = {"goal": "maximize", "low": 10.0, "high": 20.0}
         assert _individual_desirability(25.0, goal) == 1.0
 
     def test_minimize_goal(self) -> None:
+        """Minimize goal below low gives d=1."""
         goal = {"goal": "minimize", "low": 10.0, "high": 20.0}
         assert _individual_desirability(5.0, goal) == 1.0
 
     def test_target_goal(self) -> None:
+        """Target goal at target gives d=1."""
         goal = {"goal": "target", "low": 10.0, "high": 20.0, "target": 15.0}
         assert _individual_desirability(15.0, goal) == pytest.approx(1.0)
 
     def test_unknown_goal_raises(self) -> None:
+        """Unknown goal type raises ValueError."""
         goal = {"goal": "unknown", "low": 10.0, "high": 20.0}
         with pytest.raises(ValueError, match="Unknown goal"):
             _individual_desirability(15.0, goal)
 
 
 class TestCompositeDesirability:
+    """Verify weighted geometric mean composite desirability."""
+
     def test_all_ones(self) -> None:
+        """All d=1 gives composite D=1."""
         assert _composite_desirability([1.0, 1.0, 1.0]) == pytest.approx(1.0)
 
     def test_any_zero_gives_zero(self) -> None:
+        """Any d=0 makes composite D=0."""
         assert _composite_desirability([1.0, 0.0, 1.0]) == 0.0
 
     def test_geometric_mean(self) -> None:
-        # D = (0.5 * 0.8)^(1/2) = sqrt(0.4)
+        """Unweighted: D = sqrt(0.5 * 0.8) = sqrt(0.4)."""
         d = _composite_desirability([0.5, 0.8])
         assert d == pytest.approx(np.sqrt(0.4))
 
     def test_weighted(self) -> None:
+        """Weighted geometric mean with importances [2, 1]."""
         d = _composite_desirability([0.5, 0.8], importances=[2.0, 1.0])
         expected = np.exp((2.0 * np.log(0.5) + 1.0 * np.log(0.8)) / 3.0)
         assert d == pytest.approx(expected)
 
     def test_empty_list(self) -> None:
+        """Empty list returns 0."""
         assert _composite_desirability([]) == 0.0
 
 
@@ -407,7 +477,10 @@ class TestCompositeDesirability:
 
 
 class TestOptimizeDesirability:
+    """Verify end-to-end desirability optimisation via scipy."""
+
     def test_single_response_maximize(self) -> None:
+        """Single-response maximize yields positive composite desirability."""
         model = {
             "response_name": "yield",
             "coefficients": _quadratic_2f_coeffs(),
@@ -421,6 +494,7 @@ class TestOptimizeDesirability:
         assert d_result["composite_desirability"] > 0.0
 
     def test_two_response_desirability(self) -> None:
+        """Two-response optimisation returns predictions for both responses."""
         model1 = {
             "response_name": "yield",
             "coefficients": _quadratic_2f_coeffs(),
@@ -449,6 +523,7 @@ class TestOptimizeDesirability:
         assert "purity" in d_result["predicted_responses"]
 
     def test_with_factor_ranges(self) -> None:
+        """Factor ranges produce actual-unit optimal settings."""
         model = {
             "response_name": "yield",
             "coefficients": _quadratic_2f_coeffs(),
@@ -468,7 +543,10 @@ class TestOptimizeDesirability:
 
 
 class TestStubs:
+    """Verify stub methods return appropriate not-implemented messages."""
+
     def test_ridge_analysis_stub(self) -> None:
+        """Ridge analysis returns error with stub status."""
         model = {
             "response_name": "yield",
             "coefficients": _quadratic_2f_coeffs(),
@@ -479,6 +557,7 @@ class TestStubs:
         assert result["ridge_analysis"]["status"] == "stub"
 
     def test_pareto_front_stub(self) -> None:
+        """Pareto front returns error with stub status."""
         model = {
             "response_name": "yield",
             "coefficients": _quadratic_2f_coeffs(),
@@ -496,7 +575,10 @@ class TestStubs:
 
 
 class TestDispatcher:
+    """Verify optimize_responses routes to the correct method."""
+
     def test_stationary_point_via_dispatcher(self) -> None:
+        """Stationary point method produces stationary_point key."""
         model = {
             "response_name": "yield",
             "coefficients": _quadratic_2f_coeffs(),
@@ -507,6 +589,7 @@ class TestDispatcher:
         assert "stationary_point" in result
 
     def test_canonical_via_dispatcher(self) -> None:
+        """Canonical analysis also includes stationary point for context."""
         model = {
             "response_name": "yield",
             "coefficients": _quadratic_2f_coeffs(),
@@ -514,9 +597,10 @@ class TestDispatcher:
         }
         result = optimize_responses([model], method="canonical_analysis")
         assert "canonical_analysis" in result
-        assert "stationary_point" in result  # also included
+        assert "stationary_point" in result
 
     def test_steepest_ascent_via_dispatcher(self) -> None:
+        """Steepest ascent produces steepest_path key."""
         model = {
             "response_name": "yield",
             "coefficients": _linear_2f_coeffs(),
@@ -526,6 +610,7 @@ class TestDispatcher:
         assert "steepest_path" in result
 
     def test_steepest_descent_via_dispatcher(self) -> None:
+        """Steepest descent sets direction to descent."""
         model = {
             "response_name": "yield",
             "coefficients": _linear_2f_coeffs(),
@@ -536,6 +621,7 @@ class TestDispatcher:
         assert result["steepest_path"]["direction"] == "descent"
 
     def test_unknown_method_raises(self) -> None:
+        """Unknown method name raises ValueError."""
         model = {
             "response_name": "y",
             "coefficients": _linear_2f_coeffs(),
@@ -545,10 +631,12 @@ class TestDispatcher:
             optimize_responses([model], method="bogus")
 
     def test_empty_models_raises(self) -> None:
+        """Empty fitted_models list raises ValueError."""
         with pytest.raises(ValueError, match="At least one"):
             optimize_responses([], method="stationary_point")
 
     def test_desirability_without_goals_raises(self) -> None:
+        """Desirability method without goals raises ValueError."""
         model = {
             "response_name": "y",
             "coefficients": _linear_2f_coeffs(),
@@ -558,6 +646,7 @@ class TestDispatcher:
             optimize_responses([model], method="desirability")
 
     def test_factor_names_in_result(self) -> None:
+        """Result always includes factor_names."""
         model = {
             "response_name": "y",
             "coefficients": _linear_2f_coeffs(),
@@ -573,9 +662,10 @@ class TestDispatcher:
 
 
 class TestToolWrapper:
-    def test_tool_returns_dict(self) -> None:
-        from process_improve.experiments.tools import optimize_responses_tool
+    """Verify the @tool_spec wrapper for optimize_responses."""
 
+    def test_tool_returns_dict(self) -> None:
+        """Tool wrapper returns a JSON-serialisable dict."""
         result = optimize_responses_tool(
             fitted_models=[{
                 "response_name": "yield",
@@ -588,21 +678,18 @@ class TestToolWrapper:
         assert "method" in result
 
     def test_tool_error_handling(self) -> None:
-        from process_improve.experiments.tools import optimize_responses_tool
-
+        """Missing required args returns error dict instead of raising."""
         result = optimize_responses_tool(
             fitted_models=[{
                 "coefficients": _linear_2f_coeffs(),
                 "factor_names": FACTOR_NAMES_2F,
             }],
             method="desirability",
-            # Missing goals → should error
         )
         assert "error" in result
 
     def test_tool_registered(self) -> None:
-        from process_improve.tool_spec import get_tool_specs
-
+        """optimize_responses appears in the experiments tool registry."""
         specs = get_tool_specs(category="experiments")
         names = [s["name"] for s in specs]
         assert "optimize_responses" in names

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -166,3 +166,87 @@ class TestExtractBandB:
         # Interaction coeff 1.5 is split: B[0,1] = B[1,0] = 0.75
         assert B[0, 1] == pytest.approx(0.75)
         assert B[1, 0] == pytest.approx(0.75)
+
+
+# ---------------------------------------------------------------------------
+# Stationary point
+# ---------------------------------------------------------------------------
+
+
+class TestStationaryPoint:
+    def test_maximum_classification(self) -> None:
+        result = _find_stationary_point(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
+        assert result["classification"] == "maximum"
+
+    def test_saddle_classification(self) -> None:
+        result = _find_stationary_point(_saddle_2f_coeffs(), FACTOR_NAMES_2F)
+        assert result["classification"] == "saddle_point"
+
+    def test_minimum_classification(self) -> None:
+        result = _find_stationary_point(_minimum_2f_coeffs(), FACTOR_NAMES_2F)
+        assert result["classification"] == "minimum"
+
+    def test_stationary_point_keys(self) -> None:
+        result = _find_stationary_point(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
+        assert "stationary_point_coded" in result
+        assert "predicted_response" in result
+        assert "classification" in result
+        assert "eigenvalues" in result
+        assert "inside_design_space" in result
+
+    def test_predicted_response_is_float(self) -> None:
+        result = _find_stationary_point(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
+        assert isinstance(result["predicted_response"], float)
+
+    def test_with_factor_ranges(self) -> None:
+        result = _find_stationary_point(_quadratic_2f_coeffs(), FACTOR_NAMES_2F, FACTOR_RANGES_2F)
+        assert "stationary_point_actual" in result
+        actual = result["stationary_point_actual"]
+        assert "A" in actual
+        assert "B" in actual
+
+    def test_linear_model_errors(self) -> None:
+        result = _find_stationary_point(_linear_2f_coeffs(), FACTOR_NAMES_2F)
+        assert "error" in result
+
+    def test_eigenvalues_count(self) -> None:
+        result = _find_stationary_point(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
+        assert len(result["eigenvalues"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Canonical analysis
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalAnalysis:
+    def test_maximum_classification(self) -> None:
+        result = _canonical_analysis(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
+        assert result["classification"] == "maximum"
+
+    def test_saddle_classification(self) -> None:
+        result = _canonical_analysis(_saddle_2f_coeffs(), FACTOR_NAMES_2F)
+        assert result["classification"] == "saddle_point"
+
+    def test_minimum_classification(self) -> None:
+        result = _canonical_analysis(_minimum_2f_coeffs(), FACTOR_NAMES_2F)
+        assert result["classification"] == "minimum"
+
+    def test_eigenvalues_sorted_by_absolute(self) -> None:
+        result = _canonical_analysis(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
+        evs = result["eigenvalues"]
+        assert abs(evs[0]) >= abs(evs[1])
+
+    def test_eigenvectors_present(self) -> None:
+        result = _canonical_analysis(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
+        assert "eigenvectors" in result
+        assert len(result["eigenvectors"]) == 2
+
+    def test_canonical_form_description(self) -> None:
+        result = _canonical_analysis(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
+        assert "canonical_form_description" in result
+        assert len(result["canonical_form_description"]) == 2
+
+    def test_linear_model_errors(self) -> None:
+        result = _canonical_analysis(_linear_2f_coeffs(), FACTOR_NAMES_2F)
+        assert "error" in result

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -97,3 +97,72 @@ class TestParseTerm:
 
     def test_three_way_interaction(self) -> None:
         assert _parse_term("A:B:C") == ("A", "B", "C")
+
+
+# ---------------------------------------------------------------------------
+# Model evaluator
+# ---------------------------------------------------------------------------
+
+
+class TestModelEvaluator:
+    def test_intercept_only(self) -> None:
+        coeffs = [{"term": "Intercept", "coefficient": 42.0}]
+        val = evaluate_model(coeffs, ["A"], {"A": 0.0})
+        assert val == pytest.approx(42.0)
+
+    def test_linear_model_at_origin(self) -> None:
+        coeffs = _linear_2f_coeffs()
+        val = evaluate_model(coeffs, FACTOR_NAMES_2F, {"A": 0.0, "B": 0.0})
+        assert val == pytest.approx(30.0)
+
+    def test_linear_model_at_plus_one(self) -> None:
+        coeffs = _linear_2f_coeffs()
+        # y = 30 + 4*1 + 3*1 = 37
+        val = evaluate_model(coeffs, FACTOR_NAMES_2F, {"A": 1.0, "B": 1.0})
+        assert val == pytest.approx(37.0)
+
+    def test_quadratic_model_at_origin(self) -> None:
+        coeffs = _quadratic_2f_coeffs()
+        # At origin: y = 40 (intercept only, all x=0)
+        val = evaluate_model(coeffs, FACTOR_NAMES_2F, {"A": 0.0, "B": 0.0})
+        assert val == pytest.approx(40.0)
+
+    def test_quadratic_model_at_corner(self) -> None:
+        coeffs = _quadratic_2f_coeffs()
+        # At (1,1): y = 40 + 5.25 - 2 - 3 - 1.5 + 1.5 = 40.25
+        val = evaluate_model(coeffs, FACTOR_NAMES_2F, {"A": 1.0, "B": 1.0})
+        assert val == pytest.approx(40.25)
+
+    def test_build_evaluator_returns_callable(self) -> None:
+        f = _build_model_evaluator(_linear_2f_coeffs(), FACTOR_NAMES_2F)
+        assert callable(f)
+        assert f(np.array([0.0, 0.0])) == pytest.approx(30.0)
+
+
+# ---------------------------------------------------------------------------
+# Extract b and B
+# ---------------------------------------------------------------------------
+
+
+class TestExtractBandB:
+    def test_linear_model_has_zero_B(self) -> None:
+        b0, b, B = _extract_b_and_B(_linear_2f_coeffs(), FACTOR_NAMES_2F)
+        assert b0 == pytest.approx(30.0)
+        assert b[0] == pytest.approx(4.0)
+        assert b[1] == pytest.approx(3.0)
+        assert np.allclose(B, 0)
+
+    def test_quadratic_model_B_is_symmetric(self) -> None:
+        _b0, _b, B = _extract_b_and_B(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
+        assert B[0, 1] == pytest.approx(B[1, 0])
+
+    def test_quadratic_diagonals(self) -> None:
+        _b0, _b, B = _extract_b_and_B(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
+        assert B[0, 0] == pytest.approx(-3.0)
+        assert B[1, 1] == pytest.approx(-1.5)
+
+    def test_interaction_split(self) -> None:
+        _b0, _b, B = _extract_b_and_B(_quadratic_2f_coeffs(), FACTOR_NAMES_2F)
+        # Interaction coeff 1.5 is split: B[0,1] = B[1,0] = 0.75
+        assert B[0, 1] == pytest.approx(0.75)
+        assert B[1, 0] == pytest.approx(0.75)

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -250,3 +250,60 @@ class TestCanonicalAnalysis:
     def test_linear_model_errors(self) -> None:
         result = _canonical_analysis(_linear_2f_coeffs(), FACTOR_NAMES_2F)
         assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Steepest ascent / descent
+# ---------------------------------------------------------------------------
+
+
+class TestSteepestPath:
+    def test_ascent_direction(self) -> None:
+        result = _steepest_path(_linear_2f_coeffs(), FACTOR_NAMES_2F, direction="ascent")
+        dv = result["direction_vector"]
+        # For y = 30 + 4A + 3B, direction should be positive for both
+        assert dv["A"] > 0
+        assert dv["B"] > 0
+
+    def test_descent_direction(self) -> None:
+        result = _steepest_path(_linear_2f_coeffs(), FACTOR_NAMES_2F, direction="descent")
+        dv = result["direction_vector"]
+        assert dv["A"] < 0
+        assert dv["B"] < 0
+
+    def test_step_count(self) -> None:
+        result = _steepest_path(_linear_2f_coeffs(), FACTOR_NAMES_2F, n_steps=5)
+        # n_steps + 1 because step 0 (center) is included
+        assert len(result["steps"]) == 6
+
+    def test_first_step_is_center(self) -> None:
+        result = _steepest_path(_linear_2f_coeffs(), FACTOR_NAMES_2F)
+        step0 = result["steps"][0]
+        assert step0["step"] == 0
+        assert step0["coded"]["A"] == pytest.approx(0.0)
+        assert step0["coded"]["B"] == pytest.approx(0.0)
+
+    def test_predicted_response_increases_for_ascent(self) -> None:
+        result = _steepest_path(_linear_2f_coeffs(), FACTOR_NAMES_2F, direction="ascent")
+        responses = [s["predicted_response"] for s in result["steps"]]
+        # Each step should give a higher predicted response
+        for i in range(1, len(responses)):
+            assert responses[i] > responses[i - 1]
+
+    def test_actual_values_with_factor_ranges(self) -> None:
+        result = _steepest_path(
+            _linear_2f_coeffs(), FACTOR_NAMES_2F, factor_ranges=FACTOR_RANGES_2F
+        )
+        step1 = result["steps"][1]
+        assert "actual" in step1
+        assert "A" in step1["actual"]
+        assert "B" in step1["actual"]
+
+    def test_zero_coefficients_error(self) -> None:
+        coeffs = [
+            {"term": "Intercept", "coefficient": 10.0},
+            {"term": "A", "coefficient": 0.0},
+            {"term": "B", "coefficient": 0.0},
+        ]
+        result = _steepest_path(coeffs, FACTOR_NAMES_2F)
+        assert "error" in result

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1,0 +1,99 @@
+"""Tests for the optimize_responses() API (Tool 4)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from process_improve.experiments.optimization import (
+    _build_model_evaluator,
+    _canonical_analysis,
+    _composite_desirability,
+    _desirability_maximize,
+    _desirability_minimize,
+    _desirability_target,
+    _extract_b_and_B,
+    _find_stationary_point,
+    _individual_desirability,
+    _parse_term,
+    _steepest_path,
+    evaluate_model,
+    optimize_responses,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — reusable model coefficient dicts
+# ---------------------------------------------------------------------------
+
+
+def _quadratic_2f_coeffs() -> list[dict]:
+    """Two-factor quadratic model: y = 40 + 5.25*A - 2*B - 3*A^2 - 1.5*B^2 + 1.5*A:B.
+
+    Stationary point is a maximum (both eigenvalues of B negative).
+    """
+    return [
+        {"term": "Intercept", "coefficient": 40.0},
+        {"term": "A", "coefficient": 5.25},
+        {"term": "B", "coefficient": -2.0},
+        {"term": "I(A ** 2)", "coefficient": -3.0},
+        {"term": "I(B ** 2)", "coefficient": -1.5},
+        {"term": "A:B", "coefficient": 1.5},
+    ]
+
+
+def _linear_2f_coeffs() -> list[dict]:
+    """Two-factor first-order model: y = 30 + 4*A + 3*B."""
+    return [
+        {"term": "Intercept", "coefficient": 30.0},
+        {"term": "A", "coefficient": 4.0},
+        {"term": "B", "coefficient": 3.0},
+    ]
+
+
+def _saddle_2f_coeffs() -> list[dict]:
+    """Two-factor quadratic with saddle point: y = 50 + 2*A - A^2 + 3*B^2."""
+    return [
+        {"term": "Intercept", "coefficient": 50.0},
+        {"term": "A", "coefficient": 2.0},
+        {"term": "B", "coefficient": 0.0},
+        {"term": "I(A ** 2)", "coefficient": -1.0},
+        {"term": "I(B ** 2)", "coefficient": 3.0},
+    ]
+
+
+def _minimum_2f_coeffs() -> list[dict]:
+    """Two-factor quadratic with minimum: y = 10 - 1*A + 2*A^2 + 3*B^2."""
+    return [
+        {"term": "Intercept", "coefficient": 10.0},
+        {"term": "A", "coefficient": -1.0},
+        {"term": "B", "coefficient": 0.0},
+        {"term": "I(A ** 2)", "coefficient": 2.0},
+        {"term": "I(B ** 2)", "coefficient": 3.0},
+    ]
+
+
+FACTOR_NAMES_2F = ["A", "B"]
+FACTOR_RANGES_2F = {"A": {"low": 150, "high": 200}, "B": {"low": 1, "high": 5}}
+
+
+# ---------------------------------------------------------------------------
+# Term parser
+# ---------------------------------------------------------------------------
+
+
+class TestParseTerm:
+    def test_intercept(self) -> None:
+        assert _parse_term("Intercept") == ()
+
+    def test_linear(self) -> None:
+        assert _parse_term("A") == ("A",)
+        assert _parse_term("Temperature") == ("Temperature",)
+
+    def test_interaction(self) -> None:
+        assert _parse_term("A:B") == ("A", "B")
+
+    def test_quadratic(self) -> None:
+        assert _parse_term("I(A ** 2)") == ("A", "A")
+
+    def test_three_way_interaction(self) -> None:
+        assert _parse_term("A:B:C") == ("A", "B", "C")

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -307,3 +307,95 @@ class TestSteepestPath:
         ]
         result = _steepest_path(coeffs, FACTOR_NAMES_2F)
         assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Desirability functions
+# ---------------------------------------------------------------------------
+
+
+class TestDesirabilityMaximize:
+    def test_below_low(self) -> None:
+        assert _desirability_maximize(5.0, 10.0, 20.0) == 0.0
+
+    def test_above_high(self) -> None:
+        assert _desirability_maximize(25.0, 10.0, 20.0) == 1.0
+
+    def test_at_midpoint(self) -> None:
+        assert _desirability_maximize(15.0, 10.0, 20.0) == pytest.approx(0.5)
+
+    def test_weight_effect(self) -> None:
+        d_linear = _desirability_maximize(15.0, 10.0, 20.0, weight=1.0)
+        d_concave = _desirability_maximize(15.0, 10.0, 20.0, weight=0.5)
+        # weight < 1 → concave → higher d at midpoint
+        assert d_concave > d_linear
+
+
+class TestDesirabilityMinimize:
+    def test_below_low(self) -> None:
+        assert _desirability_minimize(5.0, 10.0, 20.0) == 1.0
+
+    def test_above_high(self) -> None:
+        assert _desirability_minimize(25.0, 10.0, 20.0) == 0.0
+
+    def test_at_midpoint(self) -> None:
+        assert _desirability_minimize(15.0, 10.0, 20.0) == pytest.approx(0.5)
+
+
+class TestDesirabilityTarget:
+    def test_at_target(self) -> None:
+        assert _desirability_target(15.0, 10.0, 15.0, 20.0) == pytest.approx(1.0)
+
+    def test_below_low(self) -> None:
+        assert _desirability_target(5.0, 10.0, 15.0, 20.0) == 0.0
+
+    def test_above_high(self) -> None:
+        assert _desirability_target(25.0, 10.0, 15.0, 20.0) == 0.0
+
+    def test_between_low_and_target(self) -> None:
+        d = _desirability_target(12.5, 10.0, 15.0, 20.0)
+        assert 0.0 < d < 1.0
+
+    def test_between_target_and_high(self) -> None:
+        d = _desirability_target(17.5, 10.0, 15.0, 20.0)
+        assert 0.0 < d < 1.0
+
+
+class TestIndividualDesirability:
+    def test_maximize_goal(self) -> None:
+        goal = {"goal": "maximize", "low": 10.0, "high": 20.0}
+        assert _individual_desirability(25.0, goal) == 1.0
+
+    def test_minimize_goal(self) -> None:
+        goal = {"goal": "minimize", "low": 10.0, "high": 20.0}
+        assert _individual_desirability(5.0, goal) == 1.0
+
+    def test_target_goal(self) -> None:
+        goal = {"goal": "target", "low": 10.0, "high": 20.0, "target": 15.0}
+        assert _individual_desirability(15.0, goal) == pytest.approx(1.0)
+
+    def test_unknown_goal_raises(self) -> None:
+        goal = {"goal": "unknown", "low": 10.0, "high": 20.0}
+        with pytest.raises(ValueError, match="Unknown goal"):
+            _individual_desirability(15.0, goal)
+
+
+class TestCompositeDesirability:
+    def test_all_ones(self) -> None:
+        assert _composite_desirability([1.0, 1.0, 1.0]) == pytest.approx(1.0)
+
+    def test_any_zero_gives_zero(self) -> None:
+        assert _composite_desirability([1.0, 0.0, 1.0]) == 0.0
+
+    def test_geometric_mean(self) -> None:
+        # D = (0.5 * 0.8)^(1/2) = sqrt(0.4)
+        d = _composite_desirability([0.5, 0.8])
+        assert d == pytest.approx(np.sqrt(0.4))
+
+    def test_weighted(self) -> None:
+        d = _composite_desirability([0.5, 0.8], importances=[2.0, 1.0])
+        expected = np.exp((2.0 * np.log(0.5) + 1.0 * np.log(0.8)) / 3.0)
+        assert d == pytest.approx(expected)
+
+    def test_empty_list(self) -> None:
+        assert _composite_desirability([]) == 0.0


### PR DESCRIPTION
## Summary

Implement Tool 4 (`optimize_responses`) — find optimal factor settings for one or multiple responses after fitting a model with `analyze_experiment` (Tool 3).

### Implemented methods
- **Derringer-Suich desirability** — single and multi-response optimization with weighted geometric mean composite, optimized via scipy SLSQP with multi-start
- **Stationary point** — locate the optimum of a second-order model via `numpy.linalg.solve`
- **Canonical analysis** — eigenvalue decomposition of the B matrix to classify response surface shape (maximum / minimum / saddle)
- **Steepest ascent / descent** — move along the gradient of a first-order model from the design centre, generating a step table in coded and actual units
- **Model evaluation layer** — parse coefficient term names (`Intercept`, `A`, `A:B`, `I(A ** 2)`) and evaluate the polynomial at arbitrary coded points (the glue between Tool 3 output and the optimizer)

### Stubs (planned for later)
- Ridge analysis — trace optimum along increasing radii
- Pareto front — multi-objective NSGA-II

### Changes
- **`process_improve/experiments/optimization.py`** — Complete rewrite replacing legacy MATLAB skeleton (~500 lines)
- **`process_improve/experiments/tools.py`** — New `optimize_responses` tool wrapper with full JSON schema for LLM integration
- **`process_improve/experiments/__init__.py`** — Export `optimize_responses`
- **`tests/test_optimization.py`** — 74 unit tests covering all methods, desirability functions, dispatcher, validation, and tool wrapper
- **`docs/doe/coverage.md`** — Updated status from "Not started" to "Partial"

## Test plan
- [x] All 74 new tests pass (`pytest tests/test_optimization.py -v`)
- [x] All 38 existing analysis tests pass (no regressions)
- [x] `ruff check` passes on all modified files
- [x] Tool discovery includes `optimize_responses` in experiments category

https://claude.ai/code/session_01Br5mDwaoXvGsaQJZLS5oCV