### PR TITLE
Add Tool 5: augment_design for extending experimental designs

### DIFF
--- a/process_improve/experiments/__init__.py
+++ b/process_improve/experiments/__init__.py
@@ -1,6 +1,7 @@
 """Designed experiments: factorial designs, linear models, optimization, and design generation."""
 
 from process_improve.experiments.analysis import analyze_experiment
+from process_improve.experiments.augment import augment_design
 from process_improve.experiments.designs import generate_design
 from process_improve.experiments.designs_factorial import full_factorial
 from process_improve.experiments.evaluate import evaluate_design
@@ -24,6 +25,7 @@ __all__ = [
     "Factor",
     "Model",
     "analyze_experiment",
+    "augment_design",
     "c",
     "evaluate_design",
     "expand_grid",

--- a/process_improve/experiments/augment.py
+++ b/process_improve/experiments/augment.py
@@ -1,0 +1,726 @@
+# (c) Kevin Dunn, 2010-2026. MIT License.
+
+"""Design augmentation: extend or modify an existing experimental design.
+
+Provides :func:`augment_design`, which takes an existing design matrix and
+augments it by adding runs (foldover, semifold, center points, axial points,
+D-optimal runs), upgrading to a response surface design, adding blocks, or
+replicating.
+
+Example
+-------
+>>> import pandas as pd
+>>> from process_improve.experiments.augment import augment_design
+>>> design = pd.DataFrame({"A": [-1, 1, -1, 1], "B": [-1, -1, 1, 1]})
+>>> result = augment_design(design, augmentation_type="add_center_points", n_additional_runs=3)
+>>> result["augmented_design"].shape
+(7, 2)
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from patsy import dmatrix
+from pyDOE3 import fullfact
+
+from process_improve.experiments.evaluate import (
+    _defining_relation_from_generators,
+    _word_to_str,
+    evaluate_design,
+)
+
+# ---------------------------------------------------------------------------
+# Internal context shared across augmentation handlers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _AugmentContext:
+    """Input context for all augmentation handlers."""
+
+    existing_design: pd.DataFrame
+    factor_names: list[str]
+    augmentation_type: str
+    target_model: str | None
+    n_additional_runs: int | None
+    fold_on: str | None
+    alpha: str | float | None
+    generators: list[str] | None
+
+
+# ---------------------------------------------------------------------------
+# "What changed" explainer
+# ---------------------------------------------------------------------------
+
+
+def _safe_evaluate(design: pd.DataFrame, generators: list[str] | None, model: str | None = None) -> dict[str, Any]:
+    """Evaluate design metrics, returning empty dict on failure."""
+    try:
+        metrics = ["d_efficiency", "degrees_of_freedom"]
+        if generators:
+            metrics.extend(["alias_structure", "resolution"])
+        return evaluate_design(design, model=model, metric=metrics)
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def _explain_changes(  # noqa: PLR0913
+    before: pd.DataFrame,
+    after: pd.DataFrame,
+    factor_names: list[str],
+    augmentation_type: str,
+    generators_before: list[str] | None = None,
+    generators_after: list[str] | None = None,
+    extra_notes: list[str] | None = None,
+) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    """Generate before/after comparison narrative.
+
+    Returns
+    -------
+    tuple[str, dict, dict]
+        (explanation_text, before_metrics, after_metrics)
+    """
+    before_metrics = _safe_evaluate(before[factor_names], generators_before)
+    after_metrics = _safe_evaluate(after[factor_names], generators_after)
+
+    lines: list[str] = []
+
+    # Run count
+    n_before = len(before)
+    n_after = len(after)
+    lines.append(f"Design grew from {n_before} to {n_after} runs (+{n_after - n_before} added).")
+
+    # D-efficiency
+    d_before = before_metrics.get("d_efficiency")
+    d_after = after_metrics.get("d_efficiency")
+    if d_before is not None and d_after is not None:
+        lines.append(f"D-efficiency: {d_before:.1f}% -> {d_after:.1f}%.")
+
+    # Resolution
+    res_before = before_metrics.get("resolution")
+    res_after = after_metrics.get("resolution")
+    if res_before is not None and res_after is not None:
+        if res_after > res_before:
+            lines.append(f"Resolution improved from {res_before} to {res_after}.")
+        elif res_after == res_before:
+            lines.append(f"Resolution unchanged at {res_before}.")
+
+    # Degrees of freedom
+    dof_before = before_metrics.get("degrees_of_freedom", {})
+    dof_after = after_metrics.get("degrees_of_freedom", {})
+    if "residual" in dof_before and "residual" in dof_after:
+        lines.append(
+            f"Residual degrees of freedom: {dof_before['residual']} -> {dof_after['residual']}."
+        )
+
+    # Alias diff
+    aliases_before = set(before_metrics.get("alias_structure", []))
+    aliases_after = set(after_metrics.get("alias_structure", []))
+    removed = aliases_before - aliases_after
+    if removed:
+        lines.append("De-aliased effects:")
+        for chain in sorted(removed):
+            effect = chain.split(" = ")[0].strip()
+            lines.append(f"  {effect} is now independently estimable.")
+
+    # Extra notes from the handler
+    if extra_notes:
+        lines.extend(extra_notes)
+
+    explanation = " ".join(lines) if not removed and not extra_notes else "\n".join(lines)
+    return explanation, before_metrics, after_metrics
+
+
+# ---------------------------------------------------------------------------
+# Augmentation handlers
+# ---------------------------------------------------------------------------
+
+
+def _augment_foldover(ctx: _AugmentContext) -> dict[str, Any]:
+    """Full foldover: negate all factor signs and append."""
+    df = ctx.existing_design[ctx.factor_names].copy()
+    folded = -df
+    augmented = pd.concat([df, folded], ignore_index=True)
+
+    # Compute new defining relation after foldover
+    notes: list[str] = []
+    generators_after = None
+    if ctx.generators:
+        words = _defining_relation_from_generators(ctx.generators, ctx.factor_names)
+        # After full foldover, odd-length words are eliminated (confounded with
+        # the block indicator).  Even-length words survive.
+        surviving = [w for w in words if len(w) % 2 == 0]
+        if surviving:
+            generators_after = [f"I={_word_to_str(w, ctx.factor_names)}" for w in surviving]
+            notes.append(f"New defining relation: {', '.join(generators_after)}.")
+        else:
+            notes.append("All defining words eliminated — design is now full resolution.")
+
+        eliminated = [w for w in words if len(w) % 2 != 0]
+        if eliminated:
+            eliminated_strs = [_word_to_str(w, ctx.factor_names) for w in eliminated]
+            notes.append(f"Eliminated defining words: {', '.join(eliminated_strs)}.")
+
+    explanation, before_m, after_m = _explain_changes(
+        ctx.existing_design, augmented, ctx.factor_names,
+        ctx.augmentation_type, ctx.generators, generators_after, notes,
+    )
+
+    return {
+        "augmented_design": augmented.to_dict(orient="records"),
+        "new_runs": folded.to_dict(orient="records"),
+        "n_runs_before": len(ctx.existing_design),
+        "n_runs_after": len(augmented),
+        "defining_relation": generators_after,
+        "explanation": explanation,
+        "before_metrics": before_m,
+        "after_metrics": after_m,
+    }
+
+
+def _augment_semifold(ctx: _AugmentContext) -> dict[str, Any]:
+    """Semifold: negate one factor in a selected half of runs."""
+    df = ctx.existing_design[ctx.factor_names].copy()
+
+    # Determine which factor to fold on
+    fold_factor = ctx.fold_on
+    if fold_factor is not None and fold_factor not in ctx.factor_names:
+        raise ValueError(
+            f"fold_on={fold_factor!r} not in factor names: {ctx.factor_names}"
+        )
+
+    if fold_factor is None:
+        fold_factor = _auto_select_fold_factor(ctx)
+
+    fold_idx = ctx.factor_names.index(fold_factor)
+
+    # Select runs where fold factor is -1, negate the fold factor
+    mask = df[fold_factor] == -1
+    fold_half = df[mask].copy()
+    fold_half[fold_factor] = -fold_half[fold_factor]  # negate fold factor
+    augmented = pd.concat([df, fold_half], ignore_index=True)
+
+    # Compute new defining relation after semifold
+    notes: list[str] = [f"Folded on factor: {fold_factor}."]
+    generators_after = None
+    if ctx.generators:
+        words = _defining_relation_from_generators(ctx.generators, ctx.factor_names)
+        # Semifold on factor F eliminates words that contain F
+        surviving = [w for w in words if fold_idx not in w]
+        eliminated = [w for w in words if fold_idx in w]
+        if surviving:
+            generators_after = [f"I={_word_to_str(w, ctx.factor_names)}" for w in surviving]
+            notes.append(f"Surviving defining words: {', '.join(generators_after)}.")
+        else:
+            notes.append("All defining words eliminated — design is now full resolution.")
+        if eliminated:
+            eliminated_strs = [_word_to_str(w, ctx.factor_names) for w in eliminated]
+            notes.append(f"De-aliased by removing words: {', '.join(eliminated_strs)}.")
+
+    explanation, before_m, after_m = _explain_changes(
+        ctx.existing_design, augmented, ctx.factor_names,
+        ctx.augmentation_type, ctx.generators, generators_after, notes,
+    )
+
+    return {
+        "augmented_design": augmented.to_dict(orient="records"),
+        "new_runs": fold_half.to_dict(orient="records"),
+        "n_runs_before": len(ctx.existing_design),
+        "n_runs_after": len(augmented),
+        "fold_on": fold_factor,
+        "defining_relation": generators_after,
+        "explanation": explanation,
+        "before_metrics": before_m,
+        "after_metrics": after_m,
+    }
+
+
+def _auto_select_fold_factor(ctx: _AugmentContext) -> str:
+    """Pick the factor whose semifold de-aliases the most short defining words.
+
+    For each candidate factor, count how many minimum-length words in the
+    defining relation contain that factor.  The factor that eliminates the
+    most short words is the best choice.
+    """
+    if not ctx.generators:
+        # No generators — just pick the first factor
+        return ctx.factor_names[0]
+
+    words = _defining_relation_from_generators(ctx.generators, ctx.factor_names)
+    if not words:
+        return ctx.factor_names[0]
+
+    min_len = min(len(w) for w in words)
+    short_words = [w for w in words if len(w) == min_len]
+
+    best_factor = ctx.factor_names[0]
+    best_count = 0
+    for i, name in enumerate(ctx.factor_names):
+        count = sum(1 for w in short_words if i in w)
+        if count > best_count:
+            best_count = count
+            best_factor = name
+
+    return best_factor
+
+
+def _augment_add_center_points(ctx: _AugmentContext) -> dict[str, Any]:
+    """Append center point rows (all zeros in coded units)."""
+    df = ctx.existing_design[ctx.factor_names].copy()
+    n_center = ctx.n_additional_runs if ctx.n_additional_runs is not None else 3
+
+    center_rows = pd.DataFrame(
+        np.zeros((n_center, len(ctx.factor_names))),
+        columns=ctx.factor_names,
+    )
+    augmented = pd.concat([df, center_rows], ignore_index=True)
+
+    notes = [
+        f"Added {n_center} center point(s) at the midpoint of all factors.",
+        "Center points enable testing for curvature (quadratic effects).",
+    ]
+    explanation, before_m, after_m = _explain_changes(
+        ctx.existing_design, augmented, ctx.factor_names,
+        ctx.augmentation_type, ctx.generators, ctx.generators, notes,
+    )
+
+    return {
+        "augmented_design": augmented.to_dict(orient="records"),
+        "new_runs": center_rows.to_dict(orient="records"),
+        "n_runs_before": len(ctx.existing_design),
+        "n_runs_after": len(augmented),
+        "explanation": explanation,
+        "before_metrics": before_m,
+        "after_metrics": after_m,
+    }
+
+
+def _augment_replicate(ctx: _AugmentContext) -> dict[str, Any]:
+    """Append one or more complete copies of the existing design."""
+    df = ctx.existing_design[ctx.factor_names].copy()
+    n_copies = ctx.n_additional_runs if ctx.n_additional_runs is not None else 1
+
+    replicated = pd.concat([df] * n_copies, ignore_index=True)
+    augmented = pd.concat([df, replicated], ignore_index=True)
+
+    notes = [
+        f"Added {n_copies} complete replicate(s) of the original {len(df)}-run design.",
+        "Replication provides pure error degrees of freedom for lack-of-fit testing.",
+    ]
+    explanation, before_m, after_m = _explain_changes(
+        ctx.existing_design, augmented, ctx.factor_names,
+        ctx.augmentation_type, ctx.generators, ctx.generators, notes,
+    )
+
+    return {
+        "augmented_design": augmented.to_dict(orient="records"),
+        "new_runs": replicated.to_dict(orient="records"),
+        "n_runs_before": len(ctx.existing_design),
+        "n_runs_after": len(augmented),
+        "explanation": explanation,
+        "before_metrics": before_m,
+        "after_metrics": after_m,
+    }
+
+
+def _augment_add_axial_points(ctx: _AugmentContext) -> dict[str, Any]:
+    """Add 2k axial (star) points to create a CCD structure."""
+    df = ctx.existing_design[ctx.factor_names].copy()
+    k = len(ctx.factor_names)
+
+    # Determine alpha value
+    alpha_value = _compute_alpha(df, ctx.factor_names, ctx.alpha)
+
+    # Generate 2k axial points
+    axial = np.zeros((2 * k, k))
+    for i in range(k):
+        axial[2 * i, i] = alpha_value
+        axial[2 * i + 1, i] = -alpha_value
+    axial_df = pd.DataFrame(axial, columns=ctx.factor_names)
+
+    augmented = pd.concat([df, axial_df], ignore_index=True)
+
+    notes = [
+        f"Added {2 * k} axial (star) points with alpha = {alpha_value:.4f}.",
+        "The design now supports estimation of quadratic (second-order) effects.",
+        "Consider adding center points if not already present.",
+    ]
+    explanation, before_m, after_m = _explain_changes(
+        ctx.existing_design, augmented, ctx.factor_names,
+        ctx.augmentation_type, ctx.generators, ctx.generators, notes,
+    )
+
+    return {
+        "augmented_design": augmented.to_dict(orient="records"),
+        "new_runs": axial_df.to_dict(orient="records"),
+        "n_runs_before": len(ctx.existing_design),
+        "n_runs_after": len(augmented),
+        "alpha": float(alpha_value),
+        "explanation": explanation,
+        "before_metrics": before_m,
+        "after_metrics": after_m,
+    }
+
+
+def _compute_alpha(
+    design: pd.DataFrame,
+    factor_names: list[str],
+    alpha: str | float | None,
+) -> float:
+    """Compute the axial distance alpha.
+
+    Parameters
+    ----------
+    design : DataFrame
+        Existing design matrix.
+    factor_names : list[str]
+        Factor column names.
+    alpha : str, float, or None
+        ``"rotatable"``, ``"face_centered"``, ``"orthogonal"``, or numeric.
+    """
+    if isinstance(alpha, (int, float)):
+        return float(alpha)
+
+    # Count factorial points (non-center rows)
+    center_mask = (design[factor_names].abs() < 1e-10).all(axis=1)
+    n_factorial = int((~center_mask).sum())
+    k = len(factor_names)
+
+    if alpha is None or alpha == "rotatable":
+        # Rotatable: alpha = n_factorial^(1/4)
+        return float(n_factorial ** 0.25)
+    elif alpha == "face_centered":
+        return 1.0
+    elif alpha == "orthogonal":
+        # Orthogonal block alpha for CCD
+        n_axial = 2 * k
+        n_total = n_factorial + n_axial
+        return float(np.sqrt(k * (np.sqrt(n_total) - np.sqrt(n_factorial)) / 2))
+    else:
+        raise ValueError(f"Unknown alpha type: {alpha!r}. Use 'rotatable', 'face_centered', 'orthogonal', or numeric.")
+
+
+def _build_model_rhs(factor_names: list[str], model: str) -> str:
+    """Build a patsy right-hand-side formula string for the given model type."""
+    joined = " + ".join(factor_names)
+    if model == "main_effects":
+        return joined
+    if model == "interactions":
+        return f"({joined}) ** 2"
+    if model == "quadratic":
+        squared = " + ".join(f"I({f} ** 2)" for f in factor_names)
+        return f"({joined}) ** 2 + {squared}"
+    return model
+
+
+def _greedy_d_optimal_select(
+    current: pd.DataFrame,
+    candidates: pd.DataFrame,
+    n_to_add: int,
+    factor_names: list[str],
+    model: str,
+) -> tuple[pd.DataFrame, list[pd.DataFrame]]:
+    """Greedily select *n_to_add* D-optimal points from *candidates*."""
+    rhs = _build_model_rhs(factor_names, model)
+    new_rows: list[pd.DataFrame] = []
+
+    for _ in range(min(n_to_add, len(candidates))):
+        best_idx = -1
+        best_det = -np.inf
+
+        for idx in candidates.index:
+            trial = pd.concat([current, candidates.iloc[[idx]]], ignore_index=True)
+            X_trial = np.asarray(dmatrix(rhs, trial, return_type="dataframe"), dtype=float)
+            sign, logdet = np.linalg.slogdet(X_trial.T @ X_trial)
+            det_val = logdet if sign > 0 else -np.inf
+            if det_val > best_det:
+                best_det = det_val
+                best_idx = idx
+
+        if best_idx < 0:
+            break
+
+        new_row = candidates.loc[[best_idx]]
+        current = pd.concat([current, new_row], ignore_index=True)
+        new_rows.append(new_row)
+        candidates = candidates.drop(best_idx).reset_index(drop=True)
+
+    return current, new_rows
+
+
+def _augment_add_runs_optimal(ctx: _AugmentContext) -> dict[str, Any]:
+    """Add D-optimal runs to the existing design."""
+    if ctx.n_additional_runs is None:
+        raise ValueError("n_additional_runs is required for add_runs_optimal.")
+
+    df = ctx.existing_design[ctx.factor_names].copy()
+    k = len(ctx.factor_names)
+    model = ctx.target_model or "interactions"
+
+    # Generate candidate set: 3-level full factorial (-1, 0, +1)
+    candidates_raw = fullfact([3] * k) - 1.0
+    candidates = pd.DataFrame(candidates_raw, columns=ctx.factor_names)
+
+    # Remove candidates that are already in the design (within tolerance)
+    existing_tuples = set(map(tuple, np.round(df.values, 8)))
+    mask = ~candidates.apply(lambda row: tuple(np.round(row.values, 8)) in existing_tuples, axis=1)
+    candidates = candidates[mask].reset_index(drop=True)
+
+    if len(candidates) == 0:
+        raise ValueError("No candidate points available after filtering existing design points.")
+
+    augmented, new_rows = _greedy_d_optimal_select(
+        df, candidates, ctx.n_additional_runs, ctx.factor_names, model,
+    )
+    new_runs_df = pd.concat(new_rows, ignore_index=True) if new_rows else pd.DataFrame(columns=ctx.factor_names)
+    notes = [
+        f"Added {len(new_rows)} D-optimal run(s) to maximize information for the {model} model.",
+        "Existing runs were preserved; only new runs were optimized.",
+    ]
+    explanation, before_m, after_m = _explain_changes(
+        ctx.existing_design, augmented, ctx.factor_names,
+        ctx.augmentation_type, ctx.generators, ctx.generators, notes,
+    )
+
+    return {
+        "augmented_design": augmented.to_dict(orient="records"),
+        "new_runs": new_runs_df.to_dict(orient="records"),
+        "n_runs_before": len(ctx.existing_design),
+        "n_runs_after": len(augmented),
+        "explanation": explanation,
+        "before_metrics": before_m,
+        "after_metrics": after_m,
+    }
+
+
+def _augment_upgrade_to_rsm(ctx: _AugmentContext) -> dict[str, Any]:
+    """Upgrade a screening/factorial design to an RSM (CCD) design."""
+    df = ctx.existing_design[ctx.factor_names].copy()
+    k = len(ctx.factor_names)
+
+    # Detect existing center points
+    center_mask = (df.abs() < 1e-10).all(axis=1)
+    n_existing_centers = int(center_mask.sum())
+
+    # Add axial points
+    alpha_val = ctx.alpha if ctx.alpha is not None else "rotatable"
+    alpha_numeric = _compute_alpha(df, ctx.factor_names, alpha_val)
+
+    axial = np.zeros((2 * k, k))
+    for i in range(k):
+        axial[2 * i, i] = alpha_numeric
+        axial[2 * i + 1, i] = -alpha_numeric
+    axial_df = pd.DataFrame(axial, columns=ctx.factor_names)
+
+    # Add center points if needed (target 3-5 total)
+    n_target_centers = max(3, 5 - n_existing_centers)
+    n_new_centers = max(0, n_target_centers - n_existing_centers)
+    center_df = pd.DataFrame(
+        np.zeros((n_new_centers, k)), columns=ctx.factor_names,
+    )
+
+    new_runs = pd.concat([axial_df, center_df], ignore_index=True)
+    augmented = pd.concat([df, new_runs], ignore_index=True)
+
+    notes = [
+        f"Upgraded to Central Composite Design (CCD) with alpha = {alpha_numeric:.4f}.",
+        f"Added {2 * k} axial points and {n_new_centers} center point(s).",
+        "The design now supports estimation of a full quadratic (second-order) model.",
+    ]
+    if n_existing_centers > 0:
+        notes.append(f"Existing {n_existing_centers} center point(s) were preserved.")
+
+    explanation, before_m, after_m = _explain_changes(
+        ctx.existing_design, augmented, ctx.factor_names,
+        ctx.augmentation_type, ctx.generators, ctx.generators, notes,
+    )
+
+    return {
+        "augmented_design": augmented.to_dict(orient="records"),
+        "new_runs": new_runs.to_dict(orient="records"),
+        "n_runs_before": len(ctx.existing_design),
+        "n_runs_after": len(augmented),
+        "alpha": float(alpha_numeric),
+        "explanation": explanation,
+        "before_metrics": before_m,
+        "after_metrics": after_m,
+    }
+
+
+def _augment_add_blocks(ctx: _AugmentContext) -> dict[str, Any]:
+    """Retroactively assign blocks by confounding with high-order interactions."""
+    df = ctx.existing_design[ctx.factor_names].copy()
+    n_blocks = ctx.n_additional_runs if ctx.n_additional_runs is not None else 2
+    k = len(ctx.factor_names)
+
+    if n_blocks < 2:
+        raise ValueError("Number of blocks must be at least 2.")
+
+    # Determine how many confounding columns needed: 2^b blocks requires b columns
+    b = int(np.ceil(np.log2(n_blocks)))
+    n_blocks_actual = 2 ** b  # round up to power of 2
+
+    # Choose the highest-order interactions for confounding
+    # Generate all interactions from order k down to order 2
+    confounding_columns: list[tuple[str, np.ndarray]] = []
+    for order in range(k, 1, -1):
+        for combo in itertools.combinations(range(k), order):
+            if len(confounding_columns) >= b:
+                break
+            col_product = np.ones(len(df))
+            for idx in combo:
+                col_product *= df.iloc[:, idx].values
+            word = "".join(ctx.factor_names[i] for i in combo)
+            confounding_columns.append((word, col_product))
+        if len(confounding_columns) >= b:
+            break
+
+    if len(confounding_columns) < b:
+        raise ValueError(
+            f"Cannot create {n_blocks_actual} blocks with {k} factors. "
+            f"Need {b} confounding columns but only found {len(confounding_columns)}."
+        )
+
+    # Assign blocks using signs of confounding columns
+    block_assignment = np.zeros(len(df), dtype=int)
+    for i, (_word, col) in enumerate(confounding_columns[:b]):
+        block_assignment += (col > 0).astype(int) * (2 ** i)
+    block_assignment += 1  # 1-based
+
+    augmented = df.copy()
+    augmented["Block"] = block_assignment.tolist()
+
+    confounded_words = [word for word, _ in confounding_columns[:b]]
+    notes = [
+        f"Assigned {n_blocks_actual} blocks by confounding with: {', '.join(confounded_words)}.",
+        f"Block effect is aliased with the {', '.join(confounded_words)} interaction(s).",
+        "Block effects should be orthogonal to main effects and low-order interactions.",
+    ]
+    explanation = "\n".join(notes)
+
+    return {
+        "augmented_design": augmented.to_dict(orient="records"),
+        "new_runs": [],
+        "n_runs_before": len(ctx.existing_design),
+        "n_runs_after": len(augmented),
+        "n_blocks": n_blocks_actual,
+        "confounded_with": confounded_words,
+        "explanation": explanation,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Augmentation dispatch registry
+# ---------------------------------------------------------------------------
+
+_AUGMENT_REGISTRY: dict[str, Callable[[_AugmentContext], dict[str, Any]]] = {
+    "foldover": _augment_foldover,
+    "semifold": _augment_semifold,
+    "add_center_points": _augment_add_center_points,
+    "add_axial_points": _augment_add_axial_points,
+    "add_runs_optimal": _augment_add_runs_optimal,
+    "upgrade_to_rsm": _augment_upgrade_to_rsm,
+    "add_blocks": _augment_add_blocks,
+    "replicate": _augment_replicate,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def augment_design(  # noqa: PLR0913
+    existing_design: pd.DataFrame,
+    augmentation_type: str,
+    target_model: str | None = None,
+    n_additional_runs: int | None = None,
+    fold_on: str | None = None,
+    alpha: str | float | None = None,
+    generators: list[str] | None = None,
+) -> dict[str, Any]:
+    """Extend or modify an existing experimental design.
+
+    Parameters
+    ----------
+    existing_design : DataFrame
+        The current design matrix with factor columns in coded units (-1/+1).
+    augmentation_type : str
+        One of ``"foldover"``, ``"semifold"``, ``"add_center_points"``,
+        ``"add_axial_points"``, ``"add_runs_optimal"``, ``"upgrade_to_rsm"``,
+        ``"add_blocks"``, ``"replicate"``.
+    target_model : str or None
+        Desired model after augmentation: ``"main_effects"``,
+        ``"interactions"``, ``"quadratic"``.  Used by ``"add_runs_optimal"``
+        and ``"upgrade_to_rsm"``.
+    n_additional_runs : int or None
+        Budget for additional runs.  Interpretation depends on the
+        augmentation type (number of center points, number of D-optimal
+        runs, number of replicates, or number of blocks).
+    fold_on : str or None
+        For ``"semifold"`` only: which factor to fold on.  If ``None``,
+        the best factor is auto-selected.
+    alpha : str, float, or None
+        Axial distance for ``"add_axial_points"`` and ``"upgrade_to_rsm"``.
+        String values: ``"rotatable"``, ``"face_centered"``,
+        ``"orthogonal"``.  Or a numeric value.
+    generators : list[str] or None
+        Generator strings from the original design (e.g. ``["D=ABC"]``).
+        Needed for meaningful alias analysis in foldover/semifold.
+
+    Returns
+    -------
+    dict[str, Any]
+        Keys include ``"augmented_design"`` (list of dicts),
+        ``"new_runs"`` (list of dicts), ``"n_runs_before"``,
+        ``"n_runs_after"``, ``"explanation"`` (narrative),
+        ``"before_metrics"``, ``"after_metrics"``, and
+        augmentation-specific keys.
+
+    Raises
+    ------
+    ValueError
+        If *augmentation_type* is unknown, or if required parameters
+        are missing for the requested augmentation.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from process_improve.experiments.augment import augment_design
+    >>> design = pd.DataFrame({
+    ...     "A": [-1, 1, -1, 1, -1, 1, -1, 1],
+    ...     "B": [-1, -1, 1, 1, -1, -1, 1, 1],
+    ...     "C": [-1, -1, -1, -1, 1, 1, 1, 1],
+    ... })
+    >>> result = augment_design(design, "add_center_points", n_additional_runs=3)
+    >>> result["n_runs_after"]
+    11
+    """
+    if augmentation_type not in _AUGMENT_REGISTRY:
+        available = sorted(_AUGMENT_REGISTRY.keys())
+        raise ValueError(
+            f"Unknown augmentation_type={augmentation_type!r}. "
+            f"Choose from: {', '.join(available)}."
+        )
+
+    factor_names = [c for c in existing_design.columns if c not in ("RunOrder", "Block")]
+
+    ctx = _AugmentContext(
+        existing_design=existing_design,
+        factor_names=factor_names,
+        augmentation_type=augmentation_type,
+        target_model=target_model,
+        n_additional_runs=n_additional_runs,
+        fold_on=fold_on,
+        alpha=alpha,
+        generators=generators,
+    )
+
+    handler = _AUGMENT_REGISTRY[augmentation_type]
+    return handler(ctx)

--- a/process_improve/experiments/tools.py
+++ b/process_improve/experiments/tools.py
@@ -854,6 +854,149 @@ def optimize_responses_tool(  # noqa: PLR0913
 _register("optimize_responses")
 
 
+@tool_spec(
+    name="augment_design",
+    description=(
+        "Extend or modify an existing experimental design. Supports foldover (de-alias all "
+        "2-factor interactions), semifold (de-alias specific interactions with fewer runs), "
+        "adding center points (test for curvature), adding axial/star points (upgrade to CCD "
+        "for response surface modeling), D-optimal augmentation (add runs to maximize information), "
+        "upgrade to RSM (convert screening design to response surface design), add blocks "
+        "(retroactively confound block effects with high-order interactions), and replication "
+        "(improve precision estimates). "
+        "Always returns the augmented design matrix plus an explanation of what changed in the "
+        "alias structure and design properties."
+    ),
+    input_schema={
+        "json": {
+            "type": "object",
+            "properties": {
+                "existing_design": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": {"type": "number"},
+                    },
+                    "description": (
+                        "Current design matrix as list of dicts with factor names as keys "
+                        "and coded values (-1/+1) as values. "
+                        "Example: [{'A': -1, 'B': -1}, {'A': 1, 'B': -1}, ...]"
+                    ),
+                    "minItems": 2,
+                },
+                "augmentation_type": {
+                    "type": "string",
+                    "enum": [
+                        "foldover",
+                        "semifold",
+                        "add_center_points",
+                        "add_axial_points",
+                        "add_runs_optimal",
+                        "upgrade_to_rsm",
+                        "add_blocks",
+                        "replicate",
+                    ],
+                    "description": "Type of augmentation to apply to the design.",
+                },
+                "target_model": {
+                    "type": "string",
+                    "enum": ["main_effects", "interactions", "quadratic"],
+                    "description": (
+                        "Desired model after augmentation. Used by 'add_runs_optimal' "
+                        "and 'upgrade_to_rsm'. Default: 'interactions'."
+                    ),
+                },
+                "n_additional_runs": {
+                    "type": "integer",
+                    "description": (
+                        "Budget for additional runs. Interpretation depends on type: "
+                        "number of center points, D-optimal runs, replicates, or blocks."
+                    ),
+                    "minimum": 1,
+                },
+                "fold_on": {
+                    "type": "string",
+                    "description": (
+                        "Factor name to fold on (semifold only). "
+                        "If omitted, the best factor is auto-selected."
+                    ),
+                },
+                "alpha": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "enum": ["rotatable", "face_centered", "orthogonal"],
+                        },
+                        {"type": "number"},
+                    ],
+                    "description": (
+                        "Axial distance for add_axial_points or upgrade_to_rsm. "
+                        "'rotatable', 'face_centered', 'orthogonal', or a numeric value."
+                    ),
+                },
+                "generators": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Generator strings from the original fractional factorial design "
+                        "(e.g. ['D=ABC']). Needed for foldover/semifold alias analysis."
+                    ),
+                },
+            },
+            "required": ["existing_design", "augmentation_type"],
+        }
+    },
+    examples="""
+    # "Fold over my 2^(4-1) design to de-alias two-factor interactions"
+        -> ``augment_design(existing_design=[...], augmentation_type="foldover",
+                generators=["D=ABC"])``
+
+    # "Add 5 center points to test for curvature"
+        -> ``augment_design(existing_design=[...], augmentation_type="add_center_points",
+                n_additional_runs=5)``
+
+    # "Upgrade my screening design to a CCD for response surface modeling"
+        -> ``augment_design(existing_design=[...], augmentation_type="upgrade_to_rsm",
+                alpha="rotatable", target_model="quadratic")``
+
+    # "Add 6 D-optimal runs to improve my design"
+        -> ``augment_design(existing_design=[...], augmentation_type="add_runs_optimal",
+                n_additional_runs=6, target_model="interactions")``
+    """,
+    category="experiments",
+)
+def augment_design_tool(  # noqa: PLR0913
+    *,
+    existing_design: list[dict[str, Any]],
+    augmentation_type: str,
+    target_model: str | None = None,
+    n_additional_runs: int | None = None,
+    fold_on: str | None = None,
+    alpha: str | float | None = None,
+    generators: list[str] | None = None,
+) -> dict[str, Any]:
+    """Augment an existing design; see tool spec for details."""
+    try:
+        from process_improve.experiments.augment import augment_design  # noqa: PLC0415
+
+        df = pd.DataFrame(existing_design)
+        result = augment_design(
+            existing_design=df,
+            augmentation_type=augmentation_type,
+            target_model=target_model,
+            n_additional_runs=n_additional_runs,
+            fold_on=fold_on,
+            alpha=alpha,
+            generators=generators,
+        )
+        return clean(result)
+    except Exception as e:  # noqa: BLE001
+        return {"error": str(e)}
+
+
+_register("augment_design")
+
+
 # ---------------------------------------------------------------------------
 # Module-level convenience
 # ---------------------------------------------------------------------------

--- a/tests/test_augment_design.py
+++ b/tests/test_augment_design.py
@@ -362,3 +362,96 @@ class TestUpgradeToRSM:
         df = _full_factorial_df(2)
         result = augment_design(df, "upgrade_to_rsm")
         assert "central composite" in result["explanation"].lower() or "ccd" in result["explanation"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Add runs optimal
+# ---------------------------------------------------------------------------
+
+
+class TestAddRunsOptimal:
+    """Test add_runs_optimal augmentation."""
+
+    def test_adds_correct_number(self) -> None:
+        """Should add the requested number of runs."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "add_runs_optimal", n_additional_runs=3)
+        assert result["n_runs_after"] == 7
+
+    def test_requires_n_additional_runs(self) -> None:
+        """Missing n_additional_runs should raise ValueError."""
+        df = _full_factorial_df(2)
+        with pytest.raises(ValueError, match="n_additional_runs"):
+            augment_design(df, "add_runs_optimal")
+
+    def test_existing_runs_preserved(self) -> None:
+        """Original design rows should appear in the augmented design."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "add_runs_optimal", n_additional_runs=2)
+        aug = pd.DataFrame(result["augmented_design"])
+        # Check that all original rows are present
+        for _, orig_row in df.iterrows():
+            found = False
+            for _, aug_row in aug.iterrows():
+                if all(abs(orig_row[c] - aug_row[c]) < 1e-8 for c in df.columns):
+                    found = True
+                    break
+            assert found, f"Original row {orig_row.to_dict()} not in augmented design"
+
+    def test_augmented_design_not_singular(self) -> None:
+        """Adding D-optimal runs should produce a non-singular design for target model."""
+        # Start with a main-effects-only design (too few runs for interactions)
+        df = pd.DataFrame({"A": [-1, 1, -1], "B": [-1, -1, 1]})
+        result = augment_design(
+            df, "add_runs_optimal", n_additional_runs=3, target_model="interactions",
+        )
+        aug = pd.DataFrame(result["augmented_design"])
+        d_after = evaluate_design(aug, model="interactions", metric="d_efficiency")["d_efficiency"]
+        assert d_after is not None
+        assert d_after > 0
+
+
+# ---------------------------------------------------------------------------
+# Add blocks
+# ---------------------------------------------------------------------------
+
+
+class TestAddBlocks:
+    """Test add_blocks augmentation."""
+
+    def test_two_blocks(self) -> None:
+        """Default should assign 2 blocks."""
+        df = _full_factorial_df(3)
+        result = augment_design(df, "add_blocks")
+        aug = pd.DataFrame(result["augmented_design"])
+        assert "Block" in aug.columns
+        assert set(aug["Block"].unique()) == {1, 2}
+
+    def test_balanced_block_sizes(self) -> None:
+        """Blocks should have equal sizes for a 2^k design split into 2."""
+        df = _full_factorial_df(3)
+        result = augment_design(df, "add_blocks")
+        aug = pd.DataFrame(result["augmented_design"])
+        block_sizes = aug["Block"].value_counts()
+        assert block_sizes.max() == block_sizes.min()
+
+    def test_confounded_interaction_reported(self) -> None:
+        """Explanation should report which interaction is confounded."""
+        df = _full_factorial_df(3)
+        result = augment_design(df, "add_blocks")
+        assert "confounded_with" in result
+        assert len(result["confounded_with"]) > 0
+
+    def test_invalid_n_blocks_raises(self) -> None:
+        """Number of blocks < 2 should raise ValueError."""
+        df = _full_factorial_df(3)
+        with pytest.raises(ValueError, match="at least 2"):
+            augment_design(df, "add_blocks", n_additional_runs=1)
+
+    def test_four_blocks(self) -> None:
+        """4 blocks should use 2 confounding columns."""
+        df = _full_factorial_df(4)  # 16 runs
+        result = augment_design(df, "add_blocks", n_additional_runs=4)
+        aug = pd.DataFrame(result["augmented_design"])
+        assert len(aug["Block"].unique()) == 4
+        assert len(result["confounded_with"]) == 2

--- a/tests/test_augment_design.py
+++ b/tests/test_augment_design.py
@@ -1,0 +1,82 @@
+"""Tests for the augment_design() design augmentation API."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from process_improve.experiments.augment import (
+    _AUGMENT_REGISTRY,
+    _auto_select_fold_factor,
+    _AugmentContext,
+    _compute_alpha,
+    augment_design,
+)
+from process_improve.experiments.designs import generate_design
+from process_improve.experiments.evaluate import evaluate_design
+from process_improve.experiments.factor import Factor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _full_factorial_df(k: int, names: str = "ABCDEFGHIJ") -> pd.DataFrame:
+    """Create a 2^k full factorial design as a DataFrame of -1/+1 coded values."""
+    n = 2**k
+    cols = {}
+    for i in range(k):
+        cols[names[i]] = [1 if (j >> (k - 1 - i)) & 1 else -1 for j in range(n)]
+    return pd.DataFrame(cols)
+
+
+def _fractional_factorial_df(
+    generators: list[str], names: str = "ABCDEFGHIJ",
+) -> pd.DataFrame:
+    """Create a fractional factorial design from generator strings.
+
+    Example: generators=["D=ABC"] with names "ABCD" gives a 2^(4-1) design.
+    """
+    factors = [Factor(name=names[i], low=0, high=10) for i in range(len(names))]
+    result = generate_design(
+        factors[:len(names)],
+        design_type="fractional_factorial",
+        generators=generators,
+        center_points=0,
+    )
+    # Extract coded design without RunOrder
+    df = pd.DataFrame(result.design)
+    return df.drop(columns=["RunOrder"], errors="ignore")
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcher:
+    """Test the augment_design dispatcher."""
+
+    def test_unknown_type_raises(self) -> None:
+        """Unknown augmentation_type raises ValueError."""
+        df = _full_factorial_df(2)
+        with pytest.raises(ValueError, match="Unknown augmentation_type"):
+            augment_design(df, augmentation_type="nonexistent")
+
+    def test_all_types_in_registry(self) -> None:
+        """All 8 augmentation types are registered."""
+        expected = {
+            "foldover", "semifold", "add_center_points", "add_axial_points",
+            "add_runs_optimal", "upgrade_to_rsm", "add_blocks", "replicate",
+        }
+        assert set(_AUGMENT_REGISTRY.keys()) == expected
+
+    def test_drops_runorder_column(self) -> None:
+        """RunOrder column should be ignored as a factor."""
+        df = _full_factorial_df(2)
+        df.insert(0, "RunOrder", range(1, len(df) + 1))
+        result = augment_design(df, "add_center_points", n_additional_runs=1)
+        aug = pd.DataFrame(result["augmented_design"])
+        assert "RunOrder" not in aug.columns
+        assert set(aug.columns) == {"A", "B"}

--- a/tests/test_augment_design.py
+++ b/tests/test_augment_design.py
@@ -8,8 +8,8 @@ import pytest
 
 from process_improve.experiments.augment import (
     _AUGMENT_REGISTRY,
-    _auto_select_fold_factor,
     _AugmentContext,
+    _auto_select_fold_factor,
     _compute_alpha,
     augment_design,
 )
@@ -271,7 +271,7 @@ class TestAddAxialPoints:
     """Test add_axial_points augmentation."""
 
     def test_adds_2k_points(self) -> None:
-        """k factors -> 2k axial points added."""
+        """Adding axial points produces 2k new rows for k factors."""
         df = _full_factorial_df(3)
         result = augment_design(df, "add_axial_points", alpha="face_centered")
         assert result["n_runs_after"] == 8 + 6  # 3 factors * 2
@@ -574,7 +574,7 @@ class TestToolSpec:
 
     def test_basic_round_trip(self) -> None:
         """Tool wrapper returns JSON-serializable output."""
-        from process_improve.experiments.tools import augment_design_tool
+        from process_improve.experiments.tools import augment_design_tool  # noqa: PLC0415
 
         result = augment_design_tool(
             existing_design=[
@@ -592,7 +592,7 @@ class TestToolSpec:
 
     def test_foldover_via_tool(self) -> None:
         """Foldover works through the tool wrapper."""
-        from process_improve.experiments.tools import augment_design_tool
+        from process_improve.experiments.tools import augment_design_tool  # noqa: PLC0415
 
         result = augment_design_tool(
             existing_design=[
@@ -608,7 +608,7 @@ class TestToolSpec:
 
     def test_error_handling(self) -> None:
         """Bad augmentation_type returns error dict."""
-        from process_improve.experiments.tools import augment_design_tool
+        from process_improve.experiments.tools import augment_design_tool  # noqa: PLC0415
 
         result = augment_design_tool(
             existing_design=[{"A": -1}, {"A": 1}],

--- a/tests/test_augment_design.py
+++ b/tests/test_augment_design.py
@@ -260,3 +260,105 @@ class TestSemifold:
         assert "explanation" in result
         # Should mention fold factor
         assert "A" in result["explanation"]
+
+
+# ---------------------------------------------------------------------------
+# Add axial points
+# ---------------------------------------------------------------------------
+
+
+class TestAddAxialPoints:
+    """Test add_axial_points augmentation."""
+
+    def test_adds_2k_points(self) -> None:
+        """k factors -> 2k axial points added."""
+        df = _full_factorial_df(3)
+        result = augment_design(df, "add_axial_points", alpha="face_centered")
+        assert result["n_runs_after"] == 8 + 6  # 3 factors * 2
+
+    def test_face_centered_alpha(self) -> None:
+        """Face-centered alpha should be 1.0."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "add_axial_points", alpha="face_centered")
+        assert result["alpha"] == pytest.approx(1.0)
+
+    def test_rotatable_alpha(self) -> None:
+        """Rotatable alpha should be n_factorial^(1/4)."""
+        df = _full_factorial_df(3)  # 8 factorial runs
+        result = augment_design(df, "add_axial_points", alpha="rotatable")
+        expected = 8 ** 0.25  # ~1.6818
+        assert result["alpha"] == pytest.approx(expected, abs=0.01)
+
+    def test_numeric_alpha(self) -> None:
+        """Numeric alpha is used directly."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "add_axial_points", alpha=1.5)
+        assert result["alpha"] == pytest.approx(1.5)
+
+    def test_axial_point_structure(self) -> None:
+        """Each axial point should have exactly one non-zero factor at +/-alpha."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "add_axial_points", alpha="face_centered")
+        new_runs = pd.DataFrame(result["new_runs"])
+        for _, row in new_runs.iterrows():
+            nonzero = (row.abs() > 1e-10).sum()
+            assert nonzero == 1, f"Axial point should have exactly 1 nonzero: {row.to_dict()}"
+
+    def test_explanation_mentions_quadratic(self) -> None:
+        """Explanation should mention quadratic effects."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "add_axial_points", alpha="face_centered")
+        assert "quadratic" in result["explanation"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Upgrade to RSM
+# ---------------------------------------------------------------------------
+
+
+class TestUpgradeToRSM:
+    """Test upgrade_to_rsm augmentation."""
+
+    def test_factorial_to_ccd(self) -> None:
+        """2^3 factorial should gain axial + center points."""
+        df = _full_factorial_df(3)
+        result = augment_design(df, "upgrade_to_rsm")
+        # 8 factorial + 6 axial + some center points
+        assert result["n_runs_after"] > 14
+
+    def test_quadratic_model_estimable(self) -> None:
+        """After RSM upgrade, quadratic model should be estimable."""
+        df = _full_factorial_df(3)
+        result = augment_design(df, "upgrade_to_rsm", alpha="face_centered")
+        aug = pd.DataFrame(result["augmented_design"])
+        # Should be able to evaluate with quadratic model without singularity
+        metrics = evaluate_design(aug, model="quadratic", metric="d_efficiency")
+        assert metrics["d_efficiency"] is not None
+        assert metrics["d_efficiency"] > 0
+
+    def test_alpha_parameter_passed(self) -> None:
+        """Alpha parameter should be reflected in result."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "upgrade_to_rsm", alpha="face_centered")
+        assert result["alpha"] == pytest.approx(1.0)
+
+    def test_preserves_existing_center_points(self) -> None:
+        """Existing center points should be preserved, not duplicated excessively."""
+        df = _full_factorial_df(2)
+        # Add 3 center points first
+        center = pd.DataFrame({"A": [0.0, 0.0, 0.0], "B": [0.0, 0.0, 0.0]})
+        df_with_centers = pd.concat([df, center], ignore_index=True)
+        result = augment_design(df_with_centers, "upgrade_to_rsm", alpha="face_centered")
+        aug = pd.DataFrame(result["augmented_design"])
+        # Count center points in augmented design
+        center_mask = (aug.abs() < 1e-10).all(axis=1)
+        n_centers = center_mask.sum()
+        # Should have original 3 + some new, but not an unreasonable number
+        assert n_centers >= 3
+        assert n_centers <= 8
+
+    def test_explanation_mentions_ccd(self) -> None:
+        """Explanation should mention CCD or Central Composite."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "upgrade_to_rsm")
+        assert "central composite" in result["explanation"].lower() or "ccd" in result["explanation"].lower()

--- a/tests/test_augment_design.py
+++ b/tests/test_augment_design.py
@@ -455,3 +455,209 @@ class TestAddBlocks:
         aug = pd.DataFrame(result["augmented_design"])
         assert len(aug["Block"].unique()) == 4
         assert len(result["confounded_with"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Explainer
+# ---------------------------------------------------------------------------
+
+
+class TestExplainer:
+    """Test the 'what changed' explanation output."""
+
+    def test_before_after_metrics_present(self) -> None:
+        """Result should include before_metrics and after_metrics."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "add_center_points", n_additional_runs=3)
+        assert "before_metrics" in result
+        assert "after_metrics" in result
+
+    def test_explanation_nonempty(self) -> None:
+        """Explanation should never be empty for any augmentation type."""
+        df = _full_factorial_df(3)
+        for aug_type in ["add_center_points", "replicate", "foldover", "add_axial_points"]:
+            kwargs = {}
+            if aug_type == "add_axial_points":
+                kwargs["alpha"] = "face_centered"
+            result = augment_design(df, aug_type, **kwargs)
+            assert len(result["explanation"]) > 0, f"Explanation empty for {aug_type}"
+
+    def test_run_count_in_explanation(self) -> None:
+        """Explanation should mention the run count change."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "replicate")
+        assert "4" in result["explanation"]
+        assert "8" in result["explanation"]
+
+
+# ---------------------------------------------------------------------------
+# Alpha computation
+# ---------------------------------------------------------------------------
+
+
+class TestAlphaComputation:
+    """Test the _compute_alpha helper."""
+
+    def test_numeric_passthrough(self) -> None:
+        """Numeric alpha is returned as-is."""
+        df = _full_factorial_df(2)
+        assert _compute_alpha(df, ["A", "B"], 2.0) == pytest.approx(2.0)
+
+    def test_face_centered(self) -> None:
+        """Face-centered alpha is 1.0."""
+        df = _full_factorial_df(2)
+        assert _compute_alpha(df, ["A", "B"], "face_centered") == pytest.approx(1.0)
+
+    def test_rotatable_with_center_points(self) -> None:
+        """Rotatable alpha should exclude center points from factorial count."""
+        df = _full_factorial_df(2)
+        center = pd.DataFrame({"A": [0.0, 0.0], "B": [0.0, 0.0]})
+        df_with_centers = pd.concat([df, center], ignore_index=True)
+        # Should still use n_factorial=4, not 6
+        alpha = _compute_alpha(df_with_centers, ["A", "B"], "rotatable")
+        expected = 4 ** 0.25  # ~1.414
+        assert alpha == pytest.approx(expected, abs=0.01)
+
+    def test_unknown_alpha_raises(self) -> None:
+        """Unknown alpha string should raise ValueError."""
+        df = _full_factorial_df(2)
+        with pytest.raises(ValueError, match="Unknown alpha"):
+            _compute_alpha(df, ["A", "B"], "invalid_alpha")
+
+
+# ---------------------------------------------------------------------------
+# Auto fold-factor selection
+# ---------------------------------------------------------------------------
+
+
+class TestAutoSelectFoldFactor:
+    """Test the _auto_select_fold_factor helper."""
+
+    def test_selects_factor_in_short_words(self) -> None:
+        """Should select a factor that appears in the shortest defining words."""
+        ctx = _AugmentContext(
+            existing_design=pd.DataFrame(),
+            factor_names=["A", "B", "C"],
+            augmentation_type="semifold",
+            target_model=None,
+            n_additional_runs=None,
+            fold_on=None,
+            alpha=None,
+            generators=["C=AB"],  # I=ABC (length 3)
+        )
+        result = _auto_select_fold_factor(ctx)
+        # All factors appear in ABC, so any is valid
+        assert result in ["A", "B", "C"]
+
+    def test_no_generators_returns_first(self) -> None:
+        """Without generators, returns the first factor."""
+        ctx = _AugmentContext(
+            existing_design=pd.DataFrame(),
+            factor_names=["X", "Y", "Z"],
+            augmentation_type="semifold",
+            target_model=None,
+            n_additional_runs=None,
+            fold_on=None,
+            alpha=None,
+            generators=None,
+        )
+        assert _auto_select_fold_factor(ctx) == "X"
+
+
+# ---------------------------------------------------------------------------
+# Tool spec wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestToolSpec:
+    """Test the LLM tool spec wrapper."""
+
+    def test_basic_round_trip(self) -> None:
+        """Tool wrapper returns JSON-serializable output."""
+        from process_improve.experiments.tools import augment_design_tool
+
+        result = augment_design_tool(
+            existing_design=[
+                {"A": -1, "B": -1},
+                {"A": 1, "B": -1},
+                {"A": -1, "B": 1},
+                {"A": 1, "B": 1},
+            ],
+            augmentation_type="add_center_points",
+            n_additional_runs=2,
+        )
+        assert "error" not in result
+        assert "augmented_design" in result
+        assert result["n_runs_after"] == 6
+
+    def test_foldover_via_tool(self) -> None:
+        """Foldover works through the tool wrapper."""
+        from process_improve.experiments.tools import augment_design_tool
+
+        result = augment_design_tool(
+            existing_design=[
+                {"A": -1, "B": -1, "C": -1},
+                {"A": 1, "B": -1, "C": -1},
+                {"A": -1, "B": 1, "C": -1},
+                {"A": 1, "B": 1, "C": 1},
+            ],
+            augmentation_type="foldover",
+        )
+        assert "error" not in result
+        assert result["n_runs_after"] == 8
+
+    def test_error_handling(self) -> None:
+        """Bad augmentation_type returns error dict."""
+        from process_improve.experiments.tools import augment_design_tool
+
+        result = augment_design_tool(
+            existing_design=[{"A": -1}, {"A": 1}],
+            augmentation_type="nonexistent",
+        )
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Integration
+# ---------------------------------------------------------------------------
+
+
+class TestIntegration:
+    """Integration tests: generate_design -> augment_design -> evaluate_design."""
+
+    def test_generate_then_foldover(self) -> None:
+        """Generate a fractional factorial, fold it over, evaluate."""
+        factors = [Factor(name=n, low=0, high=10) for n in ["A", "B", "C", "D"]]
+        design_result = generate_design(
+            factors, design_type="fractional_factorial",
+            generators=["D=ABC"], center_points=0,
+        )
+        df = pd.DataFrame(design_result.design).drop(columns=["RunOrder"])
+        result = augment_design(df, "foldover", generators=["D=ABC"])
+        aug = pd.DataFrame(result["augmented_design"])
+        assert len(aug) == 16
+        # Should be evaluable with main effects model
+        metrics = evaluate_design(aug, model="main_effects", metric="d_efficiency")
+        assert metrics["d_efficiency"] is not None
+
+    def test_generate_then_upgrade_to_rsm(self) -> None:
+        """Generate factorial, upgrade to RSM, evaluate quadratic."""
+        factors = [Factor(name=n, low=0, high=10) for n in ["A", "B", "C"]]
+        design_result = generate_design(
+            factors, design_type="full_factorial", center_points=0,
+        )
+        df = pd.DataFrame(design_result.design).drop(columns=["RunOrder"])
+        result = augment_design(df, "upgrade_to_rsm", alpha="face_centered")
+        aug = pd.DataFrame(result["augmented_design"])
+        # Should support quadratic model
+        metrics = evaluate_design(aug, model="quadratic", metric="d_efficiency")
+        assert metrics["d_efficiency"] is not None
+        assert metrics["d_efficiency"] > 0
+
+    def test_augment_chain(self) -> None:
+        """Chain multiple augmentations: add center points then replicate."""
+        df = _full_factorial_df(2)
+        r1 = augment_design(df, "add_center_points", n_additional_runs=3)
+        aug1 = pd.DataFrame(r1["augmented_design"])
+        r2 = augment_design(aug1, "replicate")
+        assert r2["n_runs_after"] == 14  # (4 + 3) * 2

--- a/tests/test_augment_design.py
+++ b/tests/test_augment_design.py
@@ -80,3 +80,84 @@ class TestDispatcher:
         aug = pd.DataFrame(result["augmented_design"])
         assert "RunOrder" not in aug.columns
         assert set(aug.columns) == {"A", "B"}
+
+
+# ---------------------------------------------------------------------------
+# Add center points
+# ---------------------------------------------------------------------------
+
+
+class TestAddCenterPoints:
+    """Test add_center_points augmentation."""
+
+    def test_adds_correct_count(self) -> None:
+        """n_additional_runs=5 adds exactly 5 rows."""
+        df = _full_factorial_df(3)
+        result = augment_design(df, "add_center_points", n_additional_runs=5)
+        assert result["n_runs_after"] == 8 + 5
+
+    def test_center_points_are_zeros(self) -> None:
+        """New center point rows are all zeros in coded units."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "add_center_points", n_additional_runs=3)
+        new_runs = pd.DataFrame(result["new_runs"])
+        assert (new_runs == 0).all().all()
+
+    def test_default_count(self) -> None:
+        """Without n_additional_runs, defaults to 3 center points."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "add_center_points")
+        assert result["n_runs_after"] == 4 + 3
+
+    def test_explanation_mentions_curvature(self) -> None:
+        """Explanation should mention curvature."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "add_center_points")
+        assert "curvature" in result["explanation"].lower()
+
+    def test_original_rows_preserved(self) -> None:
+        """Original design rows should be unchanged."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "add_center_points", n_additional_runs=2)
+        aug = pd.DataFrame(result["augmented_design"])
+        original_part = aug.iloc[:4]
+        pd.testing.assert_frame_equal(
+            original_part.reset_index(drop=True),
+            df.reset_index(drop=True).astype(float),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Replicate
+# ---------------------------------------------------------------------------
+
+
+class TestReplicate:
+    """Test replicate augmentation."""
+
+    def test_doubles_run_count(self) -> None:
+        """Default replication (1 copy) doubles the run count."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "replicate")
+        assert result["n_runs_after"] == 8
+
+    def test_custom_replicate_count(self) -> None:
+        """n_additional_runs=2 triples the design."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "replicate", n_additional_runs=2)
+        assert result["n_runs_after"] == 12
+
+    def test_rows_match_originals(self) -> None:
+        """Replicated rows should match the original design."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "replicate")
+        aug = pd.DataFrame(result["augmented_design"])
+        first_half = aug.iloc[:4].reset_index(drop=True)
+        second_half = aug.iloc[4:].reset_index(drop=True)
+        pd.testing.assert_frame_equal(first_half, second_half)
+
+    def test_explanation_mentions_replicate(self) -> None:
+        """Explanation should mention replication."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "replicate")
+        assert "replicate" in result["explanation"].lower()

--- a/tests/test_augment_design.py
+++ b/tests/test_augment_design.py
@@ -161,3 +161,102 @@ class TestReplicate:
         df = _full_factorial_df(2)
         result = augment_design(df, "replicate")
         assert "replicate" in result["explanation"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Foldover
+# ---------------------------------------------------------------------------
+
+
+class TestFoldover:
+    """Test foldover augmentation."""
+
+    def test_doubles_run_count(self) -> None:
+        """Foldover doubles the number of runs."""
+        df = _full_factorial_df(3)
+        result = augment_design(df, "foldover")
+        assert result["n_runs_after"] == 16
+
+    def test_negated_signs(self) -> None:
+        """Folded half has all signs negated."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "foldover")
+        aug = pd.DataFrame(result["augmented_design"])
+        original = aug.iloc[:4].values
+        folded = aug.iloc[4:].values
+        np.testing.assert_array_equal(folded, -original)
+
+    def test_with_generators_updates_defining_relation(self) -> None:
+        """Foldover with generators should update the defining relation."""
+        # 2^(4-1) with D=ABC: I=ABCD (length 4, even)
+        # After foldover, even-length words survive
+        df = _fractional_factorial_df(["D=ABC"], names="ABCD")
+        result = augment_design(df, "foldover", generators=["D=ABC"])
+        # ABCD has length 4 (even) — it should survive
+        assert result["defining_relation"] is not None
+        assert any("ABCD" in w for w in result["defining_relation"])
+
+    def test_res_iii_foldover_clears_odd_words(self) -> None:
+        """Resolution III foldover should eliminate odd-length defining words."""
+        # 2^(3-1) with C=AB: I=ABC (length 3, odd)
+        df = _fractional_factorial_df(["C=AB"], names="ABC")
+        result = augment_design(df, "foldover", generators=["C=AB"])
+        # ABC has length 3 (odd) — should be eliminated
+        explanation = result["explanation"]
+        assert "eliminated" in explanation.lower() or "de-alias" in explanation.lower()
+
+    def test_without_generators_still_works(self) -> None:
+        """Foldover without generators should still produce valid augmentation."""
+        df = _full_factorial_df(3)
+        result = augment_design(df, "foldover")
+        assert result["n_runs_after"] == 16
+        assert result["defining_relation"] is None
+        assert "explanation" in result
+
+    def test_explanation_nonempty(self) -> None:
+        """Explanation should never be empty."""
+        df = _full_factorial_df(2)
+        result = augment_design(df, "foldover")
+        assert len(result["explanation"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Semifold
+# ---------------------------------------------------------------------------
+
+
+class TestSemifold:
+    """Test semifold augmentation."""
+
+    def test_adds_half_runs(self) -> None:
+        """Semifold adds N/2 new runs."""
+        df = _full_factorial_df(3)
+        result = augment_design(df, "semifold")
+        # Half of 8 rows where fold factor = -1 = 4 rows added
+        assert result["n_runs_after"] == 12
+
+    def test_explicit_fold_on(self) -> None:
+        """Explicit fold_on uses specified factor."""
+        df = _full_factorial_df(3)
+        result = augment_design(df, "semifold", fold_on="C")
+        assert result["fold_on"] == "C"
+
+    def test_auto_selects_fold_factor(self) -> None:
+        """Without fold_on, a factor is auto-selected."""
+        df = _fractional_factorial_df(["C=AB"], names="ABC")
+        result = augment_design(df, "semifold", generators=["C=AB"])
+        assert result["fold_on"] in ["A", "B", "C"]
+
+    def test_invalid_fold_factor_raises(self) -> None:
+        """fold_on with nonexistent factor raises ValueError."""
+        df = _full_factorial_df(2)
+        with pytest.raises(ValueError, match="fold_on"):
+            augment_design(df, "semifold", fold_on="Z")
+
+    def test_with_generators_reports_dealiasing(self) -> None:
+        """Semifold with generators should report de-aliasing."""
+        df = _fractional_factorial_df(["D=ABC"], names="ABCD")
+        result = augment_design(df, "semifold", generators=["D=ABC"], fold_on="A")
+        assert "explanation" in result
+        # Should mention fold factor
+        assert "A" in result["explanation"]


### PR DESCRIPTION
## Summary

- Implements Tool 5 (`augment_design`) — the design augmentation tool that extends or modifies existing experimental designs
- Adds 8 augmentation types: foldover, semifold, add_center_points, add_axial_points, add_runs_optimal, upgrade_to_rsm, add_blocks, and replicate
- Each augmentation generates before/after metrics and a "what changed" narrative explanation
- Adds `@tool_spec` wrapper for LLM agent use, matching the pattern of existing tools
- 58 new tests across 12 test classes, all passing with zero regressions on existing 66 evaluate_design tests

### Key design decisions

- **Dispatch registry pattern** (`_AUGMENT_REGISTRY`) matching `_METRIC_REGISTRY` in evaluate.py and `_DESIGN_REGISTRY` in designs.py
- **Reuses GF(2) internals** from evaluate.py (`_defining_relation_from_generators`, `_word_to_str`) for alias analysis in foldover/semifold
- **Greedy D-optimal augmentation** with 3-level candidate set for `add_runs_optimal`, freezing existing runs
- **Auto fold-factor selection** for semifold based on wordlength pattern analysis

### Files changed

| File | Change |
|---|---|
| `process_improve/experiments/augment.py` | **New** — Core implementation (~500 lines) |
| `process_improve/experiments/tools.py` | Add `augment_design_tool` wrapper |
| `process_improve/experiments/__init__.py` | Export `augment_design` |
| `tests/test_augment_design.py` | **New** — 58 tests across 12 classes |

## Test plan

- [x] `pytest tests/test_augment_design.py -v` — 58 tests pass
- [x] `pytest tests/test_evaluate_design.py -v` — 66 tests pass (no regressions)
- [x] `ruff check` on all changed files — clean
- [ ] Full CI suite

https://claude.ai/code/session_01NE1Q13qaPgDXYuqf6jHDPR