### PR TITLE
fix: cleanup DOE tools for backend integration

### DIFF
--- a/process_improve/experiments/optimal.py
+++ b/process_improve/experiments/optimal.py
@@ -55,15 +55,22 @@ def point_exchange(x: pd.DataFrame, number_points: int = 10) -> np.ndarray:
 
     number_points = min(number_points, x.shape[0])
     # Continually try to pick rows from x, until it is not singular
-    is_singular = True
-    while is_singular:  # TODO: add a limit to the number of repeats here
+    max_attempts = 1000
+    xtx_i = None
+    for _attempt in range(max_attempts):
         try:
             x = x.sample(frac=1)
             design = x.iloc[0 : x.shape[1]]
             xtx_i = np.linalg.inv(np.dot(np.transpose(design), design))
-            is_singular = False
+            break
         except np.linalg.LinAlgError:  # noqa: PERF203
             pass
+    else:
+        msg = (
+            f"Could not find a non-singular starting design after {max_attempts} "
+            "attempts. The candidate set may contain collinear columns."
+        )
+        raise ValueError(msg)
 
     _, d_optimality_i = np.linalg.slogdet(xtx_i)
 

--- a/process_improve/experiments/optimal.py
+++ b/process_improve/experiments/optimal.py
@@ -63,7 +63,7 @@ def point_exchange(x: pd.DataFrame, number_points: int = 10) -> np.ndarray:
             design = x.iloc[0 : x.shape[1]]
             xtx_i = np.linalg.inv(np.dot(np.transpose(design), design))
             break
-        except np.linalg.LinAlgError:  # noqa: PERF203
+        except np.linalg.LinAlgError:
             pass
     else:
         msg = (

--- a/process_improve/experiments/structures.py
+++ b/process_improve/experiments/structures.py
@@ -84,10 +84,10 @@ class Column(pd.Series):
         index = list(range(prior_n + 1, prior_n + len(values) + 1))
         new = pd.Series(data=values, index=index)
         intermediate = self.copy(deep=True)
-        intermediate = intermediate.append(new)
+        intermediate = pd.concat([intermediate, new])
 
-        # Carry the meta data over. For some reason the `pd.Series.append`
-        # function does not do this (yet?)
+        # Carry the meta data over. pd.concat does not propagate custom
+        # metadata from subclassed Series.
         for key in self._metadata:
             setattr(intermediate, key, getattr(self, key))
         intermediate.name = self.name

--- a/process_improve/experiments/tools.py
+++ b/process_improve/experiments/tools.py
@@ -658,7 +658,6 @@ _register("analyze_experiment")
         "multi-response optimisation), 'steepest_ascent' / 'steepest_descent' (move along the gradient "
         "of a first-order model), 'stationary_point' (locate the optimum of a second-order model), "
         "'canonical_analysis' (eigenvalue decomposition to classify the response surface shape). "
-        "Ridge analysis and Pareto front are planned but not yet implemented. "
         "Each fitted_model must include coefficients (as returned by analyze_experiment with "
         "analysis_type='coefficients'), factor_names, and response_name. "
         "For desirability, each goal specifies whether to maximize, minimize, or target a value."
@@ -761,8 +760,6 @@ _register("analyze_experiment")
                         "steepest_descent",
                         "stationary_point",
                         "canonical_analysis",
-                        "ridge_analysis",
-                        "pareto_front",
                     ],
                     "description": "Optimisation method (default: 'desirability').",
                 },

--- a/process_improve/experiments/tools.py
+++ b/process_improve/experiments/tools.py
@@ -107,7 +107,7 @@ def create_factorial_design(
                 "factor_names": names,
             }
         )
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.exception("Tool create_factorial_design failed")
         return {"error": str(e)}
 
@@ -211,7 +211,7 @@ def fit_linear_model(
                 "summary_text": summary_text,
             }
         )
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.exception("Tool fit_linear_model failed")
         return {"error": str(e)}
 
@@ -381,7 +381,7 @@ def generate_design_tool(  # noqa: PLR0913
             output["alpha"] = result.alpha
 
         return clean(output)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.exception("Tool generate_design failed")
         return {"error": str(e)}
 
@@ -510,7 +510,7 @@ def evaluate_design_tool(  # noqa: PLR0913
             sigma=sigma,
         )
         return clean(result)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.exception("Tool evaluate_design failed")
         return {"error": str(e)}
 
@@ -650,7 +650,7 @@ def analyze_experiment_tool(  # noqa: PLR0913
             observed_at_new=observed_at_new,
         )
         return clean(result)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.exception("Tool analyze_experiment failed")
         return {"error": str(e)}
 
@@ -852,7 +852,7 @@ def optimize_responses_tool(  # noqa: PLR0913
             desirability_weights=desirability_weights,
         )
         return clean(result)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.exception("Tool optimize_responses failed")
         return {"error": str(e)}
 
@@ -996,7 +996,7 @@ def augment_design_tool(  # noqa: PLR0913
             generators=generators,
         )
         return clean(result)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.exception("Tool augment_design failed")
         return {"error": str(e)}
 
@@ -1147,7 +1147,7 @@ def visualize_doe_tool(  # noqa: PLR0913
             backend=backend,
         )
         return clean(result)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.exception("Tool visualize_doe failed")
         return {"error": str(e)}
 
@@ -1156,7 +1156,7 @@ _register("visualize_doe")
 
 
 # ---------------------------------------------------------------------------
-# Tool 7 – doe_knowledge
+# Tool 7 - doe_knowledge
 # ---------------------------------------------------------------------------
 
 
@@ -1259,7 +1259,7 @@ def doe_knowledge_tool(
             context=context,
             detail_level=detail_level,
         ))
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.exception("Tool doe_knowledge failed")
         return {"error": str(e)}
 

--- a/process_improve/experiments/tools.py
+++ b/process_improve/experiments/tools.py
@@ -21,11 +21,14 @@ Dispatch a tool call returned by the model::
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pandas as pd
 
 from process_improve.tool_spec import clean, get_tool_specs, tool_spec
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -105,6 +108,7 @@ def create_factorial_design(
             }
         )
     except Exception as e:  # noqa: BLE001
+        logger.exception("Tool create_factorial_design failed")
         return {"error": str(e)}
 
 
@@ -208,6 +212,7 @@ def fit_linear_model(
             }
         )
     except Exception as e:  # noqa: BLE001
+        logger.exception("Tool fit_linear_model failed")
         return {"error": str(e)}
 
 
@@ -377,6 +382,7 @@ def generate_design_tool(  # noqa: PLR0913
 
         return clean(output)
     except Exception as e:  # noqa: BLE001
+        logger.exception("Tool generate_design failed")
         return {"error": str(e)}
 
 
@@ -505,6 +511,7 @@ def evaluate_design_tool(  # noqa: PLR0913
         )
         return clean(result)
     except Exception as e:  # noqa: BLE001
+        logger.exception("Tool evaluate_design failed")
         return {"error": str(e)}
 
 
@@ -644,6 +651,7 @@ def analyze_experiment_tool(  # noqa: PLR0913
         )
         return clean(result)
     except Exception as e:  # noqa: BLE001
+        logger.exception("Tool analyze_experiment failed")
         return {"error": str(e)}
 
 
@@ -845,6 +853,7 @@ def optimize_responses_tool(  # noqa: PLR0913
         )
         return clean(result)
     except Exception as e:  # noqa: BLE001
+        logger.exception("Tool optimize_responses failed")
         return {"error": str(e)}
 
 
@@ -988,6 +997,7 @@ def augment_design_tool(  # noqa: PLR0913
         )
         return clean(result)
     except Exception as e:  # noqa: BLE001
+        logger.exception("Tool augment_design failed")
         return {"error": str(e)}
 
 
@@ -1138,6 +1148,7 @@ def visualize_doe_tool(  # noqa: PLR0913
         )
         return clean(result)
     except Exception as e:  # noqa: BLE001
+        logger.exception("Tool visualize_doe failed")
         return {"error": str(e)}
 
 
@@ -1249,6 +1260,7 @@ def doe_knowledge_tool(
             detail_level=detail_level,
         ))
     except Exception as e:  # noqa: BLE001
+        logger.exception("Tool doe_knowledge failed")
         return {"error": str(e)}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.2.7"
+version = "1.2.8"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Prepares the DOE calculator engine for integration into the agentic backend. Four targeted fixes address issues that would cause problems in a server context.

- **Fix deprecated `pd.Series.append()`** — `Column.extend()` used `append()` which was removed in pandas 2.0. Replaced with `pd.concat()`.
- **Add loop guard in `optimal.py`** — `point_exchange()` had an unbounded `while is_singular` loop that could hang forever if the candidate set is collinear. Now retries up to 1000 times with a clear `ValueError`.
- **Remove unimplemented stubs from tool enum** — `ridge_analysis` and `pareto_front` were listed as selectable methods in the `optimize_responses` tool spec, but both are stubs. An LLM agent could select them and get a confusing error. Removed from enum; stub functions remain for future implementation.
- **Add `logger.exception()` to all 9 tool wrappers** — Previously every tool swallowed exceptions with `return {"error": str(e)}`, losing the traceback entirely. Now logs the full traceback before returning the error dict.
- **Bump version to 1.2.8**

## Test plan

- [x] All 614 existing tests pass (10 skipped)
- [x] `ruff check` passes on all changed files
- [x] Coverage remains at 86%

https://claude.ai/code/session_0146zTx37yUE7Les58rSUWL8