### PR TITLE
Add PyPI publish workflow via trusted publishers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # Required for trusted publishing
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build
+        run: |
+          pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml` that automatically publishes to PyPI when a GitHub Release is created
- Uses OIDC trusted publishing — no API tokens or secrets needed
- Installs `uv` since the build backend is `uv_build`

## Before merging
You need to do a one-time setup:
1. **PyPI:** Log into [pypi.org](https://pypi.org) → your `process-improve` project → Manage → Publishing → add a GitHub trusted publisher with owner `kgdunn`, repo `process-improve`, workflow `publish.yml`, environment `pypi`
2. **GitHub:** Go to repo Settings → Environments → New environment → name it `pypi`

## After merging — to publish a release
1. Bump the version in `pyproject.toml`
2. Go to Releases → Draft a new release → create a tag (e.g. `v1.2.9`) → Publish
3. The workflow builds and uploads to PyPI automatically