### PR TITLE
Add factori.al reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Process Improvement using Data
 
-A Python package for multivariate data analysis, designed experiments, and process monitoring. Companion to the online textbook [Process Improvement using Data](https://learnche.org/pid).
+A Python package for multivariate data analysis, designed experiments, and process monitoring. Companion to the online textbook [Process Improvement using Data](https://learnche.org/pid). This package also powers the statistical engine behind [factori.al](https://factori.al).
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- Add a sentence to the README introduction noting that this package powers the statistical engine behind https://factori.al
- Keeps the package's identity as a standalone Python library front and center

## Test plan

- [ ] Verify README renders correctly on GitHub

https://claude.ai/code/session_01GcdmsE7qzzn2VH7AgHxv3m