### PR TITLE
Replace release-triggered PyPI publish with version-change detection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,13 @@
 name: Publish to PyPI
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"  # Only run when this file changes
 
 jobs:
-  build-and-publish:
+  publish:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -13,18 +15,42 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Need previous commit to diff
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
+      - name: Check if version changed
+        id: version_check
+        run: |
+          pip install tomli
+          NEW=$(python -c "import tomli; print(tomli.load(open('pyproject.toml','rb'))['project']['version'])")
+          git show HEAD~1:pyproject.toml > /tmp/old_pyproject.toml 2>/dev/null || echo "first_run"
+          OLD=$(python -c "
+          import tomli, sys
+          try:
+              print(tomli.load(open('/tmp/old_pyproject.toml','rb'))['project']['version'])
+          except:
+              print('none')
+          ")
+          echo "old=$OLD new=$NEW"
+          if [ "$OLD" != "$NEW" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "version=$NEW" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install uv
+        if: steps.version_check.outputs.changed == 'true'
         uses: astral-sh/setup-uv@v4
 
       - name: Build
+        if: steps.version_check.outputs.changed == 'true'
         run: |
           pip install build
           python -m build
 
       - name: Publish to PyPI
+        if: steps.version_check.outputs.changed == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,17 @@ process_improve/
     datasets/        # Sample datasets for examples and tests
 ```
 
+## Versioning
+
+The version is defined in `pyproject.toml` under `[project] version`. It uses 3-part semver: `MAJOR.MINOR.PATCH` (e.g., `1.3.1`).
+
+**Auto-bump the version with every PR that changes code or configuration:**
+- **PATCH** (last position, e.g., 1.3.0 → 1.3.1): bug fixes, CI/workflow changes, docs updates, dependency bumps, small refactors, and other minor changes.
+- **MINOR** (middle position, e.g., 1.3.1 → 1.4.0): new features, new modules, significant API additions, or meaningful behavioral changes. Resets PATCH to 0.
+- **If unsure** whether a change is major or minor, **ask the user** before bumping.
+
+The PyPI publish workflow (`.github/workflows/publish.yml`) automatically detects version changes on push to `main` and publishes to PyPI when the version differs from the previous commit.
+
 ## Key Architectural Decisions
 
 ### sklearn API Compatibility

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.3.0"
+version = "1.3.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Replaces the existing `publish.yml` workflow that triggered on GitHub release events
- New workflow triggers on push to `main` only when `pyproject.toml` changes (via `paths` filter)
- Diffs the `version` field in `pyproject.toml` against the previous commit — only builds and publishes when the version actually changed (not just a metadata edit)
- Keeps the `uv` setup step since the build backend is `uv_build`

## How it works

1. `paths: ["pyproject.toml"]` ensures the workflow only runs when that file is touched
2. The version check step extracts the version from the current and previous commit's `pyproject.toml`
3. If they differ, the build and publish steps run; otherwise the workflow exits early
4. Uses PyPI trusted publishing (OIDC) — no API tokens needed

## New workflow

Edit `version` in `pyproject.toml`, commit to `main` — done.

## Test plan

- [ ] Verify the workflow YAML is valid (GitHub will show syntax errors on the Actions tab)
- [ ] Ensure the PyPI trusted publisher is configured for this repo (one-time manual step via PyPI browser UI)
- [ ] Test by bumping the version in `pyproject.toml` and pushing to `main`

https://claude.ai/code/session_01BnKv3Z7XENMNmbvcaSJKEu