### PR TITLE
Add GitHub Release and tag creation to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      id-token: write  # Required for trusted publishing
+      id-token: write    # Required for trusted publishing
+      contents: write    # Required for creating tags and releases
 
     steps:
       - uses: actions/checkout@v4
@@ -54,3 +55,12 @@ jobs:
       - name: Publish to PyPI
         if: steps.version_check.outputs.changed == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub Release
+        if: steps.version_check.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.version_check.outputs.version }}" \
+            --title "v${{ steps.version_check.outputs.version }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary

- Adds automatic GitHub Release and git tag creation after successful PyPI publish
- Adds `contents: write` permission (needed for `gh release create` to create tags and releases)
- Uses `gh release create` with `--generate-notes` for auto-generated release notes from PRs/commits since the last tag
- Tag format: `v1.3.1` (standard Python convention)

## How it works

After the existing PyPI publish step succeeds, a new step runs:
```
gh release create "v$VERSION" --title "v$VERSION" --generate-notes
```

This creates both the git tag and the GitHub Release in one command. If PyPI publish fails, the release step is never reached.

## Test plan

- [ ] Verify workflow YAML syntax is valid on the Actions tab
- [ ] After merging, bump version in `pyproject.toml` on `main` and confirm a tag + release appear on the repo's [releases page](https://github.com/kgdunn/process-improve/releases)

https://claude.ai/code/session_01BnKv3Z7XENMNmbvcaSJKEu