### PR TITLE
Fix docstring / signature inconsistencies across core modules

### DIFF
--- a/process_improve/batch/features.py
+++ b/process_improve/batch/features.py
@@ -279,6 +279,11 @@ def f_robust_mad(
     The constant correction factor is so that MAD agrees with standard
     deviation for normally distributed data.
 
+    .. warning::
+        This function is **not yet implemented**. Calling it always raises
+        ``AssertionError``; the underlying group-wise calculation below the
+        raise is a placeholder that still needs to be corrected.
+
     See also: f_mad, f_std, f_iqr,
     """
     c_MAD_const = norm.ppf(3 / 4.0)

--- a/process_improve/batch/preprocessing.py
+++ b/process_improve/batch/preprocessing.py
@@ -24,7 +24,14 @@ def determine_scaling(
     Parameters
     ----------
     batches : dict[str, pd.DataFrame]
-        Batch data, in the standard format.
+        Batch data, in the standard format (keyed by batch identifier).
+    columns_to_align : list, optional
+        The column names (tags) to be scaled. If ``None``, the columns of the
+        first batch are used.
+    settings : dict, optional
+        Optional overrides. Currently supports the key ``"robust"`` (bool,
+        default ``True``) which switches between a robust range (q98 - q02)
+        and the raw (max - min) range.
 
     Returns
     -------

--- a/process_improve/experiments/optimal.py
+++ b/process_improve/experiments/optimal.py
@@ -3,6 +3,8 @@ from collections.abc import Callable
 import numpy as np
 import pandas as pd
 
+IndexOrList = int | list
+
 
 def optimization_function(x: pd.DataFrame) -> float:
     """Return the D-optimality of the design."""
@@ -19,8 +21,19 @@ def index_to_replace_in_design_row(
     candidate_point: pd.DataFrame,
     current_optimum: float,
     optimization_function: Callable,
-) -> pd.DataFrame:
-    """Find index to replace in design with the candidate point if the D-optimality of the new design is better."""
+) -> IndexOrList:
+    """Find the row index in ``design`` to replace with ``candidate_point``.
+
+    Iterates over each row of ``design`` and evaluates the D-optimality of the
+    design that results from swapping that row with ``candidate_point``.
+
+    Returns
+    -------
+    int | list
+        The index of the row whose replacement yields the best (lowest)
+        optimality score. If no row produces an improvement over
+        ``current_optimum``, an empty list is returned.
+    """
     design_index = []
     new_optimimum = []
     design_to_consider = design.copy()
@@ -38,7 +51,7 @@ def index_to_replace_in_design_row(
         return design_index
 
 
-def point_exchange(x: pd.DataFrame, number_points: int = 10) -> np.ndarray:
+def point_exchange(x: pd.DataFrame, number_points: int = 10) -> tuple[pd.DataFrame, float]:
     """
     Return a design that is optimal in terms of D-optimality.
 
@@ -48,6 +61,12 @@ def point_exchange(x: pd.DataFrame, number_points: int = 10) -> np.ndarray:
 
     When do you swap a row? E.g. you request 2 points, and the 2 it selected are (-1,-1) and (-1, 1).
     While the optimum should be the opposite ends, right?
+
+    Returns
+    -------
+    tuple[pd.DataFrame, float]
+        The selected design (sorted by the original row index) and its
+        D-optimality value (log-determinant of ``(X'X)^-1``).
     """
     assert number_points >= x.shape[1], f"`number_point`s must be at least {x.shape[1]} (the number of columns in `x`)"
     assert number_points <= x.shape[0], f"`number_point`s must be at most {x.shape[0]} (the number of rows in `x`)"

--- a/process_improve/multivariate/methods.py
+++ b/process_improve/multivariate/methods.py
@@ -1751,11 +1751,16 @@ def hotellings_t2_limit(conf_level: float = 0.95, n_components: int = 0, n_rows:
     ----------
     conf_level : float, optional
         Fractional confidence limit, less that 1.00; by default 0.95
+    n_components : int
+        Number of components in the fitted multivariate model.
+    n_rows : int
+        Number of rows (observations) used to fit the model. Must be > 0.
 
     Returns
     -------
     float
-        The Hotelling's T2 limit at the given level of confidence.
+        The Hotelling's T2 limit at the given level of confidence. Returns
+        ``inf`` when ``n_components == n_rows``.
     """
     assert 0.0 < conf_level < 1.0
     assert n_rows > 0
@@ -1775,6 +1780,9 @@ def spe_limit(model: BaseEstimator, conf_level: float = 0.95) -> float:
 
     Parameters
     ----------
+    model : BaseEstimator
+        A fitted multivariate model exposing a ``spe_`` attribute and an
+        ``n_components`` attribute (e.g. a fitted PCA or PLS instance).
     conf_level : float, optional
         Fractional confidence limit, less that 1.00; by default 0.95
 
@@ -1796,9 +1804,9 @@ def spe_calculation(spe_values: np.ndarray, conf_level: float = 0.95) -> float:
 
     Parameters
     ----------
-    spe_values : pd.Series
+    spe_values : np.ndarray
         The SPE values from the last component in the multivariate model.
-    conf_level : [float], optional
+    conf_level : float, optional
         The confidence level, by default 0.95, i.e. the 95% confidence level.
 
     Returns

--- a/process_improve/univariate/metrics.py
+++ b/process_improve/univariate/metrics.py
@@ -301,17 +301,15 @@ def ttest_independent_from_df(
 
 
 def ttest_paired(differences: pd.Series, conflevel: float = 0.995) -> dict:
-    """Core calculation for a test of differences.
+    """Core calculation for a test of paired differences.
 
     Parameters
     ----------
-    sample_A : iterable
-        Vector of n_a measurements.
-    sample_B : iterable
-        Vector of n_b measurements.
-    conflevel : float
+    differences : pd.Series
+        The paired differences (e.g. ``sample_A - sample_B``) for which the test is run.
+    conflevel : float, optional
         Value between 0 and 1 (closer to 1.0), that gives the level of confidence required for
-        the 2-sided test.
+        the 2-sided test. Default is 0.995.
 
     Returns
     -------

--- a/process_improve/visualization/plots.py
+++ b/process_improve/visualization/plots.py
@@ -1,8 +1,13 @@
 import pandas as pd
 
 
-def raincloud(sequence: pd.Series) -> dict:
+def raincloud(sequence: pd.Series) -> dict | None:
     """Create a raincloud plot from a series of data. Raincloud plot = violin + boxplot + jitter.
+
+    .. warning::
+        This function is **not yet implemented**. The body is a stub and the
+        call returns ``None``; it does not yet produce the described
+        dictionary.
 
     Parameters
     ----------
@@ -11,8 +16,9 @@ def raincloud(sequence: pd.Series) -> dict:
 
     Returns
     -------
-    dict
-        A dictionary, which can be sent directly to Plotly for visualization.
+    dict | None
+        When implemented, will return a dictionary that can be sent directly
+        to Plotly for visualization. Currently returns ``None``.
     """
     # TODO: split violin plot: https://plotly.com/python/violin/
     # TODO: rug/dotplot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.4.0"
+version = "1.4.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

A sweep of the computational and user-facing functions turned up several places where the docstring (or the documented type annotation) disagreed with what the code actually does. This PR fixes the docstrings/annotations only — no behaviour changes.

Rebased on top of `main` after #90 landed. The overlap with #90 (the `determine_scaling` parameter rename, the `t_value_cdf` example fix, and the `ellipse_coordinates` `[description]` placeholders) has been folded in; this PR keeps only the additional, unique fixes plus a few extras on top of #90 (e.g. documenting `columns_to_align` / `settings` in `determine_scaling`).

## Inconsistencies fixed (unique to this PR)

- **`univariate/metrics.py:303` `ttest_paired`** — Parameters block documented `sample_A` and `sample_B`, but the signature is `(differences, conflevel)`. Rewrote the block to match.
- **`batch/preprocessing.py:16` `determine_scaling`** — On top of #90's rename, document `columns_to_align` and `settings` (they were previously undocumented).
- **`batch/features.py:255` `f_robust_mad`** — The function unconditionally raises `AssertionError("This next line of code fails. Fix it.")` before any computation runs, yet the docstring described it as a working robust-MAD feature. Added a warning that the function is not yet implemented. (Code left as-is to preserve existing behaviour.)
- **`multivariate/methods.py:1747` `hotellings_t2_limit`** — Parameters block only documented `conf_level`; added `n_components` and `n_rows`, plus the `inf` return corner case.
- **`multivariate/methods.py:1773` `spe_limit`** — Missing `model` parameter; added it.
- **`multivariate/methods.py:1794` `spe_calculation`** — Docstring typed `spe_values` as `pd.Series` but the signature says `np.ndarray`. Aligned the docstring with the signature.
- **`experiments/optimal.py:17` `index_to_replace_in_design_row`** — Return annotation said `pd.DataFrame`, but the function returns an `int` (from `np.argmin`) or an empty `list`. Changed the annotation to `int | list` and documented the contract.
- **`experiments/optimal.py:41` `point_exchange`** — Return annotation said `np.ndarray`, but the function returns `(design: pd.DataFrame, d_optimality: float)`. Changed the annotation to `tuple[pd.DataFrame, float]` and documented it.
- **`visualization/plots.py:4` `raincloud`** — Docstring claimed it returns a Plotly-ready dict, but the body is a stub that returns `None`. Added a warning that the function is not yet implemented and loosened the return annotation to `dict | None`.

## Version

Bumped `pyproject.toml` from `1.4.0` → `1.4.1` (PATCH: docs / type-annotation fixes only).

## Test plan

- [ ] `ruff check .` passes (verified locally on the touched files)
- [ ] `pytest` passes in CI (no runtime behaviour was changed)

https://claude.ai/code/session_013QwkYNGcVctVEnATzKnMZn