### PR TITLE
Fix docstring inconsistencies in computational functions

### DIFF
--- a/process_improve/batch/preprocessing.py
+++ b/process_improve/batch/preprocessing.py
@@ -23,7 +23,7 @@ def determine_scaling(
 
     Parameters
     ----------
-    dict_df : dict[str, pd.DataFrame]
+    batches : dict[str, pd.DataFrame]
         Batch data, in the standard format.
 
     Returns

--- a/process_improve/experiments/designs_utils.py
+++ b/process_improve/experiments/designs_utils.py
@@ -185,8 +185,10 @@ def build_design_result(  # noqa: PLR0913
         Number of full replicates.
     blocks : int or None
         Number of blocks (None = no blocking).
-    random_seed : int
-        Seed for reproducible randomization.
+    random_seed : int or None
+        Seed for reproducible randomization. When ``None`` the original run
+        order of *coded_matrix* is preserved (used for designs whose run order
+        is part of the solution, e.g. split-plot optimal designs).
     generators : list[str] or None
         Generator strings (fractional factorials).
     defining_relation : list[str] or None

--- a/process_improve/monitoring/control_charts.py
+++ b/process_improve/monitoring/control_charts.py
@@ -57,7 +57,7 @@ class ControlChart:
         self.style = style.strip()
         self.variant = variant.strip().lower()
 
-        # Will be calculated by the self.fit_limits() function
+        # Will be calculated by the self.calculate_limits() function
         self.target = None
         self._given_target = None
         self._given_s = None

--- a/process_improve/multivariate/methods.py
+++ b/process_improve/multivariate/methods.py
@@ -1840,13 +1840,24 @@ def ellipse_coordinates(  # noqa: PLR0913
     Parameters
     ----------
     score_horiz : int
-        [description]
+        1-based index of the score to plot on the horizontal axis. Must satisfy
+        ``1 <= score_horiz <= n_components``.
     score_vert : int
-        [description]
+        1-based index of the score to plot on the vertical axis. Must satisfy
+        ``1 <= score_vert <= n_components``.
     conf_level : float
         The `conf_level` confidence value: e.g. 0.95 is for the 95% confidence limit.
     n_points : int, optional
         Number of points to use in the ellipse; by default 100.
+    n_components : int
+        Number of components `A` in the fitted model. Required to look up the
+        Hotelling's T^2 limit and to bound `score_horiz`/`score_vert`.
+    scaling_factor_for_scores : pd.Series
+        Per-component standard deviations of the scores (``model.scaling_factor_for_scores_``).
+        Used to scale the ellipse axes.
+    n_rows : int
+        Number of rows `N` in the data used to fit the model. Required to compute the
+        Hotelling's T^2 limit; must be strictly positive.
 
     Returns
     -------

--- a/process_improve/univariate/metrics.py
+++ b/process_improve/univariate/metrics.py
@@ -68,7 +68,7 @@ def t_value_cdf(z: float, v: float) -> float:
 
     100% fractional area is always at :math:`+\infty`:
 
-    >>> t_value(np.inf, v)
+    >>> t_value_cdf(np.inf, v)
     1.0
 
     See also

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.3.2"
+version = "1.3.3"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Audited both `kgdunn/agentic-doe` and `kgdunn/process-improve` for docstring-vs-implementation mismatches on computational and user-facing functions. The `agentic-doe` backend was clean; this PR addresses the five issues found in `process-improve`.

## Inconsistencies fixed

- **`process_improve/batch/preprocessing.py:16` — `determine_scaling`**
  Docstring listed the first parameter as `dict_df`, but the function signature calls it `batches`. Renamed in the docstring.

- **`process_improve/multivariate/methods.py:1824` — `ellipse_coordinates`**
  Three parameters that the function actually uses (and asserts on) were missing from the docstring: `n_components`, `scaling_factor_for_scores`, `n_rows`. `score_horiz` / `score_vert` descriptions were the literal placeholder `[description]`. All now documented.

- **`process_improve/experiments/designs_utils.py:148` — `build_design_result`**
  Docstring declared `random_seed : int`, but the signature is `int | None = 42` and the code has a dedicated branch for `None` that preserves the original run order. Updated to `int or None` and described the `None` behavior.

- **`process_improve/monitoring/control_charts.py:34` — `ControlChart.__init__`**
  Inline comment referenced a `self.fit_limits()` method that doesn't exist; the method is `calculate_limits()`. Comment corrected.

- **`process_improve/univariate/metrics.py:49` — `t_value_cdf`**
  Example code called `t_value(np.inf, v)` (copy-paste from the inverse function) inside the `t_value_cdf` docstring. Fixed to call `t_value_cdf`.

Patch version bumped to `1.3.3` per `CLAUDE.md`.

## Test plan
- [ ] `ruff check .`
- [ ] `pytest -o "addopts="`
- [ ] Spot-check rendered docs for the five functions

https://claude.ai/code/session_01GLNogYfJaEFJfScXkCbR1s