### PR TITLE
Fix docs build: resolve duplicate cross-references in visualization

### DIFF
--- a/docs/api/visualization.rst
+++ b/docs/api/visualization.rst
@@ -5,6 +5,7 @@ Visualization
    :members:
    :undoc-members:
    :show-inheritance:
+   :exclude-members: Annotation, AnnotationType, ChartSpec, Encoding, LayerSpec, MarkType, PanelSpec, ScaleType
 
 Chart specification (IR)
 ------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.5.0"
+version = "1.5.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Fixes the failing docs deploy introduced by #95. The `process_improve.visualization` package re-exports `ChartSpec`, `PanelSpec`, `ScaleType`, `MarkType`, `AnnotationType`, `Annotation`, `Encoding`, and `LayerSpec` from its submodules. Sphinx autodoc was documenting each class under **both** the top-level package path and its submodule path, producing `more than one target found for cross-reference` warnings that failed the build (which uses `sphinx-build -W`).
- Add `:exclude-members:` to the top-level `automodule` directive in `docs/api/visualization.rst` so each class is documented exactly once — in its submodule.
- Bump version 1.5.0 → 1.5.1 (PATCH) per CLAUDE.md.

## Original failure

```
docs/api/visualization.rst:10: WARNING: more than one target found for cross-reference 'ScaleType'
docs/api/visualization.rst:10: WARNING: more than one target found for cross-reference 'MarkType'
docs/api/visualization.rst:10: WARNING: more than one target found for cross-reference 'AnnotationType'
docs/api/visualization.rst:23: WARNING: more than one target found for cross-reference 'ChartSpec'
docs/api/visualization.rst:23: WARNING: more than one target found for cross-reference 'PanelSpec'
```

## Test plan

- [x] Run `uv run sphinx-build docs docs/_build/html -b html -W` locally — the four duplicate-target warnings are gone
- [ ] Docs workflow succeeds on CI after merge

https://claude.ai/code/session_PWbuw