### PR TITLE
Add CodeQL workflow and extend Dependabot to pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,23 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# Dependabot version updates
+# Docs: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    # Workflow files stored in the
-    # default location of `.github/workflows`
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly run so new advisories applied to unchanged code still surface.
+    - cron: "0 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

After evaluating SonarCloud against what GitHub already offers for free on public repos, we're starting with the GitHub-native security stack — CodeQL + Dependabot — before committing to a third-party quality dashboard.

- **CodeQL** (`.github/workflows/codeql.yml`): static analysis with the `security-and-quality` query pack for Python. Runs on push/PR to `main` and weekly (so new advisories applied to unchanged code still surface). Results appear in the repo's Security tab.
- **Dependabot** (`.github/dependabot.yml`): existing `github-actions` config is preserved; added a `pip` ecosystem pointing at the project root. Minor/patch updates are grouped per ecosystem so PR volume stays manageable.

## Manual follow-ups (GitHub UI)

These are settings toggles, not file changes:

- Settings → Code security → enable **Dependabot alerts** (likely already on for public repos) and **Dependabot security updates** so advisory-triggered PRs open automatically.
- Settings → Code security → confirm **secret scanning** is enabled.

## Test plan

- [ ] CodeQL workflow runs successfully on the PR
- [ ] No new CodeQL alerts are introduced (baseline the current set)
- [ ] First weekly scheduled run completes
- [ ] First Dependabot `pip` PR opens on the next weekly tick (or trigger manually via the Insights → Dependency graph → Dependabot tab)

https://claude.ai/code/session_01KeJrngWULHkoLSKKaZpccV