### PR TITLE
Add fake-data simulator tools (create/simulate/reveal)

### DIFF
--- a/process_improve/simulation/__init__.py
+++ b/process_improve/simulation/__init__.py
@@ -1,0 +1,18 @@
+"""(c) Kevin Dunn, 2010-2026. MIT License.
+
+Fake-data / process-simulator subpackage.
+
+Provides three agent-callable tools used to demonstrate DOE workflows
+against a synthetic (but deterministic) response surface:
+
+- ``create_simulator`` — records a hidden model from a seed + factor
+  specs + structural hints.
+- ``simulate_process`` — evaluates the hidden surface at given factor
+  settings, adding fresh Gaussian noise each call.
+- ``reveal_simulator`` — returns the underlying coefficients, gated
+  behind a ``confirmed`` flag that the host application enforces.
+
+The math itself lives in :mod:`process_improve.simulation.model`; the
+tools in :mod:`process_improve.simulation.tools` are the
+JSON-schema-wrapped entry points registered with ``@tool_spec``.
+"""

--- a/process_improve/simulation/model.py
+++ b/process_improve/simulation/model.py
@@ -22,6 +22,11 @@ yield similar-but-not-identical outputs — matching the behaviour of a
 real physical asset.
 """
 
+# ruff: noqa: ANN401
+# The public tool-call contract uses ``dict[str, Any]`` and ``list[dict[str, Any]]``
+# deliberately: the schema that the LLM sees is declared as JSON Schema in
+# ``simulation/tools.py``, not as Python types, so tightening the Python side
+# with TypedDicts would be duplicative and brittle.
 from __future__ import annotations
 
 import re
@@ -47,17 +52,23 @@ _NOISE_FRACTIONS: dict[str, float] = {
 # carries the corresponding meaning; ties (both positive *and* negative in
 # the same hint) fall back to \"no direction\" and are ignored.
 _POS_WORDS: frozenset[str] = frozenset(
-    {"positive", "increase", "increases", "increasing", "synergy",
-     "synergistic", "synergise", "synergize", "boost", "boosts", "promotes"}
+    {
+        "positive", "increase", "increases", "increasing", "synergy",
+        "synergistic", "synergise", "synergize", "boost", "boosts", "promotes",
+    }
 )
 _NEG_WORDS: frozenset[str] = frozenset(
-    {"negative", "decrease", "decreases", "decreasing", "antagonistic",
-     "antagonise", "antagonize", "antagonism", "adverse", "inhibits",
-     "suppresses"}
+    {
+        "negative", "decrease", "decreases", "decreasing", "antagonistic",
+        "antagonise", "antagonize", "antagonism", "adverse", "inhibits",
+        "suppresses",
+    }
 )
 _QUAD_WORDS: frozenset[str] = frozenset(
-    {"quadratic", "curvature", "curved", "nonlinear", "non", "parabolic",
-     "optimum", "maximum", "minimum"}
+    {
+        "quadratic", "curvature", "curved", "nonlinear", "non", "parabolic",
+        "optimum", "maximum", "minimum",
+    }
 )
 
 _VALID_NOISE_LEVELS: tuple[str, ...] = tuple(_NOISE_FRACTIONS)
@@ -158,6 +169,48 @@ def _parse_hint(
     }
 
 
+def _apply_interaction_hint(
+    out_coefs: dict[str, Any],
+    factors: list[str],
+    sign: float,
+    rng: np.random.Generator,
+) -> None:
+    """Set (or strengthen) the interaction coefficient for a factor pair."""
+    a, b = sorted(factors)
+    magnitude = float(rng.uniform(1.8, 3.5))
+    for inter in out_coefs["interactions"]:
+        if tuple(sorted(inter["factors"])) == (a, b):
+            inter["coefficient"] = sign * max(abs(inter["coefficient"]), magnitude)
+            return
+    out_coefs["interactions"].append(
+        {"factors": [a, b], "coefficient": sign * magnitude}
+    )
+
+
+def _apply_main_hint(out_coefs: dict[str, Any], factor: str, sign: float) -> None:
+    """Set the main-effect coefficient for *factor* to the given sign."""
+    current = out_coefs["main"].get(factor, 0.0)
+    magnitude = max(abs(current), 3.0)
+    out_coefs["main"][factor] = sign * magnitude
+
+
+def _apply_quadratic_hint(
+    out_coefs: dict[str, Any],
+    factor: str,
+    direction: str | None,
+    rng: np.random.Generator,
+) -> None:
+    """Set the quadratic coefficient for *factor* (concave by default)."""
+    magnitude = float(rng.uniform(1.5, 3.0))
+    if direction == "+":
+        out_coefs["quadratic"][factor] = magnitude
+    elif direction == "-":
+        out_coefs["quadratic"][factor] = -magnitude
+    else:
+        # Default to concave (typical optimum-in-the-middle shape).
+        out_coefs["quadratic"][factor] = -magnitude
+
+
 def _apply_hint(
     coefficients: dict[str, dict[str, Any]],
     parsed: dict[str, Any],
@@ -169,43 +222,20 @@ def _apply_hint(
     is_quadratic = parsed["is_quadratic"]
     applied_outputs = parsed["outputs"] or list(coefficients.keys())
     sign_map = {"+": 1.0, "-": -1.0, None: 0.0}
+    has_dir = direction is not None
 
     for out_name in applied_outputs:
         if out_name not in coefficients:
             continue
         out_coefs = coefficients[out_name]
+        sign = sign_map[direction]
 
-        if len(factors) == 2 and direction is not None and not is_quadratic:
-            # Pairwise interaction with a known sign.
-            a, b = sorted(factors)
-            sign = sign_map[direction]
-            magnitude = float(rng.uniform(1.8, 3.5))
-            updated = False
-            for inter in out_coefs["interactions"]:
-                if tuple(sorted(inter["factors"])) == (a, b):
-                    inter["coefficient"] = sign * max(abs(inter["coefficient"]), magnitude)
-                    updated = True
-                    break
-            if not updated:
-                out_coefs["interactions"].append(
-                    {"factors": [a, b], "coefficient": sign * magnitude}
-                )
-
-        if len(factors) == 1 and direction is not None and not is_quadratic:
-            f_name = factors[0]
-            sign = sign_map[direction]
-            current = out_coefs["main"].get(f_name, 0.0)
-            magnitude = max(abs(current), 3.0)
-            out_coefs["main"][f_name] = sign * magnitude
-
-        if len(factors) == 1 and is_quadratic:
-            f_name = factors[0]
-            magnitude = float(rng.uniform(1.5, 3.0))
-            if direction is not None:
-                out_coefs["quadratic"][f_name] = sign_map[direction] * magnitude
-            else:
-                # Default to concave (typical optimum-in-the-middle shape).
-                out_coefs["quadratic"][f_name] = -magnitude
+        if len(factors) == 2 and has_dir and not is_quadratic:
+            _apply_interaction_hint(out_coefs, factors, sign, rng)
+        elif len(factors) == 1 and has_dir and not is_quadratic:
+            _apply_main_hint(out_coefs, factors[0], sign)
+        elif len(factors) == 1 and is_quadratic:
+            _apply_quadratic_hint(out_coefs, factors[0], direction, rng)
 
 
 # ---------------------------------------------------------------------------
@@ -283,7 +313,7 @@ def materialize_model(private_state: dict[str, Any]) -> dict[str, Any]:
         _apply_hint(per_output, _parse_hint(hint, factor_names, output_names), rng)
 
     noise_fraction = _NOISE_FRACTIONS[noise_level]
-    for name, coefs in per_output.items():
+    for coefs in per_output.values():
         coefs["noise_sigma"] = noise_fraction * _total_abs_magnitude(coefs)
         if time_drift:
             coefs["drift_rate_per_day"] = float(
@@ -309,6 +339,48 @@ def _coded_setting(value: float, low: float, high: float) -> float:
     if high == low:
         return 0.0
     return 2.0 * (value - low) / (high - low) - 1.0
+
+
+def _resolve_setting(
+    name: str,
+    low: float,
+    high: float,
+    settings: dict[str, float],
+    warnings: list[str],
+) -> float:
+    """Return the effective factor value, warning on missing/clipped inputs."""
+    if name not in settings:
+        val = (low + high) / 2.0
+        warnings.append(f"Factor {name!r} not provided; using mid-range value {val}.")
+        return val
+    val = float(settings[name])
+    if val < low:
+        warnings.append(f"Factor {name!r}={val} below low={low}; clipped to {low}.")
+        return low
+    if val > high:
+        warnings.append(f"Factor {name!r}={val} above high={high}; clipped to {high}.")
+        return high
+    return val
+
+
+def _evaluate_surface(
+    out_coefs: dict[str, Any],
+    coded: dict[str, float],
+    timestamp_offset_days: float,
+    noise_rng: np.random.Generator,
+) -> float:
+    """Evaluate the full polynomial for one output, including noise + drift."""
+    y = float(out_coefs["intercept"])
+    for f_name, coef in out_coefs["main"].items():
+        y += coef * coded[f_name]
+    for inter in out_coefs["interactions"]:
+        a, b = inter["factors"]
+        y += inter["coefficient"] * coded[a] * coded[b]
+    for f_name, coef in out_coefs["quadratic"].items():
+        y += coef * (coded[f_name] ** 2)
+    y += out_coefs["drift_rate_per_day"] * float(timestamp_offset_days)
+    y += float(noise_rng.normal(0.0, out_coefs["noise_sigma"]))
+    return y
 
 
 def simulate(
@@ -347,42 +419,16 @@ def simulate(
     effective_settings: dict[str, float] = {}
     coded: dict[str, float] = {}
     for name, (low, high) in factor_ranges.items():
-        if name not in settings:
-            val = (low + high) / 2.0
-            warnings.append(
-                f"Factor {name!r} not provided; using mid-range value {val}."
-            )
-        else:
-            val = float(settings[name])
-            if val < low:
-                warnings.append(
-                    f"Factor {name!r}={val} below low={low}; clipped to {low}."
-                )
-                val = low
-            elif val > high:
-                warnings.append(
-                    f"Factor {name!r}={val} above high={high}; clipped to {high}."
-                )
-                val = high
+        val = _resolve_setting(name, low, high, settings, warnings)
         effective_settings[name] = val
         coded[name] = _coded_setting(val, low, high)
 
     # Fresh (unseeded) RNG — noise is genuinely different on every call.
     noise_rng = np.random.default_rng()
-    outputs: dict[str, float] = {}
-
-    for out_name, out_coefs in model["per_output"].items():
-        y = float(out_coefs["intercept"])
-        for f_name, coef in out_coefs["main"].items():
-            y += coef * coded[f_name]
-        for inter in out_coefs["interactions"]:
-            a, b = inter["factors"]
-            y += inter["coefficient"] * coded[a] * coded[b]
-        for f_name, coef in out_coefs["quadratic"].items():
-            y += coef * (coded[f_name] ** 2)
-        y += out_coefs["drift_rate_per_day"] * float(timestamp_offset_days)
-        y += float(noise_rng.normal(0.0, out_coefs["noise_sigma"]))
-        outputs[out_name] = float(y)
+    outputs: dict[str, float] = {
+        out_name: float(_evaluate_surface(out_coefs, coded, timestamp_offset_days, noise_rng))
+        for out_name, out_coefs in model["per_output"].items()
+    }
 
     return {
         "settings": effective_settings,

--- a/process_improve/simulation/model.py
+++ b/process_improve/simulation/model.py
@@ -1,0 +1,399 @@
+"""(c) Kevin Dunn, 2010-2026. MIT License.
+
+Deterministic fake-data simulator for DOE demonstrations.
+
+The simulator is fully specified by a JSON-serialisable ``private_state``
+dict containing:
+
+- ``seed``:             int  — base RNG seed for coefficient generation.
+- ``factors``:          list of ``{name, low, high, units?}``.
+- ``outputs``:          list of ``{name, units?, direction?}``.
+- ``structural_hints``: list of free-text hints (\"negative interaction
+  between pH and surfactant\", etc).
+- ``noise_level``:      ``\"low\"`` | ``\"medium\"`` | ``\"high\"``.
+- ``time_drift``:       bool.
+- ``model_version``:    int (schema version for future migrations).
+
+Given this state, :func:`materialize_model` regenerates the exact same
+response-surface coefficients on every call, across processes, across
+machines.  :func:`simulate` evaluates that surface at a given factor
+setting and adds *fresh* Gaussian noise each call so identical inputs
+yield similar-but-not-identical outputs — matching the behaviour of a
+real physical asset.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MODEL_VERSION: int = 1
+
+# Fraction of the total coefficient magnitude used as the Gaussian noise
+# standard deviation, keyed by the ``noise_level`` string.
+_NOISE_FRACTIONS: dict[str, float] = {
+    "low": 0.01,
+    "medium": 0.05,
+    "high": 0.15,
+}
+
+# Hint-parsing keyword sets.  Any token intersection with one of these sets
+# carries the corresponding meaning; ties (both positive *and* negative in
+# the same hint) fall back to \"no direction\" and are ignored.
+_POS_WORDS: frozenset[str] = frozenset(
+    {"positive", "increase", "increases", "increasing", "synergy",
+     "synergistic", "synergise", "synergize", "boost", "boosts", "promotes"}
+)
+_NEG_WORDS: frozenset[str] = frozenset(
+    {"negative", "decrease", "decreases", "decreasing", "antagonistic",
+     "antagonise", "antagonize", "antagonism", "adverse", "inhibits",
+     "suppresses"}
+)
+_QUAD_WORDS: frozenset[str] = frozenset(
+    {"quadratic", "curvature", "curved", "nonlinear", "non", "parabolic",
+     "optimum", "maximum", "minimum"}
+)
+
+_VALID_NOISE_LEVELS: tuple[str, ...] = tuple(_NOISE_FRACTIONS)
+
+# ---------------------------------------------------------------------------
+# Input validation (shared by the tool layer)
+# ---------------------------------------------------------------------------
+
+
+def validate_factors(factors: list[dict[str, Any]]) -> None:
+    """Validate the ``factors`` list from a ``create_simulator`` call."""
+    if not isinstance(factors, list) or not factors:
+        raise ValueError("'factors' must be a non-empty list of dicts.")
+    seen: set[str] = set()
+    for f in factors:
+        if not isinstance(f, dict):
+            raise ValueError("Each factor must be a dict.")
+        name = f.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError("Each factor must have a non-empty 'name' string.")
+        if name in seen:
+            raise ValueError(f"Duplicate factor name: {name!r}.")
+        seen.add(name)
+        low = f.get("low")
+        high = f.get("high")
+        if not isinstance(low, (int, float)) or not isinstance(high, (int, float)):
+            raise ValueError(f"Factor {name!r}: 'low' and 'high' must be numbers.")
+        if float(low) >= float(high):
+            raise ValueError(f"Factor {name!r}: low ({low}) must be < high ({high}).")
+
+
+def validate_outputs(outputs: list[dict[str, Any]]) -> None:
+    """Validate the ``outputs`` list from a ``create_simulator`` call."""
+    if not isinstance(outputs, list) or not outputs:
+        raise ValueError("'outputs' must be a non-empty list of dicts.")
+    seen: set[str] = set()
+    for o in outputs:
+        if not isinstance(o, dict):
+            raise ValueError("Each output must be a dict.")
+        name = o.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError("Each output must have a non-empty 'name' string.")
+        if name in seen:
+            raise ValueError(f"Duplicate output name: {name!r}.")
+        seen.add(name)
+
+
+def validate_noise_level(noise_level: str) -> None:
+    """Reject any ``noise_level`` outside the fixed enum."""
+    if noise_level not in _VALID_NOISE_LEVELS:
+        raise ValueError(
+            f"'noise_level' must be one of {list(_VALID_NOISE_LEVELS)}, got {noise_level!r}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Hint parsing
+# ---------------------------------------------------------------------------
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
+
+
+def _tokenise(text: str) -> set[str]:
+    return {t.lower() for t in _TOKEN_RE.findall(text)}
+
+
+def _parse_hint(
+    hint: str,
+    factor_names: list[str],
+    output_names: list[str],
+) -> dict[str, Any]:
+    """Turn a free-text hint into a structured directive.
+
+    The returned dict has keys:
+    ``factors`` (subset of *factor_names*),
+    ``outputs`` (subset of *output_names*; empty means \"all\"),
+    ``direction`` (``\"+\"`` / ``\"-\"`` / ``None``),
+    ``is_quadratic`` (bool).
+    """
+    tokens = _tokenise(hint)
+    matched_factors = [f for f in factor_names if f.lower() in tokens]
+    matched_outputs = [o for o in output_names if o.lower() in tokens]
+    has_pos = bool(tokens & _POS_WORDS)
+    has_neg = bool(tokens & _NEG_WORDS)
+    # Ambiguous hints (both directions) are treated as direction-less.
+    direction: str | None = None
+    if has_pos and not has_neg:
+        direction = "+"
+    elif has_neg and not has_pos:
+        direction = "-"
+    # Bare \"non\" also matches (\"non-linear\" etc).
+    is_quadratic = bool(tokens & _QUAD_WORDS)
+    return {
+        "factors": matched_factors,
+        "outputs": matched_outputs,
+        "direction": direction,
+        "is_quadratic": is_quadratic,
+    }
+
+
+def _apply_hint(
+    coefficients: dict[str, dict[str, Any]],
+    parsed: dict[str, Any],
+    rng: np.random.Generator,
+) -> None:
+    """Mutate *coefficients* to reflect a single parsed hint."""
+    factors = parsed["factors"]
+    direction = parsed["direction"]
+    is_quadratic = parsed["is_quadratic"]
+    applied_outputs = parsed["outputs"] or list(coefficients.keys())
+    sign_map = {"+": 1.0, "-": -1.0, None: 0.0}
+
+    for out_name in applied_outputs:
+        if out_name not in coefficients:
+            continue
+        out_coefs = coefficients[out_name]
+
+        if len(factors) == 2 and direction is not None and not is_quadratic:
+            # Pairwise interaction with a known sign.
+            a, b = sorted(factors)
+            sign = sign_map[direction]
+            magnitude = float(rng.uniform(1.8, 3.5))
+            updated = False
+            for inter in out_coefs["interactions"]:
+                if tuple(sorted(inter["factors"])) == (a, b):
+                    inter["coefficient"] = sign * max(abs(inter["coefficient"]), magnitude)
+                    updated = True
+                    break
+            if not updated:
+                out_coefs["interactions"].append(
+                    {"factors": [a, b], "coefficient": sign * magnitude}
+                )
+
+        if len(factors) == 1 and direction is not None and not is_quadratic:
+            f_name = factors[0]
+            sign = sign_map[direction]
+            current = out_coefs["main"].get(f_name, 0.0)
+            magnitude = max(abs(current), 3.0)
+            out_coefs["main"][f_name] = sign * magnitude
+
+        if len(factors) == 1 and is_quadratic:
+            f_name = factors[0]
+            magnitude = float(rng.uniform(1.5, 3.0))
+            if direction is not None:
+                out_coefs["quadratic"][f_name] = sign_map[direction] * magnitude
+            else:
+                # Default to concave (typical optimum-in-the-middle shape).
+                out_coefs["quadratic"][f_name] = -magnitude
+
+
+# ---------------------------------------------------------------------------
+# Coefficient materialisation
+# ---------------------------------------------------------------------------
+
+
+def _empty_output_coefs(rng: np.random.Generator, factor_names: list[str]) -> dict[str, Any]:
+    """Draw a baseline set of coefficients for one output."""
+    k = len(factor_names)
+    intercept = 50.0 + float(rng.normal(0.0, 10.0))
+    main = {f: float(rng.normal(0.0, 5.0)) for f in factor_names}
+
+    interactions: list[dict[str, Any]] = []
+    # Sparse: each pair is non-zero with 30 % probability.
+    for i in range(k):
+        for j in range(i + 1, k):
+            if rng.random() < 0.30:
+                interactions.append(
+                    {
+                        "factors": [factor_names[i], factor_names[j]],
+                        "coefficient": float(rng.normal(0.0, 2.5)),
+                    }
+                )
+
+    quadratic: dict[str, float] = {}
+    for f in factor_names:
+        if rng.random() < 0.40:
+            quadratic[f] = float(rng.normal(0.0, 2.0))
+
+    return {
+        "intercept": intercept,
+        "main": main,
+        "interactions": interactions,
+        "quadratic": quadratic,
+    }
+
+
+def _total_abs_magnitude(out_coefs: dict[str, Any]) -> float:
+    return (
+        abs(out_coefs["intercept"])
+        + sum(abs(v) for v in out_coefs["main"].values())
+        + sum(abs(inter["coefficient"]) for inter in out_coefs["interactions"])
+        + sum(abs(v) for v in out_coefs["quadratic"].values())
+    )
+
+
+def materialize_model(private_state: dict[str, Any]) -> dict[str, Any]:
+    """Regenerate the full coefficient set from a ``private_state`` dict.
+
+    Deterministic: identical *private_state* always returns identical
+    coefficients, across processes and machines.  This is the secret
+    the simulator hides from the LLM — callers that have *private_state*
+    already have the model, so \"revealing\" is free.
+    """
+    seed = int(private_state["seed"])
+    factors = private_state["factors"]
+    outputs = private_state["outputs"]
+    hints = private_state.get("structural_hints") or []
+    noise_level = private_state.get("noise_level", "medium")
+    time_drift = bool(private_state.get("time_drift", False))
+
+    factor_names = [f["name"] for f in factors]
+    output_names = [o["name"] for o in outputs]
+
+    rng = np.random.default_rng(seed)
+
+    per_output: dict[str, dict[str, Any]] = {
+        name: _empty_output_coefs(rng, factor_names) for name in output_names
+    }
+
+    for hint in hints:
+        if not isinstance(hint, str):
+            continue
+        _apply_hint(per_output, _parse_hint(hint, factor_names, output_names), rng)
+
+    noise_fraction = _NOISE_FRACTIONS[noise_level]
+    for name, coefs in per_output.items():
+        coefs["noise_sigma"] = noise_fraction * _total_abs_magnitude(coefs)
+        if time_drift:
+            coefs["drift_rate_per_day"] = float(
+                rng.normal(0.0, 0.01) * abs(coefs["intercept"])
+            )
+        else:
+            coefs["drift_rate_per_day"] = 0.0
+
+    return {
+        "per_output": per_output,
+        "noise_level": noise_level,
+        "time_drift": time_drift,
+        "model_version": MODEL_VERSION,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Simulation
+# ---------------------------------------------------------------------------
+
+
+def _coded_setting(value: float, low: float, high: float) -> float:
+    if high == low:
+        return 0.0
+    return 2.0 * (value - low) / (high - low) - 1.0
+
+
+def simulate(
+    private_state: dict[str, Any],
+    settings: dict[str, float],
+    timestamp_offset_days: float = 0.0,
+) -> dict[str, Any]:
+    """Evaluate the hidden response surface at *settings*, with fresh noise.
+
+    Parameters
+    ----------
+    private_state:
+        The state dict produced by ``create_simulator`` (and persisted
+        by the host).  Passed in whole so this function stays pure.
+    settings:
+        Mapping of factor-name → numeric value, in the same units as
+        the factor's declared range.  Missing factors are filled with
+        the mid-range value (with a warning).  Out-of-range values are
+        clipped to the declared bounds (with a warning).
+    timestamp_offset_days:
+        Optional time axis passed by the caller when ``time_drift`` is
+        enabled on the simulator.  Ignored otherwise.
+
+    Returns
+    -------
+    dict
+        ``{settings, outputs, warnings, timestamp_offset_days}``.
+    """
+    model = materialize_model(private_state)
+    factor_ranges = {
+        f["name"]: (float(f["low"]), float(f["high"]))
+        for f in private_state["factors"]
+    }
+
+    warnings: list[str] = []
+    effective_settings: dict[str, float] = {}
+    coded: dict[str, float] = {}
+    for name, (low, high) in factor_ranges.items():
+        if name not in settings:
+            val = (low + high) / 2.0
+            warnings.append(
+                f"Factor {name!r} not provided; using mid-range value {val}."
+            )
+        else:
+            val = float(settings[name])
+            if val < low:
+                warnings.append(
+                    f"Factor {name!r}={val} below low={low}; clipped to {low}."
+                )
+                val = low
+            elif val > high:
+                warnings.append(
+                    f"Factor {name!r}={val} above high={high}; clipped to {high}."
+                )
+                val = high
+        effective_settings[name] = val
+        coded[name] = _coded_setting(val, low, high)
+
+    # Fresh (unseeded) RNG — noise is genuinely different on every call.
+    noise_rng = np.random.default_rng()
+    outputs: dict[str, float] = {}
+
+    for out_name, out_coefs in model["per_output"].items():
+        y = float(out_coefs["intercept"])
+        for f_name, coef in out_coefs["main"].items():
+            y += coef * coded[f_name]
+        for inter in out_coefs["interactions"]:
+            a, b = inter["factors"]
+            y += inter["coefficient"] * coded[a] * coded[b]
+        for f_name, coef in out_coefs["quadratic"].items():
+            y += coef * (coded[f_name] ** 2)
+        y += out_coefs["drift_rate_per_day"] * float(timestamp_offset_days)
+        y += float(noise_rng.normal(0.0, out_coefs["noise_sigma"]))
+        outputs[out_name] = float(y)
+
+    return {
+        "settings": effective_settings,
+        "outputs": outputs,
+        "warnings": warnings,
+        "timestamp_offset_days": float(timestamp_offset_days),
+    }
+
+
+def draw_initial_seed() -> int:
+    """Return a non-negative int suitable for use as a seed in *private_state*."""
+    # Keep it in a comfortable numpy range (< 2**31) so JSON int handling and
+    # SQLAlchemy Integer columns don't need to think about width.
+    return int(np.random.SeedSequence().entropy % (2**31))

--- a/process_improve/simulation/model.py
+++ b/process_improve/simulation/model.py
@@ -8,9 +8,9 @@ dict containing:
 - ``seed``:             int  — base RNG seed for coefficient generation.
 - ``factors``:          list of ``{name, low, high, units?}``.
 - ``outputs``:          list of ``{name, units?, direction?}``.
-- ``structural_hints``: list of free-text hints (\"negative interaction
-  between pH and surfactant\", etc).
-- ``noise_level``:      ``\"low\"`` | ``\"medium\"`` | ``\"high\"``.
+- ``structural_hints``: list of free-text hints ("negative interaction
+  between pH and surfactant", etc).
+- ``noise_level``:      ``"low"`` | ``"medium"`` | ``"high"``.
 - ``time_drift``:       bool.
 - ``model_version``:    int (schema version for future migrations).
 
@@ -22,7 +22,6 @@ yield similar-but-not-identical outputs — matching the behaviour of a
 real physical asset.
 """
 
-# ruff: noqa: ANN401
 # The public tool-call contract uses ``dict[str, Any]`` and ``list[dict[str, Any]]``
 # deliberately: the schema that the LLM sees is declared as JSON Schema in
 # ``simulation/tools.py``, not as Python types, so tightening the Python side
@@ -50,7 +49,7 @@ _NOISE_FRACTIONS: dict[str, float] = {
 
 # Hint-parsing keyword sets.  Any token intersection with one of these sets
 # carries the corresponding meaning; ties (both positive *and* negative in
-# the same hint) fall back to \"no direction\" and are ignored.
+# the same hint) fall back to "no direction" and are ignored.
 _POS_WORDS: frozenset[str] = frozenset(
     {
         "positive", "increase", "increases", "increasing", "synergy",
@@ -85,7 +84,7 @@ def validate_factors(factors: list[dict[str, Any]]) -> None:
     seen: set[str] = set()
     for f in factors:
         if not isinstance(f, dict):
-            raise ValueError("Each factor must be a dict.")
+            raise TypeError("Each factor must be a dict.")
         name = f.get("name")
         if not isinstance(name, str) or not name:
             raise ValueError("Each factor must have a non-empty 'name' string.")
@@ -95,7 +94,7 @@ def validate_factors(factors: list[dict[str, Any]]) -> None:
         low = f.get("low")
         high = f.get("high")
         if not isinstance(low, (int, float)) or not isinstance(high, (int, float)):
-            raise ValueError(f"Factor {name!r}: 'low' and 'high' must be numbers.")
+            raise TypeError(f"Factor {name!r}: 'low' and 'high' must be numbers.")
         if float(low) >= float(high):
             raise ValueError(f"Factor {name!r}: low ({low}) must be < high ({high}).")
 
@@ -107,7 +106,7 @@ def validate_outputs(outputs: list[dict[str, Any]]) -> None:
     seen: set[str] = set()
     for o in outputs:
         if not isinstance(o, dict):
-            raise ValueError("Each output must be a dict.")
+            raise TypeError("Each output must be a dict.")
         name = o.get("name")
         if not isinstance(name, str) or not name:
             raise ValueError("Each output must have a non-empty 'name' string.")
@@ -144,8 +143,8 @@ def _parse_hint(
 
     The returned dict has keys:
     ``factors`` (subset of *factor_names*),
-    ``outputs`` (subset of *output_names*; empty means \"all\"),
-    ``direction`` (``\"+\"`` / ``\"-\"`` / ``None``),
+    ``outputs`` (subset of *output_names*; empty means "all"),
+    ``direction`` (``"+"`` / ``"-"`` / ``None``),
     ``is_quadratic`` (bool).
     """
     tokens = _tokenise(hint)
@@ -159,7 +158,7 @@ def _parse_hint(
         direction = "+"
     elif has_neg and not has_pos:
         direction = "-"
-    # Bare \"non\" also matches (\"non-linear\" etc).
+    # Bare "non" also matches ("non-linear" etc).
     is_quadratic = bool(tokens & _QUAD_WORDS)
     return {
         "factors": matched_factors,
@@ -249,17 +248,16 @@ def _empty_output_coefs(rng: np.random.Generator, factor_names: list[str]) -> di
     intercept = 50.0 + float(rng.normal(0.0, 10.0))
     main = {f: float(rng.normal(0.0, 5.0)) for f in factor_names}
 
-    interactions: list[dict[str, Any]] = []
     # Sparse: each pair is non-zero with 30 % probability.
-    for i in range(k):
-        for j in range(i + 1, k):
-            if rng.random() < 0.30:
-                interactions.append(
-                    {
-                        "factors": [factor_names[i], factor_names[j]],
-                        "coefficient": float(rng.normal(0.0, 2.5)),
-                    }
-                )
+    interactions: list[dict[str, Any]] = [
+        {
+            "factors": [factor_names[i], factor_names[j]],
+            "coefficient": float(rng.normal(0.0, 2.5)),
+        }
+        for i in range(k)
+        for j in range(i + 1, k)
+        if rng.random() < 0.30
+    ]
 
     quadratic: dict[str, float] = {}
     for f in factor_names:
@@ -289,7 +287,7 @@ def materialize_model(private_state: dict[str, Any]) -> dict[str, Any]:
     Deterministic: identical *private_state* always returns identical
     coefficients, across processes and machines.  This is the secret
     the simulator hides from the LLM — callers that have *private_state*
-    already have the model, so \"revealing\" is free.
+    already have the model, so "revealing" is free.
     """
     seed = int(private_state["seed"])
     factors = private_state["factors"]

--- a/process_improve/simulation/tools.py
+++ b/process_improve/simulation/tools.py
@@ -18,7 +18,6 @@ kwarg. The JSON schema advertised to the LLM does not mention
 so the LLM cannot bypass the reveal policy or fabricate state.
 """
 
-# ruff: noqa: ANN401
 # ``dict[str, Any]`` is the tool-call contract shape; the real schema
 # lives in the @tool_spec JSON blocks below, not in the Python types.
 from __future__ import annotations
@@ -26,6 +25,8 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 from typing import Any
+
+from process_improve.tool_spec import clean, get_tool_specs, tool_spec
 
 from process_improve.simulation.model import (
     draw_initial_seed,
@@ -35,7 +36,6 @@ from process_improve.simulation.model import (
     validate_noise_level,
     validate_outputs,
 )
-from process_improve.tool_spec import clean, get_tool_specs, tool_spec
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -326,7 +326,7 @@ def simulate_process(
             ),
         }
     if not isinstance(settings, dict):
-        raise ValueError("'settings' must be a dict of factor-name to numeric value.")
+        raise TypeError("'settings' must be a dict of factor-name to numeric value.")
 
     result = simulate(
         simulator_state,

--- a/process_improve/simulation/tools.py
+++ b/process_improve/simulation/tools.py
@@ -1,0 +1,425 @@
+"""(c) Kevin Dunn, 2010-2026. MIT License.
+
+Agent-callable tool wrappers for the fake-data simulator.
+
+Three tools are exposed:
+
+- ``create_simulator`` — records a hidden response-surface model.
+- ``simulate_process`` — evaluates the hidden model at given factor
+  settings, with fresh Gaussian noise each call.
+- ``reveal_simulator`` — returns the underlying coefficients, gated
+  behind a ``confirmed`` flag enforced by the host.
+
+The tools are intentionally stateless: the hidden model lives in a
+``private_state`` dict that the host (e.g. the factorial web app)
+persists and injects on each call via a hidden ``simulator_state``
+kwarg. The JSON schema advertised to the LLM does not mention
+``simulator_state`` or ``confirmed`` — those are injected server-side
+so the LLM cannot bypass the reveal policy or fabricate state.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from process_improve.simulation.model import (
+    draw_initial_seed,
+    materialize_model,
+    simulate,
+    validate_factors,
+    validate_noise_level,
+    validate_outputs,
+)
+from process_improve.tool_spec import clean, get_tool_specs, tool_spec
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SIMULATION_TOOL_NAMES: list[str] = []
+
+
+def _register(name: str) -> None:
+    _SIMULATION_TOOL_NAMES.append(name)
+
+
+def _public_from_private(private: dict[str, Any], process_description: str, created_at: str) -> dict[str, Any]:
+    """Build the LLM-visible summary of a simulator from its private state."""
+    return {
+        "factors": [
+            {
+                "name": f["name"],
+                "low": float(f["low"]),
+                "high": float(f["high"]),
+                "units": f.get("units"),
+            }
+            for f in private["factors"]
+        ],
+        "outputs": [
+            {"name": o["name"], "units": o.get("units"), "direction": o.get("direction")}
+            for o in private["outputs"]
+        ],
+        "noise_level": private["noise_level"],
+        "time_drift": private["time_drift"],
+        "process_description": process_description,
+        "created_at": created_at,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@tool_spec(
+    name="create_simulator",
+    description=(
+        "Create a hidden process-simulator that the user can query for synthetic "
+        "response data. Use this when the user wants fake but realistic data to "
+        "plan or demonstrate a designed experiment. "
+        "Pick factor ranges silently from your domain knowledge; pass them in "
+        "the 'factors' list. The 'outputs' list must come from the user — "
+        "propose defaults if they are undecided but confirm before calling. "
+        "The underlying model (intercepts, main effects, 2-factor interactions, "
+        "quadratic terms) is generated internally and must NOT be disclosed to "
+        "the user unless they explicitly ask to reveal it, in which case call "
+        "'reveal_simulator'. "
+        "Returns a 'sim_id' to pass to subsequent 'simulate_process' calls, plus "
+        "a public summary of the declared factors, outputs, and noise level. "
+        "The host application persists the hidden state — do NOT try to store "
+        "or paraphrase it yourself."
+    ),
+    input_schema={
+        "json": {
+            "type": "object",
+            "properties": {
+                "process_description": {
+                    "type": "string",
+                    "description": (
+                        "One-sentence description of the process being simulated, "
+                        "e.g. 'nickel flotation vessel for recovery and grade'."
+                    ),
+                },
+                "factors": {
+                    "type": "array",
+                    "description": (
+                        "Input variables the user can set. Choose plausible low/high "
+                        "bounds from your domain expertise; do not ask the user for "
+                        "ranges unless they insist."
+                    ),
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "low": {"type": "number"},
+                            "high": {"type": "number"},
+                            "units": {"type": "string"},
+                        },
+                        "required": ["name", "low", "high"],
+                    },
+                },
+                "outputs": {
+                    "type": "array",
+                    "description": (
+                        "Response variables the user wants measured. Confirm with the "
+                        "user before calling the tool."
+                    ),
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "units": {"type": "string"},
+                            "direction": {
+                                "type": "string",
+                                "enum": ["maximize", "minimize", "target"],
+                                "description": "Optional optimisation direction.",
+                            },
+                        },
+                        "required": ["name"],
+                    },
+                },
+                "structural_hints": {
+                    "type": "array",
+                    "description": (
+                        "Free-text biases for the hidden model, e.g. 'negative "
+                        "interaction between pH and surfactant', 'flow has a "
+                        "quadratic effect on recovery'. Unparseable hints are "
+                        "silently ignored."
+                    ),
+                    "items": {"type": "string"},
+                },
+                "noise_level": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high"],
+                    "description": (
+                        "Noise magnitude as a fraction of the output range "
+                        "(~1 %, ~5 %, ~15 %). Default 'medium'."
+                    ),
+                },
+                "time_drift": {
+                    "type": "boolean",
+                    "description": (
+                        "When true, each output gets a slow linear drift applied "
+                        "whenever the user passes 'timestamp_offset_days' to "
+                        "'simulate_process'. Default false."
+                    ),
+                },
+            },
+            "required": ["process_description", "factors", "outputs"],
+        }
+    },
+    examples="""
+    # "Simulate a Ni flotation vessel with flow, pH, surfactant and the known
+    #  negative pH*surfactant interaction; recovery and grade as outputs."
+        -> ``create_simulator(
+                process_description="Ni flotation vessel",
+                factors=[
+                    {"name": "flow", "low": 100, "high": 300, "units": "L/min"},
+                    {"name": "pH", "low": 7.0, "high": 11.0},
+                    {"name": "surfactant", "low": 10, "high": 80, "units": "ppm"},
+                ],
+                outputs=[
+                    {"name": "recovery", "units": "%", "direction": "maximize"},
+                    {"name": "grade", "units": "%", "direction": "maximize"},
+                ],
+                structural_hints=["negative interaction between pH and surfactant"],
+                noise_level="medium",
+            )``
+    """,
+    category="simulation",
+)
+def create_simulator(
+    *,
+    process_description: str,
+    factors: list[dict[str, Any]],
+    outputs: list[dict[str, Any]],
+    structural_hints: list[str] | None = None,
+    noise_level: str = "medium",
+    time_drift: bool = False,
+    seed: int | None = None,
+) -> dict:
+    """Create a simulator; see tool spec for parameter details.
+
+    The ``seed`` kwarg is intentionally missing from the public JSON schema
+    so the LLM cannot pin a seed it will later try to reason about; callers
+    that need reproducibility (tests, notebooks) pass it in Python directly.
+    """
+    validate_factors(factors)
+    validate_outputs(outputs)
+    validate_noise_level(noise_level)
+    if not isinstance(process_description, str) or not process_description.strip():
+        raise ValueError("'process_description' must be a non-empty string.")
+
+    seed_value = int(seed) if seed is not None else draw_initial_seed()
+    sim_id = str(uuid.uuid4())
+    created_at = datetime.now(UTC).isoformat()
+
+    private_state: dict[str, Any] = {
+        "seed": seed_value,
+        "factors": [
+            {
+                "name": f["name"],
+                "low": float(f["low"]),
+                "high": float(f["high"]),
+                "units": f.get("units"),
+            }
+            for f in factors
+        ],
+        "outputs": [
+            {"name": o["name"], "units": o.get("units"), "direction": o.get("direction")}
+            for o in outputs
+        ],
+        "structural_hints": list(structural_hints or []),
+        "noise_level": noise_level,
+        "time_drift": bool(time_drift),
+        "model_version": 1,
+    }
+
+    public = _public_from_private(private_state, process_description, created_at)
+
+    # ``_private`` uses a leading underscore so hosts can identify and
+    # strip it before forwarding the tool result to the LLM.
+    return clean({"sim_id": sim_id, "public": public, "_private": private_state})
+
+
+_register("create_simulator")
+
+
+@tool_spec(
+    name="simulate_process",
+    description=(
+        "Evaluate a previously created simulator at specific factor settings. "
+        "Returns the simulated output values (with fresh Gaussian noise per call, "
+        "so identical settings yield similar but not identical outputs — this is "
+        "intentional, matching real asset behaviour). "
+        "Pass 'sim_id' from the 'create_simulator' response. Supply all declared "
+        "factors in 'settings'; missing factors default to their mid-range value "
+        "and out-of-range values are clipped to the declared bounds (both with a "
+        "warning in the response). "
+        "Use 'timestamp_offset_days' only when the simulator was created with "
+        "time_drift=true."
+    ),
+    input_schema={
+        "json": {
+            "type": "object",
+            "properties": {
+                "sim_id": {
+                    "type": "string",
+                    "description": "Simulator id returned by 'create_simulator'.",
+                },
+                "settings": {
+                    "type": "object",
+                    "description": (
+                        "Mapping of factor-name to numeric value, in the factor's "
+                        "declared units."
+                    ),
+                    "additionalProperties": {"type": "number"},
+                },
+                "timestamp_offset_days": {
+                    "type": "number",
+                    "description": (
+                        "Optional time axis, in days since simulator creation. "
+                        "Only meaningful if the simulator was created with "
+                        "time_drift=true."
+                    ),
+                },
+            },
+            "required": ["sim_id", "settings"],
+        }
+    },
+    examples="""
+    # "Run the simulator at flow=200, pH=9, surfactant=50"
+        -> ``simulate_process(
+                sim_id="<uuid>",
+                settings={"flow": 200, "pH": 9, "surfactant": 50},
+            )``
+    """,
+    category="simulation",
+)
+def simulate_process(
+    *,
+    sim_id: str,
+    settings: dict[str, float],
+    timestamp_offset_days: float = 0.0,
+    simulator_state: dict[str, Any] | None = None,
+) -> dict:
+    """Evaluate a simulator at *settings*; see tool spec for details.
+
+    ``simulator_state`` is not in the JSON schema: the host injects it
+    from its own persistence layer. If it is missing we return a
+    structured error rather than dispatch with a guessed state.
+    """
+    if simulator_state is None:
+        return {
+            "sim_id": sim_id,
+            "error": "simulator_state_missing",
+            "message": (
+                "The host did not inject 'simulator_state'. Ensure sim_id refers "
+                "to a simulator created in this conversation."
+            ),
+        }
+    if not isinstance(settings, dict):
+        raise ValueError("'settings' must be a dict of factor-name to numeric value.")
+
+    result = simulate(
+        simulator_state,
+        settings,
+        timestamp_offset_days=float(timestamp_offset_days),
+    )
+    result["sim_id"] = sim_id
+    return clean(result)
+
+
+_register("simulate_process")
+
+
+@tool_spec(
+    name="reveal_simulator",
+    description=(
+        "Reveal the hidden model behind a simulator. The host application gates "
+        "this call behind a double-confirmation: the first attempt returns a "
+        "'confirmation_needed' status (surface it to the user verbatim), the "
+        "second attempt after the user confirms returns the full coefficient "
+        "set. Only use this when the user explicitly asks to see the underlying "
+        "model."
+    ),
+    input_schema={
+        "json": {
+            "type": "object",
+            "properties": {
+                "sim_id": {
+                    "type": "string",
+                    "description": "Simulator id returned by 'create_simulator'.",
+                },
+            },
+            "required": ["sim_id"],
+        }
+    },
+    examples="""
+    # "Show me the hidden model behind the simulator"
+        -> ``reveal_simulator(sim_id="<uuid>")``
+    """,
+    category="simulation",
+)
+def reveal_simulator(
+    *,
+    sim_id: str,
+    simulator_state: dict[str, Any] | None = None,
+    confirmed: bool = False,
+) -> dict:
+    """Return the materialised model; see tool spec for details.
+
+    ``simulator_state`` and ``confirmed`` are injected by the host, not
+    by the LLM (their absence from the JSON schema is intentional).
+    """
+    if not confirmed:
+        return {
+            "sim_id": sim_id,
+            "status": "confirmation_needed",
+            "message": (
+                "Revealing the simulator will expose the hidden response model. "
+                "Ask the user to confirm; call reveal_simulator again after they "
+                "confirm."
+            ),
+        }
+    if simulator_state is None:
+        return {
+            "sim_id": sim_id,
+            "error": "simulator_state_missing",
+            "message": (
+                "The host did not inject 'simulator_state' even though the "
+                "reveal was confirmed. Ensure sim_id refers to a simulator "
+                "created in this conversation."
+            ),
+        }
+
+    model = materialize_model(simulator_state)
+    return clean(
+        {
+            "sim_id": sim_id,
+            "status": "revealed",
+            "factors": simulator_state["factors"],
+            "outputs": simulator_state["outputs"],
+            "structural_hints": simulator_state.get("structural_hints", []),
+            "noise_level": simulator_state["noise_level"],
+            "time_drift": simulator_state["time_drift"],
+            "model": model,
+        }
+    )
+
+
+_register("reveal_simulator")
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience
+# ---------------------------------------------------------------------------
+
+
+def get_simulation_tool_specs() -> list[dict]:
+    """Return tool specs for all simulation tools registered in this module."""
+    return get_tool_specs(names=_SIMULATION_TOOL_NAMES)

--- a/process_improve/simulation/tools.py
+++ b/process_improve/simulation/tools.py
@@ -26,8 +26,6 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from process_improve.tool_spec import clean, get_tool_specs, tool_spec
-
 from process_improve.simulation.model import (
     draw_initial_seed,
     materialize_model,
@@ -36,6 +34,7 @@ from process_improve.simulation.model import (
     validate_noise_level,
     validate_outputs,
 )
+from process_improve.tool_spec import clean, get_tool_specs, tool_spec
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/process_improve/simulation/tools.py
+++ b/process_improve/simulation/tools.py
@@ -18,6 +18,9 @@ kwarg. The JSON schema advertised to the LLM does not mention
 so the LLM cannot bypass the reveal policy or fabricate state.
 """
 
+# ruff: noqa: ANN401
+# ``dict[str, Any]`` is the tool-call contract shape; the real schema
+# lives in the @tool_spec JSON blocks below, not in the Python types.
 from __future__ import annotations
 
 import uuid
@@ -192,7 +195,7 @@ def _public_from_private(private: dict[str, Any], process_description: str, crea
     """,
     category="simulation",
 )
-def create_simulator(
+def create_simulator(  # noqa: PLR0913
     *,
     process_description: str,
     factors: list[dict[str, Any]],

--- a/process_improve/simulation/tools.py
+++ b/process_improve/simulation/tools.py
@@ -21,7 +21,7 @@ so the LLM cannot bypass the reveal policy or fabricate state.
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from process_improve.simulation.model import (
@@ -216,7 +216,7 @@ def create_simulator(
 
     seed_value = int(seed) if seed is not None else draw_initial_seed()
     sim_id = str(uuid.uuid4())
-    created_at = datetime.now(UTC).isoformat()
+    created_at = datetime.now(timezone.utc).isoformat()
 
     private_state: dict[str, Any] = {
         "seed": seed_value,

--- a/process_improve/tool_spec.py
+++ b/process_improve/tool_spec.py
@@ -184,6 +184,7 @@ def discover_tools() -> None:
         "process_improve.experiments.tools",
         "process_improve.batch.tools",
         "process_improve.visualization.tools",
+        "process_improve.simulation.tools",
     ]:
         with contextlib.suppress(ImportError):
             importlib.import_module(module)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -6,6 +6,7 @@ from concurrent.futures import ProcessPoolExecutor
 
 import numpy as np
 import pytest
+from process_improve.tool_spec import execute_tool_call, get_tool_specs
 
 from process_improve.simulation.model import materialize_model
 from process_improve.simulation.tools import (
@@ -14,7 +15,6 @@ from process_improve.simulation.tools import (
     reveal_simulator,
     simulate_process,
 )
-from process_improve.tool_spec import execute_tool_call, get_tool_specs
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -61,7 +61,8 @@ def _make_sim(seed: int = 42, **overrides) -> dict:
 class TestCreateSimulator:
     def test_returns_sim_id_public_and_private(self):
         sim = _make_sim()
-        assert isinstance(sim["sim_id"], str) and len(sim["sim_id"]) > 10
+        assert isinstance(sim["sim_id"], str)
+        assert len(sim["sim_id"]) > 10
         assert "public" in sim
         assert "_private" in sim
 
@@ -96,7 +97,7 @@ class TestCreateSimulator:
             )
 
     def test_low_must_be_less_than_high(self):
-        with pytest.raises(ValueError, match="low .* must be"):
+        with pytest.raises(ValueError, match=r"low .* must be"):
             create_simulator(
                 process_description="x",
                 factors=[{"name": "A", "low": 5.0, "high": 5.0}],

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,433 @@
+"""Tests for the fake-data simulator (process_improve.simulation)."""
+
+from __future__ import annotations
+
+from concurrent.futures import ProcessPoolExecutor
+
+import numpy as np
+import pytest
+
+from process_improve.simulation.model import (
+    materialize_model,
+    simulate,
+)
+from process_improve.simulation.tools import (
+    _SIMULATION_TOOL_NAMES,
+    create_simulator,
+    get_simulation_tool_specs,
+    reveal_simulator,
+    simulate_process,
+)
+from process_improve.tool_spec import execute_tool_call, get_tool_specs
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_factors() -> list[dict]:
+    return [
+        {"name": "flow", "low": 100.0, "high": 300.0, "units": "L/min"},
+        {"name": "pH", "low": 7.0, "high": 11.0},
+        {"name": "surfactant", "low": 10.0, "high": 80.0, "units": "ppm"},
+    ]
+
+
+def _default_outputs() -> list[dict]:
+    return [
+        {"name": "recovery", "units": "%", "direction": "maximize"},
+        {"name": "grade", "units": "%", "direction": "maximize"},
+    ]
+
+
+def _mid_settings() -> dict[str, float]:
+    return {"flow": 200.0, "pH": 9.0, "surfactant": 45.0}
+
+
+def _make_sim(seed: int = 42, **overrides) -> dict:
+    payload = {
+        "process_description": "Ni flotation vessel",
+        "factors": _default_factors(),
+        "outputs": _default_outputs(),
+        "noise_level": "medium",
+        "time_drift": False,
+        "seed": seed,
+    }
+    payload.update(overrides)
+    return create_simulator(**payload)
+
+
+# ---------------------------------------------------------------------------
+# create_simulator: validation + shape
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSimulator:
+    def test_returns_sim_id_public_and_private(self):
+        sim = _make_sim()
+        assert isinstance(sim["sim_id"], str) and len(sim["sim_id"]) > 10
+        assert "public" in sim
+        assert "_private" in sim
+
+    def test_public_does_not_leak_seed_or_coefficients(self):
+        sim = _make_sim()
+        pub = sim["public"]
+        # The public summary is what the LLM sees after the host strips
+        # _private. It must not contain the seed or any coefficients.
+        flat = str(pub)
+        assert "seed" not in pub
+        assert "intercept" not in flat
+        assert "coefficient" not in flat
+
+    def test_private_carries_everything_needed_to_reproduce(self):
+        sim = _make_sim(seed=777)
+        priv = sim["_private"]
+        assert priv["seed"] == 777
+        assert [f["name"] for f in priv["factors"]] == ["flow", "pH", "surfactant"]
+        assert [o["name"] for o in priv["outputs"]] == ["recovery", "grade"]
+        assert priv["noise_level"] == "medium"
+        assert priv["time_drift"] is False
+
+    def test_duplicate_factor_names_rejected(self):
+        with pytest.raises(ValueError, match="Duplicate factor"):
+            create_simulator(
+                process_description="x",
+                factors=[
+                    {"name": "A", "low": 0.0, "high": 1.0},
+                    {"name": "A", "low": 0.0, "high": 2.0},
+                ],
+                outputs=_default_outputs(),
+            )
+
+    def test_low_must_be_less_than_high(self):
+        with pytest.raises(ValueError, match="low .* must be"):
+            create_simulator(
+                process_description="x",
+                factors=[{"name": "A", "low": 5.0, "high": 5.0}],
+                outputs=_default_outputs(),
+            )
+
+    def test_invalid_noise_level_rejected(self):
+        with pytest.raises(ValueError, match="noise_level"):
+            _make_sim(noise_level="enormous")
+
+    def test_empty_outputs_rejected(self):
+        with pytest.raises(ValueError, match="outputs"):
+            create_simulator(
+                process_description="x",
+                factors=_default_factors(),
+                outputs=[],
+            )
+
+
+# ---------------------------------------------------------------------------
+# simulate_process: noise semantics, clipping, drift
+# ---------------------------------------------------------------------------
+
+
+class TestSimulateProcess:
+    def test_requires_simulator_state(self):
+        result = simulate_process(sim_id="abc", settings=_mid_settings())
+        assert result["error"] == "simulator_state_missing"
+
+    def test_returns_one_value_per_output(self):
+        sim = _make_sim()
+        result = simulate_process(
+            sim_id=sim["sim_id"],
+            settings=_mid_settings(),
+            simulator_state=sim["_private"],
+        )
+        assert set(result["outputs"]) == {"recovery", "grade"}
+        for v in result["outputs"].values():
+            assert isinstance(v, float)
+
+    def test_fresh_noise_each_call(self):
+        sim = _make_sim()
+        calls = [
+            simulate_process(
+                sim_id=sim["sim_id"],
+                settings=_mid_settings(),
+                simulator_state=sim["_private"],
+            )
+            for _ in range(20)
+        ]
+        recovery = [c["outputs"]["recovery"] for c in calls]
+        # Variance must be non-trivial: fresh-noise policy, not sticky.
+        assert float(np.std(recovery)) > 1e-6
+
+    def test_mean_converges_to_deterministic_surface(self):
+        """Many noisy draws at the same point should average to the noiseless surface."""
+        sim = _make_sim(seed=123, noise_level="medium")
+        priv = sim["_private"]
+        samples = 400
+        recovery_sum = 0.0
+        for _ in range(samples):
+            r = simulate_process(
+                sim_id=sim["sim_id"],
+                settings=_mid_settings(),
+                simulator_state=priv,
+            )
+            recovery_sum += r["outputs"]["recovery"]
+        empirical_mean = recovery_sum / samples
+
+        # The revealed model lets us compute the noiseless prediction.
+        model = materialize_model(priv)
+        # At mid-range, all coded values are 0 ==> y = intercept.
+        expected = model["per_output"]["recovery"]["intercept"]
+        sigma = model["per_output"]["recovery"]["noise_sigma"]
+        # 99.9 % band of the sample mean is ~3.3 * sigma / sqrt(n).
+        tol = 3.5 * sigma / np.sqrt(samples)
+        assert abs(empirical_mean - expected) < max(tol, 0.05)
+
+    def test_out_of_range_settings_clipped(self):
+        sim = _make_sim()
+        result = simulate_process(
+            sim_id=sim["sim_id"],
+            settings={"flow": 9999.0, "pH": 9.0, "surfactant": 45.0},
+            simulator_state=sim["_private"],
+        )
+        assert result["settings"]["flow"] == 300.0
+        assert any("clipped" in w for w in result["warnings"])
+
+    def test_missing_factor_uses_midrange(self):
+        sim = _make_sim()
+        result = simulate_process(
+            sim_id=sim["sim_id"],
+            settings={"pH": 9.0, "surfactant": 45.0},  # no flow
+            simulator_state=sim["_private"],
+        )
+        assert result["settings"]["flow"] == 200.0
+        assert any("mid-range" in w for w in result["warnings"])
+
+    def test_time_drift_off_ignores_offset(self):
+        sim = _make_sim(time_drift=False, noise_level="low")
+        priv = sim["_private"]
+
+        def mean_recovery_at(t: float, n: int = 200) -> float:
+            return float(
+                np.mean(
+                    [
+                        simulate_process(
+                            sim_id=sim["sim_id"],
+                            settings=_mid_settings(),
+                            simulator_state=priv,
+                            timestamp_offset_days=t,
+                        )["outputs"]["recovery"]
+                        for _ in range(n)
+                    ]
+                )
+            )
+
+        m0 = mean_recovery_at(0.0)
+        m30 = mean_recovery_at(30.0)
+        # With noise_level=low and n=200, |mean diff| << 1 % of intercept.
+        assert abs(m0 - m30) < 1.0
+
+    def test_time_drift_on_shifts_mean(self):
+        # Find a seed whose drift rate is non-negligible; most seeds qualify,
+        # but the draw comes from a N(0, 1%*|intercept|) prior so a few are
+        # near zero. Search deterministically to keep the test stable.
+        for seed in range(1, 20):
+            sim = _make_sim(seed=seed, time_drift=True, noise_level="low")
+            model = materialize_model(sim["_private"])
+            drift = model["per_output"]["recovery"]["drift_rate_per_day"]
+            if abs(drift) >= 0.05:
+                break
+        else:
+            pytest.skip("No seed produced a meaningful drift rate.")
+
+        priv = sim["_private"]
+        sigma = model["per_output"]["recovery"]["noise_sigma"]
+        n = 400
+        m0 = float(
+            np.mean(
+                [
+                    simulate_process(
+                        sim_id=sim["sim_id"],
+                        settings=_mid_settings(),
+                        simulator_state=priv,
+                        timestamp_offset_days=0.0,
+                    )["outputs"]["recovery"]
+                    for _ in range(n)
+                ]
+            )
+        )
+        m30 = float(
+            np.mean(
+                [
+                    simulate_process(
+                        sim_id=sim["sim_id"],
+                        settings=_mid_settings(),
+                        simulator_state=priv,
+                        timestamp_offset_days=30.0,
+                    )["outputs"]["recovery"]
+                    for _ in range(n)
+                ]
+            )
+        )
+        expected_shift = drift * 30.0
+        tol = 5.0 * sigma / np.sqrt(n)
+        assert abs((m30 - m0) - expected_shift) < max(tol, 0.2)
+
+
+# ---------------------------------------------------------------------------
+# reveal_simulator: confirmation gating
+# ---------------------------------------------------------------------------
+
+
+class TestRevealSimulator:
+    def test_pending_when_not_confirmed(self):
+        sim = _make_sim()
+        out = reveal_simulator(sim_id=sim["sim_id"], simulator_state=sim["_private"])
+        assert out["status"] == "confirmation_needed"
+        assert "model" not in out
+
+    def test_returns_full_model_when_confirmed(self):
+        sim = _make_sim(seed=9)
+        out = reveal_simulator(
+            sim_id=sim["sim_id"],
+            simulator_state=sim["_private"],
+            confirmed=True,
+        )
+        assert out["status"] == "revealed"
+        model = out["model"]
+        assert "per_output" in model
+        assert "recovery" in model["per_output"]
+        assert "intercept" in model["per_output"]["recovery"]
+
+    def test_same_seed_reveals_identical_model(self):
+        a = _make_sim(seed=55)
+        b = _make_sim(seed=55)
+        ra = reveal_simulator(
+            sim_id=a["sim_id"],
+            simulator_state=a["_private"],
+            confirmed=True,
+        )
+        rb = reveal_simulator(
+            sim_id=b["sim_id"],
+            simulator_state=b["_private"],
+            confirmed=True,
+        )
+        assert ra["model"] == rb["model"]
+
+    def test_different_seeds_different_model(self):
+        a = _make_sim(seed=55)
+        b = _make_sim(seed=56)
+        ma = reveal_simulator(
+            sim_id=a["sim_id"],
+            simulator_state=a["_private"],
+            confirmed=True,
+        )["model"]
+        mb = reveal_simulator(
+            sim_id=b["sim_id"],
+            simulator_state=b["_private"],
+            confirmed=True,
+        )["model"]
+        assert ma != mb
+
+
+# ---------------------------------------------------------------------------
+# Structural hints
+# ---------------------------------------------------------------------------
+
+
+class TestStructuralHints:
+    def test_negative_interaction_hint_is_honoured(self):
+        """At least 8/10 seeds should produce a negative pH*surfactant coef."""
+        negatives = 0
+        for seed in range(10):
+            sim = _make_sim(
+                seed=seed,
+                structural_hints=["negative interaction between pH and surfactant"],
+            )
+            model = materialize_model(sim["_private"])
+            for out_coefs in model["per_output"].values():
+                for inter in out_coefs["interactions"]:
+                    if sorted(inter["factors"]) == sorted(["pH", "surfactant"]):
+                        if inter["coefficient"] < 0:
+                            negatives += 1
+                        break
+        assert negatives >= 8, f"Only {negatives}/10 interactions were negative"
+
+    def test_positive_main_effect_hint(self):
+        sim = _make_sim(
+            seed=1,
+            structural_hints=["positive effect of flow on recovery"],
+        )
+        model = materialize_model(sim["_private"])
+        coef = model["per_output"]["recovery"]["main"]["flow"]
+        assert coef > 0
+
+    def test_quadratic_hint_creates_quadratic_term(self):
+        sim = _make_sim(
+            seed=2,
+            structural_hints=["flow has a quadratic effect on recovery"],
+        )
+        model = materialize_model(sim["_private"])
+        assert "flow" in model["per_output"]["recovery"]["quadratic"]
+        assert abs(model["per_output"]["recovery"]["quadratic"]["flow"]) >= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Determinism across processes
+# ---------------------------------------------------------------------------
+
+
+def _materialize_in_child(private_state: dict) -> dict:
+    """Pickled worker target for the cross-process determinism test."""
+    return materialize_model(private_state)
+
+
+class TestCrossProcessDeterminism:
+    def test_materialize_model_is_bit_identical_in_subprocess(self):
+        sim = _make_sim(seed=101)
+        priv = sim["_private"]
+        local = materialize_model(priv)
+        with ProcessPoolExecutor(max_workers=1) as pool:
+            remote = pool.submit(_materialize_in_child, priv).result()
+        # Dict comparison: every intercept, every coefficient, equal.
+        assert local == remote
+
+
+# ---------------------------------------------------------------------------
+# Tool registry integration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryIntegration:
+    def test_tools_registered(self):
+        names = {s["name"] for s in get_tool_specs()}
+        assert {"create_simulator", "simulate_process", "reveal_simulator"} <= names
+
+    def test_simulation_helper_lists_all_three(self):
+        assert set(_SIMULATION_TOOL_NAMES) == {
+            "create_simulator",
+            "simulate_process",
+            "reveal_simulator",
+        }
+        assert len(get_simulation_tool_specs()) == 3
+
+    def test_dispatch_via_execute_tool_call(self):
+        out = execute_tool_call(
+            "create_simulator",
+            {
+                "process_description": "toy process",
+                "factors": [{"name": "A", "low": 0.0, "high": 1.0}],
+                "outputs": [{"name": "y"}],
+                "seed": 1,
+            },
+        )
+        assert "sim_id" in out
+        assert "public" in out
+        assert "_private" in out
+
+    def test_simulator_state_not_in_public_schema(self):
+        """The LLM must not be able to forge state: simulator_state is hidden."""
+        specs = {s["name"]: s for s in get_simulation_tool_specs()}
+        for name in ("simulate_process", "reveal_simulator"):
+            props = specs[name]["input_schema"].get("properties", {})
+            assert "simulator_state" not in props
+        # ``confirmed`` is also server-injected.
+        assert "confirmed" not in specs["reveal_simulator"]["input_schema"].get(
+            "properties", {}
+        )

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -9,7 +9,6 @@ import pytest
 
 from process_improve.simulation.model import materialize_model
 from process_improve.simulation.tools import (
-    _SIMULATION_TOOL_NAMES,
     create_simulator,
     get_simulation_tool_specs,
     reveal_simulator,
@@ -397,12 +396,13 @@ class TestRegistryIntegration:
         assert {"create_simulator", "simulate_process", "reveal_simulator"} <= names
 
     def test_simulation_helper_lists_all_three(self):
-        assert set(_SIMULATION_TOOL_NAMES) == {
+        specs = get_simulation_tool_specs()
+        assert {s["name"] for s in specs} == {
             "create_simulator",
             "simulate_process",
             "reveal_simulator",
         }
-        assert len(get_simulation_tool_specs()) == 3
+        assert len(specs) == 3
 
     def test_dispatch_via_execute_tool_call(self):
         out = execute_tool_call(

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -7,10 +7,7 @@ from concurrent.futures import ProcessPoolExecutor
 import numpy as np
 import pytest
 
-from process_improve.simulation.model import (
-    materialize_model,
-    simulate,
-)
+from process_improve.simulation.model import materialize_model
 from process_improve.simulation.tools import (
     _SIMULATION_TOOL_NAMES,
     create_simulator,

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -6,7 +6,6 @@ from concurrent.futures import ProcessPoolExecutor
 
 import numpy as np
 import pytest
-from process_improve.tool_spec import execute_tool_call, get_tool_specs
 
 from process_improve.simulation.model import materialize_model
 from process_improve.simulation.tools import (
@@ -15,6 +14,7 @@ from process_improve.simulation.tools import (
     reveal_simulator,
     simulate_process,
 )
+from process_improve.tool_spec import execute_tool_call, get_tool_specs
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers


### PR DESCRIPTION
Adds a process_improve.simulation subpackage that exposes three new
agent-callable tools:

- create_simulator: records a hidden response-surface model from a
  seed + factor/output specs + structural hints.
- simulate_process: evaluates the hidden surface at given factor
  settings, with fresh Gaussian noise per call so identical inputs
  yield similar-but-not-identical outputs (matching a real asset).
- reveal_simulator: returns the materialised coefficients, gated
  by a confirmed flag that a host (e.g. factorial) enforces.

The simulator is fully stateless: the hidden model is regenerated
bit-for-bit from a stored seed on every call, so persistence is the
host's concern.