### PR TITLE
chore(release): 1.6.0 — ship simulator tools to PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.5.1"
+version = "1.6.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Release PR — bumps `pyproject.toml` from `1.5.1` → `1.6.0` so the publish workflow ships `process_improve.simulation/` to PyPI.

The module itself landed on `main` in #101 (`e174826` — "Add fake-data simulator tools (create/simulate/reveal)") but the pinned PyPI version hasn't moved, so anyone pip-installing `process-improve` today still gets 1.5.1 without `simulation/`.

Per `CLAUDE.md`:
- **MINOR** bump is correct — a new public module with new `@tool_spec` registrations (`create_simulator`, `simulate_process`, `reveal_simulator`).
- The publish workflow triggers automatically on `pyproject.toml` version changes on `main` and creates the `v1.6.0` tag + GitHub release.

## Why now

The downstream `factorial` backend has a test-skip guard (`requires_simulator_tools` in `tests/test_simulator_flow.py`) that short-circuits three integration tests because the installed `process-improve` (1.5.1 from PyPI) doesn't register the simulator tool names. Once this release ships, factorial can bump its `process-improve>=1.4.0` pin to `>=1.6.0` and drop the skip guard — follow-up PR already queued.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run pytest -o "addopts=" -q` — **777 passed, 10 skipped, 0 failed**
- [x] `tests/test_simulation.py` — 27 pass; simulator tools register and dispatch through `execute_tool_call` end-to-end
- [x] `uv.lock` intentionally **not** committed (per `CLAUDE.md` lock-file rule)
- [ ] Reviewer: confirm the `publish.yml` run on merge creates the `v1.6.0` tag + PyPI release
- [ ] Reviewer: after publish, the `factorial` follow-up PR will bump the pin and drop the skip

https://claude.ai/code/session_01EL8jKS3jBcSBdk6HK8n2wq

---
_Generated by [Claude Code](https://claude.ai/code/session_01EL8jKS3jBcSBdk6HK8n2wq)_