### PR TITLE
docs(univariate): fix t_value_cdf docstring to describe the correct function

### DIFF
--- a/process_improve/univariate/metrics.py
+++ b/process_improve/univariate/metrics.py
@@ -48,25 +48,23 @@ def t_value(p: float, v: float) -> float:
 
 def t_value_cdf(z: float, v: float) -> float:
     r"""
-    Return the value on the y-axis if you plot the cumulative t-distribution with a fractional
-    area of `p` (p is therefore a fractional value between 0 and 1 on the y-axis) and `v` is the
-    degrees of freedom.
-
+    Return the fractional area under the cumulative t-distribution (y-axis value) at the t-value
+    `z` on the x-axis, with `v` degrees of freedom.
 
     Examples
     --------
-    Since the cumulative distribution passes symmetrically through the x-axis at 0.0 for any
-    number of degrees of freedom
+    The cumulative distribution is symmetric through the x-axis at 0.0 for any number of degrees
+    of freedom, so half of the area lies below zero:
 
-    >>> t_value_cdf(z=0.0, v)
+    >>> t_value_cdf(0.0, v)
     0.5
 
-    Zero fractional area under the curve is always at :math:`-\infty`:
+    Zero fractional area under the curve is at :math:`-\infty`:
 
-    >>> t_value_cdf(np.ninf, v)
+    >>> t_value_cdf(-np.inf, v)
     0.0
 
-    100% fractional area is always at :math:`+\infty`:
+    100% fractional area is at :math:`+\infty`:
 
     >>> t_value_cdf(np.inf, v)
     1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.6.0"
+version = "1.6.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Audited computational and user-facing functions in this repo (and the companion `agentic-doe` repo) for docstring-vs-code inconsistencies. Found one real inconsistency to fix here.

## Inconsistency fixed

- **`process_improve/univariate/metrics.py:49` — `t_value_cdf(z, v)`**
  - Docstring described the parameter as `p` ("Return the value on the y-axis ... with a fractional area of `p` ... p is a fractional value between 0 and 1 on the y-axis") while the actual signature takes `z` (a t-value on the x-axis).
  - That description matched the **inverse** function (`t_value`, which uses `t.ppf`). The code here calls `t.cdf(z, df=v)`, so `z` is the x-axis input and the return is the cumulative probability.
  - The doctests also used syntactically invalid `t_value_cdf(z=0.0, v)` (positional after keyword) and referenced `np.ninf`, which does not exist.

The rewrite:
- Describes the function as "return the fractional area under the cumulative t-distribution at the t-value `z`".
- Fixes the doctests to use positional args and `-np.inf`.

Also bumps version `1.6.0 → 1.6.1` per `CLAUDE.md` (patch — docs-only change).

## Inconsistencies considered but not flagged

- `summary_stats` in `metrics.py` documents `"center"` and `"spread"` as the "most interesting" keys but the dict also contains `mean`, `median`, percentiles, etc. Docstring phrasing ("most interesting") is not exhaustive, so this is not a mismatch.
- Private helpers (`_find_stationary_point`, etc.) sometimes list a subset of returned keys, but they are internal and out of scope.

## Companion repo (`kgdunn/agentic-doe`)

Audited `backend/src/app/services/` (doe_service, experiment_service, simulator_service, pricing, balance_service, export_service, reproducible_export_service, chart_render_service, tools, agent_loop, agent_service, anthropic_status). No docstring-vs-code inconsistencies found, so no companion PR is being opened there.

## Test plan

- [ ] `pytest tests/ -k "t_value"` still passes (behaviour unchanged — docstring-only edit).
- [ ] `ruff check process_improve/univariate/metrics.py` clean.
- [ ] Sphinx build renders the updated docstring (no invalid doctest syntax).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JJjJFcNNYafAK5TQ8ymxcM)_