### PR TITLE
Add RNG metadata to @tool_spec + opt-in seeds for optimize_responses / simulate

### DIFF
--- a/process_improve/tool_spec.py
+++ b/process_improve/tool_spec.py
@@ -47,16 +47,70 @@ _discovery_done: bool = False
 
 
 # ---------------------------------------------------------------------------
+# RNG metadata validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_rng_metadata(name: str, rng: dict[str, Any]) -> None:
+    """Reject ``rng`` payloads that don't match the published contract.
+
+    The contract is intentionally narrow so downstream consumers (the
+    factorial reproducible-export service) can introspect specs without
+    defensive type-checking. See ``CLAUDE.md`` for the full schema.
+    """
+    if not isinstance(rng, dict):
+        raise TypeError(
+            f"@tool_spec(name={name!r}): 'rng' must be a dict, got {type(rng).__name__}."
+        )
+    if "uses_rng" not in rng or not isinstance(rng["uses_rng"], bool):
+        raise ValueError(
+            f"@tool_spec(name={name!r}): 'rng' must have a boolean 'uses_rng' key."
+        )
+    allowed_keys = {"uses_rng", "seed_param", "default_seed", "note"}
+    extra = set(rng) - allowed_keys
+    if extra:
+        raise ValueError(
+            f"@tool_spec(name={name!r}): unknown keys in 'rng': {sorted(extra)}. "
+            f"Allowed: {sorted(allowed_keys)}."
+        )
+    if not rng["uses_rng"]:
+        # Deterministic tools shouldn't carry a seed_param / default_seed.
+        if rng.get("seed_param") is not None or rng.get("default_seed") is not None:
+            raise ValueError(
+                f"@tool_spec(name={name!r}): 'seed_param' / 'default_seed' "
+                "must be omitted when uses_rng is False."
+            )
+        return
+    seed_param = rng.get("seed_param")
+    if seed_param is not None and not isinstance(seed_param, str):
+        raise TypeError(
+            f"@tool_spec(name={name!r}): 'seed_param' must be a string or None, "
+            f"got {type(seed_param).__name__}."
+        )
+    default_seed = rng.get("default_seed")
+    if default_seed is not None and not isinstance(default_seed, int):
+        raise TypeError(
+            f"@tool_spec(name={name!r}): 'default_seed' must be an int or None, "
+            f"got {type(default_seed).__name__}."
+        )
+    if seed_param is None and default_seed is not None:
+        raise ValueError(
+            f"@tool_spec(name={name!r}): 'default_seed' requires a 'seed_param' name."
+        )
+
+
+# ---------------------------------------------------------------------------
 # Decorator
 # ---------------------------------------------------------------------------
 
 
-def tool_spec(
+def tool_spec(  # noqa: PLR0913
     name: str,
     description: str,
     input_schema: dict[str, Any],
     examples: str = "",
     category: str = "",
+    rng: dict[str, Any] | None = None,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Mark a function as an agent-callable tool.
 
@@ -81,6 +135,23 @@ def tool_spec(
     category:
         Optional category string (e.g. ``"univariate"``, ``"multivariate"``).
         Used for filtering with :func:`get_tool_specs`.
+    rng:
+        Optional reproducibility metadata.  Tools that touch RNG should
+        declare whether the seed is user-controllable so downstream
+        reproducible-export tooling can introspect rather than guess.
+
+        Permitted shapes::
+
+            {"uses_rng": False}
+            {"uses_rng": True, "seed_param": "<kwarg-name>",
+             "default_seed": <int>}
+            {"uses_rng": True, "seed_param": None,
+             "note": "<why no user seed>"}
+
+        Omit entirely to leave the spec without an ``rng`` key (legacy
+        behavior; downstream consumers treat that as "unknown — assume
+        deterministic"). The Anthropic API ignores unknown spec keys, so
+        adding ``rng`` is safe.
 
     Returns
     -------
@@ -105,10 +176,13 @@ def tool_spec(
             }},
             examples='# "What is 2 + 3?" -> ``add_numbers(a=2, b=3)``',
             category="math",
+            rng={"uses_rng": False},
         )
         def add_numbers(*, a: float, b: float) -> dict:
             return {"result": a + b}
     """
+    if rng is not None:
+        _validate_rng_metadata(name, rng)
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         full_description = description
@@ -122,6 +196,8 @@ def tool_spec(
         }
         if category:
             spec["category"] = category
+        if rng is not None:
+            spec["rng"] = dict(rng)
 
         func._tool_spec = spec  # type: ignore[attr-defined]
         _TOOL_REGISTRY[name] = func
@@ -216,7 +292,9 @@ def get_tool_specs(
     -------
     list[dict]
         Each dict has keys ``"name"``, ``"description"``, and
-        ``"input_schema"`` as required by the Anthropic API.
+        ``"input_schema"`` as required by the Anthropic API.  Tools that
+        opt in via ``rng=`` on the decorator also carry an ``"rng"`` key
+        describing their reproducibility contract; see :func:`tool_spec`.
     """
     discover_tools()
     registry = _TOOL_REGISTRY


### PR DESCRIPTION
Closes the upstream side of three "Determinism gaps in `process-improve`" TODOs tracked in `kgdunn/factorial`'s `TODO.md`. Once this releases as 1.7.0, the factorial reproducible-export service can introspect tool specs (rather than hardcode `_DESIGN_SEED_KEYS`) and synthesize seeds it injects into the bundle when the original tool call omitted one.

## What's in this PR

1. **Extend `@tool_spec`** with an optional `rng=` kwarg + a strict `_validate_rng_metadata` contract. Stored on `spec["rng"]` only when supplied, so the Anthropic API and existing decorator users are unaffected (unknown spec keys are ignored).

   Permitted shapes:
   ```python
   {"uses_rng": False}
   {"uses_rng": True, "seed_param": "<kwarg>", "default_seed": <int>}
   {"uses_rng": True, "seed_param": None, "note": "<reason>"}
   ```

2. **Annotate every registered tool** with the new metadata. Most tools are deterministic (`{"uses_rng": False}`); the few that touch RNG are tagged with their seed kwarg so downstream consumers can introspect rather than guess.

3. **Expose `random_seed: int = 42` on `optimize_responses`** so the multi-start initial points in `_optimize_desirability` are user-overridable. The default (42) preserves bit-for-bit existing behavior.

4. **Add opt-in `noise_seed: int | None = None` to `simulate()`** and the `simulate_process` tool. Default `None` keeps the documented "fresh noise per call" behavior; setting an int makes simulator runs reproducible (needed for bundling simulator-driven sessions).

5. **Reproducibility & seeding docs** in `CLAUDE.md` + a pointer in `README.md` explaining the contract downstream consumers can rely on.

6. **`tests/test_tool_spec_rng_metadata.py`** asserts every registered tool has a valid `rng` payload, that seeded tools are determinism-stable across two calls with the same seed, and that the validator rejects malformed metadata.

7. **Version bump 1.6.0 → 1.7.0** (MINOR — additive feature).

## Why

The downstream factorial reproducible-export service today does:
```python
_DESIGN_SEED_KEYS = frozenset({"seed", "random_state", "random_seed"})
if call.tool_name == "generate_design" and not _DESIGN_SEED_KEYS & set(tool_input):
    warnings.append("...no seed captured...")
```
That's hardcoded to one tool and one set of names. Once 1.7.0 ships, factorial can read `spec["rng"]["seed_param"]` and decide whether to synthesize + inject a seed, then record it in the bundle README so the run replays identically.

## In-progress

The first commit lands the decorator + validator. Subsequent commits on this branch will add the per-module annotations, the `random_seed` / `noise_seed` plumbing, the tests, the docs, and the version bump. PR will be marked ready for review once those land.

## Verification (after all commits land)

```bash
uv sync --all-extras --dev
uv run pytest tests/test_tool_spec_rng_metadata.py -xvs
uv run pytest                          # full suite must stay green
uv run ruff check .
uv run mypy process_improve
python -c "
from process_improve.tool_spec import get_tool_specs
for s in get_tool_specs():
    print(s['name'], '->', s.get('rng'))
"
```

Tracking branch: `claude/add-seed-parameter-I78et`. Downstream factorial PR will follow once 1.7.0 is on PyPI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sw3bzq6eiPCoQxNLzeXR9L)_