### PR TITLE
feat: automated GitHub release tag on every merge to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,12 +30,12 @@ jobs:
           NEW=$(python -c "import tomli; print(tomli.load(open('pyproject.toml','rb'))['project']['version'])")
           git show HEAD~1:pyproject.toml > /tmp/old_pyproject.toml 2>/dev/null || echo "first_run"
           OLD=$(python -c "
-          import tomli, sys
-          try:
-              print(tomli.load(open('/tmp/old_pyproject.toml','rb'))['project']['version'])
-          except:
-              print('none')
-          ")
+import tomli, sys
+try:
+    print(tomli.load(open('/tmp/old_pyproject.toml','rb'))['project']['version'])
+except:
+    print('none')
+")
           echo "old=$OLD new=$NEW"
           if [ "$OLD" != "$NEW" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -61,6 +61,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "v${{ steps.version_check.outputs.version }}" \
-            --title "v${{ steps.version_check.outputs.version }}" \
-            --generate-notes
+          TAG="v${{ steps.version_check.outputs.version }}"
+          if gh release view "${TAG}" > /dev/null 2>&1; then
+            echo "Release ${TAG} already exists (created by release workflow), skipping."
+          else
+            gh release create "${TAG}" \
+              --title "${TAG}" \
+              --generate-notes
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create release if version is new
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          TAG="v${VERSION}"
+          if gh release view "${TAG}" > /dev/null 2>&1; then
+            echo "Release ${TAG} already exists, skipping."
+          else
+            gh release create "${TAG}" \
+              --title "Release ${TAG}" \
+              --generate-notes
+          fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` — fires on every push to `main`, reads the version from `pyproject.toml`, and creates a GitHub Release (tag `vX.Y.Z`) if one doesn't already exist
- Updates `.github/workflows/publish.yml` — makes its "Create GitHub Release" step idempotent (check-before-create) so it doesn't conflict when both workflows run concurrently on a version-bump commit

## Why two files?

`publish.yml` already creates a release, but only when `pyproject.toml` changes *and* the version bumps. The new `release.yml` provides coverage for all other merges to `main` (e.g. doc changes, CI tweaks) by reading the current version and skipping if the release already exists.

The `publish.yml` update prevents a race condition: `release.yml` is much faster (no build/PyPI steps), so it would typically create the release first — the old `publish.yml` would then fail on `gh release create` because the tag already exists. Now both workflows check before creating.

## Test plan

- [ ] Merge this PR to `main` — `release.yml` should fire and create `v1.6.1` (current version)
- [ ] Check the **Releases** tab to confirm `v1.6.1` appears with auto-generated notes
- [ ] On the next version-bump PR: both `release.yml` and `publish.yml` will run — confirm only one release is created and neither workflow fails
- [ ] Merge a non-version-bump PR (e.g. docs change): `release.yml` fires, finds `v1.6.1` already exists, logs "skipping" — no duplicate release created

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoE5UzZCkRKpgdQnhQExC8)_