### PR TITLE
fix: resolve YAML syntax error in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,16 +26,9 @@ jobs:
       - name: Check if version changed
         id: version_check
         run: |
-          pip install tomli
-          NEW=$(python -c "import tomli; print(tomli.load(open('pyproject.toml','rb'))['project']['version'])")
-          git show HEAD~1:pyproject.toml > /tmp/old_pyproject.toml 2>/dev/null || echo "first_run"
-          OLD=$(python -c "
-import tomli, sys
-try:
-    print(tomli.load(open('/tmp/old_pyproject.toml','rb'))['project']['version'])
-except:
-    print('none')
-")
+          NEW=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          git show HEAD~1:pyproject.toml > /tmp/old_pyproject.toml 2>/dev/null || true
+          OLD=$(python -c "import tomllib; print(tomllib.load(open('/tmp/old_pyproject.toml','rb'))['project']['version'])" 2>/dev/null || echo "none")
           echo "old=$OLD new=$NEW"
           if [ "$OLD" != "$NEW" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

The multi-line Python script embedded in the `run: |` block dropped to column 0, breaking YAML's block scalar indentation rules — GitHub Actions rejected the file with an "Invalid workflow file" error.

## Fix

Replace the multi-line `python -c "..."` with single-line equivalents using `tomllib` (stdlib since Python 3.11, which this workflow already targets). This also removes the `pip install tomli` step.

**Before:**
```bash
pip install tomli
NEW=$(python -c "import tomli; ...")
OLD=$(python -c "
import tomli, sys        # ← column 0 — breaks YAML block scalar
try:
    ...
")
```

**After:**
```bash
NEW=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
git show HEAD~1:pyproject.toml > /tmp/old_pyproject.toml 2>/dev/null || true
OLD=$(python -c "import tomllib; print(tomllib.load(open('/tmp/old_pyproject.toml','rb'))['project']['version'])" 2>/dev/null || echo "none")
```

## Test plan

- [ ] Merge to `main` — confirm no "Invalid workflow file" email
- [ ] Bump version in `pyproject.toml` and merge — confirm `publish` job detects the change, builds, publishes to PyPI, and creates the release

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoE5UzZCkRKpgdQnhQExC8)_