### PR TITLE
fix(experiments): repair grocery() input checks (closes #1)

### DIFF
--- a/process_improve/experiments/simulations.py
+++ b/process_improve/experiments/simulations.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
 
 
 def popcorn(t: float = 120, T: float | None = None) -> None:
@@ -84,10 +83,10 @@ def grocery(
     if H is None:
         H = h
 
-    if (len(P) > 1) | (len(H) > 1):
+    if np.ndim(P) > 0 or np.ndim(H) > 0:
         raise ValueError("Running the grocery store experiments in parallel is (intentionally) not allowed.")
 
-    if pd.isna(P) or pd.isna(H):
+    if not np.isfinite(P) or not np.isfinite(H):
         raise ValueError("All function inputs must be finite numbers.")
     if P < 0:
         raise ValueError("Please provide a positive sales price, P.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.6.1"
+version = "1.6.2"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_experiments_simulations.py
+++ b/tests/test_experiments_simulations.py
@@ -1,0 +1,44 @@
+"""Tests for `process_improve.experiments.simulations.grocery`."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from process_improve.experiments.simulations import grocery
+
+
+class TestGroceryDefaults:
+    def test_returns_int_with_defaults(self):
+        result = grocery()
+        assert isinstance(result, int)
+
+
+class TestGroceryInputChecks:
+    @pytest.mark.parametrize("bad", [math.nan, math.inf, -math.inf])
+    def test_non_finite_price_rejected(self, bad):
+        with pytest.raises(ValueError, match="finite"):
+            grocery(P=bad, H=150.0)
+
+    @pytest.mark.parametrize("bad", [math.nan, math.inf, -math.inf])
+    def test_non_finite_height_rejected(self, bad):
+        with pytest.raises(ValueError, match="finite"):
+            grocery(P=3.5, H=bad)
+
+    def test_negative_price_rejected(self):
+        with pytest.raises(ValueError, match="positive sales price"):
+            grocery(P=-1.0, H=150.0)
+
+    def test_negative_height_rejected(self):
+        with pytest.raises(ValueError, match="height of the shelving"):
+            grocery(P=3.5, H=-1.0)
+
+    def test_list_input_rejected(self):
+        with pytest.raises(ValueError, match="parallel"):
+            grocery(P=[3.5, 4.0], H=150.0)
+
+    def test_array_input_rejected(self):
+        with pytest.raises(ValueError, match="parallel"):
+            grocery(P=3.5, H=np.array([100.0, 150.0]))


### PR DESCRIPTION
## Summary
- Note: there is no PR #1 in this repo, but issue #1 ("Add input checks to 'grocery' simulation") was open and matched the branch name `claude/solve-pr-1-...`, so this PR resolves that issue.
- `grocery()` was actually broken on every scalar call: `len(P) > 1` raised `TypeError` because `P` is a float. Replaced the parallel-input guard with `np.ndim(P) > 0`, which correctly accepts scalar floats and rejects lists/arrays.
- Tightened the finite-value check from `pd.isna` (NaN only) to `np.isfinite` so that ±inf is rejected too — this matches the intent of the original R code quoted in the issue (`is.finite(...)`).
- Removed the now-unused `pandas` import from `simulations.py`.
- Bumped version `1.6.1` → `1.6.2` (PATCH, bug fix) per CLAUDE.md.

## Test plan
- [x] New `tests/test_experiments_simulations.py` covers: defaults return `int`, NaN/±inf rejected for both `P` and `H`, negative `P`/`H` rejected, list and `np.ndarray` inputs rejected.
- [x] `uv run pytest tests/test_experiments_simulations.py -o "addopts="` → 11 passed.
- [x] `uv run ruff check` on changed files passes.

https://claude.ai/code/session_01EpPfrdQccJ2KSf6iDBXGqs

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpPfrdQccJ2KSf6iDBXGqs)_