### PR TITLE
fix(experiments): validate values against `levels` in c() (closes #4)

### DIFF
--- a/process_improve/experiments/structures.py
+++ b/process_improve/experiments/structures.py
@@ -297,9 +297,22 @@ def c(*args, **kwargs) -> Column:  # noqa: C901, PLR0912, PLR0915
 
     elif "levels" in kwargs:
         msg = "Levels must be list or tuple of the unique level names."
-        # TODO: Check that all entries in the level list are accounted for.
-        assert isinstance(kwargs.get("levels"), Iterable), msg
-        out.pi_levels = {out.pi_name: list(kwargs.get("levels", []))}
+        levels = kwargs.get("levels")
+        assert isinstance(levels, Iterable), msg
+        levels_list = list(levels)
+        raw_values: list = []
+        for arg in args:
+            if isinstance(arg, str) or not isinstance(arg, Iterable):
+                raw_values.append(arg)
+            else:
+                raw_values.extend(list(arg))
+        extras = {v for v in raw_values if not pd.isna(v)} - set(levels_list)
+        if extras:
+            raise ValueError(
+                f"All values must be present in `levels`. "
+                f"Found value(s) not in levels: {sorted(extras, key=str)}."
+            )
+        out.pi_levels = {out.pi_name: levels_list}
     else:
         levels = out.unique()
         levels.sort()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.8.0"
+version = "1.8.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_doe.py
+++ b/tests/test_doe.py
@@ -479,6 +479,19 @@ def test_column_categorical_with_levels() -> None:
     assert hasattr(D, "pi_levels")
 
 
+def test_column_categorical_levels_missing_value_raises() -> None:
+    """c() must error if a value is not in the explicit levels list."""
+    with pytest.raises(ValueError, match="not in levels"):
+        c("A", "B", "C", levels=["A", "B"])
+
+
+def test_column_categorical_levels_all_present_ok() -> None:
+    """c() should accept input when every value is covered by levels."""
+    D = c("A", "B", "A", levels=["A", "B", "C"])
+    assert hasattr(D, "pi_levels")
+    assert D.pi_levels[D.pi_name] == ["A", "B", "C"]
+
+
 def test_gather_drops_missing_values() -> None:
     """Gather should drop rows with any NaN values."""
     A = c(-1, +1, -1, +1, float("nan"))

--- a/tests/test_doe.py
+++ b/tests/test_doe.py
@@ -492,6 +492,18 @@ def test_column_categorical_levels_all_present_ok() -> None:
     assert D.pi_levels[D.pi_name] == ["A", "B", "C"]
 
 
+def test_column_categorical_levels_list_arg_validated() -> None:
+    """A list arg whose elements are not in levels should raise."""
+    with pytest.raises(ValueError, match="not in levels"):
+        c(["A", "B", "C"], levels=["A", "B"])
+
+
+def test_column_categorical_levels_skips_nan() -> None:
+    """NaN entries should be ignored by the levels-membership check."""
+    D = c(0, 1, float("nan"), levels=(0, 1))
+    assert hasattr(D, "pi_levels")
+
+
 def test_gather_drops_missing_values() -> None:
     """Gather should drop rows with any NaN values."""
     A = c(-1, +1, -1, +1, float("nan"))


### PR DESCRIPTION
## Summary

Closes #4. The `c()` function in `process_improve/experiments/structures.py` previously had a `# TODO: Check that all entries in the level list are accounted for.` and would silently accept inputs whose values were not in the explicit `levels` list:

```python
c("A", "B", "C", levels=["A", "B"])  # used to silently build a broken column
```

This PR replaces the TODO with a real validation step. If any non-NaN value passed to `c()` is missing from `levels`, a `ValueError` is raised with a deterministic message listing the offending value(s).

## Changes

- `process_improve/experiments/structures.py` — In the `levels` branch of `c()`, gather the user-supplied values (treating `str` as a scalar, since `str` is technically `Iterable`), then compare them as a set against the provided `levels` and raise `ValueError` on any mismatch. NaN entries are tolerated.
- `tests/test_doe.py` — Two new tests: one asserting the error path, one asserting that a values⊆levels superset still works.
- `pyproject.toml` — Version bump `1.8.0` → `1.8.1` (PATCH, per CLAUDE.md).

All four existing call sites that use `levels=` already pass values that are subsets of their levels, so no other test or example needed changes.

## Test plan

- [x] `python -m pytest tests/test_doe.py -v -o "addopts="` — 35 passed, 1 skipped (pre-existing).
- [x] `python -m pytest -o "addopts="` — full suite: 807 passed, 11 skipped.
- [x] `ruff check process_improve/experiments/structures.py tests/test_doe.py` — clean.
- [x] Manual: `c("A", "B", "C", levels=["A", "B"])` now raises `ValueError` listing `['C']`; `c("A", "B", "A", levels=["A", "B", "C"])` succeeds.

https://claude.ai/code/session_01AvbbnSEV3ciRMD3HgPnHHX

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvbbnSEV3ciRMD3HgPnHHX)_