### PR TITLE
feat(viz): add main_effects_plot convenience function (closes #8)

### DIFF
--- a/process_improve/experiments/__init__.py
+++ b/process_improve/experiments/__init__.py
@@ -18,7 +18,7 @@ from process_improve.experiments.structures import (
     gather,
     supplement,
 )
-from process_improve.experiments.visualization import visualize_doe
+from process_improve.experiments.visualization import main_effects_plot, visualize_doe
 
 __all__ = [
     "Column",
@@ -39,6 +39,7 @@ __all__ = [
     "gather",
     "generate_design",
     "lm",
+    "main_effects_plot",
     "optimize_responses",
     "predict",
     "recommend_strategy",

--- a/process_improve/experiments/visualization/__init__.py
+++ b/process_improve/experiments/visualization/__init__.py
@@ -27,6 +27,6 @@ Quick start
     echarts_opt = result["echarts"] # ECharts option dict
 """
 
-from process_improve.experiments.visualization.api import visualize_doe
+from process_improve.experiments.visualization.api import main_effects_plot, visualize_doe
 
-__all__ = ["visualize_doe"]
+__all__ = ["main_effects_plot", "visualize_doe"]

--- a/process_improve/experiments/visualization/api.py
+++ b/process_improve/experiments/visualization/api.py
@@ -3,11 +3,21 @@
 :func:`visualize_doe` is the single entry point.  It dispatches to the
 correct plot class, builds the ChartSpec IR, runs the requested backend
 adapters, and returns a JSON-serialisable dict.
+
+:func:`main_effects_plot` is a convenience wrapper that accepts either
+a fitted :class:`~process_improve.experiments.models.Model` or a
+DataFrame, and returns a Plotly figure directly.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+import pandas as pd
+import plotly.graph_objects as go
+
+if TYPE_CHECKING:
+    from process_improve.experiments.models import Model
 
 
 def visualize_doe(  # noqa: PLR0913
@@ -92,3 +102,99 @@ def visualize_doe(  # noqa: PLR0913
         result["echarts"] = None
 
     return result
+
+
+def main_effects_plot(
+    model_or_data: Model | pd.DataFrame,
+    response_column: str | None = None,
+    factors_to_plot: list[str] | None = None,
+    *,
+    factor_labels: dict[str, str] | None = None,
+) -> go.Figure:
+    """Generate a main-effects plot from a fitted model or a design DataFrame.
+
+    For each factor, the mean response at every observed level is drawn
+    as a line.  A flat line indicates no main effect; a steep line
+    indicates a strong one.  The grand mean is shown as a horizontal
+    dotted reference line.
+
+    Parameters
+    ----------
+    model_or_data : Model or pandas.DataFrame
+        Either a fitted ``Model`` returned by
+        :func:`~process_improve.experiments.models.lm`, or a DataFrame
+        containing one column per factor plus a response column.
+    response_column : str, optional
+        Name of the response column.  Required when *model_or_data* is
+        a DataFrame; ignored (and inferred from the model formula) when
+        a fitted ``Model`` is supplied.
+    factors_to_plot : list of str, optional
+        Subset of factors to display.  By default all main-effect
+        factors are shown — for a ``Model`` these are the level-1
+        factors from the formula; for a DataFrame they are all columns
+        other than *response_column*.
+    factor_labels : dict, optional
+        Mapping ``{factor_symbol: full_name}`` used for legend entries
+        (e.g. ``{"A": "Temperature [°C]"}``).
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+        Plotly figure ready for display or further customisation.
+
+    Examples
+    --------
+    From a fitted model::
+
+        from process_improve.experiments import c, gather, lm, main_effects_plot
+        A = c(-1, +1, -1, +1)
+        B = c(-1, -1, +1, +1)
+        y = c(52, 74, 62, 80, name="y")
+        expt = gather(A=A, B=B, y=y)
+        model = lm("y ~ A + B", expt)
+        fig = main_effects_plot(model)
+
+    From a raw DataFrame::
+
+        fig = main_effects_plot(df, response_column="yield")
+
+    See Also
+    --------
+    visualize_doe : General DOE plotting entry point.
+    """
+    from process_improve.experiments.models import Model as _Model  # noqa: PLC0415
+
+    if isinstance(model_or_data, _Model):
+        df = pd.DataFrame(model_or_data.data).copy()
+        response_column = model_or_data.get_response_name()
+        if factors_to_plot is None:
+            factors_to_plot = model_or_data.get_factor_names(level=1)
+    elif isinstance(model_or_data, pd.DataFrame):
+        if response_column is None:
+            raise ValueError(
+                "response_column must be provided when passing a DataFrame.",
+            )
+        df = pd.DataFrame(model_or_data).copy()
+    else:
+        raise TypeError(
+            "model_or_data must be a fitted Model or a pandas DataFrame; "
+            f"got {type(model_or_data).__name__}.",
+        )
+
+    if response_column not in df.columns:
+        raise ValueError(
+            f"response_column {response_column!r} not found in data columns: "
+            f"{list(df.columns)}.",
+        )
+
+    design_data = df.to_dict(orient="records")
+
+    result = visualize_doe(
+        plot_type="main_effects",
+        design_data=design_data,
+        response_column=response_column,
+        factors_to_plot=factors_to_plot,
+        factor_labels=factor_labels,
+        backend="plotly",
+    )
+    return go.Figure(result["plotly"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.8.0"
+version = "1.9.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import pytest
 
-from process_improve.experiments.visualization import visualize_doe
+from process_improve.experiments.visualization import main_effects_plot, visualize_doe
 from process_improve.experiments.visualization.plots.registry import (
     create_plot,
     get_available_plot_types,
@@ -242,6 +242,62 @@ class TestMainEffectsPlot:
         plot = create_plot("main_effects")
         spec = plot.to_spec()
         assert "no data" in spec.title.lower()
+
+
+class TestMainEffectsPlotConvenience:
+    """Tests for the standalone ``main_effects_plot`` convenience function."""
+
+    def test_from_dataframe(self, design_data_2f: list) -> None:
+        import pandas as pd
+        import plotly.graph_objects as go
+
+        df = pd.DataFrame(design_data_2f)
+        fig = main_effects_plot(df, response_column="y")
+        assert isinstance(fig, go.Figure)
+        # One trace per factor (A and B)
+        assert len(fig.data) >= 2
+
+    def test_from_model(self) -> None:
+        import plotly.graph_objects as go
+
+        from process_improve.experiments import c, gather, lm
+
+        A = c(-1, +1, -1, +1)
+        B = c(-1, -1, +1, +1)
+        y = c(52, 74, 62, 80, name="y")
+        expt = gather(A=A, B=B, y=y, title="ME convenience test")
+        model = lm("y ~ A + B", expt)
+
+        fig = main_effects_plot(model)
+        assert isinstance(fig, go.Figure)
+        # A and B factors → 2 line traces
+        assert len(fig.data) >= 2
+
+    def test_factors_subset(self, design_data_3f: list) -> None:
+        import pandas as pd
+
+        df = pd.DataFrame(design_data_3f)
+        fig = main_effects_plot(df, response_column="y", factors_to_plot=["A", "C"])
+        # Two factors plotted → at least two line traces
+        assert len(fig.data) >= 2
+
+    def test_dataframe_missing_response_column(self, design_data_2f: list) -> None:
+        import pandas as pd
+
+        df = pd.DataFrame(design_data_2f)
+        with pytest.raises(ValueError, match="response_column"):
+            main_effects_plot(df)
+
+    def test_response_column_not_in_data(self, design_data_2f: list) -> None:
+        import pandas as pd
+
+        df = pd.DataFrame(design_data_2f)
+        with pytest.raises(ValueError, match="not found in data columns"):
+            main_effects_plot(df, response_column="missing")
+
+    def test_invalid_input_type(self) -> None:
+        with pytest.raises(TypeError, match="Model or a pandas DataFrame"):
+            main_effects_plot([1, 2, 3])  # type: ignore[arg-type]
 
 
 class TestInteractionPlot:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -281,6 +281,22 @@ class TestMainEffectsPlotConvenience:
         # Two factors plotted → at least two line traces
         assert len(fig.data) >= 2
 
+    def test_from_model_with_explicit_factors(self) -> None:
+        """Passing factors_to_plot with a Model should override the level-1 list."""
+        import plotly.graph_objects as go
+
+        from process_improve.experiments import c, gather, lm
+
+        A = c(-1, +1, -1, +1, -1, +1, -1, +1)
+        B = c(-1, -1, +1, +1, -1, -1, +1, +1)
+        C = c(-1, -1, -1, -1, +1, +1, +1, +1)
+        y = c(22, 32, 15, 29, 24, 35, 17, 31, name="y")
+        expt = gather(A=A, B=B, C=C, y=y, title="ME factor subset")
+        model = lm("y ~ A + B + C", expt)
+
+        fig = main_effects_plot(model, factors_to_plot=["A"])
+        assert isinstance(fig, go.Figure)
+
     def test_dataframe_missing_response_column(self, design_data_2f: list) -> None:
         import pandas as pd
 


### PR DESCRIPTION
## Summary

Closes #8 ("TODO: main_effects_plot").

- Adds a top-level `main_effects_plot()` convenience function in `process_improve.experiments.visualization.api` and re-exports it from `process_improve.experiments`.
- Accepts either a fitted `Model` (returned by `lm()`) or a `pandas.DataFrame` plus `response_column`, and returns a `plotly.graph_objects.Figure` directly — mirroring the multivariate helpers (`score_plot`, `loading_plot`, …).
- Internally delegates to the existing `visualize_doe(plot_type="main_effects", …)` infrastructure (no new plotting logic, no behavioural changes for current callers).
- Bumps version `1.8.0 → 1.9.0` (MINOR — public API addition).

### Usage

```python
from process_improve.experiments import c, gather, lm, main_effects_plot

A = c(-1, +1, -1, +1)
B = c(-1, -1, +1, +1)
y = c(52, 74, 62, 80, name="y")
expt = gather(A=A, B=B, y=y)
model = lm("y ~ A + B", expt)

fig = main_effects_plot(model)            # from a fitted Model
fig = main_effects_plot(df, response_column="yield")   # or from a DataFrame
```

## Test plan

- [x] `pytest tests/test_visualization.py -k MainEffects -o "addopts="` — 8 passed
- [x] `pytest tests/test_visualization.py tests/test_doe.py tests/test_analysis.py -o "addopts="` — 143 passed
- [x] `ruff check` on all modified files — clean
- [x] New `TestMainEffectsPlotConvenience` class covers: DataFrame input, fitted-Model input, factor subsetting, missing `response_column`, unknown `response_column`, and invalid input type.

https://claude.ai/code/session_01CpkWHGYV1paSLGJJyi3Mp8

---
_Generated by [Claude Code](https://claude.ai/code/session_01CpkWHGYV1paSLGJJyi3Mp8)_