### PR TITLE
ci: remove duplicate pull_request trigger in run-tests workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,8 +11,6 @@ on:
   create:
     branches: [main]
     tags: ['**']
-  pull_request:
-    branches: ['**']
   # schedule:
   #   - cron: "0 4 * * *"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.9.1"
+version = "1.9.2"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Remove the duplicate `pull_request` key under `on:` in `.github/workflows/run-tests.yml` that was producing the GitHub Actions error: `(Line: 14, Col: 3): 'pull_request' is already defined`.
- Bump version to `1.9.2` per `CLAUDE.md` PATCH guidance for CI/workflow changes.

## Test plan
- [ ] GitHub Actions accepts the workflow file (no "Invalid workflow file" error).
- [ ] PR-triggered workflow runs on this PR.

https://claude.ai/code/session_01W9YpQLrNcw2n56MDscJnCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9YpQLrNcw2n56MDscJnCB)_