### PR TITLE
feat(viz): add error bars to Pareto plot (closes #9)

### DIFF
--- a/process_improve/experiments/analysis.py
+++ b/process_improve/experiments/analysis.py
@@ -115,10 +115,19 @@ def _run_anova(ols_result: RegressionResultsWrapper, anova_type: int = 2) -> dic
 
 
 def _run_effects(ols_result: RegressionResultsWrapper) -> dict[str, Any]:
-    """Coefficient effects (2x the coefficient for coded ±1 factors)."""
+    """Coefficient effects (2x the coefficient for coded ±1 factors).
+
+    Also returns ``effect_std_errors`` (twice the coefficient standard
+    error) when residual degrees of freedom are available; consumers such
+    as the Pareto plot use this to draw effect-level error bars.
+    """
     params = ols_result.params.drop("Intercept", errors="ignore")
     effects = (2.0 * params).to_dict()
-    return {"effects": effects}
+    result: dict[str, Any] = {"effects": effects}
+    if int(ols_result.df_resid) > 0:
+        bse = ols_result.bse.drop("Intercept", errors="ignore")
+        result["effect_std_errors"] = {str(k): float(2.0 * v) for k, v in bse.items()}
+    return result
 
 
 def _run_coefficients(ols_result: RegressionResultsWrapper) -> dict[str, Any]:

--- a/process_improve/experiments/visualization/plots/significance.py
+++ b/process_improve/experiments/visualization/plots/significance.py
@@ -74,15 +74,24 @@ class ParetoPlot(BasePlot):
             for _, v in sorted_items
         ]
 
+        # Per-bar error half-widths.  Source of truth (in priority order):
+        # 1. ``effect_std_errors`` from a replicated-design fit, or
+        # 2. Lenth's PSE applied uniformly to every effect for an
+        #    unreplicated design.
+        error_bars = self._effect_error_bars(names)
+
         # --- Layers ---
         bar_data = [{"name": n, "abs_effect": v} for n, v in zip(names, abs_vals)]  # noqa: B905
+        bar_style: dict[str, object] = {"colors": bar_colors}
+        if error_bars is not None:
+            bar_style["error_y"] = error_bars
         bar_layer = LayerSpec(
             mark=MarkType.bar,
             data=bar_data,
             x=Encoding(field="name", scale=ScaleType.category),
             y=Encoding(field="abs_effect", title="|Effect|"),
             name="Absolute Effect",
-            style={"colors": bar_colors},
+            style=bar_style,
         )
 
         cum_data = [{"name": n, "cum_pct": p} for n, p in zip(names, cum_pct)]  # noqa: B905
@@ -128,6 +137,33 @@ class ParetoPlot(BasePlot):
             title="Pareto Chart of Effects",
             plot_type="pareto",
         )
+
+    def _effect_error_bars(self, names: list[str]) -> list[float] | None:
+        """Resolve per-effect error-bar half-widths for the Pareto plot.
+
+        Parameters
+        ----------
+        names : list[str]
+            Term names in display order.
+
+        Returns
+        -------
+        list[float] or None
+            One non-negative half-width per term, or ``None`` if no
+            error information is available.
+        """
+        std_errors = self.analysis_results.get("effect_std_errors")
+        if isinstance(std_errors, dict) and std_errors:
+            resolved = [std_errors.get(n) for n in names]
+            if any(v is not None for v in resolved):
+                return [abs(float(v)) if v is not None else 0.0 for v in resolved]
+
+        lenth = self._get_lenth()
+        pse = lenth.get("PSE") if lenth else None
+        if pse is not None:
+            return [abs(float(pse))] * len(names)
+
+        return None
 
 
 # ---------------------------------------------------------------------------

--- a/process_improve/visualization/adapters/echarts_adapter.py
+++ b/process_improve/visualization/adapters/echarts_adapter.py
@@ -89,10 +89,7 @@ class EChartsAdapter(AbstractAdapter):
         mark_lines, mark_areas = self._collect_annotations(panel.annotations)
         if series and (mark_lines or mark_areas):
             if mark_lines:
-                series[0].setdefault("markLine", {})
-                series[0]["markLine"]["data"] = mark_lines
-                series[0]["markLine"]["silent"] = True
-                series[0]["markLine"]["symbol"] = "none"
+                self._merge_mark_lines(series[0], mark_lines)
             if mark_areas:
                 series[0].setdefault("markArea", {})
                 series[0]["markArea"]["data"] = mark_areas
@@ -182,10 +179,7 @@ class EChartsAdapter(AbstractAdapter):
             if all_series and (mark_lines or mark_areas):
                 last_series = all_series[-1]
                 if mark_lines:
-                    last_series.setdefault("markLine", {})
-                    last_series["markLine"]["data"] = mark_lines
-                    last_series["markLine"]["silent"] = True
-                    last_series["markLine"]["symbol"] = "none"
+                    self._merge_mark_lines(last_series, mark_lines)
                 if mark_areas:
                     last_series.setdefault("markArea", {})
                     last_series["markArea"]["data"] = mark_areas
@@ -257,6 +251,30 @@ class EChartsAdapter(AbstractAdapter):
             ]
         elif layer.color:
             series["itemStyle"] = {"color": layer.color}
+
+        error_y = layer.style.get("error_y")
+        if error_y and layer.x:
+            categories = [row[layer.x.field] for row in layer.data]
+            mark_data: list[list[dict[str, Any]]] = []
+            for cat, value, err in zip(categories, data, error_y):  # noqa: B905
+                if err is None:
+                    continue
+                err_abs = abs(float(err))
+                if err_abs <= 0:
+                    continue
+                low = max(0.0, float(value) - err_abs)
+                high = float(value) + err_abs
+                mark_data.append([
+                    {"coord": [cat, low], "symbol": "none"},
+                    {"coord": [cat, high], "symbol": "none"},
+                ])
+            if mark_data:
+                series["markLine"] = {
+                    "silent": True,
+                    "symbol": ["none", "none"],
+                    "lineStyle": {"color": "#333", "width": 1.5},
+                    "data": mark_data,
+                }
         return series
 
     def _line_series(self, layer: LayerSpec) -> dict[str, Any]:
@@ -480,6 +498,22 @@ class EChartsAdapter(AbstractAdapter):
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _merge_mark_lines(
+        self,
+        series: dict[str, Any],
+        new_lines: list[dict[str, Any]],
+    ) -> None:
+        """Append annotation markLines to a series, preserving any existing
+        per-series markLines (e.g. bar-layer error bars).
+        """
+        existing = series.setdefault("markLine", {})
+        if "data" in existing:
+            existing["data"] = list(existing["data"]) + list(new_lines)
+        else:
+            existing["data"] = list(new_lines)
+            existing.setdefault("silent", True)
+            existing.setdefault("symbol", "none")
 
     def _paired_data(self, layer: LayerSpec) -> list[list]:
         """Build ECharts ``[[x, y], ...]`` paired data from a layer."""

--- a/process_improve/visualization/adapters/plotly_adapter.py
+++ b/process_improve/visualization/adapters/plotly_adapter.py
@@ -200,13 +200,19 @@ class PlotlyAdapter(AbstractAdapter):
         y_vals: list,
     ) -> go.Bar:
         colors = layer.style.get("colors")
-        return go.Bar(
-            x=x_vals,
-            y=y_vals,
-            name=layer.name,
-            marker=dict(color=colors or layer.color or DOE_PALETTE["primary"]),
-            opacity=layer.opacity,
-        )
+        kwargs: dict[str, Any] = {
+            "x": x_vals,
+            "y": y_vals,
+            "name": layer.name,
+            "marker": dict(color=colors or layer.color or DOE_PALETTE["primary"]),
+            "opacity": layer.opacity,
+        }
+        error_y = layer.style.get("error_y")
+        if error_y is not None:
+            arr = [abs(float(e)) if e is not None else 0.0 for e in error_y]
+            if any(v > 0 for v in arr):
+                kwargs["error_y"] = dict(type="data", array=arr, visible=True)
+        return go.Bar(**kwargs)
 
     def _line_trace(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.9.1"
+version = "1.9.2"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -199,6 +199,87 @@ class TestParetoPlot:
         spec = plot.to_spec()
         assert "no effects" in spec.title.lower() or spec.plot_type == "pareto"
 
+    def test_no_error_bars_without_uncertainty(self, two_factor_effects: dict) -> None:
+        """Bar layer should not carry error_y when no uncertainty info supplied."""
+        plot = create_plot("pareto", analysis_results={"effects": two_factor_effects})
+        spec = plot.to_spec()
+        bar_layer = spec.panels[0].layers[0]
+        assert "error_y" not in bar_layer.style
+
+    def test_error_bars_from_effect_std_errors(self, two_factor_effects: dict) -> None:
+        """``effect_std_errors`` should drive per-bar error bars sorted with the bars."""
+        std_errors = {"A": 0.5, "B": 0.4, "A:B": 0.3}
+        plot = create_plot(
+            "pareto",
+            analysis_results={
+                "effects": two_factor_effects,
+                "effect_std_errors": std_errors,
+            },
+        )
+        spec = plot.to_spec()
+        bar_layer = spec.panels[0].layers[0]
+        names = [row["name"] for row in bar_layer.data]
+        expected = [std_errors[n] for n in names]
+        assert bar_layer.style["error_y"] == pytest.approx(expected)
+
+    def test_error_bars_fall_back_to_lenth_pse(
+        self,
+        three_factor_effects: dict,
+        lenth_data: dict,
+    ) -> None:
+        """Without explicit std errors, Lenth's PSE should populate uniform error bars."""
+        plot = create_plot(
+            "pareto",
+            analysis_results={"effects": three_factor_effects, "lenth_method": lenth_data},
+        )
+        spec = plot.to_spec()
+        bar_layer = spec.panels[0].layers[0]
+        errors = bar_layer.style["error_y"]
+        assert len(errors) == len(three_factor_effects)
+        assert all(e == pytest.approx(lenth_data["PSE"]) for e in errors)
+
+    def test_plotly_renders_error_bars(self, two_factor_effects: dict) -> None:
+        """Plotly bar trace should expose ``error_y`` when uncertainty is present."""
+        plot = create_plot(
+            "pareto",
+            analysis_results={
+                "effects": two_factor_effects,
+                "effect_std_errors": {"A": 0.5, "B": 0.4, "A:B": 0.3},
+            },
+        )
+        fig_dict = plot.to_plotly()
+        bar_traces = [t for t in fig_dict["data"] if t.get("type") == "bar"]
+        assert bar_traces
+        err = bar_traces[0].get("error_y")
+        assert err is not None
+        assert err.get("visible") is True
+        assert len(err["array"]) == 3
+
+    def test_echarts_renders_error_bars_alongside_thresholds(
+        self,
+        two_factor_effects: dict,
+        lenth_data: dict,
+    ) -> None:
+        """ECharts bar series should carry markLine pairs for error bars,
+        and Lenth threshold annotations must coexist with them.
+        """
+        plot = create_plot(
+            "pareto",
+            analysis_results={
+                "effects": two_factor_effects,
+                "effect_std_errors": {"A": 0.5, "B": 0.4, "A:B": 0.3},
+                "lenth_method": lenth_data,
+            },
+        )
+        config = plot.to_echarts()
+        bar_series = next(s for s in config["series"] if s["type"] == "bar")
+        mark_data = bar_series["markLine"]["data"]
+        # Three error-bar pairs (each is [start, end]) + ME + SME annotations
+        pair_entries = [d for d in mark_data if isinstance(d, list)]
+        threshold_entries = [d for d in mark_data if isinstance(d, dict)]
+        assert len(pair_entries) == 3
+        assert len(threshold_entries) >= 1
+
 
 class TestHalfNormalPlot:
     def test_spec_structure(self, three_factor_effects: dict) -> None:


### PR DESCRIPTION
## Summary

Closes #9 ("TODO: error bars on pareto plot").

- `analyze_experiment(..., analysis_type="effects")` now also returns `effect_std_errors` (twice the OLS coefficient standard error) whenever residual degrees of freedom are available.
- The Pareto plot's bar layer attaches per-term half-widths (`style["error_y"]`), with priority:
  1. `analysis_results["effect_std_errors"]` from a replicated-design fit, then
  2. Lenth's PSE applied uniformly to every effect (for unreplicated designs that already produced `lenth_method`).
  3. No error bars at all when neither source is available — preserving the previous behaviour for callers that only pass `effects`.
- The Plotly adapter renders error bars via Plotly's native `go.Bar(error_y=...)`.
- The ECharts adapter emits a `markLine` pair per bar (using the category name and the ±half-width as coordinates). Threshold annotations (Lenth ME/SME) now *extend* the bar series' `markLine.data` instead of overwriting it, so error bars and significance lines render together.

Version bumped 1.9.1 → 1.9.2 (PATCH per `CLAUDE.md`).

## Test plan

- [x] `python -m pytest tests/test_visualization.py -v -o "addopts=" -k "Pareto"` — 14 passed (6 new Pareto tests cover: no error bars without uncertainty, error bars from std-errors, Lenth-PSE fallback, Plotly `error_y` rendering, ECharts `markLine` + threshold coexistence).
- [x] `python -m pytest tests/test_visualization.py tests/test_analysis.py tests/test_doe.py -o "addopts="` — 153 passed, 1 skipped.
- [x] Full suite: `python -m pytest -o "addopts=" -q` — 821 passed, 11 skipped.
- [x] `ruff check` clean on all modified files.


---
_Generated by [Claude Code](https://claude.ai/code/session_014NaB2nZLUv1LFMNcyhXNpt)_