### PR TITLE
docs: fix Python versions and CI badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 > analysis, designed experiments, and process monitoring, in one place.
 
 [![PyPI version](https://img.shields.io/pypi/v/process-improve.svg)](https://pypi.org/project/process-improve/)
-[![Python versions](https://img.shields.io/pypi/pyversions/process-improve.svg)](https://pypi.org/project/process-improve/)
+[![Python versions](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fkgdunn%2Fprocess-improve%2Fmain%2Fpyproject.toml&label=python)](https://pypi.org/project/process-improve/)
 [![License](https://img.shields.io/pypi/l/process-improve.svg)](LICENSE)
-[![CI](https://github.com/kgdunn/process-improve/actions/workflows/run-tests.yml/badge.svg)](https://github.com/kgdunn/process-improve/actions/workflows/run-tests.yml)
+[![CI](https://github.com/kgdunn/process-improve/actions/workflows/run-tests.yml/badge.svg?branch=main&event=push)](https://github.com/kgdunn/process-improve/actions/workflows/run-tests.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/kgdunn/process-improve/branch/main/graph/badge.svg)](https://codecov.io/gh/kgdunn/process-improve)
 [![Docs](https://img.shields.io/badge/docs-kgdunn.github.io-blue.svg)](https://kgdunn.github.io/process-improve/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,23 @@
 [project]
 name = "process-improve"
-version = "1.9.2"
+version = "1.9.3"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 keywords = ["Designed Experiments", "Latent Variables", "PCA", "PLS", "Multivariate Data Analysis", "Batch data analysis"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+]
 authors = [
     { name = "Kevin Dunn", email = "kgdunn@gmail.com" },
 ]


### PR DESCRIPTION
## Why

Two badges added to the README in #119 render as broken even though the underlying state is fine — Python 3.10–3.13 are supported and tests pass on `main`:

- **`Python versions`** rendered empty. `shields.io/pypi/pyversions/<pkg>` reads from PyPI Trove classifiers, and live PyPI metadata for `process-improve` reports `"classifiers": []`. `pyproject.toml` had no `[project] classifiers` table at all, so the badge had nothing to show. `requires-python` does not populate this badge.
- **`CI` badge** was observed as failing. The URL is unpinned, so it shows the most recent workflow run on **any** ref — which between #119 and #120 included the "Invalid workflow file" run on `main` caused by the duplicate `pull_request:` key. Pinning to `?branch=main&event=push` makes the badge canonical and immune to PR-side red runs.

## What changed

- **`pyproject.toml`**
  - Add `classifiers = [...]` (Development Status, Intended Audience, Programming Language for 3 / 3.10 / 3.11 / 3.12 / 3.13, OS, Topic). The Python versions match the CI matrix in `.github/workflows/run-tests.yml`. No `License ::` classifier is added — the file already uses the PEP 639 SPDX form (`license = "MIT"`) and mixing the two errors out on modern packaging.
  - Bump version `1.9.2` → `1.9.3` (PATCH per `CLAUDE.md`; docs/CI change).
- **`README.md`**
  - Swap the pyversions badge to shields.io's `required-version-toml` endpoint, which reads `requires-python` directly from raw `pyproject.toml` on `main`. This renders immediately, without waiting for the next PyPI release.
  - Append `?branch=main&event=push` to the CI badge URL and `?query=branch%3Amain` to its link target so only successful post-merge runs on `main` are reflected.

## Test plan

- [x] `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` parses cleanly; 10 classifiers present; version `1.9.3`.
- [x] `git diff` is limited to `README.md` + `pyproject.toml`.
- [ ] After merge, both badges render: `python | >=3.10` and `Unit tests | passing`.
- [ ] After the next PyPI publish (driven by the version bump), the original `pypi/pyversions` URL also resolves to `3.10 | 3.11 | 3.12 | 3.13` so downstream tooling sees correct classifiers, even though the README is no longer using that endpoint.

https://claude.ai/code/session_01ChEz7WgRQS74CoM1jZeu3W

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChEz7WgRQS74CoM1jZeu3W)_