### PR TITLE
tests: measure coverage, fill real gaps, enforce floor in CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,21 @@ pytest -o "addopts="
 
 ## Git & PR workflow (for Claude Code sessions)
 
+**Default workflow for any non-trivial task:**
+
+1. **Open a blank PR up front**, before doing the work. Push an empty commit
+   (or the first micro-commit) to `claude/<task-slug>` and open the PR as
+   ready-for-review with a description of what's about to be done. Do not
+   open it as a draft.
+2. **Micro-commit as you go.** Each commit should be a small, self-contained
+   step (one module's tests, one config tweak, one bug fix) — not a single
+   end-of-session megacommit.
+3. **Push regularly.** After every micro-commit (or at worst every 2-3),
+   `git push` to the same branch so the PR reflects current progress and the
+   user can watch it land.
+
+This is the default — don't ask the user whether to do it, just do it.
+
 **Never push lock files.** Claude Code sessions must not stage, commit, or push
 any dependency lock files. Lock-file updates are performed manually by the
 repository owner.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.13.0"
+version = "1.13.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/pytest.ini
+++ b/pytest.ini
@@ -24,4 +24,4 @@ addopts = --new-first
     --cov-config=.coveragerc
     --no-cov-on-fail
     --cov-branch
-    --cov-fail-under 70
+    --cov-fail-under 80

--- a/tests/batch/test_tools.py
+++ b/tests/batch/test_tools.py
@@ -1,0 +1,169 @@
+"""Tests for the agent-callable wrappers in `process_improve.batch.tools`.
+
+The wrappers in `batch/tools.py` were untested before this file existed. They
+flatten a list of row-dicts into a DataFrame, call into `batch.features`, and
+return a JSON-friendly result dict (or `{"error": ...}` on failure).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from process_improve.batch.tools import (
+    _FEATURE_MAP,
+    _TIME_FEATURE_MAP,
+    extract_batch_features,
+    get_batch_tool_specs,
+)
+
+
+@pytest.fixture
+def two_batch_timeseries() -> list[dict]:
+    """Two batches, each with a few timepoints and two measurement tags."""
+    return [
+        {"batch": "B1", "time": 0.0, "temp": 100.0, "press": 1.0},
+        {"batch": "B1", "time": 1.0, "temp": 102.0, "press": 1.1},
+        {"batch": "B1", "time": 2.0, "temp": 104.0, "press": 1.2},
+        {"batch": "B1", "time": 3.0, "temp": 106.0, "press": 1.3},
+        {"batch": "B2", "time": 0.0, "temp": 200.0, "press": 2.0},
+        {"batch": "B2", "time": 1.0, "temp": 198.0, "press": 2.1},
+        {"batch": "B2", "time": 2.0, "temp": 196.0, "press": 2.2},
+        {"batch": "B2", "time": 3.0, "temp": 194.0, "press": 2.3},
+    ]
+
+
+def test_extract_batch_features_default_features(two_batch_timeseries: list[dict]) -> None:
+    """Defaults extract mean and std; result has one row per batch and 4 feature columns."""
+    result = extract_batch_features(
+        data=two_batch_timeseries,
+        value_columns=["temp", "press"],
+    )
+
+    assert "error" not in result
+    assert result["features_extracted"] == ["mean", "std"]
+    assert result["n_batches"] == 2
+    # 2 features x 2 tags = 4 feature columns.
+    assert result["n_features"] == 4
+    assert len(result["feature_matrix"]) == 2
+
+    # Check the mean row for B1: temp mean is 103.0, press mean is 1.15
+    by_batch = {row["batch"]: row for row in result["feature_matrix"]}
+    assert by_batch["B1"]["temp_mean"] == pytest.approx(103.0)
+    assert by_batch["B1"]["press_mean"] == pytest.approx(1.15)
+
+
+# f_mad and f_robust_mad have pre-existing implementation issues in
+# `process_improve.batch.features` (mad: removed pandas API; robust_mad:
+# stub raises). The wrapper still surfaces them as `{"error": ...}` rather
+# than raising — that branch is covered by the unknown-feature and bad-data
+# tests below — so they're excluded here to keep this test focused on the
+# working dispatch path.
+_WORKING_LOCATION_FEATURES = sorted(set(_FEATURE_MAP) - {"mad", "robust_mad"})
+
+
+@pytest.mark.parametrize("feature_name", _WORKING_LOCATION_FEATURES)
+def test_extract_batch_features_each_location_feature(
+    two_batch_timeseries: list[dict], feature_name: str
+) -> None:
+    """Every (working) location-based feature in the documented mapping is dispatchable."""
+    result = extract_batch_features(
+        data=two_batch_timeseries,
+        value_columns=["temp"],
+        features=[feature_name],
+    )
+
+    assert "error" not in result
+    assert result["features_extracted"] == [feature_name]
+    assert result["n_batches"] == 2
+
+
+@pytest.mark.parametrize("broken_feature", ["mad", "robust_mad"])
+def test_extract_batch_features_known_broken_features_return_error(
+    two_batch_timeseries: list[dict], broken_feature: str
+) -> None:
+    """Pre-existing wrapper limitation: 'mad' and 'robust_mad' surface as errors.
+
+    Documents the current behavior so a future fix in `batch/features` is noticed
+    here and these tests can be flipped to assert success.
+    """
+    result = extract_batch_features(
+        data=two_batch_timeseries,
+        value_columns=["temp"],
+        features=[broken_feature],
+    )
+    assert "error" in result
+
+
+def test_extract_batch_features_area_with_time_column(two_batch_timeseries: list[dict]) -> None:
+    """Time-dependent feature 'area' computes correctly when a time_column is given."""
+    result = extract_batch_features(
+        data=two_batch_timeseries,
+        value_columns=["temp"],
+        features=["area"],
+        time_column="time",
+    )
+
+    assert "error" not in result
+    assert result["features_extracted"] == ["area"]
+    assert result["n_batches"] == 2
+    by_batch = {row["batch"]: row for row in result["feature_matrix"]}
+    # Trapezoidal area for B1 temp: increases linearly 100 -> 106 over t=0..3, area = 309.0
+    assert by_batch["B1"]["temp_area"] == pytest.approx(309.0)
+
+
+def test_extract_batch_features_time_feature_without_time_column_returns_error(
+    two_batch_timeseries: list[dict],
+) -> None:
+    """Time-dependent features without time_column yield an explicit error message."""
+    result = extract_batch_features(
+        data=two_batch_timeseries,
+        value_columns=["temp"],
+        features=["area"],
+        # time_column intentionally omitted
+    )
+
+    assert "error" in result
+    assert "time_column" in result["error"]
+
+
+def test_extract_batch_features_unknown_feature_returns_error(
+    two_batch_timeseries: list[dict],
+) -> None:
+    """An unknown feature name surfaces a helpful error listing the valid options."""
+    result = extract_batch_features(
+        data=two_batch_timeseries,
+        value_columns=["temp"],
+        features=["bogus"],
+    )
+
+    assert "error" in result
+    assert "bogus" in result["error"]
+    # The error should mention at least one of the valid feature names.
+    assert "mean" in result["error"]
+
+
+def test_extract_batch_features_bad_data_returns_error() -> None:
+    """Garbage inputs surface as an error dict, not an exception."""
+    result = extract_batch_features(
+        data=[{"batch": "B1"}],  # no value column data at all
+        value_columns=["nonexistent"],
+    )
+
+    assert "error" in result
+
+
+def test_get_batch_tool_specs_lists_extract_batch_features() -> None:
+    """The module-level convenience returns the registered tool spec."""
+    specs = get_batch_tool_specs()
+    names = {spec.get("name") for spec in specs}
+    assert "extract_batch_features" in names
+
+
+def test_feature_maps_documented_in_schema_match_implementations() -> None:
+    """Sanity: every key in the maps must match a real `f_*` function (cheap import test)."""
+    from process_improve.batch import features as feat_mod
+
+    for short_name, long_name in {**_FEATURE_MAP, **_TIME_FEATURE_MAP}.items():
+        assert hasattr(feat_mod, long_name), (
+            f"Mapped feature '{short_name}' -> '{long_name}' but no such function exists."
+        )

--- a/tests/test_bivariate.py
+++ b/tests/test_bivariate.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from process_improve.bivariate.methods import find_elbow_point
+from process_improve.bivariate.tools import find_elbow, get_bivariate_tool_specs
 
 
 @pytest.fixture
@@ -94,3 +95,36 @@ def test__corner_case() -> None:
         [np.nan] * 11,
     )
     assert found_elbow == -1
+
+
+# ---------------------------------------------------------------------------
+# Agent-tool wrapper: process_improve.bivariate.tools
+# ---------------------------------------------------------------------------
+
+
+def test_find_elbow_tool_returns_index_on_clean_data(elbow_with_synthetic_data: tuple) -> None:
+    """The tool wrapper returns an integer index plus the (x, y) at the elbow."""
+    x, y, break_pt = elbow_with_synthetic_data
+    result = find_elbow(x=list(x), y=list(y))
+
+    assert "error" not in result
+    assert result["n"] == len(x)
+    expected_idx = int(np.argmin(np.abs(x - break_pt)))
+    assert result["elbow_index"] == expected_idx
+    assert result["elbow_x"] == x[expected_idx]
+    assert result["elbow_y"] == y[expected_idx]
+
+
+def test_find_elbow_tool_reports_error_on_too_few_points() -> None:
+    """The wrapper's `except` branch returns {"error": ...} on bad input."""
+    # The underlying assertion in find_elbow_point requires more than 10 non-NaN values.
+    result = find_elbow(x=[1.0, 2.0, 3.0], y=[1.0, 2.0, 3.0])
+    assert "error" in result
+
+
+def test_get_bivariate_tool_specs_lists_find_elbow() -> None:
+    """The module-level convenience returns at least the find_elbow spec."""
+    specs = get_bivariate_tool_specs()
+    assert isinstance(specs, list)
+    names = {spec.get("name") for spec in specs}
+    assert "find_elbow" in names

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -6,6 +6,13 @@ import pytest
 
 from process_improve.monitoring.control_charts import ControlChart
 from process_improve.monitoring.metrics import calculate_cpk
+from process_improve.monitoring.tools import (
+    control_chart as control_chart_tool,
+)
+from process_improve.monitoring.tools import (
+    get_monitoring_tool_specs,
+    process_capability,
+)
 
 
 class TestValidateAgainstRQccXbarOne:
@@ -205,3 +212,124 @@ class TestHoltWintersControlChartBatchYield:
     cc.calculate_limits(y)  # ld_1=0.5, ld_2=0.5
     assert cc.target == pytest.approx(75.1, abs=1e-1)
     assert cc.s == pytest.approx(4.16, abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Agent-tool wrappers: process_improve.monitoring.tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def in_control_series_with_one_outlier() -> list[float]:
+    """Mostly tight series with one obvious outlier near the end."""
+    rng = np.random.default_rng(7)
+    base = list(rng.normal(loc=10.0, scale=0.1, size=30))
+    base.append(15.0)  # outlier
+    base.extend(rng.normal(loc=10.0, scale=0.1, size=10))
+    return [float(v) for v in base]
+
+
+def test_control_chart_tool_default_holt_winters(in_control_series_with_one_outlier: list[float]) -> None:
+    """Default chart_type='holt_winters' returns target, limits, and flags the outlier."""
+    result = control_chart_tool(values=in_control_series_with_one_outlier)
+
+    assert "error" not in result
+    assert result["chart_type"] == "holt_winters"
+    assert result["style"] == "robust"
+    assert result["n_observations"] == len(in_control_series_with_one_outlier)
+    assert result["target"] is not None
+    assert result["upper_control_limit"] > result["target"]
+    assert result["lower_control_limit"] < result["target"]
+    # The injected 15.0 should be flagged as out-of-control.
+    assert result["n_out_of_control"] >= 1
+    assert any(abs(v - 15.0) < 1e-9 for v in result["out_of_control_values"])
+
+
+@pytest.mark.parametrize("chart_type", ["shewhart", "holt_winters"])
+def test_control_chart_tool_supports_each_chart_type(chart_type: str) -> None:
+    """The Shewhart and Holt-Winters chart_types produce a valid result on a generic series.
+
+    'cusum' is also documented but its underlying ControlChart variant requires additional
+    setup beyond raw values, so it surfaces as an `error` dict here. Covered indirectly by
+    `test_control_chart_tool_returns_error_on_bad_input` (the same `except` branch).
+    """
+    rng = np.random.default_rng(0)
+    values = [float(v) for v in rng.normal(loc=0.0, scale=1.0, size=40)]
+    result = control_chart_tool(values=values, chart_type=chart_type)
+
+    assert "error" not in result
+    assert result["chart_type"] == chart_type
+
+
+def test_control_chart_tool_regular_style() -> None:
+    """style='regular' uses mean/std and still returns a coherent result."""
+    rng = np.random.default_rng(1)
+    values = [float(v) for v in rng.normal(loc=5.0, scale=0.5, size=30)]
+    result = control_chart_tool(values=values, style="regular")
+
+    assert "error" not in result
+    assert result["style"] == "regular"
+    assert result["target"] == pytest.approx(np.mean(values), rel=0.1)
+
+
+def test_control_chart_tool_returns_error_on_bad_input() -> None:
+    """Non-numeric values surface as an error dict, not an exception."""
+    result = control_chart_tool(values=["not", "numbers"])  # type: ignore[arg-type]
+    assert "error" in result
+
+
+def test_process_capability_tool_excellent() -> None:
+    """Tight, centered process should report excellent capability (cpk >= 1.67)."""
+    rng = np.random.default_rng(2)
+    values = [float(v) for v in rng.normal(loc=10.0, scale=0.1, size=200)]
+    result = process_capability(values=values, lower_spec=9.0, upper_spec=11.0, robust=False)
+
+    assert "error" not in result
+    assert result["cpk"] >= 1.67
+    assert "Excellent" in result["interpretation"]
+    assert result["lower_spec"] == 9.0
+    assert result["upper_spec"] == 11.0
+    assert result["n"] == len(values)
+    assert result["robust"] is False
+
+
+@pytest.mark.parametrize(
+    ("scale", "expected"),
+    [
+        (0.2, "Good"),         # cpk in [1.33, 1.67)
+        (0.3, "Marginal"),     # cpk in [1.0, 1.33)
+        (0.6, "Poor"),         # cpk < 1.0
+    ],
+)
+def test_process_capability_tool_interpretation_bands(scale: float, expected: str) -> None:
+    """The interpretation string matches the documented capability bands."""
+    rng = np.random.default_rng(3)
+    values = [float(v) for v in rng.normal(loc=10.0, scale=scale, size=300)]
+    result = process_capability(values=values, lower_spec=9.0, upper_spec=11.0, robust=False)
+
+    assert "error" not in result
+    assert expected in result["interpretation"]
+
+
+def test_process_capability_tool_one_sided_spec() -> None:
+    """Omitting one spec limit is allowed."""
+    rng = np.random.default_rng(4)
+    values = [float(v) for v in rng.normal(loc=10.0, scale=0.5, size=100)]
+    result = process_capability(values=values, lower_spec=8.0, robust=False)
+
+    assert "error" not in result
+    assert result["lower_spec"] == 8.0
+    assert result["upper_spec"] is None
+
+
+def test_process_capability_tool_returns_error_on_bad_input() -> None:
+    """The wrapper's `except` branch returns {"error": ...} on bad input."""
+    result = process_capability(values=["bad", "input"])  # type: ignore[arg-type]
+    assert "error" in result
+
+
+def test_get_monitoring_tool_specs_lists_both_tools() -> None:
+    """The module-level convenience returns both registered specs."""
+    specs = get_monitoring_tool_specs()
+    names = {spec.get("name") for spec in specs}
+    assert {"control_chart", "process_capability"}.issubset(names)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -8,6 +8,15 @@ from process_improve.regression.methods import (
     repeated_median_slope,
     robust_regression,
 )
+from process_improve.regression.tools import (
+    get_regression_tool_specs,
+)
+from process_improve.regression.tools import (
+    repeated_median as repeated_median_tool,
+)
+from process_improve.regression.tools import (
+    robust_regression as robust_regression_tool,
+)
 
 
 @pytest.fixture
@@ -626,3 +635,78 @@ def test_ols_missing_values_preserve_residual_shape() -> None:
     assert np.isnan(model.residuals_[3])
     assert model.intercept_ == pytest.approx(-0.25)
     assert model.coefficients_[0] == pytest.approx(1.75)
+
+
+# ---------------------------------------------------------------------------
+# Agent-tool wrappers: process_improve.regression.tools
+# ---------------------------------------------------------------------------
+
+
+def test_robust_regression_tool_recovers_known_line() -> None:
+    """The wrapper should recover the slope/intercept of an exact line."""
+    rng = np.random.default_rng(11)
+    x = list(np.arange(0.0, 10.0, 0.1))
+    y = [2.0 * xi + 1.0 + 0.01 * float(rng.standard_normal()) for xi in x]
+    result = robust_regression_tool(x=x, y=y)
+
+    assert "error" not in result
+    assert result["slope"] == pytest.approx(2.0, abs=0.05)
+    assert result["intercept"] == pytest.approx(1.0, abs=0.1)
+    assert result["n"] == len(x)
+    assert result["r2"] > 0.99
+    assert result["confidence_level"] == 0.95
+    assert len(result["fitted_values"]) == len(x)
+    assert len(result["residuals"]) == len(x)
+    # Confidence interval and prediction intervals should be present and well-shaped.
+    assert "slope_confidence_interval" in result
+    assert "prediction_interval_x" in result
+    assert "prediction_interval_lower" in result
+    assert "prediction_interval_upper" in result
+    assert (
+        len(result["prediction_interval_x"])
+        == len(result["prediction_interval_lower"])
+        == len(result["prediction_interval_upper"])
+    )
+
+
+def test_robust_regression_tool_no_intercept() -> None:
+    """fit_intercept=False forces the line through the origin."""
+    x = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    y = [3.0, 6.0, 9.0, 12.0, 15.0, 18.0]
+    result = robust_regression_tool(x=x, y=y, fit_intercept=False, confidence_level=0.99)
+
+    assert "error" not in result
+    assert result["slope"] == pytest.approx(3.0, abs=1e-6)
+    assert result["intercept"] == pytest.approx(0.0, abs=1e-6)
+    assert result["confidence_level"] == 0.99
+
+
+def test_robust_regression_tool_returns_error_on_mismatched_lengths() -> None:
+    """Length-mismatched inputs surface as an error dict, not an exception."""
+    result = robust_regression_tool(x=[1.0, 2.0, 3.0], y=[1.0, 2.0])
+    assert "error" in result
+
+
+def test_repeated_median_tool_matches_underlying_method() -> None:
+    """The wrapper's slope must match the underlying repeated_median_slope."""
+    rng = np.random.default_rng(13)
+    x = np.linspace(0.0, 10.0, 50)
+    y = 1.5 * x - 4.0 + rng.standard_normal(50) * 0.05
+    result = repeated_median_tool(x=list(x), y=list(y))
+
+    assert "error" not in result
+    assert result["n"] == len(x)
+    assert result["slope"] == pytest.approx(repeated_median_slope(x, y), rel=1e-9)
+
+
+def test_repeated_median_tool_returns_error_on_bad_input() -> None:
+    """Non-numeric input should surface as an error dict."""
+    result = repeated_median_tool(x=["a", "b"], y=[1.0, 2.0])  # type: ignore[arg-type]
+    assert "error" in result
+
+
+def test_get_regression_tool_specs_lists_both_tools() -> None:
+    """The module-level convenience returns both registered specs."""
+    specs = get_regression_tool_specs()
+    names = {spec.get("name") for spec in specs}
+    assert {"robust_regression", "repeated_median"}.issubset(names)


### PR DESCRIPTION
## Summary

Boost test coverage where it actually matters and lock the gain in with a CI
floor, so future regressions break the build instead of slipping by.

The repo is already well covered (~14k test lines vs ~21.5k source lines,
every submodule has a dedicated test file, Codecov runs in CI). What's
missing is **enforcement** — there is no `fail_under` in `.coveragerc` and no
`--cov-fail-under` in the workflow — and a few thin spots that the line-count
ratios don't reveal.

## Plan (executed in micro-commits on this branch)

1. **Measure first.** Run `pytest --cov=process_improve --cov-report=term-missing
   --cov-branch` to get a real baseline and per-module ranking.
2. **Targeted tests** for the worst real gaps surfaced by the report. Pre-measurement
   hypothesis: `bivariate/methods.py` (`find_line_intersection` has zero direct
   tests, `find_elbow_point` has 4 for ~115 LOC), `bivariate/tools.py`
   (agent-tool wrapper, zero tests), and possibly `experiments/datasets.py`.
   Final target list will be confirmed by the coverage report.
3. **Add a coverage floor.** Set `fail_under` in `.coveragerc` ~1-2 points
   below the new total so normal stochasticity doesn't break CI but a real
   regression does.
4. **PATCH version bump** in `pyproject.toml`.

Also recorded the default Claude Code session workflow (open blank PR up
front, micro-commit, push regularly) in `CLAUDE.md` so it doesn't need to be
re-requested each session.

## Test plan

- [ ] `pytest -o "addopts="` — full suite green
- [ ] `pytest --cov=process_improve --cov-branch -o "addopts="` — overall coverage at or above the chosen `fail_under`
- [ ] Confirm the `fail_under` gate trips: temporarily lower coverage, re-run, see CI fail; restore
- [ ] `ruff check tests/` — clean
- [ ] CI green on this branch

https://claude.ai/code/session_01FRnezqb6vbz4d3tJrXs8t1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRnezqb6vbz4d3tJrXs8t1)_