### PR TITLE
docs: remove em-dashes from docs/comments + style rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
-# CLAUDE.md — Project Context for AI Agents
+# CLAUDE.md - Project Context for AI Agents
 
 ## Overview
 
-`process-improve` is a Python package for process improvement using data. It accompanies the online textbook [Process Improvement using Data](https://learnche.org/pid). The package provides multivariate analysis (PCA, PLS, and TPLS — *PLS for T-shaped data structures*, not "Total PLS" or "Three-way PLS"), designed experiments, process monitoring, batch data analysis, and visualization tools.
+`process-improve` is a Python package for process improvement using data. It accompanies the online textbook [Process Improvement using Data](https://learnche.org/pid). The package provides multivariate analysis (PCA, PLS, and TPLS - *PLS for T-shaped data structures*, not "Total PLS" or "Three-way PLS"), designed experiments, process monitoring, batch data analysis, and visualization tools.
 
 **Repository:** https://github.com/kgdunn/process_improve
 **License:** MIT
@@ -81,9 +81,15 @@ Both PCA and PLS have `__getattr__` methods that raise `AttributeError` with hel
 
 ### Code Quality
 - Line length: 120 characters
-- Linter: ruff (with `select = ["ALL"]` and specific ignores — see `pyproject.toml`)
+- Linter: ruff (with `select = ["ALL"]` and specific ignores - see `pyproject.toml`)
 - Formatter: black
 - Type checking: mypy
+
+### Prose style
+- Do not use em-dashes (Unicode U+2014) in docs, docstrings, comments, commit
+  messages, or PR descriptions. Use a hyphen (`-`), a semicolon, or split the
+  sentence instead. This applies to Markdown, reStructuredText, Python
+  docstrings/comments, and YAML prose content.
 
 ## Testing
 
@@ -103,7 +109,7 @@ pytest -o "addopts="
 ```
 
 ### Test Conventions
-- Use **real datasets** (LDPE, SIMCA) alongside synthetic data — do not remove real dataset tests
+- Use **real datasets** (LDPE, SIMCA) alongside synthetic data - do not remove real dataset tests
 - Scale with `MCUVScaler().fit_transform(X)` in tests (not just `center()`)
 - For synthetic PLS data, use `X.values @ beta` (not `X @ beta`) to avoid pandas column mismatch producing NaN
 - Test fixtures load CSV data from `process_improve/datasets/multivariate/`
@@ -140,13 +146,13 @@ pytest -o "addopts="
    ready-for-review with a description of what's about to be done. Do not
    open it as a draft.
 2. **Micro-commit as you go.** Each commit should be a small, self-contained
-   step (one module's tests, one config tweak, one bug fix) — not a single
+   step (one module's tests, one config tweak, one bug fix) - not a single
    end-of-session megacommit.
 3. **Push regularly.** After every micro-commit (or at worst every 2-3),
    `git push` to the same branch so the PR reflects current progress and the
    user can watch it land.
 
-This is the default — don't ask the user whether to do it, just do it.
+This is the default - don't ask the user whether to do it, just do it.
 
 **Never push lock files.** Claude Code sessions must not stage, commit, or push
 any dependency lock files. Lock-file updates are performed manually by the
@@ -170,7 +176,7 @@ lock files manually outside of Claude Code sessions.
 
 If during a session you notice a recurring pattern, convention, or piece of
 project context that you think belongs in `CLAUDE.md`, **do not add it
-yourself**. Surface the proposed addition in chat — the wording you would
-add, where you would put it, and why you think it is reusable — and ask the
+yourself**. Surface the proposed addition in chat - the wording you would
+add, where you would put it, and why you think it is reusable - and ask the
 user whether it should be recorded here. The user decides what gets
 canonised in this file.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Process Improvement using Data
 
-> A pragmatic Python toolkit for industrial process data — multivariate
+> A pragmatic Python toolkit for industrial process data - multivariate
 > analysis, designed experiments, and process monitoring, in one place.
 
 [![PyPI version](https://img.shields.io/pypi/v/process-improve.svg)](https://pypi.org/project/process-improve/)
@@ -15,9 +15,9 @@
 `process-improve` is the companion package to the online textbook
 [Process Improvement using Data](https://learnche.org/pid), and powers the
 statistical engine behind [factori.al](https://factori.al). It bundles the
-methods practitioners actually reach for on real plant and lab data —
+methods practitioners actually reach for on real plant and lab data -
 PCA / PLS with proper missing-data handling, designed experiments with a
-multi-stage strategy recommender, control charts, and batch-data tooling —
+multi-stage strategy recommender, control charts, and batch-data tooling -
 behind an API that is sklearn-compatible where it makes sense and
 pandas-native throughout.
 
@@ -26,14 +26,14 @@ pandas-native throughout.
 ### 🧪 Designed Experiments
 
 - Full-factorial, fractional-factorial, and response-surface designs (built on `pyDOE3`)
-- A **DOE strategy recommender** that plans a complete multi-stage program — screening → optimization → confirmation — from ~50 deterministic rules, with budget-aware allocation and domain-specific advice for fermentation, cell culture, pharma, and 5 other domains
+- A **DOE strategy recommender** that plans a complete multi-stage program - screening → optimization → confirmation - from ~50 deterministic rules, with budget-aware allocation and domain-specific advice for fermentation, cell culture, pharma, and 5 other domains
 - ANOVA, main-effects plots, linear-model fitting, and response optimization
 
 ### 📊 Latent Variable Methods
 
 - **PCA** with SVD and NIPALS algorithms, plus missing-data via Trimmed Score Regression
 - **PLS** regression with a fully sklearn-compatible API
-- **TPLS** — PLS for *T-shaped data structures*
+- **TPLS** - PLS for *T-shaped data structures*
 - Diagnostics: Hotelling's T², SPE, score contributions, and ESD-based outlier detection
 - Component selection via PRESS / Wold's criterion
 - Interactive Plotly score, loading, SPE, and T² plots, bound directly to fitted models
@@ -71,7 +71,7 @@ Requires Python 3.10 or newer.
 
 ## Quick start
 
-### PCA — Principal Component Analysis
+### PCA - Principal Component Analysis
 
 ```python
 import pandas as pd
@@ -85,7 +85,7 @@ print(pca.r2_cumulative_)        # cumulative R² per component
 pca.score_plot()                  # interactive Plotly plot
 ```
 
-### PLS — Projection to Latent Structures
+### PLS - Projection to Latent Structures
 
 ```python
 from process_improve.multivariate.methods import PLS, MCUVScaler
@@ -98,7 +98,7 @@ result = pls.predict(X_s)
 print(result.y_hat, result.spe, result.hotellings_t2)
 ```
 
-### DOE — multi-stage experimental strategy
+### DOE - multi-stage experimental strategy
 
 ```python
 from process_improve.experiments.factor import Factor, Response
@@ -146,4 +146,4 @@ Bug reports and feature requests are welcome on the
 
 ## License
 
-MIT — see [LICENSE](LICENSE) for details.
+MIT - see [LICENSE](LICENSE) for details.

--- a/TODO.md
+++ b/TODO.md
@@ -12,30 +12,30 @@
 >   stub found in `process_improve/**/*.py` and `tests/**/*.py`.
 >
 > Provenance tags on each item:
-> - `(#NNN)` — derived from PR description.
-> - `(TODO.txt)` — from the original free-form file.
-> - `(file.py:line)` — from an in-source TODO/FIXME or stub.
+> - `(#NNN)` - derived from PR description.
+> - `(TODO.txt)` - from the original free-form file.
+> - `(file.py:line)` - from an in-source TODO/FIXME or stub.
 
 ## Multivariate (PCA / PLS / TPLS / MBPCA / MBPLS)
 
 - [ ] Add plotting routines on MV models: `model.plot_screeplot(...)` etc.; plots accept a `pc_depth` argument so a 3D plot is made instead. (TODO.txt)
-- [ ] PLS lacks an SPE limit — add it. (TODO.txt)
+- [ ] PLS lacks an SPE limit - add it. (TODO.txt)
 - [ ] Fill in `R2*` attributes on MV models. (TODO.txt)
-- [ ] `print(model)` raises `'PCA_missing_values' object has no attribute 'copy'` — fix. (TODO.txt)
+- [ ] `print(model)` raises `'PCA_missing_values' object has no attribute 'copy'` - fix. (TODO.txt)
 - [ ] Implement sklearn-style `fit_transform` on `PCA`. (TODO.txt)
 - [ ] Add a post-filter helper: snap values within ±eps of zero to zero. (TODO.txt)
-- [ ] Add VIP for PCA, PLS, TPLS. (TODO.txt, #54 — unmerged)
+- [ ] Add VIP for PCA, PLS, TPLS. (TODO.txt, #54 - unmerged)
 - [ ] Prediction intervals for PLS. (TODO.txt)
 - [ ] Jackknife confidence intervals for PLS coefficients. (TODO.txt)
 - [ ] Contribution plots and contribution-plot calculation. (TODO.txt)
 - [ ] In NIPALS, use the column of X with the greatest variance as the starting score after iteration 1. (TODO.txt)
-- [ ] PLS with missing values via TSR methods (Folch-Fortuny — see Reference snippets). (TODO.txt)
+- [ ] PLS with missing values via TSR methods (Folch-Fortuny - see Reference snippets). (TODO.txt)
 - [ ] Investigate Robust PLS (Serneels/Croux/Filzmoser/Van Espen 2005, Partial Robust M-regression). (TODO.txt)
 - [ ] Port the legacy `calc_limits` MATLAB block (verbatim in *Reference snippets*) into Python. (TODO.txt)
 - [ ] Verify sklearn pipeline compatibility (clone, `get_params` / `set_params`) for refactored PLS. (#59)
 - [ ] Verify numerical equivalence of refactored PLS with sklearn `PLSRegression` on reference datasets. (#59)
 - [ ] Add larger multi-block reference datasets (FMC, SBR, DuPont) once `.mat` conversion is wanted. (#124)
-- [ ] Multi-block batch-wise unfolding — extend `process_improve/batch/preprocessing.py`. (#124)
+- [ ] Multi-block batch-wise unfolding - extend `process_improve/batch/preprocessing.py`. (#124)
 - [ ] Multi-block cross-validation helper (single-block `Resampler` exists; multi-block CV needs its own pass). (#124)
 - [ ] Optional thin `Block` wrapper class around `dict[str, DataFrame]` (only if usage warrants). (#124)
 - [ ] Implement TSR for PLS. (multivariate/methods.py:1033)
@@ -55,11 +55,11 @@
 ## Batch
 
 - [ ] Percentage-scale x-axis for alignment, with configurable resolution. (TODO.txt)
-- [ ] Missing-data handling in batch — see verbatim `fill_na_values` in *Reference snippets*. (TODO.txt)
+- [ ] Missing-data handling in batch - see verbatim `fill_na_values` in *Reference snippets*. (TODO.txt)
 - [ ] Smoothing tools: lowess and Savitzky–Golay filter for batch data. (TODO.txt)
 - [ ] Add tests for `f_cross` and `f_elbow`. (TODO.txt)
 - [ ] Don't force batch dict keys to `str`; investigate `align_with_path` adding `batch_id` as a column and crashing on `synced.iloc[row, :] = np.nanmean(temp, axis=0)`. (TODO.txt)
-- [ ] Implement `f_robust_mad` — currently raises `AssertionError("This next line of code fails. Fix it.")`. (#89, batch/features.py:295)
+- [ ] Implement `f_robust_mad` - currently raises `AssertionError("This next line of code fails. Fix it.")`. (#89, batch/features.py:295)
 - [ ] Resolve outstanding `# TODO: check this out still`. (batch/features.py:372)
 - [ ] Investigate change-point detection via `ruptures` (https://github.com/deepcharles/ruptures). (batch/features.py:403)
 - [ ] Address the bare `# TODO` markers on two feature functions. (batch/features.py:480, batch/features.py:490)
@@ -79,11 +79,11 @@
 
 ## Univariate
 
-- [ ] Distribution-fit check (NIST handbook §3.5.7 — see *Reference snippets*). (TODO.txt)
+- [ ] Distribution-fit check (NIST handbook §3.5.7 - see *Reference snippets*). (TODO.txt)
 - [ ] Outlier detection: integrate / wrap `pyod`. (TODO.txt)
-- [ ] Grubbs / Tietjen–Moore single & multiple outlier tests (NIST §3.5.h, §3.5.h3 — see *Reference snippets*). (TODO.txt)
+- [ ] Grubbs / Tietjen–Moore single & multiple outlier tests (NIST §3.5.h, §3.5.h3 - see *Reference snippets*). (TODO.txt)
 - [ ] Holm post-hoc multiple-comparisons test. (TODO.txt)
-- [ ] Robust scale — port the verbatim Mosteller–Tukey MATLAB function in *Reference snippets*. (TODO.txt)
+- [ ] Robust scale - port the verbatim Mosteller–Tukey MATLAB function in *Reference snippets*. (TODO.txt)
 - [ ] Follow up on the `rips-irsp.com/article/10.5334/irsp.82/` reference (likely a multiple-comparisons or post-hoc test to add). (univariate/metrics.py:419)
 
 ## Monitoring
@@ -100,7 +100,7 @@
 
 ## Experiments / DOE
 
-- [ ] Build out the product-development notebook — full outline preserved verbatim under *Reference snippets*. (TODO.txt)
+- [ ] Build out the product-development notebook - full outline preserved verbatim under *Reference snippets*. (TODO.txt)
 - [ ] Implement `ridge_analysis` (trace optimum along increasing radii). Currently a stub; removed from the `optimize_responses` tool enum. (#74, #79)
 - [ ] Implement `pareto_front` (multi-objective NSGA-II). Currently a stub; removed from the `optimize_responses` tool enum. (#74, #79)
 - [ ] Verify `execute_tool_call("analyze_experiment", ...)` works end-to-end. (#72)
@@ -112,11 +112,11 @@
 
 ## Visualization
 
-- [ ] Implement `raincloud` — currently a stub that returns `None`. (#89, visualization/plots.py:4)
+- [ ] Implement `raincloud` - currently a stub that returns `None`. (#89, visualization/plots.py:4)
 
 ## Tests
 
-- [ ] Flesh out partial / placeholder test bodies — R cross-checks, SPE-vs-Simca-P comparison, Plotly assertions, etc. (tests/test_multivariate.py:388, tests/test_multivariate.py:413, tests/test_multivariate.py:478, tests/test_multivariate.py:703, tests/test_multivariate.py:747, tests/test_multivariate.py:1012, tests/test_multivariate.py:1226, tests/test_multivariate.py:1246, tests/test_multivariate.py:1309, tests/test_multivariate.py:2073, tests/test_multivariate.py:2220)
+- [ ] Flesh out partial / placeholder test bodies - R cross-checks, SPE-vs-Simca-P comparison, Plotly assertions, etc. (tests/test_multivariate.py:388, tests/test_multivariate.py:413, tests/test_multivariate.py:478, tests/test_multivariate.py:703, tests/test_multivariate.py:747, tests/test_multivariate.py:1012, tests/test_multivariate.py:1226, tests/test_multivariate.py:1246, tests/test_multivariate.py:1309, tests/test_multivariate.py:2073, tests/test_multivariate.py:2220)
 - [ ] Investigate the sequence that yields Sn = 0 despite variability. (tests/test_univariate.py:113)
 - [ ] Complete the robust-case test. (tests/test_univariate.py:394)
 - [ ] Address the bare `# TODO`. (tests/test_univariate.py:843)
@@ -139,7 +139,7 @@
 
 - [ ] Confirm Codecov "Missing Base Commit" is gone after the next PR. (#117)
 - [ ] Confirm `CODECOV_TOKEN` is set under repo Settings → Secrets and variables → Actions. (#118)
-- [ ] After merge, watch first `Unit tests` run on `main` — codecov upload should run on `ubuntu-latest` + `3.13` only. (#118)
+- [ ] After merge, watch first `Unit tests` run on `main` - codecov upload should run on `ubuntu-latest` + `3.13` only. (#118)
 - [ ] Confirm README codecov badge resolves to a percentage instead of "unknown". (#118)
 - [ ] Update the README CI badge URL when `run-tests.yml` is renamed/replaced. (#119)
 - [ ] Settings → Code security → enable Dependabot alerts + Dependabot security updates. (#97)
@@ -159,7 +159,7 @@
 Preserved verbatim from the original `TODO.txt` so the context referenced by the
 checkboxes above is not lost.
 
-### `fill_na_values` — crude batch missing-value fill
+### `fill_na_values` - crude batch missing-value fill
 
 ```python
 # Fill in missing values
@@ -194,7 +194,7 @@ for batch_id, batch in  df_dict.items():
 - PLS with TSR methods: https://riunet.upv.es/bitstream/id/303213/PCA%20model%20building%20with%20missing%20data%20new%20proposals%20and%20a%20comparative%20study%20-%20Folch-Fortuny.pdf
 - Robust PLS: S. Serneels, C. Croux, P. Filzmoser, P.J. Van Espen, *Partial Robust M-regression*, Chemometrics and Intelligent Laboratory Systems, 79 (2005), 55-64.
 
-### `robust_scale` — Mosteller & Tukey, MATLAB
+### `robust_scale` - Mosteller & Tukey, MATLAB
 
 ```matlab
 function  v = robust_scale(a)
@@ -212,7 +212,7 @@ function  v = robust_scale(a)
 end
 ```
 
-### `calc_limits` — legacy MATLAB / Python hybrid block to port
+### `calc_limits` - legacy MATLAB / Python hybrid block to port
 
 ```python
 def calc_limits(self):
@@ -292,7 +292,7 @@ def calc_limits(self):
 
 ### Product-development notebook narrative
 
-Verbatim from `TODO.txt` — captures the storyboard for the planned PD notebook
+Verbatim from `TODO.txt` - captures the storyboard for the planned PD notebook
 that walks through latent-variable model inversion for new-product design.
 
 ```

--- a/docs/doe/README.md
+++ b/docs/doe/README.md
@@ -1,4 +1,4 @@
-# DOE Module — Architecture & Requirements
+# DOE Module - Architecture & Requirements
 
 Developer reference for the `process_improve.experiments` module.
 These docs capture the tool architecture and question bank that drive development.
@@ -13,7 +13,7 @@ These docs capture the tool architecture and question bank that drive developmen
 
 | File | What's in it |
 |---|---|
-| [tools.md](tools.md) | The 8-tool architecture — what each tool does, its inputs/outputs |
+| [tools.md](tools.md) | The 8-tool architecture - what each tool does, its inputs/outputs |
 | [questions.md](questions.md) | All 162 questions organized by category (A–P) |
 | [tool-question-mapping.md](tool-question-mapping.md) | Which tool(s) answer which question |
 | [workflows.md](workflows.md) | Common workflow patterns, design type usage, multi-tool chains |

--- a/docs/doe/coverage.md
+++ b/docs/doe/coverage.md
@@ -7,13 +7,13 @@ Current implementation status across every agent-facing DoE tool.
 | Tool | Status | Implementation | Open gaps |
 |---|---|---|---|
 | `generate_design` | **Implemented** | Unified dispatcher in `experiments/designs.py`; per-family handlers in `designs_factorial.py`, `designs_screening.py`, `designs_response_surface.py`, `designs_optimal.py`, `designs_mixture.py`. Covers all 11 design types (full/fractional factorial, PB, BBD, CCD, DSD, D/I/A-optimal, mixture, Taguchi). | I/A-optimal require `pyoptex`; hard-to-change factors without `pyoptex` are ignored with a warning. |
-| `evaluate_design` | **Implemented** | `experiments/evaluate.py` — 14 metrics: `d/i/g_efficiency`, `prediction_variance`, `vif`, `condition_number`, `power`, `degrees_of_freedom`, `alias_structure`, `confounding`, `resolution`, `defining_relation`, `clear_effects`, `minimum_aberration`. | — |
-| `analyze_experiment` | **Implemented** | `analysis.py` — 13 analysis types via statsmodels/scipy. | Split-plot ANOVA (mixed-model mapping). |
-| `optimize_responses` | **Partial** | `optimization.py` — desirability, steepest ascent/descent, stationary point, canonical analysis. | Ridge analysis, Pareto front (stubs). |
-| `augment_design` | **Implemented** | `augment.py` — foldover, semifold, axial, replicate, D-optimal. | — |
-| `visualize_doe` | **Implemented** | `visualization/` — 20 plot types, dual Plotly/ECharts backends. | — |
-| `doe_knowledge` | **Implemented** | `knowledge/` — YAML knowledge graph, in-memory query engine. | Interpretation guides and worked examples (YAML stubs). |
-| `recommend_strategy` | **Implemented** | `strategy/` — deterministic rule engine, ~50 decision rules, 8 domain templates, budget allocation. | — |
+| `evaluate_design` | **Implemented** | `experiments/evaluate.py` - 14 metrics: `d/i/g_efficiency`, `prediction_variance`, `vif`, `condition_number`, `power`, `degrees_of_freedom`, `alias_structure`, `confounding`, `resolution`, `defining_relation`, `clear_effects`, `minimum_aberration`. | - |
+| `analyze_experiment` | **Implemented** | `analysis.py` - 13 analysis types via statsmodels/scipy. | Split-plot ANOVA (mixed-model mapping). |
+| `optimize_responses` | **Partial** | `optimization.py` - desirability, steepest ascent/descent, stationary point, canonical analysis. | Ridge analysis, Pareto front (stubs). |
+| `augment_design` | **Implemented** | `augment.py` - foldover, semifold, axial, replicate, D-optimal. | - |
+| `visualize_doe` | **Implemented** | `visualization/` - 20 plot types, dual Plotly/ECharts backends. | - |
+| `doe_knowledge` | **Implemented** | `knowledge/` - YAML knowledge graph, in-memory query engine. | Interpretation guides and worked examples (YAML stubs). |
+| `recommend_strategy` | **Implemented** | `strategy/` - deterministic rule engine, ~50 decision rules, 8 domain templates, budget allocation. | - |
 
 ## Design Family Details
 
@@ -24,11 +24,11 @@ Current implementation status across every agent-facing DoE tool.
 | Plackett-Burman (N ∈ {8, 12, 16, 20, 24, …}) | `designs_screening.py::dispatch_plackett_burman` via `pyDOE3.pbdesign`. | `TestPlackettBurman`, `TestPlackettBurmanProperties`. |
 | Box-Behnken | `designs_response_surface.py::dispatch_box_behnken` via `pyDOE3.bbdesign`. | `TestBoxBehnken`, `TestBoxBehnkenProperties`. |
 | Central Composite Design (face-centered, rotatable, inscribed, orthogonal) | `designs_response_surface.py::dispatch_ccd` via `pyDOE3.ccdesign`. | `TestCCD`, `TestCCDProperties`. |
-| Definitive Screening Design | `designs_response_surface.py::dispatch_dsd` — Paley conference-matrix construction (see caveat below). | `TestDSD`, `TestDSDProperties`. |
-| D-optimal | `designs_optimal.py::dispatch_d_optimal` — `pyoptex` coordinate exchange when available, otherwise point exchange on a 3-level candidate set. | `TestDOptimal`. |
+| Definitive Screening Design | `designs_response_surface.py::dispatch_dsd` - Paley conference-matrix construction (see caveat below). | `TestDSD`, `TestDSDProperties`. |
+| D-optimal | `designs_optimal.py::dispatch_d_optimal` - `pyoptex` coordinate exchange when available, otherwise point exchange on a 3-level candidate set. | `TestDOptimal`. |
 | I-optimal | `designs_optimal.py::dispatch_i_optimal` via `pyoptex`. | `TestIOptimal` (skipped without `pyoptex`). |
 | A-optimal | `designs_optimal.py::dispatch_a_optimal` via `pyoptex`. | `TestAOptimal` (skipped without `pyoptex`). |
-| Mixture (simplex-lattice, simplex-centroid) | `designs_mixture.py::dispatch_mixture` — auto-selects based on budget. | `TestMixture`. |
+| Mixture (simplex-lattice, simplex-centroid) | `designs_mixture.py::dispatch_mixture` - auto-selects based on budget. | `TestMixture`. |
 | Taguchi orthogonal arrays | `designs_screening.py::dispatch_taguchi` via `pyDOE3.taguchi_design`. | `TestTaguchi`. |
 
 ## `evaluate_design` Metrics

--- a/docs/doe/questions.md
+++ b/docs/doe/questions.md
@@ -9,24 +9,24 @@ Questions span classical/academic DOE (A–G) and applied scientific literature 
 
 | # | Question |
 |---|---|
-| 1 | I have 7 factors I want to test — how do I even start planning a DOE? |
+| 1 | I have 7 factors I want to test - how do I even start planning a DOE? |
 | 2 | How many runs do I need? I have 5 factors and a budget for about 20 experiments. |
 | 3 | What's the minimum number of experiments I need with 4 factors? |
 | 4 | What is the difference between a full factorial and a fractional factorial? |
-| 5 | I have 6 factors at 2 levels but can only afford 16 runs — design a fractional factorial and show the generators. |
+| 5 | I have 6 factors at 2 levels but can only afford 16 runs - design a fractional factorial and show the generators. |
 | 6 | When should I use Plackett-Burman vs. a regular fractional factorial for screening? |
 | 7 | What is a definitive screening design and when should I use one instead of Plackett-Burman? |
 | 8 | When should I use CCD vs. Box-Behnken? What are the tradeoffs? |
-| 9 | I have 3 factors and want to optimize yield and purity — design an experiment for me. |
+| 9 | I have 3 factors and want to optimize yield and purity - design an experiment for me. |
 | 10 | How do I augment my screening design to add runs for response surface modeling? |
 | 11 | How do I set up a DOE with both continuous and categorical factors? |
-| 12 | I need to screen 12 factors quickly with minimal runs — what design should I use? |
+| 12 | I need to screen 12 factors quickly with minimal runs - what design should I use? |
 | 13 | What is the difference between a classical design (CCD) and an optimal design (D-optimal, I-optimal)? |
 | 14 | How do I choose between D-optimal and I-optimal designs? |
-| 15 | I have a mixture of 4 ingredients summing to 100% plus 2 process factors — what design do I need? |
-| 16 | Design a DOE for 2^6 in 16 runs — what resolution will I get? |
+| 15 | I have a mixture of 4 ingredients summing to 100% plus 2 process factors - what design do I need? |
+| 16 | Design a DOE for 2^6 in 16 runs - what resolution will I get? |
 | 17 | Construct the design matrix for a 2^(4-1) with generator D=ABC, list all 8 runs, and identify the defining relation. |
-| 18 | I want a full quadratic model in 3 factors — how many runs for CCD vs. BBD, and what is alpha for a rotatable CCD? |
+| 18 | I want a full quadratic model in 3 factors - how many runs for CCD vs. BBD, and what is alpha for a rotatable CCD? |
 | 19 | How do I augment a 2^k factorial with center and axial points to create a CCD? |
 | 20 | How does a face-centered CCD compare to a rotatable CCD in prediction variance? |
 
@@ -42,41 +42,41 @@ Questions span classical/academic DOE (A–G) and applied scientific literature 
 | 26 | What is minimum aberration and why might I prefer it over maximizing resolution? |
 | 27 | What does it mean for a design to be orthogonal? What happens when orthogonality is lost? |
 | 28 | What are "clear" effects in a fractional factorial and how do I identify them? |
-| 29 | How do I calculate statistical power — is my experiment big enough? |
+| 29 | How do I calculate statistical power - is my experiment big enough? |
 | 30 | What is D-efficiency and how do I use it to compare designs? |
 
 ## C. Analysis of Designed Experiments (13 questions)
 
 | # | Question |
 |---|---|
-| 31 | I ran a 2^3 factorial with 3 replicates — walk me through the ANOVA table. |
-| 32 | I ran a single-replicate 2^4 — how do I estimate error? How does a half-normal plot help? |
+| 31 | I ran a 2^3 factorial with 3 replicates - walk me through the ANOVA table. |
+| 32 | I ran a single-replicate 2^4 - how do I estimate error? How does a half-normal plot help? |
 | 33 | Use a Pareto plot to identify significant effects from my unreplicated 2^5. |
-| 34 | My 2^(4-1) estimated effect [AB+CD]=10.4 — why is this aliased and how do I separate them? |
+| 34 | My 2^(4-1) estimated effect [AB+CD]=10.4 - why is this aliased and how do I separate them? |
 | 35 | Show me how to calculate main effects and interactions by hand for a 2^3. |
-| 36 | Residuals vs. fitted shows a funnel shape — what does that mean and how do I fix it? |
+| 36 | Residuals vs. fitted shows a funnel shape - what does that mean and how do I fix it? |
 | 37 | How do I use Box-Cox to choose a transformation? |
-| 38 | Normal probability plot of residuals shows an S-curve — what remedial action? |
-| 39 | Given model output with coefficients, SEs, and p-values — which effects are significant? |
+| 38 | Normal probability plot of residuals shows an S-curve - what remedial action? |
+| 39 | Given model output with coefficients, SEs, and p-values - which effects are significant? |
 | 40 | How do I use Lenth's method (PSE) to determine active effects in an unreplicated factorial? |
-| 41 | Center point test: factorial avg=72.3, center avg=65.8 — is curvature significant? |
-| 42 | Analyze 16 runs from my 2^4 — identify significant effects and give a reduced model. |
-| 43 | Full factorial in 3 factors, 8 runs, 8 parameters, zero residual df — how to judge importance? |
+| 41 | Center point test: factorial avg=72.3, center avg=65.8 - is curvature significant? |
+| 42 | Analyze 16 runs from my 2^4 - identify significant effects and give a reduced model. |
+| 43 | Full factorial in 3 factors, 8 runs, 8 parameters, zero residual df - how to judge importance? |
 
 ## D. Response Surface Methodology (10 questions)
 
 | # | Question |
 |---|---|
-| 44 | Describe the sequential nature of RSM — screening to steepest ascent to second-order model. |
-| 45 | Given a fitted quadratic model, find the stationary point — is it a max, min, or saddle? |
-| 46 | Explain steepest ascent — given b1=5.45 and b2=-3.20, what direction and step size? |
+| 44 | Describe the sequential nature of RSM - screening to steepest ascent to second-order model. |
+| 45 | Given a fitted quadratic model, find the stationary point - is it a max, min, or saddle? |
+| 46 | Explain steepest ascent - given b1=5.45 and b2=-3.20, what direction and step size? |
 | 47 | How do I draw and interpret a contour plot? Which direction maximizes the response? |
 | 48 | How do I optimize multiple conflicting responses? What is a desirability function? |
 | 49 | Compute desirability for three responses: maximize yield >90%, minimize cost <$5, target viscosity 50+/-5. |
 | 50 | What is a lack-of-fit test and how do center point replicates provide pure error? |
 | 51 | What is rotatability and why is it desirable? |
 | 52 | How do I know when to switch from first-order to second-order model? |
-| 53 | Stationary point is outside my experimental region — what is ridge analysis? |
+| 53 | Stationary point is outside my experimental region - what is ridge analysis? |
 
 ## E. Practical & Applied (13 questions)
 
@@ -91,26 +91,26 @@ Questions span classical/academic DOE (A–G) and applied scientific literature 
 | 60 | How do I handle missing/failed runs? |
 | 61 | How do I perform and analyze confirmation runs? How many? |
 | 62 | How do I use DOE when my response is binary (pass/fail)? |
-| 63 | 8 factors — describe a screening strategy to narrow to 2–3 important factors in 16 runs. |
-| 64 | Chemical engineer wants to maximize yield with T, P, catalyst% in ~20 runs — propose full strategy. |
-| 65 | Experiments cost $5,000 each, budget for 25 runs — how to stage this? |
-| 66 | Soap manufacturing with constraint 3T+5D<=600 — use RSM to maximize profit. |
+| 63 | 8 factors - describe a screening strategy to narrow to 2–3 important factors in 16 runs. |
+| 64 | Chemical engineer wants to maximize yield with T, P, catalyst% in ~20 runs - propose full strategy. |
+| 65 | Experiments cost $5,000 each, budget for 25 runs - how to stage this? |
+| 66 | Soap manufacturing with constraint 3T+5D<=600 - use RSM to maximize profit. |
 
 ## F. Interpretation (12 questions)
 
 | # | Question |
 |---|---|
-| 67 | ANOVA shows significant lack of fit — what does that mean? |
+| 67 | ANOVA shows significant lack of fit - what does that mean? |
 | 68 | How do I interpret an interaction plot? What does it mean when lines cross? |
-| 69 | Main effect A is not significant but AB interaction is — should I keep A? |
-| 70 | R^2=0.95 but predicted R^2=0.40 — what does that mean? |
-| 71 | Confirmation runs don't match predictions — what went wrong? |
-| 72 | PB screening gave significant effects — are these real or aliased interactions? |
-| 73 | Factor C is largest effect but aliased with ABD — how to de-alias? What is foldover? |
-| 74 | Significant p-value but tiny effects — is this practically significant? |
-| 75 | Significant curvature test from center points — what next? |
+| 69 | Main effect A is not significant but AB interaction is - should I keep A? |
+| 70 | R^2=0.95 but predicted R^2=0.40 - what does that mean? |
+| 71 | Confirmation runs don't match predictions - what went wrong? |
+| 72 | PB screening gave significant effects - are these real or aliased interactions? |
+| 73 | Factor C is largest effect but aliased with ABD - how to de-alias? What is foldover? |
+| 74 | Significant p-value but tiny effects - is this practically significant? |
+| 75 | Significant curvature test from center points - what next? |
 | 76 | Walk me through reading a Pareto plot and half-normal plot from my 2^5. |
-| 77 | 2^(7-4) Res III, largest effect C aliased with AE+BF+DG — how to resolve? |
+| 77 | 2^(7-4) Res III, largest effect C aliased with AE+BF+DG - how to resolve? |
 | 78 | After dropping insignificant effects, why don't remaining coefficients change? |
 
 ## G. Statistical Concepts (12 questions)
@@ -121,7 +121,7 @@ Questions span classical/academic DOE (A–G) and applied scientific literature 
 | 80 | Why is randomization important? Concrete example of what goes wrong without it. |
 | 81 | What are degrees of freedom and how do they partition in a 2^k factorial? |
 | 82 | Explain sparsity-of-effects (effect heredity). |
-| 83 | What is the hierarchy principle — keep main effect if its interaction is significant? |
+| 83 | What is the hierarchy principle - keep main effect if its interaction is significant? |
 | 84 | Difference between split-plot and blocked design? |
 | 85 | Why use the highest-order interaction as generator for a fractional factorial? |
 | 86 | Convert real-world units to coded units (-1 to +1). |
@@ -134,35 +134,35 @@ Questions span classical/academic DOE (A–G) and applied scientific literature 
 
 | # | Question |
 |---|---|
-| 91 | Optimize nanoparticle formulation — screen polymer concentration, surfactant %, sonication time, phase ratio. |
+| 91 | Optimize nanoparticle formulation - screen polymer concentration, surfactant %, sonication time, phase ratio. |
 | 92 | 2^3 full factorial for solid lipid nanoparticles: lipid content, emulsifier, homogenization time. |
-| 93 | 5 variables for lipid nanoparticles — design a definitive screening design. |
+| 93 | 5 variables for lipid nanoparticles - design a definitive screening design. |
 | 94 | Optimize solid dispersion with 3^2 factorial: carrier:drug ratio and adsorbent:SD ratio. |
 | 95 | 2^4 factorial for transdermal transfersome: phospholipid ratio, edge activator type, hydration volume, sonication. |
 | 96 | BBD for hydrogel microspheres: polymer %, crosslinker, drug loading. |
-| 97 | 2^3 factorial found significant effects for dropping pills — how to move to optimization? |
+| 97 | 2^3 factorial found significant effects for dropping pills - how to move to optimization? |
 | 98 | CCD for nanocapsules: polymer concentration, active ingredient, drip rate, phase ratio. |
 | 99 | Desirability function for particle size <100nm, PDI <=0.30, zeta >=30mV, EE >=70%. |
-| 100 | Hybrid DOE: 2^4 screening then CCD optimization — how to combine data? |
-| 101 | NLC optimization: factorial screening + CCD, lack-of-fit is significant — what to do? |
+| 100 | Hybrid DOE: 2^4 screening then CCD optimization - how to combine data? |
+| 101 | NLC optimization: factorial screening + CCD, lack-of-fit is significant - what to do? |
 | 102 | QbD for oral suspension: build Ishikawa/FMEA to identify CMAs and CPPs. |
-| 103 | Surfactant affects all three responses — find conditions satisfying all simultaneously. |
+| 103 | Surfactant affects all three responses - find conditions satisfying all simultaneously. |
 
 ## I. Fermentation & Bioprocess (11 questions)
 
 | # | Question |
 |---|---|
-| 104 | Optimize fermentation medium (7 factors) — too many for full factorial, what's my screening strategy? |
+| 104 | Optimize fermentation medium (7 factors) - too many for full factorial, what's my screening strategy? |
 | 105 | PB experiment to screen 7 fermentation variables in 12 runs. |
 | 106 | After PB identified 3 factors, design BBD for optimal concentrations. |
 | 107 | BBD with temperature, pH, culture time for OD600. |
-| 108 | Optimize solid-state fermentation — maximize xylanase and cellulase simultaneously. |
-| 109 | PB identified significant factors but I suspect interactions — go straight to RSM or run Res IV first? |
-| 110 | Compare RSM predictions with ANN — is this valid? |
-| 111 | Screening 11 variables — is PB in 12 runs sufficient or do I need 20? |
+| 108 | Optimize solid-state fermentation - maximize xylanase and cellulase simultaneously. |
+| 109 | PB identified significant factors but I suspect interactions - go straight to RSM or run Res IV first? |
+| 110 | Compare RSM predictions with ANN - is this valid? |
+| 111 | Screening 11 variables - is PB in 12 runs sufficient or do I need 20? |
 | 112 | BBD for cucumber fermentation: salt, temperature, brine filling temperature. |
 | 113 | Can I use an orthogonal array for second-stage fermentation optimization? |
-| 114 | RSM model R^2=0.98 but confirmation run is 15% off — what went wrong? |
+| 114 | RSM model R^2=0.98 but confirmation run is 15% off - what went wrong? |
 
 ## J. Food Science & Beverage (10 questions)
 
@@ -174,8 +174,8 @@ Questions span classical/academic DOE (A–G) and applied scientific literature 
 | 118 | CCD for polyphenol extraction: pressure, temperature, CO2 flow, co-solvent. |
 | 119 | Microwave-assisted extraction: optimize power, time, water for yield, polyphenols, cannabinoids. |
 | 120 | Mixture design for extruded snack: millet, sorghum, soy proportions. |
-| 121 | BBD for pickle fermentation — contour plots and optimal salt/temperature/time. |
-| 122 | CCD vs. BBD vs. Doehlert for extraction optimization — when to choose each? |
+| 121 | BBD for pickle fermentation - contour plots and optimal salt/temperature/time. |
+| 122 | CCD vs. BBD vs. Doehlert for extraction optimization - when to choose each? |
 | 123 | Compare PB, factorial, and Taguchi OA for screening 8 extraction parameters. |
 | 124 | DOE for enzymatic hydrolysis: enzyme concentration, pH, temperature, time. |
 
@@ -194,11 +194,11 @@ Questions span classical/academic DOE (A–G) and applied scientific literature 
 
 | # | Question |
 |---|---|
-| 131 | Optimize iPSC differentiation (6 conditions, 21-day runs) — most efficient DOE approach? |
+| 131 | Optimize iPSC differentiation (6 conditions, 21-day runs) - most efficient DOE approach? |
 | 132 | DSD for CHO cell culture: temperature, pH, DO, glucose feed rate, amino acid supplement. |
 | 133 | Factorial for transfection: lipid:DNA ratio, cell density, incubation time, serum. |
-| 134 | Stem cell experiments are expensive/slow — sequential DOE strategy with minimal runs? |
-| 135 | Continuous + categorical factors in cell culture — what design handles this? |
+| 134 | Stem cell experiments are expensive/slow - sequential DOE strategy with minimal runs? |
+| 135 | Continuous + categorical factors in cell culture - what design handles this? |
 
 ## M. mRNA/Vaccine & Biopharma (4 questions)
 
@@ -206,7 +206,7 @@ Questions span classical/academic DOE (A–G) and applied scientific literature 
 |---|---|
 | 136 | DSD for mRNA-LNP production with categorical and continuous factors. |
 | 137 | Compare RSM vs. ML (XGBoost, ANN) with only ~30 DOE runs. |
-| 138 | DSD screening + ANN hybrid model — how to combine? |
+| 138 | DSD screening + ANN hybrid model - how to combine? |
 | 139 | Optimize mRNA-LNP vaccine: particle size 40–100nm, PDI <=0.30, zeta >=30mV, EE >=70%. |
 
 ## N. Natural Product Extraction (5 questions)
@@ -215,17 +215,17 @@ Questions span classical/academic DOE (A–G) and applied scientific literature 
 |---|---|
 | 140 | CCD for supercritical CO2 extraction: pressure, temperature, flow rate, co-solvent. |
 | 141 | BBD for ultrasound-assisted extraction: power, time, solvent ratio, temperature. |
-| 142 | Compare CCD, BBD, and Doehlert for extraction — which predicts better at edges? |
-| 143 | CCD optimal at boundary — augment or shift ranges? |
+| 142 | Compare CCD, BBD, and Doehlert for extraction - which predicts better at edges? |
+| 143 | CCD optimal at boundary - augment or shift ranges? |
 | 144 | Taguchi L9 for screening before RSM optimization. |
 
 ## O. Bioprocess Scale-up & Environmental (4 questions)
 
 | # | Question |
 |---|---|
-| 145 | PHB production scale-up — hard-to-change vs. easy-to-change factors. |
+| 145 | PHB production scale-up - hard-to-change vs. easy-to-change factors. |
 | 146 | BBD for gold nanoparticle biosynthesis after PB screening. |
-| 147 | BBD model F=70.23, lack-of-fit p=0.13 — is model adequate? Interpret the ANOVA. |
+| 147 | BBD model F=70.23, lack-of-fit p=0.13 - is model adequate? Interpret the ANOVA. |
 | 148 | CCD for enzymatic saccharification with alpha=1.68 for rotatability. |
 
 ## P. Cross-Cutting Strategy (14 questions)
@@ -233,19 +233,19 @@ Questions span classical/academic DOE (A–G) and applied scientific literature 
 | # | Question |
 |---|---|
 | 149 | Two-stage strategy: PB screening then RSM for significant factors. |
-| 150 | BBD vs. CCD vs. Doehlert for RSM optimization — when to use each? |
-| 151 | Mixture components + process variables — what combined design? |
+| 150 | BBD vs. CCD vs. Doehlert for RSM optimization - when to use each? |
+| 151 | Mixture components + process variables - what combined design? |
 | 152 | ANOVA model adequacy: R^2, adj-R^2, pred-R^2, adequate precision, LOF, CV. |
-| 153 | BBD shows significant lack-of-fit — add center points, transform, or different model? |
-| 154 | ANN vs. RSM for prediction accuracy — when is ANN-DOE hybrid worthwhile? |
-| 155 | Multiple conflicting responses — walk through Derringer's desirability function. |
-| 156 | PB identified 3 factors but I suspect interactions — resolve aliases before RSM. |
+| 153 | BBD shows significant lack-of-fit - add center points, transform, or different model? |
+| 154 | ANN vs. RSM for prediction accuracy - when is ANN-DOE hybrid worthwhile? |
+| 155 | Multiple conflicting responses - walk through Derringer's desirability function. |
+| 156 | PB identified 3 factors but I suspect interactions - resolve aliases before RSM. |
 | 157 | How many center point replicates for reliable pure error estimate? |
-| 158 | Stationary point outside region — what does ridge analysis tell me? |
-| 159 | Constraint: two factors can't both be high — how to handle in DOE? |
+| 158 | Stationary point outside region - what does ridge analysis tell me? |
+| 159 | Constraint: two factors can't both be high - how to handle in DOE? |
 | 160 | After optimization, how many confirmation runs and how to verify statistically? |
-| 161 | Coded vs. actual levels for fitting — does it matter for interpreting coefficients? |
-| 162 | How to report DOE results in a publication — what tables, plots, statistics? |
+| 161 | Coded vs. actual levels for fitting - does it matter for interpreting coefficients? |
+| 162 | How to report DOE results in a publication - what tables, plots, statistics? |
 
 ---
 

--- a/docs/doe/tool-question-mapping.md
+++ b/docs/doe/tool-question-mapping.md
@@ -25,7 +25,7 @@ Use this when implementing a tool to see exactly what it must handle.
 
 ### `analyze_experiment`
 
-22 questions as primary tool. The analytical workhorse — ANOVA, effects, diagnostics, model fitting.
+22 questions as primary tool. The analytical workhorse - ANOVA, effects, diagnostics, model fitting.
 
 **Primary (22):** 31–43, 86, 101, 103, 108, 114, 121, 128–130, 147, 152–153, 157, 160–161
 
@@ -49,7 +49,7 @@ Use this when implementing a tool to see exactly what it must handle.
 
 ### `visualize_doe`
 
-3 questions as primary tool. Generates all DOE plot types — also supports many questions as secondary.
+3 questions as primary tool. Generates all DOE plot types - also supports many questions as secondary.
 
 **Primary (3):** 47, 76, 121
 
@@ -57,7 +57,7 @@ Use this when implementing a tool to see exactly what it must handle.
 
 ### `doe_knowledge`
 
-63 questions as primary tool. The most-used tool — provides conceptual grounding for 65% of all questions.
+63 questions as primary tool. The most-used tool - provides conceptual grounding for 65% of all questions.
 
 **Primary (63):** 4, 6–8, 13–14, 21, 24, 26–28, 44, 48, 50–52, 54–55, 57–59, 62, 67–72, 74, 78–85, 87–90, 102, 109–111, 113–114, 122–123, 128, 130, 134–135, 137–138, 142, 145, 150–154, 157, 159, 161–162
 
@@ -82,162 +82,162 @@ Every question with its primary and secondary tools.
 | 1 | `recommend_strategy` | `doe_knowledge` |
 | 2 | `generate_design` | `doe_knowledge` |
 | 3 | `generate_design` | `doe_knowledge` |
-| 4 | `doe_knowledge` | — |
+| 4 | `doe_knowledge` | - |
 | 5 | `generate_design` | `evaluate_design` |
-| 6 | `doe_knowledge` | — |
-| 7 | `doe_knowledge` | — |
-| 8 | `doe_knowledge` | — |
+| 6 | `doe_knowledge` | - |
+| 7 | `doe_knowledge` | - |
+| 8 | `doe_knowledge` | - |
 | 9 | `generate_design` | `recommend_strategy` |
-| 10 | `augment_design` | — |
+| 10 | `augment_design` | - |
 | 11 | `generate_design` | `doe_knowledge` |
 | 12 | `generate_design` | `doe_knowledge` |
-| 13 | `doe_knowledge` | — |
-| 14 | `doe_knowledge` | — |
+| 13 | `doe_knowledge` | - |
+| 14 | `doe_knowledge` | - |
 | 15 | `generate_design` | `doe_knowledge` |
 | 16 | `generate_design` | `evaluate_design` |
 | 17 | `generate_design` | `evaluate_design` |
 | 18 | `generate_design` | `doe_knowledge` |
-| 19 | `augment_design` | — |
+| 19 | `augment_design` | - |
 | 20 | `evaluate_design` | `doe_knowledge` |
-| 21 | `doe_knowledge` | — |
-| 22 | `evaluate_design` | — |
-| 23 | `evaluate_design` | — |
-| 24 | `doe_knowledge` | — |
-| 25 | `evaluate_design` | — |
-| 26 | `doe_knowledge` | — |
-| 27 | `doe_knowledge` | — |
+| 21 | `doe_knowledge` | - |
+| 22 | `evaluate_design` | - |
+| 23 | `evaluate_design` | - |
+| 24 | `doe_knowledge` | - |
+| 25 | `evaluate_design` | - |
+| 26 | `doe_knowledge` | - |
+| 27 | `doe_knowledge` | - |
 | 28 | `evaluate_design` | `doe_knowledge` |
-| 29 | `evaluate_design` | — |
+| 29 | `evaluate_design` | - |
 | 30 | `evaluate_design` | `doe_knowledge` |
-| 31 | `analyze_experiment` | — |
+| 31 | `analyze_experiment` | - |
 | 32 | `analyze_experiment` | `visualize_doe` |
 | 33 | `analyze_experiment` | `visualize_doe` |
 | 34 | `analyze_experiment` | `doe_knowledge` |
-| 35 | `analyze_experiment` | — |
+| 35 | `analyze_experiment` | - |
 | 36 | `analyze_experiment` | `visualize_doe`, `doe_knowledge` |
-| 37 | `analyze_experiment` | — |
+| 37 | `analyze_experiment` | - |
 | 38 | `analyze_experiment` | `visualize_doe`, `doe_knowledge` |
-| 39 | `analyze_experiment` | — |
-| 40 | `analyze_experiment` | — |
-| 41 | `analyze_experiment` | — |
-| 42 | `analyze_experiment` | — |
+| 39 | `analyze_experiment` | - |
+| 40 | `analyze_experiment` | - |
+| 41 | `analyze_experiment` | - |
+| 42 | `analyze_experiment` | - |
 | 43 | `analyze_experiment` | `doe_knowledge` |
-| 44 | `doe_knowledge` | — |
-| 45 | `optimize_responses` | — |
-| 46 | `optimize_responses` | — |
+| 44 | `doe_knowledge` | - |
+| 45 | `optimize_responses` | - |
+| 46 | `optimize_responses` | - |
 | 47 | `visualize_doe` | `optimize_responses` |
 | 48 | `doe_knowledge` | `optimize_responses` |
-| 49 | `optimize_responses` | — |
+| 49 | `optimize_responses` | - |
 | 50 | `doe_knowledge` | `analyze_experiment` |
-| 51 | `doe_knowledge` | — |
-| 52 | `doe_knowledge` | — |
+| 51 | `doe_knowledge` | - |
+| 52 | `doe_knowledge` | - |
 | 53 | `optimize_responses` | `doe_knowledge` |
-| 54 | `doe_knowledge` | — |
-| 55 | `doe_knowledge` | — |
+| 54 | `doe_knowledge` | - |
+| 55 | `doe_knowledge` | - |
 | 56 | `doe_knowledge` | `generate_design` |
-| 57 | `doe_knowledge` | — |
-| 58 | `doe_knowledge` | — |
+| 57 | `doe_knowledge` | - |
+| 58 | `doe_knowledge` | - |
 | 59 | `doe_knowledge` | `generate_design` |
 | 60 | `doe_knowledge` | `analyze_experiment` |
 | 61 | `doe_knowledge` | `analyze_experiment` |
-| 62 | `doe_knowledge` | — |
+| 62 | `doe_knowledge` | - |
 | 63 | `recommend_strategy` | `generate_design` |
 | 64 | `recommend_strategy` | `generate_design` |
-| 65 | `recommend_strategy` | — |
+| 65 | `recommend_strategy` | - |
 | 66 | `recommend_strategy` | `generate_design`, `optimize_responses` |
 | 67 | `doe_knowledge` | `analyze_experiment` |
 | 68 | `doe_knowledge` | `visualize_doe` |
-| 69 | `doe_knowledge` | — |
+| 69 | `doe_knowledge` | - |
 | 70 | `doe_knowledge` | `analyze_experiment` |
 | 71 | `doe_knowledge` | `analyze_experiment` |
 | 72 | `doe_knowledge` | `evaluate_design` |
 | 73 | `augment_design` | `doe_knowledge` |
-| 74 | `doe_knowledge` | — |
+| 74 | `doe_knowledge` | - |
 | 75 | `augment_design` | `doe_knowledge` |
 | 76 | `visualize_doe` | `doe_knowledge` |
 | 77 | `augment_design` | `evaluate_design` |
-| 78 | `doe_knowledge` | — |
-| 79 | `doe_knowledge` | — |
-| 80 | `doe_knowledge` | — |
-| 81 | `doe_knowledge` | — |
-| 82 | `doe_knowledge` | — |
-| 83 | `doe_knowledge` | — |
-| 84 | `doe_knowledge` | — |
-| 85 | `doe_knowledge` | — |
-| 86 | `analyze_experiment` | — |
-| 87 | `doe_knowledge` | — |
-| 88 | `doe_knowledge` | — |
-| 89 | `doe_knowledge` | — |
-| 90 | `doe_knowledge` | — |
+| 78 | `doe_knowledge` | - |
+| 79 | `doe_knowledge` | - |
+| 80 | `doe_knowledge` | - |
+| 81 | `doe_knowledge` | - |
+| 82 | `doe_knowledge` | - |
+| 83 | `doe_knowledge` | - |
+| 84 | `doe_knowledge` | - |
+| 85 | `doe_knowledge` | - |
+| 86 | `analyze_experiment` | - |
+| 87 | `doe_knowledge` | - |
+| 88 | `doe_knowledge` | - |
+| 89 | `doe_knowledge` | - |
+| 90 | `doe_knowledge` | - |
 | 91 | `generate_design` | `recommend_strategy` |
-| 92 | `generate_design` | — |
-| 93 | `generate_design` | — |
-| 94 | `generate_design` | — |
-| 95 | `generate_design` | — |
-| 96 | `generate_design` | — |
+| 92 | `generate_design` | - |
+| 93 | `generate_design` | - |
+| 94 | `generate_design` | - |
+| 95 | `generate_design` | - |
+| 96 | `generate_design` | - |
 | 97 | `recommend_strategy` | `augment_design` |
-| 98 | `generate_design` | — |
-| 99 | `optimize_responses` | — |
+| 98 | `generate_design` | - |
+| 99 | `optimize_responses` | - |
 | 100 | `augment_design` | `evaluate_design` |
 | 101 | `analyze_experiment` | `doe_knowledge` |
-| 102 | `doe_knowledge` | — |
+| 102 | `doe_knowledge` | - |
 | 103 | `optimize_responses` | `analyze_experiment` |
-| 104 | `recommend_strategy` | — |
-| 105 | `generate_design` | — |
-| 106 | `generate_design` | — |
-| 107 | `generate_design` | — |
+| 104 | `recommend_strategy` | - |
+| 105 | `generate_design` | - |
+| 106 | `generate_design` | - |
+| 107 | `generate_design` | - |
 | 108 | `optimize_responses` | `analyze_experiment` |
 | 109 | `doe_knowledge` | `recommend_strategy` |
-| 110 | `doe_knowledge` | — |
+| 110 | `doe_knowledge` | - |
 | 111 | `doe_knowledge` | `generate_design` |
-| 112 | `generate_design` | — |
+| 112 | `generate_design` | - |
 | 113 | `doe_knowledge` | `generate_design` |
 | 114 | `doe_knowledge` | `analyze_experiment` |
-| 115 | `generate_design` | — |
-| 116 | `generate_design` | — |
-| 117 | `recommend_strategy` | — |
-| 118 | `generate_design` | — |
+| 115 | `generate_design` | - |
+| 116 | `generate_design` | - |
+| 117 | `recommend_strategy` | - |
+| 118 | `generate_design` | - |
 | 119 | `optimize_responses` | `generate_design` |
-| 120 | `generate_design` | — |
+| 120 | `generate_design` | - |
 | 121 | `visualize_doe` | `optimize_responses` |
-| 122 | `doe_knowledge` | — |
-| 123 | `doe_knowledge` | — |
-| 124 | `generate_design` | — |
+| 122 | `doe_knowledge` | - |
+| 123 | `doe_knowledge` | - |
+| 124 | `generate_design` | - |
 | 125 | `generate_design` | `doe_knowledge` |
-| 126 | `generate_design` | — |
+| 126 | `generate_design` | - |
 | 127 | `optimize_responses` | `generate_design` |
 | 128 | `doe_knowledge` | `visualize_doe` |
-| 129 | `optimize_responses` | — |
+| 129 | `optimize_responses` | - |
 | 130 | `doe_knowledge` | `evaluate_design` |
 | 131 | `recommend_strategy` | `doe_knowledge` |
-| 132 | `generate_design` | — |
-| 133 | `generate_design` | — |
+| 132 | `generate_design` | - |
+| 133 | `generate_design` | - |
 | 134 | `recommend_strategy` | `doe_knowledge` |
 | 135 | `doe_knowledge` | `generate_design` |
-| 136 | `generate_design` | — |
-| 137 | `doe_knowledge` | — |
-| 138 | `doe_knowledge` | — |
-| 139 | `optimize_responses` | — |
-| 140 | `generate_design` | — |
-| 141 | `generate_design` | — |
+| 136 | `generate_design` | - |
+| 137 | `doe_knowledge` | - |
+| 138 | `doe_knowledge` | - |
+| 139 | `optimize_responses` | - |
+| 140 | `generate_design` | - |
+| 141 | `generate_design` | - |
 | 142 | `doe_knowledge` | `evaluate_design` |
 | 143 | `augment_design` | `doe_knowledge` |
-| 144 | `generate_design` | — |
+| 144 | `generate_design` | - |
 | 145 | `doe_knowledge` | `recommend_strategy` |
-| 146 | `generate_design` | — |
+| 146 | `generate_design` | - |
 | 147 | `analyze_experiment` | `doe_knowledge` |
-| 148 | `generate_design` | — |
-| 149 | `recommend_strategy` | — |
-| 150 | `doe_knowledge` | — |
+| 148 | `generate_design` | - |
+| 149 | `recommend_strategy` | - |
+| 150 | `doe_knowledge` | - |
 | 151 | `doe_knowledge` | `generate_design` |
 | 152 | `doe_knowledge` | `analyze_experiment` |
 | 153 | `doe_knowledge` | `analyze_experiment` |
-| 154 | `doe_knowledge` | — |
-| 155 | `optimize_responses` | — |
+| 154 | `doe_knowledge` | - |
+| 155 | `optimize_responses` | - |
 | 156 | `augment_design` | `evaluate_design`, `doe_knowledge` |
-| 157 | `doe_knowledge` | — |
+| 157 | `doe_knowledge` | - |
 | 158 | `optimize_responses` | `doe_knowledge` |
 | 159 | `doe_knowledge` | `generate_design` |
-| 160 | `analyze_experiment` | — |
+| 160 | `analyze_experiment` | - |
 | 161 | `doe_knowledge` | `analyze_experiment` |
-| 162 | `doe_knowledge` | — |
+| 162 | `doe_knowledge` | - |

--- a/docs/doe/tools.md
+++ b/docs/doe/tools.md
@@ -59,7 +59,7 @@ Compute properties and quality metrics of an existing design.
 | `alpha` | float | Significance level (default 0.05) |
 | `sigma` | float or None | Estimated noise SD |
 
-**Outputs:** Requested metrics — alias chains, power curves, efficiency values, etc.
+**Outputs:** Requested metrics - alias chains, power curves, efficiency values, etc.
 
 **Handles 7 questions as primary tool.** See [mapping](tool-question-mapping.md#evaluate_design).
 
@@ -114,7 +114,7 @@ Find optimal factor settings for one or multiple responses.
 
 ## Tool 5: `augment_design`
 
-Extend or modify an existing design — add runs, fold over, upgrade to RSM.
+Extend or modify an existing design - add runs, fold over, upgrade to RSM.
 
 **Inputs:**
 
@@ -133,12 +133,12 @@ Extend or modify an existing design — add runs, fold over, upgrade to RSM.
 
 ---
 
-## Tool 6: `visualize_doe` — **Implemented**
+## Tool 6: `visualize_doe` - **Implemented**
 
 Generate DOE plots from design data or fitted models. Returns dual-backend output
 (Plotly interactive figures + ECharts JSON configs).
 
-**Architecture:** Three-layer design — plot classes compute DOE statistics once via
+**Architecture:** Three-layer design - plot classes compute DOE statistics once via
 `to_spec()` → ChartSpec IR, then backend adapters (PlotlyAdapter, EChartsAdapter)
 translate to native formats. See `process_improve/experiments/visualization/`.
 
@@ -146,8 +146,8 @@ translate to native formats. See `process_improve/experiments/visualization/`.
 
 | Parameter | Type | Description |
 |---|---|---|
-| `plot_type` | str | One of 20 types — see enum below |
-| `analysis_results` | dict or None | From `analyze_experiment()` — coefficients, effects, residuals, lenth_method |
+| `plot_type` | str | One of 20 types - see enum below |
+| `analysis_results` | dict or None | From `analyze_experiment()` - coefficients, effects, residuals, lenth_method |
 | `design_data` | list[dict] or None | Raw design matrix (one dict per run, coded -1/+1) |
 | `response_column` | str or None | Which response column in design_data |
 | `factors_to_plot` | list[str] or None | Which factors (2 for contour/interaction, 3 for cube_plot) |
@@ -186,7 +186,7 @@ translate to native formats. See `process_improve/experiments/visualization/`.
 
 ## Tool 7: `doe_knowledge`
 
-Retrieve DOE knowledge — definitions, decision logic, interpretation guidance, worked examples.
+Retrieve DOE knowledge - definitions, decision logic, interpretation guidance, worked examples.
 
 This is the most-used tool (65% of questions). It provides the conceptual grounding that computation alone cannot.
 
@@ -221,21 +221,21 @@ WorkedExample -[DEMONSTRATES]->   Concept
 
 ### Implementation (v1)
 
-**Status: Implemented** — `process_improve/experiments/knowledge/`
+**Status: Implemented** - `process_improve/experiments/knowledge/`
 
 Three-layer architecture:
 
-1. **YAML data files** (`knowledge/data/`) — canonical knowledge authored in version-controlled YAML:
-   - `design_types.yaml` — 6 design types (full factorial, fractional factorial, Plackett-Burman, Box-Behnken, CCD, DSD) with multi-level descriptions
-   - `decision_rules.yaml` — 7 context-aware design selection rules
-   - `diagnostics.yaml` — 8 residual diagnostic patterns with remedies
-   - `concepts.yaml` — 9 statistical concepts (resolution, aliasing, replication, randomization, blocking, center points, effect hierarchy, effect sparsity, desirability)
+1. **YAML data files** (`knowledge/data/`) - canonical knowledge authored in version-controlled YAML:
+   - `design_types.yaml` - 6 design types (full factorial, fractional factorial, Plackett-Burman, Box-Behnken, CCD, DSD) with multi-level descriptions
+   - `decision_rules.yaml` - 7 context-aware design selection rules
+   - `diagnostics.yaml` - 8 residual diagnostic patterns with remedies
+   - `concepts.yaml` - 9 statistical concepts (resolution, aliasing, replication, randomization, blocking, center points, effect hierarchy, effect sparsity, desirability)
 
-2. **In-memory query engine** (`knowledge/engine.py`) — loads YAML into Python dataclasses, builds keyword and topic indices, supports filtered traversal and condition matching
+2. **In-memory query engine** (`knowledge/engine.py`) - loads YAML into Python dataclasses, builds keyword and topic indices, supports filtered traversal and condition matching
 
-3. **Public API** (`knowledge/api.py`) — `doe_knowledge(query, topic, context, detail_level)` routes to topic-specific handlers
+3. **Public API** (`knowledge/api.py`) - `doe_knowledge(query, topic, context, detail_level)` routes to topic-specific handlers
 
-**Registered as `@tool_spec`** in `tools.py` — callable via `execute_tool_call("doe_knowledge", {...})`
+**Registered as `@tool_spec`** in `tools.py` - callable via `execute_tool_call("doe_knowledge", {...})`
 
 **Tests:** 38 tests in `tests/test_doe_knowledge.py`
 
@@ -273,15 +273,15 @@ Total: ~40 runs
 
 ### Implementation (v1)
 
-**Status: Implemented** — `process_improve/experiments/strategy/`
+**Status: Implemented** - `process_improve/experiments/strategy/`
 
 Deterministic rule engine architecture:
 
-1. **Pydantic models** (`strategy/models.py`) — `ExperimentalStrategy`, `ExperimentalStage`, `TransitionRule`, `DOEProblemSpec`, `PriorKnowledge`, `DomainType`
-2. **Budget allocator** (`strategy/budget.py`) — 25-40-55-15 framework with domain-specific adjustments and run estimation for PB, DSD, fractional factorial, CCD, BBD designs
-3. **Domain templates** (`strategy/domain_templates.py`) — 8 domain templates (pharma, fermentation, food science, extraction, analytical method, cell culture, bioprocess, general) with design preferences and budget weights
-4. **Rule engine** (`strategy/engine.py`) — ~50 deterministic decision rules from Montgomery, NIST, Stat-Ease SCOR; pipeline: classify → stage selection → design selection → budget allocation → transition rules → assembly
+1. **Pydantic models** (`strategy/models.py`) - `ExperimentalStrategy`, `ExperimentalStage`, `TransitionRule`, `DOEProblemSpec`, `PriorKnowledge`, `DomainType`
+2. **Budget allocator** (`strategy/budget.py`) - 25-40-55-15 framework with domain-specific adjustments and run estimation for PB, DSD, fractional factorial, CCD, BBD designs
+3. **Domain templates** (`strategy/domain_templates.py`) - 8 domain templates (pharma, fermentation, food science, extraction, analytical method, cell culture, bioprocess, general) with design preferences and budget weights
+4. **Rule engine** (`strategy/engine.py`) - ~50 deterministic decision rules from Montgomery, NIST, Stat-Ease SCOR; pipeline: classify → stage selection → design selection → budget allocation → transition rules → assembly
 
-**Registered as `@tool_spec`** in `tools.py` — callable via `execute_tool_call("recommend_strategy", {...})`
+**Registered as `@tool_spec`** in `tools.py` - callable via `execute_tool_call("recommend_strategy", {...})`
 
 **Tests:** 74 tests in `tests/test_recommend_strategy.py`

--- a/docs/doe/workflows.md
+++ b/docs/doe/workflows.md
@@ -48,10 +48,10 @@ doe_knowledge  →  recommend_strategy  →  generate_design  →  evaluate_desi
 
 Example: "Design a screening experiment for my 7 fermentation factors"
 
-1. `doe_knowledge` — retrieve design selection guidance for 7 factors
-2. `recommend_strategy` — propose staged plan (screening → RSM)
-3. `generate_design` — create PB design in 12 runs
-4. `evaluate_design` — check alias structure and resolution
+1. `doe_knowledge` - retrieve design selection guidance for 7 factors
+2. `recommend_strategy` - propose staged plan (screening → RSM)
+3. `generate_design` - create PB design in 12 runs
+4. `evaluate_design` - check alias structure and resolution
 
 ### Factorial Analysis + Optimization
 
@@ -61,10 +61,10 @@ analyze_experiment  →  visualize_doe  →  optimize_responses  →  visualize_
 
 Example: "Analyze my 2^4 factorial data and find the optimum"
 
-1. `analyze_experiment` — ANOVA, effects, residual diagnostics
-2. `visualize_doe` — Pareto plot and normal probability plot
-3. `optimize_responses` — find optimal factor settings
-4. `visualize_doe` — contour plot at optimum
+1. `analyze_experiment` - ANOVA, effects, residual diagnostics
+2. `visualize_doe` - Pareto plot and normal probability plot
+3. `optimize_responses` - find optimal factor settings
+4. `visualize_doe` - contour plot at optimum
 
 ### Troubleshooting
 
@@ -72,10 +72,10 @@ Example: "Analyze my 2^4 factorial data and find the optimum"
 doe_knowledge  →  analyze_experiment
 ```
 
-Example: "My confirmation runs don't match — what went wrong?"
+Example: "My confirmation runs don't match - what went wrong?"
 
-1. `doe_knowledge` — retrieve troubleshooting guidance
-2. `analyze_experiment` — run confirmation test analysis with observed vs predicted
+1. `doe_knowledge` - retrieve troubleshooting guidance
+2. `analyze_experiment` - run confirmation test analysis with observed vs predicted
 
 ## Agent Orchestration
 

--- a/docs/user_guide/cross_validation.rst
+++ b/docs/user_guide/cross_validation.rst
@@ -46,7 +46,7 @@ Wold's Criterion
 
 The default threshold of 0.95 means: stop adding components when the PRESS
 ratio exceeds 0.95. A ratio close to 1.0 means the new component barely
-improves prediction — it is likely fitting noise.
+improves prediction - it is likely fitting noise.
 
 Lower thresholds (e.g., 0.90) are more conservative (fewer components).
 Higher thresholds (e.g., 0.98) are more liberal (more components).

--- a/docs/user_guide/doe_strategy.rst
+++ b/docs/user_guide/doe_strategy.rst
@@ -3,24 +3,24 @@ Experimental Strategy Recommendation
 
 Before running any experiments, the most important question is: *"How should
 I plan my experimental program?"*  The ``recommend_strategy`` function answers
-this by generating a complete multi-stage experimental plan — screening,
-optimization, and confirmation — using deterministic decision rules from
+this by generating a complete multi-stage experimental plan - screening,
+optimization, and confirmation - using deterministic decision rules from
 Montgomery, NIST, and the Stat-Ease SCOR framework.
 
 The recommender is fully deterministic: identical inputs always produce
-identical outputs.  There is no randomness and no LLM — just ~50 codified
+identical outputs.  There is no randomness and no LLM - just ~50 codified
 rules that encode best practices from the DOE literature.
 
 When to Use This Tool
 ---------------------
 
-- **Before your first experiment** — plan the entire workflow upfront so that
+- **Before your first experiment** - plan the entire workflow upfront so that
   budget and time are spent efficiently.
-- **When you have many candidate factors** — the tool decides whether a
+- **When you have many candidate factors** - the tool decides whether a
   screening stage is needed and which design to use.
-- **When budget is limited** — it allocates runs across stages to maximize
+- **When budget is limited** - it allocates runs across stages to maximize
   information per experiment.
-- **When working in a specialized domain** — domain-specific templates
+- **When working in a specialized domain** - domain-specific templates
   (fermentation, cell culture, pharma, etc.) adjust design choices and
   center-point requirements automatically.
 
@@ -32,13 +32,13 @@ Multi-stage workflows
 
 Most experimental programs follow a three-stage sequence:
 
-1. **Screening** — Identify the vital few factors from many candidates.
+1. **Screening** - Identify the vital few factors from many candidates.
    Typical designs: Plackett-Burman, Definitive Screening Design (DSD), or
    fractional factorial.
-2. **Optimization** — Fit a response surface model for the significant
+2. **Optimization** - Fit a response surface model for the significant
    factors.  Typical designs: Central Composite Design (CCD), Box-Behnken,
    or D-optimal.
-3. **Confirmation** — Run replicates at the predicted optimum to verify
+3. **Confirmation** - Run replicates at the predicted optimum to verify
    that the model predictions hold.
 
 Each stage has *transition rules* that tell you what to do next based on
@@ -111,7 +111,7 @@ This outputs::
 
 The engine selected Plackett-Burman screening (the fermentation domain
 default), a CCD for response surface optimization, and 3 confirmation
-replicates — all within the 40-run budget.
+replicates - all within the 40-run budget.
 
 Interpreting the Output
 -----------------------
@@ -144,7 +144,7 @@ Interpreting the Output
    * - ``alternative_strategies``
      - Brief descriptions of other approaches worth considering.
    * - ``strategy_id``
-     - Deterministic hash of the input — same inputs always produce the
+     - Deterministic hash of the input - same inputs always produce the
        same ID.
    * - ``domain``
      - The application domain used.
@@ -204,18 +204,18 @@ entirely:
 
 .. code-block:: python
 
-   # No prior knowledge — full screening
+   # No prior knowledge - full screening
    s1 = recommend_strategy(factors=factors, budget=40, domain="fermentation")
    print(f"No prior: {len(s1['stages'])} stages")
 
-   # Low confidence — still screens
+   # Low confidence - still screens
    s2 = recommend_strategy(
        factors=factors, budget=40, domain="fermentation",
        prior_knowledge="We suspect Temperature and pH are important.",
    )
    print(f"Low confidence: {len(s2['stages'])} stages")
 
-   # High confidence — screening skipped
+   # High confidence - screening skipped
    s3 = recommend_strategy(
        factors=factors, budget=40, domain="fermentation",
        prior_knowledge=(
@@ -287,7 +287,7 @@ Comparing two domains on the same factors shows how design choices differ:
 
 Fermentation uses Plackett-Burman (efficient, many-factor screening), while
 cell culture uses a Definitive Screening Design because it combines screening
-and curvature detection in a single stage — saving an entire experimental
+and curvature detection in a single stage - saving an entire experimental
 cycle when each run takes 2–3 weeks.
 
 Hard-to-Change Factors
@@ -323,7 +323,7 @@ split-plot structure:
 With split-plot designs, runs are grouped within whole-plot factor levels
 to minimize the number of hard-to-change factor resets.  The output risks
 will include a reminder that standard ANOVA gives incorrect p-values for
-split-plot experiments — a restricted maximum likelihood (REML) analysis
+split-plot experiments - a restricted maximum likelihood (REML) analysis
 is needed instead.
 
 Multiple Responses
@@ -346,7 +346,7 @@ When optimizing for more than one response, define each with its own goal:
        domain="fermentation",
    )
 
-The strategy structure is the same — the engine plans the experimental
+The strategy structure is the same - the engine plans the experimental
 stages needed to build models for all responses simultaneously.  After
 running the experiments, use
 :func:`~process_improve.experiments.optimize_responses` with desirability
@@ -355,10 +355,10 @@ functions to find the best trade-off across responses.
 See Also
 --------
 
-- :doc:`/api/experiments` — Full API reference for all DOE functions.
-- :func:`~process_improve.experiments.generate_design` — Generate the actual
+- :doc:`/api/experiments` - Full API reference for all DOE functions.
+- :func:`~process_improve.experiments.generate_design` - Generate the actual
   design matrix once you know which design to use.
-- :func:`~process_improve.experiments.analyze_experiment` — Analyze the
+- :func:`~process_improve.experiments.analyze_experiment` - Analyze the
   results after running experiments.
-- :func:`~process_improve.experiments.optimize_responses` — Find optimal
+- :func:`~process_improve.experiments.optimize_responses` - Find optimal
   factor settings for single or multiple responses.

--- a/docs/user_guide/multiblock.rst
+++ b/docs/user_guide/multiblock.rst
@@ -2,7 +2,7 @@ Multi-block PCA and PLS (MBPCA / MBPLS)
 =======================================
 
 Generic multi-block latent-variable models for the case where your X
-data is naturally organized into several semantically distinct blocks —
+data is naturally organized into several semantically distinct blocks -
 for example, one block per processing zone, plant unit, or sensor group.
 
 Multi-block models give you per-block diagnostics (which block is
@@ -66,13 +66,13 @@ Both classes use the same ``dict[str, pd.DataFrame]`` API for X-blocks::
 After fitting, every model exposes:
 
 - ``super_scores_``, ``super_loadings_`` (or ``super_weights_`` for MBPLS)
-- ``block_scores_``, ``block_loadings_`` — both ``dict[str, DataFrame]``
+- ``block_scores_``, ``block_loadings_`` - both ``dict[str, DataFrame]``
 - ``r2_x_per_block_cumulative_``, ``r2_x_per_block_per_component_``
-- ``block_vip_`` — per-block VIPs as ``dict[str, Series]``
+- ``block_vip_`` - per-block VIPs as ``dict[str, Series]``
 - ``block_spe_``, ``block_hotellings_t2_``, ``super_hotellings_t2_``
-- ``predict(X_new)`` — returns super-scores, block-scores, per-block SPE,
+- ``predict(X_new)`` - returns super-scores, block-scores, per-block SPE,
   super Hotelling's T² (and Y predictions for MBPLS)
-- ``spe_contributions(X)`` — per-variable squared residuals for fault
+- ``spe_contributions(X)`` - per-variable squared residuals for fault
   diagnosis
 - ``block_spe_limit(name, conf_level)``, ``super_spe_limit(conf_level)``,
   ``hotellings_t2_limit(conf_level)``

--- a/docs/user_guide/multivariate.rst
+++ b/docs/user_guide/multivariate.rst
@@ -3,8 +3,8 @@ Multivariate Analysis
 
 Latent variable methods summarize high-dimensional, correlated data into a
 small number of underlying variables that capture the dominant structure.
-A latent variable is an unobservable quantity — your overall health, for
-example — that manifests through measurable indicators (blood pressure,
+A latent variable is an unobservable quantity - your overall health, for
+example - that manifests through measurable indicators (blood pressure,
 cholesterol, heart rate). In process data, a single underlying phenomenon
 such as a feed quality change can shift dozens of correlated sensors
 simultaneously. Latent variable models recover those phenomena from the
@@ -16,28 +16,28 @@ When to Use These Methods
 Latent variable methods are the right tool when your data has one or more of
 these characteristics (common in process industries):
 
-- **Many correlated variables** — traditional regression struggles with
+- **Many correlated variables** - traditional regression struggles with
   collinearity, but latent variable methods thrive on it.
-- **More variables than observations** (K > N) — ordinary least squares
+- **More variables than observations** (K > N) - ordinary least squares
   cannot be computed, but PCA/PLS handle this naturally.
-- **Missing values** — sensors fail, lab samples are skipped. The algorithms
+- **Missing values** - sensors fail, lab samples are skipped. The algorithms
   in this package handle incomplete data natively.
-- **Low signal-to-noise ratio** — by separating systematic variation from
+- **Low signal-to-noise ratio** - by separating systematic variation from
   noise, latent variable models act as multivariate filters.
-- **Need for visualization** — score plots and loading plots reveal structure
+- **Need for visualization** - score plots and loading plots reveal structure
   that is invisible in univariate views.
 
 Five common applications drive their use:
 
-1. **Process understanding** — confirm existing knowledge or discover
+1. **Process understanding** - confirm existing knowledge or discover
    unexpected variable relationships through score and loading plots.
-2. **Troubleshooting** — after a problem occurs, screen variables to isolate
+2. **Troubleshooting** - after a problem occurs, screen variables to isolate
    the most relevant ones using contribution plots.
-3. **Optimization** — move along favorable directions in the latent variable
+3. **Optimization** - move along favorable directions in the latent variable
    space to improve yield, quality, or throughput.
-4. **Predictive modeling** — build inferential sensors that predict
+4. **Predictive modeling** - build inferential sensors that predict
    hard-to-measure quality variables from readily available process data.
-5. **Process monitoring** — extend univariate control charts (Shewhart, CUSUM)
+5. **Process monitoring** - extend univariate control charts (Shewhart, CUSUM)
    to the multivariate case with SPE and Hotelling's T² charts.
 
 Available Methods

--- a/docs/user_guide/pca.rst
+++ b/docs/user_guide/pca.rst
@@ -16,18 +16,18 @@ PCA decomposes an (N × K) data matrix into scores, loadings, and residuals:
 
 where:
 
-- **T** (N × A) — scores: the coordinates of each observation in the
+- **T** (N × A) - scores: the coordinates of each observation in the
   reduced space.
-- **P** (K × A) — loadings: the direction vectors that define the model
+- **P** (K × A) - loadings: the direction vectors that define the model
   plane.
-- **E** (N × K) — residuals: what the model does not explain.
-- A — the number of components retained.
+- **E** (N × K) - residuals: what the model does not explain.
+- A - the number of components retained.
 
 Geometrically, PCA fits a best-fit hyperplane through the cloud of
 observations in K-dimensional space. Each observation is projected
 perpendicularly onto this plane; the projected coordinates are the scores.
 Minimizing the perpendicular residual distance is equivalent to maximizing
-the variance captured in the scores — the two formulations yield the same
+the variance captured in the scores - the two formulations yield the same
 solution.
 
 Preprocessing
@@ -55,7 +55,7 @@ for sklearn-compatible autoscaling:
 
 **Transformations** (log, square root) can reduce the effect of extreme
 measurements or improve linearity. Consider adding derived columns
-(interactions, squared terms, ratios) to the raw data matrix — the model
+(interactions, squared terms, ratios) to the raw data matrix - the model
 will sort out which are informative.
 
 Interpreting Scores
@@ -64,13 +64,13 @@ Interpreting Scores
 Scores (``model.scores_``) are the coordinates of each observation in the
 latent variable space. They reveal the dominant patterns in the data:
 
-- **Clusters** — observations that are similar in the original K variables
+- **Clusters** - observations that are similar in the original K variables
   will be close together in score space.
-- **Outliers** — observations far from the main cluster may represent unusual
+- **Outliers** - observations far from the main cluster may represent unusual
   operating conditions or measurement errors.
-- **Time trends** — when rows are ordered by time, gradual drifts or sudden
+- **Time trends** - when rows are ordered by time, gradual drifts or sudden
   shifts become visible as trajectories in the score plot.
-- **Groups** — coloring scores by a categorical variable (grade, shift,
+- **Groups** - coloring scores by a categorical variable (grade, shift,
   equipment ID) can reveal systematic differences.
 
 Use ``model.score_plot()`` for quick visualization.
@@ -86,7 +86,7 @@ contributes to each component:
 - Variables that are **positively correlated** cluster together in the
   loading plot; variables that are **negatively correlated** appear on
   opposite sides.
-- The **sign of a loading** can flip between different runs or software — the
+- The **sign of a loading** can flip between different runs or software - the
   sign of the component as a whole is arbitrary, so always interpret loading
   *patterns* rather than individual signs.
 
@@ -104,7 +104,7 @@ residuals for that observation:
    \text{SPE}_i = \mathbf{e}_i^T \mathbf{e}_i
 
 - SPE = 0 means the observation lies exactly on the model plane.
-- **High SPE** means the observation *breaks* the correlation structure — a
+- **High SPE** means the observation *breaks* the correlation structure - a
   new event or fault has introduced variation that the model's A components
   do not describe.
 - Column-wise residuals give the per-variable R² (``model.r2_per_variable_``),
@@ -127,7 +127,7 @@ where :math:`s_a^2` is the variance of the *a*-th score column.
 - T² is always non-negative and follows an F-distribution, so confidence
   limits (e.g., 95 %) can be computed analytically.
 - **High T²** means the observation follows the correlation structure but
-  with **unusual magnitude** — it is extreme *within* the model, not outside
+  with **unusual magnitude** - it is extreme *within* the model, not outside
   it.
 - On a score plot of component *a* vs *b*, the T² limit traces an
   **elliptical boundary**. This single ellipse replaces examining
@@ -169,8 +169,8 @@ Outlier Detection
 
 The ``detect_outliers()`` method combines two complementary approaches:
 
-1. **Statistical limits** — SPE and T² limits at a specified confidence level
-2. **Robust ESD test** — Generalized Extreme Studentized Deviate test using
+1. **Statistical limits** - SPE and T² limits at a specified confidence level
+2. **Robust ESD test** - Generalized Extreme Studentized Deviate test using
    median and MAD, which is robust to masking effects where multiple outliers
    hide each other
 
@@ -193,7 +193,7 @@ improving indicates the useful number of components.
 
 Use ``PCA.select_n_components()`` for automated selection via PRESS
 cross-validation with Wold's criterion (see :doc:`cross_validation` for
-details). Remember that the answer is never exact — examine one or two
+details). Remember that the answer is never exact - examine one or two
 components beyond and before the suggestion, and consider the interpretability
 of each additional component in the context of your application.
 
@@ -207,7 +207,7 @@ applications. The workflow:
 2. **Preprocess new observations** using the *same* centering and scaling
    learned from the training data (e.g., the same ``MCUVScaler`` instance).
 3. **Project new observations** into the model with ``model.predict(X_new)``.
-4. **Monitor SPE and T²** — compare each new observation's SPE and T² against
+4. **Monitor SPE and T²** - compare each new observation's SPE and T² against
    the control limits:
 
    .. code-block:: python
@@ -230,17 +230,17 @@ Both can occur simultaneously.
 Missing Data
 ------------
 
-Real process data often has missing values — sensor failures, skipped lab
+Real process data often has missing values - sensor failures, skipped lab
 analyses, or variables recorded at different frequencies. The PCA
 implementation supports several iterative algorithms for fitting models in
 the presence of missing data:
 
-- **TSR** (Trimmed Scores Regression) — generally the best default choice;
+- **TSR** (Trimmed Scores Regression) - generally the best default choice;
   uses the available data to estimate scores, then reconstructs missing
   values.
-- **NIPALS** — the classical algorithm; handles moderate amounts of missing
+- **NIPALS** - the classical algorithm; handles moderate amounts of missing
   data well.
-- **SCP** — Single Component Projection; a simpler alternative.
+- **SCP** - Single Component Projection; a simpler alternative.
 
 Enable missing data handling by passing a settings dictionary:
 
@@ -275,7 +275,7 @@ Troubleshooting
        duplicate or perfectly correlated variables.
    * - Missing-data algorithm does not converge
      - Increase ``md_max_iter`` or relax ``md_tol``. If the fraction of
-       missing data is very large (>40 %), the algorithm may struggle — try
+       missing data is very large (>40 %), the algorithm may struggle - try
        removing rows or columns with excessive missingness first.
    * - Shape mismatch in ``predict()``
      - The new data must have the same columns (K) as the training data, in
@@ -283,7 +283,7 @@ Troubleshooting
        ``scaler.transform(X_new)`` to apply the training centering/scaling.
    * - Very different results with different software
      - Check that the same preprocessing (centering, scaling) was applied.
-       Also note that the sign of a component can flip — this is normal and
+       Also note that the sign of a component can flip - this is normal and
        does not affect interpretation.
    * - First component explains almost all variance
      - The data may not have been centered. Without centering, the first

--- a/docs/user_guide/pls.rst
+++ b/docs/user_guide/pls.rst
@@ -18,16 +18,16 @@ PLS simultaneously decomposes both the X and Y matrices:
 
 where:
 
-- **T** (N × A) — X-scores (projections of observations in X-space).
-- **U** (N × A) — Y-scores (projections in Y-space).
-- **P** (K × A) — X-loadings.
-- **Q** (M × A) — Y-loadings.
-- **E_X**, **E_Y** — residual matrices.
+- **T** (N × A) - X-scores (projections of observations in X-space).
+- **U** (N × A) - Y-scores (projections in Y-space).
+- **P** (K × A) - X-loadings.
+- **Q** (M × A) - Y-loadings.
+- **E_X**, **E_Y** - residual matrices.
 
 The algorithm pursues three objectives simultaneously: explain the variance
 in X, explain the variance in Y, and maximize the *covariance* between the
 two sets of scores. This is what distinguishes PLS from simply applying PCA
-to X and then regressing on Y (which is PCR — Principal Components
+to X and then regressing on Y (which is PCR - Principal Components
 Regression).
 
 Why PLS Over Alternatives
@@ -59,15 +59,15 @@ Interpreting Scores
 
 PLS produces two sets of scores:
 
-- **T** (``model.scores_``) — the X-scores, always available even for new
+- **T** (``model.scores_``) - the X-scores, always available even for new
   observations where Y is unknown. These are the primary scores for
   interpretation and monitoring.
-- **U** (``model.y_scores_``) — the Y-scores, available only when Y data
+- **U** (``model.y_scores_``) - the Y-scores, available only when Y data
   exists. Useful for examining inner-model relationships.
 
 A critical difference from PCA: *PCA scores explain only X variance; PLS
 scores are calculated to also explain Y*. This means PLS components may not
-capture the largest X variation — they capture the variation most relevant to
+capture the largest X variation - they capture the variation most relevant to
 predicting Y.
 
 Score interpretation otherwise follows PCA: look for clusters, outliers, and
@@ -78,16 +78,16 @@ Interpreting Loadings and Weights
 
 PLS has several related vectors that describe variable importance:
 
-- **X-weights** (``model.x_weights_``) — the raw weight vectors **w** used
+- **X-weights** (``model.x_weights_``) - the raw weight vectors **w** used
   during the iterative algorithm. Each **w** is found on deflated data.
-- **X-loadings** (``model.x_loadings_``) — the regression coefficients **p**
+- **X-loadings** (``model.x_loadings_``) - the regression coefficients **p**
   relating X to T.
-- **Direct weights** (``model.direct_weights_``) — also called **r** or
+- **Direct weights** (``model.direct_weights_``) - also called **r** or
   **w*** in the literature. These show the effect of each *original*
   (undeflated) variable on the scores. Prefer these for interpretation:
   they account for all prior components and give a clearer picture of each
   variable's total contribution.
-- **Y-loadings** (``model.y_loadings_``) — how each Y variable contributes
+- **Y-loadings** (``model.y_loadings_``) - how each Y variable contributes
   to the latent structure.
 
 A powerful visualization technique is to **overlay the X and Y loadings** on
@@ -101,23 +101,23 @@ SPE, T², Contributions, and Outlier Detection
 
 These diagnostics work identically to PCA (see :doc:`pca`):
 
-- ``model.spe_`` and ``model.spe_limit()`` — conformity to the X-space
+- ``model.spe_`` and ``model.spe_limit()`` - conformity to the X-space
   correlation structure.
-- ``model.hotellings_t2_`` and ``model.hotellings_t2_limit()`` — extremity
+- ``model.hotellings_t2_`` and ``model.hotellings_t2_limit()`` - extremity
   within the model.
-- ``model.score_contributions()`` — decompose scores back to original
+- ``model.score_contributions()`` - decompose scores back to original
   variables.
-- ``model.detect_outliers()`` — combined statistical + robust ESD detection.
+- ``model.detect_outliers()`` - combined statistical + robust ESD detection.
 
 Predictions
 -----------
 
 After fitting, ``model.predict(X_new)`` returns a ``Bunch`` with:
 
-- ``predictions_`` — the predicted Y values.
-- ``scores_`` — the X-scores for the new observations.
-- ``spe_`` — SPE values for the new observations.
-- ``hotellings_t2_`` — T² values for the new observations.
+- ``predictions_`` - the predicted Y values.
+- ``scores_`` - the X-scores for the new observations.
+- ``spe_`` - SPE values for the new observations.
+- ``hotellings_t2_`` - T² values for the new observations.
 
 The underlying regression relationship is captured in
 ``model.beta_coefficients_``, which maps directly from (preprocessed) X to
@@ -139,5 +139,5 @@ and you should reduce the number of components.
 Missing Data and Troubleshooting
 --------------------------------
 
-See the :doc:`pca` page — the same algorithms (TSR, NIPALS, SCP), settings,
+See the :doc:`pca` page - the same algorithms (TSR, NIPALS, SCP), settings,
 and troubleshooting advice apply to PLS models.

--- a/docs/user_guide/tpls.rst
+++ b/docs/user_guide/tpls.rst
@@ -11,13 +11,13 @@ When to Use TPLS
 Use TPLS when your data has a natural multi-block structure that standard PLS
 cannot represent. Typical applications include:
 
-- **Pharmaceutical manufacturing** — formulation recipes, raw material
+- **Pharmaceutical manufacturing** - formulation recipes, raw material
   properties, process conditions, and tablet quality form distinct blocks.
-- **Chemical reaction optimization** — catalyst properties, feed
+- **Chemical reaction optimization** - catalyst properties, feed
   compositions, operating conditions, and product quality.
-- **Food processing** — ingredient properties, recipes, process settings,
+- **Food processing** - ingredient properties, recipes, process settings,
   and sensory or nutritional outcomes.
-- **Biotechnology** — media composition, strain properties, fermentation
+- **Biotechnology** - media composition, strain properties, fermentation
   trajectories, and yield/quality metrics.
 
 If your data fits naturally into a single X matrix and a single Y matrix,
@@ -60,7 +60,7 @@ batch (rows). F, Z, and Y must all have the same number of rows (batches).
 Basic Usage
 -----------
 
-Data blocks are organized using ``DataFrameDict`` — a dictionary of
+Data blocks are organized using ``DataFrameDict`` - a dictionary of
 DataFrames, optionally grouped:
 
 .. code-block:: python
@@ -82,7 +82,7 @@ DataFrames, optionally grouped:
 **Key requirements:**
 
 - Column names in each F group must match the row index of the corresponding
-  D group — this is how TPLS knows which material properties correspond to
+  D group - this is how TPLS knows which material properties correspond to
   which formulation amounts.
 - All F, Z, and Y DataFrames must have the same number of rows.
 - The ``d_matrix`` parameter passed to the constructor should be the D block

--- a/process_improve/bivariate/tools.py
+++ b/process_improve/bivariate/tools.py
@@ -26,7 +26,7 @@ def _register(name: str) -> None:
 @tool_spec(
     name="find_elbow",
     description=(
-        "Find the elbow (knee) point in an x-y curve — the point where the curve transitions "
+        "Find the elbow (knee) point in an x-y curve - the point where the curve transitions "
         "from steep to flat (or vice versa). "
         "Common use cases: selecting the number of PCA components from a scree plot, determining "
         "optimal cluster count from an elbow plot, or finding a saturation point. "

--- a/process_improve/experiments/analysis.py
+++ b/process_improve/experiments/analysis.py
@@ -96,7 +96,7 @@ class AnalysisResult:
 def _run_anova(ols_result: RegressionResultsWrapper, anova_type: int = 2) -> dict[str, Any]:
     """ANOVA table via statsmodels."""
     if ols_result.df_resid <= 0:
-        return {"anova_table": [], "note": "Saturated model — no residual degrees of freedom for ANOVA."}
+        return {"anova_table": [], "note": "Saturated model - no residual degrees of freedom for ANOVA."}
     table = sm.stats.anova_lm(ols_result, typ=anova_type)
     records = [
         {
@@ -246,7 +246,7 @@ def _run_lack_of_fit(
             df_pure_error += ni - 1
 
     if df_pure_error == 0:
-        return {"lack_of_fit": {"error": "No replicated points — cannot test lack of fit."}}
+        return {"lack_of_fit": {"error": "No replicated points - cannot test lack of fit."}}
 
     ss_residual = float((residuals**2).sum())
     df_residual = int(ols_result.df_resid)
@@ -434,7 +434,7 @@ def _run_box_cox(design_df: pd.DataFrame, response_col: str) -> dict[str, Any]:
 def _run_lenth_method(ols_result: RegressionResultsWrapper) -> dict[str, Any]:
     """Lenth's method (PSE) for unreplicated factorials.
 
-    Not available in mainstream Python libraries — custom (~30 lines).
+    Not available in mainstream Python libraries - custom (~30 lines).
     """
     params = ols_result.params.drop("Intercept", errors="ignore")
     effects = 2.0 * params.values  # coded ±1 → effect = 2 * coefficient
@@ -443,7 +443,7 @@ def _run_lenth_method(ols_result: RegressionResultsWrapper) -> dict[str, Any]:
     # Step 1: initial median
     s0 = 1.5 * np.median(abs_effects)
 
-    # Step 2: pseudo standard error — median of |effects| <= 2.5 * s0
+    # Step 2: pseudo standard error - median of |effects| <= 2.5 * s0
     trimmed = abs_effects[abs_effects <= 2.5 * s0]
     pse = s0 if len(trimmed) == 0 else 1.5 * np.median(trimmed)
 

--- a/process_improve/experiments/augment.py
+++ b/process_improve/experiments/augment.py
@@ -160,7 +160,7 @@ def _augment_foldover(ctx: _AugmentContext) -> dict[str, Any]:
             generators_after = [f"I={_word_to_str(w, ctx.factor_names)}" for w in surviving]
             notes.append(f"New defining relation: {', '.join(generators_after)}.")
         else:
-            notes.append("All defining words eliminated — design is now full resolution.")
+            notes.append("All defining words eliminated - design is now full resolution.")
 
         eliminated = [w for w in words if len(w) % 2 != 0]
         if eliminated:
@@ -218,7 +218,7 @@ def _augment_semifold(ctx: _AugmentContext) -> dict[str, Any]:
             generators_after = [f"I={_word_to_str(w, ctx.factor_names)}" for w in surviving]
             notes.append(f"Surviving defining words: {', '.join(generators_after)}.")
         else:
-            notes.append("All defining words eliminated — design is now full resolution.")
+            notes.append("All defining words eliminated - design is now full resolution.")
         if eliminated:
             eliminated_strs = [_word_to_str(w, ctx.factor_names) for w in eliminated]
             notes.append(f"De-aliased by removing words: {', '.join(eliminated_strs)}.")
@@ -249,7 +249,7 @@ def _auto_select_fold_factor(ctx: _AugmentContext) -> str:
     most short words is the best choice.
     """
     if not ctx.generators:
-        # No generators — just pick the first factor
+        # No generators - just pick the first factor
         return ctx.factor_names[0]
 
     words = _defining_relation_from_generators(ctx.generators, ctx.factor_names)

--- a/process_improve/experiments/designs.py
+++ b/process_improve/experiments/designs.py
@@ -32,7 +32,7 @@ from process_improve.experiments.designs_utils import build_design_result
 from process_improve.experiments.factor import Constraint, DesignResult, Factor, FactorType
 
 # ---------------------------------------------------------------------------
-# Dispatch handlers — each returns (coded_matrix, metadata_dict)
+# Dispatch handlers - each returns (coded_matrix, metadata_dict)
 # ---------------------------------------------------------------------------
 
 

--- a/process_improve/experiments/designs_optimal.py
+++ b/process_improve/experiments/designs_optimal.py
@@ -282,7 +282,7 @@ def dispatch_d_optimal(
 
     if hard_to_change:
         logger.warning(
-            "pyoptex is not installed — hard_to_change factors will be ignored. "
+            "pyoptex is not installed - hard_to_change factors will be ignored. "
             "Install with: pip install pyoptex"
         )
     return _run_point_exchange_fallback(factors, budget)

--- a/process_improve/experiments/evaluate.py
+++ b/process_improve/experiments/evaluate.py
@@ -102,7 +102,7 @@ def _build_model_matrix(
         squared = " + ".join(f"I({f} ** 2)" for f in factor_names)
         rhs = f"({joined}) ** 2 + {squared}"
     elif "~" in model:
-        # Explicit formula with response side — strip LHS
+        # Explicit formula with response side - strip LHS
         rhs = model.split("~", 1)[1].strip()
     else:
         # Assume it is already a valid RHS formula
@@ -407,7 +407,7 @@ def _word_to_str(indices: frozenset[int], factor_names: list[str]) -> str:
 
 
 def _multiply_words(w1: frozenset[int], w2: frozenset[int]) -> frozenset[int]:
-    """Multiply two words in GF(2) — symmetric difference of factor sets."""
+    """Multiply two words in GF(2) - symmetric difference of factor sets."""
     return w1.symmetric_difference(w2)
 
 
@@ -736,7 +736,7 @@ def evaluate_design(  # noqa: PLR0913
     -------
     dict[str, Any]
         Results keyed by metric name.  The structure of each value depends
-        on the metric — see individual metric documentation.
+        on the metric - see individual metric documentation.
 
     Examples
     --------

--- a/process_improve/experiments/knowledge/__init__.py
+++ b/process_improve/experiments/knowledge/__init__.py
@@ -1,4 +1,4 @@
-"""DOE knowledge graph — definitions, decision logic, interpretation guidance.
+"""DOE knowledge graph - definitions, decision logic, interpretation guidance.
 
 This subpackage encodes DOE domain knowledge as structured YAML files and
 provides an in-memory query engine for retrieving it.

--- a/process_improve/experiments/knowledge/api.py
+++ b/process_improve/experiments/knowledge/api.py
@@ -1,6 +1,6 @@
 """Public API for the DOE knowledge graph.
 
-Provides :func:`doe_knowledge` — the single entry-point for retrieving
+Provides :func:`doe_knowledge` - the single entry-point for retrieving
 DOE concepts, design selection logic, interpretation guidance, diagnostic
 patterns, and worked examples.
 """
@@ -44,10 +44,10 @@ def doe_knowledge(
     context : dict, optional
         Experimental context for design-selection queries.  Recognised keys:
 
-        * ``n_factors`` (int) — number of factors
-        * ``budget`` (int) — maximum number of runs
-        * ``goal`` (str) — ``"screening"`` | ``"optimization"``
-        * ``sequential`` (bool) — whether the design will be augmented later
+        * ``n_factors`` (int) - number of factors
+        * ``budget`` (int) - maximum number of runs
+        * ``goal`` (str) - ``"screening"`` | ``"optimization"``
+        * ``sequential`` (bool) - whether the design will be augmented later
         * ``curvature_important`` (bool)
         * ``has_hard_to_change`` (bool)
     detail_level : str, default ``"intermediate"``
@@ -59,11 +59,11 @@ def doe_knowledge(
     dict
         A dictionary with keys:
 
-        * ``"results"`` — list of matching knowledge entries
-        * ``"query"`` — the original query string
-        * ``"topic"`` — the topic used for filtering
-        * ``"detail_level"`` — the detail level applied
-        * ``"n_results"`` — number of results returned
+        * ``"results"`` - list of matching knowledge entries
+        * ``"query"`` - the original query string
+        * ``"topic"`` - the topic used for filtering
+        * ``"detail_level"`` - the detail level applied
+        * ``"n_results"`` - number of results returned
 
     Examples
     --------

--- a/process_improve/experiments/knowledge/data/concepts.yaml
+++ b/process_improve/experiments/knowledge/data/concepts.yaml
@@ -30,7 +30,7 @@
   content:
     novice: >
       When you run fewer experiments than a full factorial, some effects get
-      tangled together — you cannot tell which one caused the result. This
+      tangled together - you cannot tell which one caused the result. This
       tangling is called aliasing.
     intermediate: >
       Aliasing occurs in fractional factorial designs when two or more effects
@@ -40,7 +40,7 @@
     expert: >
       The alias structure is determined by the defining relation I = word1 =
       word2 = ... Multiplying any effect by the defining relation words gives
-      its alias chain. In non-regular designs (PB, DSD), aliasing is partial —
+      its alias chain. In non-regular designs (PB, DSD), aliasing is partial -
       effects are correlated rather than completely confounded, with correlation
       coefficients determined by the inner products of the design columns.
   related_to: [resolution, fractional_factorial, plackett_burman]
@@ -147,7 +147,7 @@
       resolution III screening designs (sacrificing 2FI estimation) and the
       convention of pooling three-factor and higher interactions into error.
     expert: >
-      Effect hierarchy underpins effect sparsity — the assumption that only a
+      Effect hierarchy underpins effect sparsity - the assumption that only a
       few effects are active (the Pareto principle applied to factorials). It
       is the basis for Lenth's PSE, the half-normal plot, and Bayesian variable
       selection in unreplicated factorials. Wu & Hamada (2009) formalize this
@@ -162,7 +162,7 @@
   content:
     novice: >
       In most experiments, only a few factors (maybe 2–4 out of 10) actually
-      matter. This is why screening designs work — you do not need to estimate
+      matter. This is why screening designs work - you do not need to estimate
       every possible effect.
     intermediate: >
       Effect sparsity says that the number of active effects is small relative

--- a/process_improve/experiments/knowledge/data/decision_rules.yaml
+++ b/process_improve/experiments/knowledge/data/decision_rules.yaml
@@ -188,7 +188,7 @@
     intermediate: >
       Split-plot designs have whole plots (hard-to-change factors) and subplots
       (easy-to-change factors). The analysis must use restricted randomization
-      error structure — ordinary ANOVA gives incorrect p-values for whole-plot
+      error structure - ordinary ANOVA gives incorrect p-values for whole-plot
       factors.
     expert: >
       The REML-based mixed model is the correct analysis for split-plot DOE.

--- a/process_improve/experiments/knowledge/data/design_types.yaml
+++ b/process_improve/experiments/knowledge/data/design_types.yaml
@@ -15,7 +15,7 @@
       k <= 5 or so.
     expert: >
       The 2^k full factorial is the benchmark against which all other two-level
-      designs are judged. Resolution is technically infinite — no alias chains
+      designs are judged. Resolution is technically infinite - no alias chains
       exist. The design is both D-optimal and I-optimal within the class of
       orthogonal two-level designs. Center points can be added to test for
       curvature without inflating the factorial portion.
@@ -49,7 +49,7 @@
     - "Cannot estimate quadratic effects without center points"
     - "Inefficient when many factors are likely inert"
   common_misconceptions:
-    - "A full factorial is always the best design — it is only best when you can afford it and need all interactions"
+    - "A full factorial is always the best design - it is only best when you can afford it and need all interactions"
   references:
     - "Montgomery (2019), Ch. 5–6"
     - "Box, Hunter & Hunter (2005), Ch. 5"
@@ -97,15 +97,15 @@
     - {target: fractional_factorial, method: "Foldover to increase resolution"}
   advantages:
     - "Dramatically reduces run count compared to full factorial"
-    - "Orthogonal — clean estimation of non-aliased effects"
+    - "Orthogonal - clean estimation of non-aliased effects"
     - "Can augment (foldover, add runs) sequentially"
   disadvantages:
     - "Aliased effects cannot be separated without additional runs"
     - "Requires understanding of confounding structure"
     - "Low-resolution fractions may miss important interactions"
   common_misconceptions:
-    - "Resolution IV means all two-factor interactions are estimable — they are aliased with each other"
-    - "You must always use the minimum-aberration generator — other generators may be better for specific alias priorities"
+    - "Resolution IV means all two-factor interactions are estimable - they are aliased with each other"
+    - "You must always use the minimum-aberration generator - other generators may be better for specific alias priorities"
   references:
     - "Montgomery (2019), Ch. 8"
     - "Box, Hunter & Hunter (2005), Ch. 6"
@@ -159,7 +159,7 @@
     - "Complex partial aliasing makes interpretation harder than regular fractions"
     - "No information on curvature"
   common_misconceptions:
-    - "PB designs estimate two-factor interactions — they do not; interactions are partially aliased with every main effect"
+    - "PB designs estimate two-factor interactions - they do not; interactions are partially aliased with every main effect"
   references:
     - "Plackett & Burman (1946)"
     - "Montgomery (2019), Ch. 8.6"
@@ -174,7 +174,7 @@
     intermediate: >
       Box-Behnken designs (BBD) are three-level response surface designs that
       estimate all main effects, interactions, and quadratic terms. They avoid
-      the extreme vertices of the cube — all design points are at the midpoints
+      the extreme vertices of the cube - all design points are at the midpoints
       of edges or at center. This makes them useful when factor extremes are
       operationally difficult.
     expert: >
@@ -213,7 +213,7 @@
     - "Prediction variance higher at corners"
     - "Cannot be built sequentially from a factorial base"
   common_misconceptions:
-    - "BBD is always better than CCD because it uses fewer runs — CCD may be preferred when corner points are feasible and rotatability matters"
+    - "BBD is always better than CCD because it uses fewer runs - CCD may be preferred when corner points are feasible and rotatability matters"
   references:
     - "Box & Behnken (1960)"
     - "Myers, Montgomery & Anderson-Cook (2016), Ch. 7"
@@ -266,8 +266,8 @@
     - "Axial points may extend beyond the feasible region"
     - "Five levels per factor (if alpha != 1)"
   common_misconceptions:
-    - "CCD always requires 5 factor levels — face-centered CCD (alpha=1) uses only 3"
-    - "You must start with a full factorial — a resolution V fraction works as the cube portion"
+    - "CCD always requires 5 factor levels - face-centered CCD (alpha=1) uses only 3"
+    - "You must start with a full factorial - a resolution V fraction works as the cube portion"
   references:
     - "Box & Wilson (1951)"
     - "Myers, Montgomery & Anderson-Cook (2016), Ch. 7"
@@ -318,9 +318,9 @@
   disadvantages:
     - "Requires three levels per factor"
     - "Cannot estimate full quadratic model if more than ~3 factors are active"
-    - "Relatively new — less practitioner experience"
+    - "Relatively new - less practitioner experience"
   common_misconceptions:
-    - "DSDs replace RSM designs — they supplement screening, but follow-up RSM is needed when many factors are active"
+    - "DSDs replace RSM designs - they supplement screening, but follow-up RSM is needed when many factors are active"
   references:
     - "Jones & Nachtsheim (2011)"
-    - "Jones & Nachtsheim (2013) — categorical factors"
+    - "Jones & Nachtsheim (2013) - categorical factors"

--- a/process_improve/experiments/knowledge/data/diagnostics.yaml
+++ b/process_improve/experiments/knowledge/data/diagnostics.yaml
@@ -9,7 +9,7 @@
       description: "Variance of the response increases with the mean"
   remedies:
     - action: log_transform
-      detail: "Apply log(y) transform — often the first choice for multiplicative variance"
+      detail: "Apply log(y) transform - often the first choice for multiplicative variance"
     - action: box_cox_transform
       detail: "Use Box-Cox to find the optimal power transform (lambda)"
     - action: weighted_least_squares
@@ -38,10 +38,10 @@
   visual_pattern: "One or a few residuals are much larger than others (|e_i| > 3-4 sigma)"
   indicates:
     - problem: outlier
-      description: "Unusual observation — may be a measurement error or special cause"
+      description: "Unusual observation - may be a measurement error or special cause"
   remedies:
     - action: investigate_run
-      detail: "Check the lab notebook for that run — was there an identifiable cause?"
+      detail: "Check the lab notebook for that run - was there an identifiable cause?"
     - action: rerun_point
       detail: "If cause is found, re-run that experimental point"
     - action: robust_fit
@@ -60,9 +60,9 @@
     - action: box_cox_transform
       detail: "Apply Box-Cox transform to stabilize variance and improve normality"
     - action: check_outliers
-      detail: "Heavy tails may be caused by outliers — investigate extreme residuals"
+      detail: "Heavy tails may be caused by outliers - investigate extreme residuals"
     - action: often_minor
-      detail: "Moderate non-normality has little effect on F-tests — may not need a fix"
+      detail: "Moderate non-normality has little effect on F-tests - may not need a fix"
   severity: low
 
 - id: time_trend_residuals
@@ -75,7 +75,7 @@
       description: "Measurement equipment may be drifting"
   remedies:
     - action: randomize_run_order
-      detail: "Ensure the run order was truly randomized — re-randomize if not"
+      detail: "Ensure the run order was truly randomized - re-randomize if not"
     - action: add_blocking
       detail: "Block on time periods to separate the trend from factor effects"
     - action: covariate

--- a/process_improve/experiments/optimization.py
+++ b/process_improve/experiments/optimization.py
@@ -7,19 +7,19 @@ a model with :func:`analyze_experiment` (Tool 3).
 
 Implemented methods
 -------------------
-- **desirability** — Derringer-Suich desirability functions (single and
+- **desirability** - Derringer-Suich desirability functions (single and
   multi-response) with ``scipy.optimize.minimize`` (SLSQP).
-- **steepest_ascent** / **steepest_descent** — Move along the gradient
+- **steepest_ascent** / **steepest_descent** - Move along the gradient
   of a first-order model from the design centre.
-- **stationary_point** — Locate the stationary point of a second-order
+- **stationary_point** - Locate the stationary point of a second-order
   model via ``numpy.linalg.solve``.
-- **canonical_analysis** — Eigenvalue decomposition of the *B* matrix
+- **canonical_analysis** - Eigenvalue decomposition of the *B* matrix
   to classify the stationary point (max / min / saddle).
 
 Stubs (not yet implemented)
 ---------------------------
-- **ridge_analysis** — Trace the optimum along increasing radii.
-- **pareto_front** — Multi-objective Pareto frontier (NSGA-II).
+- **ridge_analysis** - Trace the optimum along increasing radii.
+- **pareto_front** - Multi-objective Pareto frontier (NSGA-II).
 """
 
 from __future__ import annotations
@@ -231,13 +231,13 @@ def _find_stationary_point(
 
     # Check that B has quadratic terms (not purely first-order)
     if np.allclose(B, 0):
-        return {"error": "Model has no quadratic or interaction terms — cannot find stationary point."}
+        return {"error": "Model has no quadratic or interaction terms - cannot find stationary point."}
 
     try:
         # Solve 2*B*x_s = -b
         x_s = np.linalg.solve(2.0 * B, -b)
     except np.linalg.LinAlgError:
-        return {"error": "Singular B matrix — stationary point does not exist."}
+        return {"error": "Singular B matrix - stationary point does not exist."}
 
     # Predicted response at stationary point
     y_s = float(b0 + b @ x_s + x_s @ B @ x_s)
@@ -301,7 +301,7 @@ def _canonical_analysis(
     _b0, _b, B = _extract_b_and_B(coefficients, factor_names)
 
     if np.allclose(B, 0):
-        return {"error": "Model has no quadratic or interaction terms — canonical analysis not applicable."}
+        return {"error": "Model has no quadratic or interaction terms - canonical analysis not applicable."}
 
     eigenvalues, eigenvectors = np.linalg.eigh(B)
 
@@ -381,7 +381,7 @@ def _steepest_path(  # noqa: PLR0913
             b[name_to_idx[components[0]]] = float(entry["coefficient"])
 
     if np.allclose(b, 0):
-        return {"error": "All linear coefficients are zero — no steepest direction."}
+        return {"error": "All linear coefficients are zero - no steepest direction."}
 
     # Direction: normalize, then scale by step_size
     norm = np.linalg.norm(b)
@@ -616,7 +616,7 @@ def _ridge_analysis(
     factor_names: list[str],
     factor_ranges: dict[str, dict[str, float]] | None = None,
 ) -> dict[str, Any]:
-    """Ridge analysis — trace the optimum along increasing radii.
+    """Ridge analysis - trace the optimum along increasing radii.
 
     .. note::
         Not yet implemented.  Planned: constrained eigenvalue computation
@@ -676,7 +676,7 @@ def _coded_to_actual(coded: dict[str, float], factor_ranges: dict[str, dict[str,
 
 
 # ---------------------------------------------------------------------------
-# Public API — dispatcher
+# Public API - dispatcher
 # ---------------------------------------------------------------------------
 
 
@@ -696,26 +696,26 @@ def optimize_responses(  # noqa: PLR0913, C901
     fitted_models : list[dict]
         Each dict describes a fitted model with keys:
 
-        - ``"response_name"`` (str) — name of the response.
-        - ``"coefficients"`` (list[dict]) — coefficient list, each with
+        - ``"response_name"`` (str) - name of the response.
+        - ``"coefficients"`` (list[dict]) - coefficient list, each with
           ``"term"`` and ``"coefficient"`` keys as returned by
           ``analyze_experiment(..., analysis_type="coefficients")``.
-        - ``"factor_names"`` (list[str]) — ordered factor names.
-        - ``"mse_residual"`` (float, optional) — mean squared error.
-        - ``"r_squared"`` (float, optional) — model R-squared.
+        - ``"factor_names"`` (list[str]) - ordered factor names.
+        - ``"mse_residual"`` (float, optional) - mean squared error.
+        - ``"r_squared"`` (float, optional) - model R-squared.
 
     goals : list[dict] or None
         Per-response optimisation goals.  Each dict has keys:
 
-        - ``"response"`` (str) — response name (must match a model).
-        - ``"goal"`` (str) — ``"maximize"``, ``"minimize"``, or
+        - ``"response"`` (str) - response name (must match a model).
+        - ``"goal"`` (str) - ``"maximize"``, ``"minimize"``, or
           ``"target"``.
-        - ``"target"`` (float, optional) — target value (required when
+        - ``"target"`` (float, optional) - target value (required when
           ``goal="target"``).
-        - ``"low"`` (float) — lower acceptable bound.
-        - ``"high"`` (float) — upper acceptable bound.
-        - ``"weight"`` (float, default 1) — desirability shape parameter.
-        - ``"importance"`` (float, default 1) — relative importance for
+        - ``"low"`` (float) - lower acceptable bound.
+        - ``"high"`` (float) - upper acceptable bound.
+        - ``"weight"`` (float, default 1) - desirability shape parameter.
+        - ``"importance"`` (float, default 1) - relative importance for
           composite desirability.
 
     method : str

--- a/process_improve/experiments/strategy/domain_templates.py
+++ b/process_improve/experiments/strategy/domain_templates.py
@@ -22,15 +22,15 @@ from typing import Any
 # ---------------------------------------------------------------------------
 #
 # Each template is a dict with the following keys:
-#   screening_preference : str — preferred screening design type
-#   rsm_preference : str — preferred RSM design type
-#   budget_weights : dict — stage -> fraction of total budget
-#   min_confirmation : int — minimum confirmation runs
-#   min_center_points : int — minimum center points for variability estimation
-#   prefer_curvature_detection : bool — prefer DSD over PB when possible
-#   notes : dict[str, str] — detail_level -> domain-specific advice
-#   extra_stages : list[str] — additional stages specific to this domain
-#   special_considerations : list[str] — domain-specific warnings/notes
+#   screening_preference : str - preferred screening design type
+#   rsm_preference : str - preferred RSM design type
+#   budget_weights : dict - stage -> fraction of total budget
+#   min_confirmation : int - minimum confirmation runs
+#   min_center_points : int - minimum center points for variability estimation
+#   prefer_curvature_detection : bool - prefer DSD over PB when possible
+#   notes : dict[str, str] - detail_level -> domain-specific advice
+#   extra_stages : list[str] - additional stages specific to this domain
+#   special_considerations : list[str] - domain-specific warnings/notes
 
 DOMAIN_TEMPLATES: dict[str, dict[str, Any]] = {
     "pharma_formulation": {
@@ -48,7 +48,7 @@ DOMAIN_TEMPLATES: dict[str, dict[str, Any]] = {
                 "Attributes (CMAs), and responses are Critical Quality Attributes (CQAs)."
             ),
             "intermediate": (
-                "Per ICH Q8, the experimental strategy should map the design space — the "
+                "Per ICH Q8, the experimental strategy should map the design space - the "
                 "multidimensional region of factor settings that provides acceptable quality. "
                 "Face-centered CCD is preferred for RSM because it stays within physical bounds, "
                 "which is important for regulatory acceptance. DSD screening efficiently detects "
@@ -111,7 +111,7 @@ DOMAIN_TEMPLATES: dict[str, dict[str, Any]] = {
         },
         "extra_stages": [],
         "special_considerations": [
-            "Check for mixture constraints — formulation components summing to a constant.",
+            "Check for mixture constraints - formulation components summing to a constant.",
             "Sensory responses may require larger replication for subjective variability.",
             "Extreme factor combinations may produce unacceptable products.",
         ],
@@ -190,7 +190,7 @@ DOMAIN_TEMPLATES: dict[str, dict[str, Any]] = {
         "extra_stages": ["library_screen", "scaleup"],
         "special_considerations": [
             "Experiments are expensive and slow (14-21 days per run).",
-            "Run minimisation is critical — every run saved is 2-3 weeks.",
+            "Run minimisation is critical - every run saved is 2-3 weeks.",
             "DSD allows screening and curvature detection in a single stage.",
             "High-dimensionality media screening may need a pre-screening step.",
         ],

--- a/process_improve/experiments/strategy/engine.py
+++ b/process_improve/experiments/strategy/engine.py
@@ -3,7 +3,7 @@
 """Deterministic rule engine for DOE strategy recommendation.
 
 Implements ~50 decision rules from Montgomery, NIST, and Stat-Ease SCOR
-to recommend multi-stage experimental strategies.  No LLM or randomness —
+to recommend multi-stage experimental strategies.  No LLM or randomness -
 identical inputs always produce identical outputs.
 """
 
@@ -82,7 +82,7 @@ def _parse_prior_knowledge(
         confidence = 0.9
         has_supporting_data = True
     else:
-        # No clear keywords — assign moderate-low confidence
+        # No clear keywords - assign moderate-low confidence
         confidence = 0.3
 
     # Extract factor names mentioned near significance keywords
@@ -149,15 +149,15 @@ def _select_screening_design(  # noqa: C901, PLR0912, PLR0915
     n = classification["n_factors"]
     reasoning: list[str] = []
 
-    # Rule: 2 or fewer factors — no screening needed
+    # Rule: 2 or fewer factors - no screening needed
     if n <= 2:
         return None
 
-    # Rule: High prior confidence — skip screening
+    # Rule: High prior confidence - skip screening
     if classification["prior_confidence"] >= 0.8:
         return None
 
-    # Rule: Mixture factors only — use mixture design path
+    # Rule: Mixture factors only - use mixture design path
     if spec.has_mixture and spec.n_continuous == 0:
         design_type = "simplex_lattice"
         runs = max(n + 1, 6)  # Minimum for simplex lattice
@@ -174,7 +174,7 @@ def _select_screening_design(  # noqa: C901, PLR0912, PLR0915
             transition_rules=_screening_transition_rules(),
         )
 
-    # Rule: 3-5 factors, all continuous — full/fractional factorial
+    # Rule: 3-5 factors, all continuous - full/fractional factorial
     if 3 <= n <= 5 and spec.n_continuous == n:
         if n <= 4:
             design_type = "full_factorial"
@@ -197,7 +197,7 @@ def _select_screening_design(  # noqa: C901, PLR0912, PLR0915
             transition_rules=_screening_transition_rules(),
         )
 
-    # Rule: 6+ factors — PB, DSD, or fractional factorial
+    # Rule: 6+ factors - PB, DSD, or fractional factorial
     # Sub-rule: Domain or user prefers curvature detection → DSD
     prefer_curvature = template.get("prefer_curvature_detection", False)
     domain_pref = template.get("screening_preference")
@@ -211,7 +211,7 @@ def _select_screening_design(  # noqa: C901, PLR0912, PLR0915
         runs = estimate_screening_runs(n, "definitive_screening")
         reasoning.append(f"Domain prefers curvature detection → DSD ({runs} runs).")
     elif classification["prior_confidence"] >= 0.6:
-        # Medium confidence — DSD to screen + detect curvature
+        # Medium confidence - DSD to screen + detect curvature
         design_type = "definitive_screening"
         runs = estimate_screening_runs(n, "definitive_screening")
         conf = classification["prior_confidence"]
@@ -316,8 +316,8 @@ def _select_rsm_design(
     elif domain_pref == "box_behnken" or (not has_screening and 3 <= n_rsm <= 7):
         design_type = "box_behnken"
         runs = estimate_rsm_runs(n_rsm, "box_behnken", center_points)
-        purpose = "BBD for response surface modeling — fewer runs, avoids extreme corners."
-    # Rule: Default — CCD
+        purpose = "BBD for response surface modeling - fewer runs, avoids extreme corners."
+    # Rule: Default - CCD
     else:
         design_type = "ccd"
         runs = estimate_rsm_runs(n_rsm, "ccd", center_points)
@@ -569,13 +569,13 @@ def _build_reasoning(
     if spec.budget:
         reasoning.append(f"Budget: {spec.budget} total runs ({spec.budget / n:.1f} runs per factor).")
     else:
-        reasoning.append("No budget constraint — recommending ideal allocation.")
+        reasoning.append("No budget constraint - recommending ideal allocation.")
 
     if spec.prior_knowledge and spec.prior_knowledge.confidence > 0:
         reasoning.append(
             f"Prior knowledge confidence: {spec.prior_knowledge.confidence:.1f}. "
             + (
-                "Skipping screening — going directly to RSM."
+                "Skipping screening - going directly to RSM."
                 if spec.prior_knowledge.confidence >= 0.8
                 else "Using prior knowledge to inform design choices."
             )
@@ -607,7 +607,7 @@ def recommend_strategy(  # noqa: C901, PLR0913
     constraints: list[Constraint] | None = None,
     hard_to_change_factors: list[str] | None = None,
     prior_knowledge: str | None = None,
-    existing_data: Any = None,  # noqa: ANN401 — DataFrame or None
+    existing_data: Any = None,  # noqa: ANN401 - DataFrame or None
     domain: str | None = None,
     detail_level: str = "intermediate",
 ) -> dict[str, Any]:

--- a/process_improve/experiments/tools.py
+++ b/process_improve/experiments/tools.py
@@ -1367,7 +1367,7 @@ _register("doe_knowledge")
                     "description": (
                         "Free-text description of prior knowledge, e.g. "
                         "'Published literature confirms Temperature and pH are significant.' "
-                        "or 'No prior data — first time running this process.'"
+                        "or 'No prior data - first time running this process.'"
                     ),
                 },
                 "existing_data": {
@@ -1399,7 +1399,7 @@ _register("doe_knowledge")
         }
     },
     examples="""
-    # "I have 7 factors — how do I plan my experiments?"
+    # "I have 7 factors - how do I plan my experiments?"
         -> ``recommend_strategy(factors=[{"name": "A", "low": 0, "high": 100}, ...7 factors...],
                 budget=40, domain="general")``
 
@@ -1408,7 +1408,7 @@ _register("doe_knowledge")
                 responses=[{"name": "Yield", "goal": "maximize"}],
                 budget=40, domain="fermentation")``
 
-    # "Expensive cell culture experiments — most efficient approach for 6 factors?"
+    # "Expensive cell culture experiments - most efficient approach for 6 factors?"
         -> ``recommend_strategy(factors=[...6 factors...],
                 responses=[{"name": "Viability", "goal": "maximize"}],
                 domain="cell_culture", detail_level="intermediate")``

--- a/process_improve/experiments/visualization/api.py
+++ b/process_improve/experiments/visualization/api.py
@@ -130,7 +130,7 @@ def main_effects_plot(
         a fitted ``Model`` is supplied.
     factors_to_plot : list of str, optional
         Subset of factors to display.  By default all main-effect
-        factors are shown — for a ``Model`` these are the level-1
+        factors are shown - for a ``Model`` these are the level-1
         factors from the formula; for a DataFrame they are all columns
         other than *response_column*.
     factor_labels : dict, optional

--- a/process_improve/experiments/visualization/plots/cube_plot.py
+++ b/process_improve/experiments/visualization/plots/cube_plot.py
@@ -1,7 +1,7 @@
 """Cube plot: 3D wireframe with response values at 2^3 design vertices.
 
 A cube plot displays the predicted (or observed) response at each
-corner of the design cube for a 3-factor experiment.  Fully custom —
+corner of the design cube for a 3-factor experiment.  Fully custom -
 no charting library provides this natively.
 """
 
@@ -45,7 +45,7 @@ class CubePlot(BasePlot):
         """
         factors = self.factors_to_plot or self._get_factor_names()
         if len(factors) < 3:
-            return ChartSpec(title="Cube Plot — need exactly 3 factors")
+            return ChartSpec(title="Cube Plot - need exactly 3 factors")
 
         f1, f2, f3 = factors[0], factors[1], factors[2]
 
@@ -54,7 +54,7 @@ class CubePlot(BasePlot):
         vertex_values = self._get_vertex_values(f1, f2, f3, vertices)
 
         if vertex_values is None:
-            return ChartSpec(title="Cube Plot — cannot compute vertex values")
+            return ChartSpec(title="Cube Plot - cannot compute vertex values")
 
         # Build vertex data with labels
         vertex_data = []

--- a/process_improve/experiments/visualization/plots/design_quality.py
+++ b/process_improve/experiments/visualization/plots/design_quality.py
@@ -49,14 +49,14 @@ class FDSPlot(BasePlot):
         import pandas as pd  # noqa: PLC0415
 
         if not self.design_data:
-            return ChartSpec(title="FDS Plot — no design data")
+            return ChartSpec(title="FDS Plot - no design data")
 
         df = pd.DataFrame(self.design_data)
         factors = self.factors_to_plot or [
             c for c in df.columns if c != self.response_column
         ]
         if len(factors) < 2:
-            return ChartSpec(title="FDS Plot — need at least 2 factors")
+            return ChartSpec(title="FDS Plot - need at least 2 factors")
 
         # Build model matrix (intercept + linear + interactions + quadratic)
         x_design = df[factors].values.astype(float)
@@ -194,7 +194,7 @@ class PowerCurvePlot(BasePlot):
 
         design_info = self._get_design_info()
         if design_info is None:
-            return ChartSpec(title="Power Curve — no design information")
+            return ChartSpec(title="Power Curve - no design information")
 
         n_runs = design_info["n_runs"]
         n_terms = design_info["n_terms"]

--- a/process_improve/experiments/visualization/plots/diagnostics.py
+++ b/process_improve/experiments/visualization/plots/diagnostics.py
@@ -57,7 +57,7 @@ class ResidualsVsFittedPlot(BasePlot):
         fitted = diag.get("fitted_values", [])
 
         if not residuals or not fitted:
-            return ChartSpec(title="Residuals vs Fitted — no data")
+            return ChartSpec(title="Residuals vs Fitted - no data")
 
         # Scatter layer
         scatter_data = [
@@ -129,7 +129,7 @@ class NormalProbabilityPlot(BasePlot):
         residuals = diag.get("residuals", [])
 
         if not residuals:
-            return ChartSpec(title="Normal Probability Plot — no data")
+            return ChartSpec(title="Normal Probability Plot - no data")
 
         # scipy.stats.probplot returns (quantiles, ordered_residuals)
         (theoretical, ordered), (slope, intercept, _r) = stats.probplot(residuals, dist="norm")
@@ -207,7 +207,7 @@ class ResidualsVsOrderPlot(BasePlot):
         residuals = diag.get("residuals", [])
 
         if not residuals:
-            return ChartSpec(title="Residuals vs Order — no data")
+            return ChartSpec(title="Residuals vs Order - no data")
 
         scatter_data = [
             {"run_order": i + 1, "residual": float(r)}
@@ -289,10 +289,10 @@ class BoxCoxPlot(BasePlot):
         # Get response values
         y = self._get_response_values()
         if y is None or len(y) < 3:
-            return ChartSpec(title="Box-Cox Plot — insufficient data")
+            return ChartSpec(title="Box-Cox Plot - insufficient data")
 
         if np.any(np.array(y) <= 0):
-            return ChartSpec(title="Box-Cox Plot — requires all positive response values")
+            return ChartSpec(title="Box-Cox Plot - requires all positive response values")
 
         y_arr = np.array(y, dtype=float)
 

--- a/process_improve/experiments/visualization/plots/effects.py
+++ b/process_improve/experiments/visualization/plots/effects.py
@@ -48,11 +48,11 @@ class MainEffectsPlot(BasePlot):
         """
         df = self._get_design_df()
         if df is None or df.empty:
-            return ChartSpec(title="Main Effects Plot — no data")
+            return ChartSpec(title="Main Effects Plot - no data")
 
         response = self.response_column or self._infer_response(df)
         if response is None or response not in df.columns:
-            return ChartSpec(title="Main Effects Plot — no response column")
+            return ChartSpec(title="Main Effects Plot - no response column")
 
         factors = self.factors_to_plot or self._get_factor_names()
         if not factors:
@@ -152,19 +152,19 @@ class InteractionPlot(BasePlot):
         """
         df = self._get_design_df()
         if df is None or df.empty:
-            return ChartSpec(title="Interaction Plot — no data")
+            return ChartSpec(title="Interaction Plot - no data")
 
         response = self.response_column or self._infer_response(df)
         if response is None or response not in df.columns:
-            return ChartSpec(title="Interaction Plot — no response column")
+            return ChartSpec(title="Interaction Plot - no response column")
 
         factors = self.factors_to_plot or self._get_factor_names()
         if len(factors) < 2:
-            return ChartSpec(title="Interaction Plot — need at least 2 factors")
+            return ChartSpec(title="Interaction Plot - need at least 2 factors")
 
         factor_a, factor_b = factors[0], factors[1]
         if factor_a not in df.columns or factor_b not in df.columns:
-            return ChartSpec(title=f"Interaction Plot — factors {factor_a}, {factor_b} not in data")
+            return ChartSpec(title=f"Interaction Plot - factors {factor_a}, {factor_b} not in data")
 
         levels_a = sorted(df[factor_a].unique())
         levels_b = sorted(df[factor_b].unique())
@@ -249,11 +249,11 @@ class PerturbationPlot(BasePlot):
         """
         coefficients = self._get_coefficients()
         if not coefficients:
-            return ChartSpec(title="Perturbation Plot — no coefficients")
+            return ChartSpec(title="Perturbation Plot - no coefficients")
 
         factors = self.factors_to_plot or self._get_factor_names()
         if not factors:
-            return ChartSpec(title="Perturbation Plot — no factors")
+            return ChartSpec(title="Perturbation Plot - no factors")
 
         # Build a simple model evaluator from coefficients
         coef_map = {c["term"]: c["coefficient"] for c in coefficients}

--- a/process_improve/experiments/visualization/plots/optimization_plots.py
+++ b/process_improve/experiments/visualization/plots/optimization_plots.py
@@ -118,7 +118,7 @@ class DesirabilityContourPlot(BasePlot):
     ------------
     Requires ``analysis_results`` with ``"coefficients"`` and
     ``"optimization"`` keys.  The ``"optimization"`` dict should contain
-    ``"responses"`` — a list of dicts each with ``"coefficients"``,
+    ``"responses"`` - a list of dicts each with ``"coefficients"``,
     ``"goal"``, ``"low"``, ``"high"``, and optionally ``"target"``,
     ``"weight"``, ``"importance"``.
     """
@@ -132,11 +132,11 @@ class DesirabilityContourPlot(BasePlot):
         """
         responses = self._get_optimization_responses()
         if not responses:
-            return ChartSpec(title="Desirability Contour — no optimisation data")
+            return ChartSpec(title="Desirability Contour - no optimisation data")
 
         factors = self.factors_to_plot or self._get_factor_names()
         if len(factors) < 2:
-            return ChartSpec(title="Desirability Contour — need at least 2 factors")
+            return ChartSpec(title="Desirability Contour - need at least 2 factors")
 
         factor_x, factor_y = factors[0], factors[1]
         n_grid = 50
@@ -241,7 +241,7 @@ class OverlayPlot(BasePlot):
     Data sources
     ------------
     Requires ``analysis_results`` with ``"optimization"`` containing
-    ``"responses"`` — each with ``"coefficients"``, and optionally
+    ``"responses"`` - each with ``"coefficients"``, and optionally
     ``"low"``/``"high"`` bounds for feasibility shading.
     """
 
@@ -254,11 +254,11 @@ class OverlayPlot(BasePlot):
         """
         responses = self._get_overlay_responses()
         if not responses:
-            return ChartSpec(title="Overlay Plot — no response data")
+            return ChartSpec(title="Overlay Plot - no response data")
 
         factors = self.factors_to_plot or self._get_factor_names()
         if len(factors) < 2:
-            return ChartSpec(title="Overlay Plot — need at least 2 factors")
+            return ChartSpec(title="Overlay Plot - need at least 2 factors")
 
         factor_x, factor_y = factors[0], factors[1]
         n_grid = 50
@@ -366,11 +366,11 @@ class RidgeTracePlot(BasePlot):
         """
         coefficients = self._get_coefficients()
         if not coefficients:
-            return ChartSpec(title="Ridge Trace — no coefficients")
+            return ChartSpec(title="Ridge Trace - no coefficients")
 
         factors = self.factors_to_plot or self._get_factor_names()
         if not factors:
-            return ChartSpec(title="Ridge Trace — no factors")
+            return ChartSpec(title="Ridge Trace - no factors")
 
         coef_map = _build_coef_map(coefficients)
         b0, b_vec, b_mat = self._extract_b_and_B(coef_map, factors)
@@ -532,11 +532,11 @@ class SteepestAscentPathPlot(BasePlot):
         """
         path_data = self._get_path_data()
         if path_data is None:
-            return ChartSpec(title="Steepest Ascent — no path data")
+            return ChartSpec(title="Steepest Ascent - no path data")
 
         steps = path_data.get("steps", [])
         if not steps:
-            return ChartSpec(title="Steepest Ascent — no steps computed")
+            return ChartSpec(title="Steepest Ascent - no steps computed")
 
         direction = path_data.get("direction", "ascent")
         direction_label = direction.capitalize()

--- a/process_improve/experiments/visualization/plots/significance.py
+++ b/process_improve/experiments/visualization/plots/significance.py
@@ -53,7 +53,7 @@ class ParetoPlot(BasePlot):
         lenth = self._get_lenth()
 
         if not effects:
-            return ChartSpec(title="Pareto Chart — no effects data")
+            return ChartSpec(title="Pareto Chart - no effects data")
 
         # Sort by absolute effect (descending)
         sorted_items = sorted(effects.items(), key=lambda kv: abs(kv[1]), reverse=True)
@@ -195,7 +195,7 @@ class HalfNormalPlot(BasePlot):
         lenth = self._get_lenth()
 
         if not effects:
-            return ChartSpec(title="Half-Normal Plot — no effects data")
+            return ChartSpec(title="Half-Normal Plot - no effects data")
 
         abs_effects = {n: abs(v) for n, v in effects.items()}
         sorted_items = sorted(abs_effects.items(), key=lambda kv: kv[1])
@@ -329,7 +329,7 @@ class DanielPlot(BasePlot):
         lenth = self._get_lenth()
 
         if not effects:
-            return ChartSpec(title="Daniel Plot — no effects data")
+            return ChartSpec(title="Daniel Plot - no effects data")
 
         sorted_items = sorted(effects.items(), key=lambda kv: kv[1])
         names = [n for n, _ in sorted_items]

--- a/process_improve/experiments/visualization/plots/surfaces.py
+++ b/process_improve/experiments/visualization/plots/surfaces.py
@@ -154,11 +154,11 @@ class ContourPlot(BasePlot):
         """
         coefficients = self._get_coefficients()
         if not coefficients:
-            return ChartSpec(title="Contour Plot — no coefficients")
+            return ChartSpec(title="Contour Plot - no coefficients")
 
         factors = self.factors_to_plot or self._get_factor_names()
         if len(factors) < 2:
-            return ChartSpec(title="Contour Plot — need at least 2 factors")
+            return ChartSpec(title="Contour Plot - need at least 2 factors")
 
         factor_x, factor_y = factors[0], factors[1]
         x_title = self._axis_title(factor_x)
@@ -320,7 +320,7 @@ def _format_point_hover(
 
     Lists every factor level (not just the two being plotted) so that
     overlapping runs in a fractional or replicated design can still be
-    distinguished — see issue #23.
+    distinguished - see issue #23.
     """
     lines: list[str] = []
     for key, value in row.items():
@@ -370,11 +370,11 @@ class Surface3DPlot(BasePlot):
         """
         coefficients = self._get_coefficients()
         if not coefficients:
-            return ChartSpec(title="3D Surface — no coefficients")
+            return ChartSpec(title="3D Surface - no coefficients")
 
         factors = self.factors_to_plot or self._get_factor_names()
         if len(factors) < 2:
-            return ChartSpec(title="3D Surface — need at least 2 factors")
+            return ChartSpec(title="3D Surface - need at least 2 factors")
 
         factor_x, factor_y = factors[0], factors[1]
         coef_map = _build_coef_map(coefficients)
@@ -445,12 +445,12 @@ class PredictionVariancePlot(BasePlot):
         import pandas as pd  # noqa: PLC0415
 
         if not self.design_data:
-            return ChartSpec(title="Prediction Variance — no design data")
+            return ChartSpec(title="Prediction Variance - no design data")
 
         df = pd.DataFrame(self.design_data)
         factors = self.factors_to_plot or [c for c in df.columns if c != self.response_column]
         if len(factors) < 2:
-            return ChartSpec(title="Prediction Variance — need at least 2 factors")
+            return ChartSpec(title="Prediction Variance - need at least 2 factors")
 
         factor_x, factor_y = factors[0], factors[1]
 

--- a/process_improve/monitoring/tools.py
+++ b/process_improve/monitoring/tools.py
@@ -183,13 +183,13 @@ def process_capability(
         cpk_float = float(cpk)
 
         if cpk_float >= 1.67:
-            interpretation = f"Cpk = {cpk_float:.3f}. Excellent capability — process is well within spec limits."
+            interpretation = f"Cpk = {cpk_float:.3f}. Excellent capability - process is well within spec limits."
         elif cpk_float >= 1.33:
-            interpretation = f"Cpk = {cpk_float:.3f}. Good capability — process fits within spec limits."
+            interpretation = f"Cpk = {cpk_float:.3f}. Good capability - process fits within spec limits."
         elif cpk_float >= 1.0:
-            interpretation = f"Cpk = {cpk_float:.3f}. Marginal capability — process barely fits within spec limits."
+            interpretation = f"Cpk = {cpk_float:.3f}. Marginal capability - process barely fits within spec limits."
         else:
-            interpretation = f"Cpk = {cpk_float:.3f}. Poor capability — process is producing out-of-spec output."
+            interpretation = f"Cpk = {cpk_float:.3f}. Poor capability - process is producing out-of-spec output."
 
         return clean({
             "cpk": cpk_float,

--- a/process_improve/multivariate/methods.py
+++ b/process_improve/multivariate/methods.py
@@ -655,10 +655,10 @@ class PCA(TransformerMixin, BaseEstimator):
         result : sklearn.utils.Bunch
             With keys:
 
-            - ``n_components`` — recommended number of components (int)
-            - ``press`` — PRESS per component count (pd.Series, indexed 1..A_max)
-            - ``press_ratio`` — PRESS_a / PRESS_{a-1} (pd.Series, indexed 2..A_max)
-            - ``cv_scores`` — per-fold scores (pd.DataFrame, A_max rows x cv cols)
+            - ``n_components`` - recommended number of components (int)
+            - ``press`` - PRESS per component count (pd.Series, indexed 1..A_max)
+            - ``press_ratio`` - PRESS_a / PRESS_{a-1} (pd.Series, indexed 2..A_max)
+            - ``cv_scores`` - per-fold scores (pd.DataFrame, A_max rows x cv cols)
         """
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X)
@@ -727,7 +727,7 @@ class PCA(TransformerMixin, BaseEstimator):
         components : list of int, optional
             **1-based** component indices to decompose over, matching the
             model's column convention. Examples: ``[2, 3]`` for a PC2-vs-PC3
-            score plot, or ``None`` (default) for all components — appropriate
+            score plot, or ``None`` (default) for all components - appropriate
             for Hotelling's T² contributions.
         weighted : bool, default False
             If True, scale the score difference by 1/sqrt(explained_variance)
@@ -773,9 +773,9 @@ class PCA(TransformerMixin, BaseEstimator):
 
         Combines two approaches:
 
-        1. **Statistical limits** — observations exceeding the SPE or T² limit
+        1. **Statistical limits** - observations exceeding the SPE or T² limit
            at ``conf_level`` are flagged.
-        2. **Robust ESD test** — the generalized ESD test (with robust median/MAD
+        2. **Robust ESD test** - the generalized ESD test (with robust median/MAD
            variant) identifies observations that are unusual *relative to the
            rest of the data*, even if they fall below the statistical limit.
 
@@ -792,13 +792,13 @@ class PCA(TransformerMixin, BaseEstimator):
         outliers : list of dict
             Sorted from most severe to least. Each dict contains:
 
-            - ``observation`` — index label of the observation
-            - ``outlier_types`` — list of ``"spe"`` and/or ``"hotellings_t2"``
-            - ``spe`` — SPE value for this observation
-            - ``hotellings_t2`` — T² value for this observation
-            - ``spe_limit`` — SPE limit at the given confidence level
-            - ``hotellings_t2_limit`` — T² limit at the given confidence level
-            - ``severity`` — max(spe/spe_limit, t2/t2_limit)
+            - ``observation`` - index label of the observation
+            - ``outlier_types`` - list of ``"spe"`` and/or ``"hotellings_t2"``
+            - ``spe`` - SPE value for this observation
+            - ``hotellings_t2`` - T² value for this observation
+            - ``spe_limit`` - SPE limit at the given confidence level
+            - ``hotellings_t2_limit`` - T² limit at the given confidence level
+            - ``severity`` - max(spe/spe_limit, t2/t2_limit)
 
         Examples
         --------
@@ -2106,11 +2106,11 @@ class TPLS(RegressorMixin, BaseEstimator):
 
     Notation mapping (paper → this code):
 
-    - X^T → D: ``d_matrix`` (external), ``d_mats`` (internal) — Database of properties
+    - X^T → D: ``d_matrix`` (external), ``d_mats`` (internal) - Database of properties
     - X → D^T: transposed D (not used directly)
-    - R → F: ``f_mats`` — Formula matrices
-    - Z → Z: ``z_mats`` — Process conditions
-    - Y → Y: ``y_mats`` — Quality indicators
+    - R → F: ``f_mats`` - Formula matrices
+    - Z → Z: ``z_mats`` - Process conditions
+    - Y → Y: ``y_mats`` - Quality indicators
 
     Notes
     1. Matrices in F, Z and Y must all have the same number of rows.
@@ -2139,8 +2139,8 @@ class TPLS(RegressorMixin, BaseEstimator):
       ``D = {"Group A": df_props_a, "Group B": df_props_b, ...}``
     - ``F``: Formula matrices (rows = blends, columns = materials).
       ``F = {"Group A": df_formulas_a, "Group B": df_formulas_b, ...}``
-    - ``Z``: Process conditions — one row per blend, one column per condition.
-    - ``Y``: Product quality indicators — one row per blend, one column per indicator.
+    - ``Z``: Process conditions - one row per blend, one column per condition.
+    - ``Y``: Product quality indicators - one row per blend, one column per indicator.
 
     Attributes
     ----------
@@ -3720,7 +3720,7 @@ class MBPLS(RegressorMixin, BaseEstimator):
             centre (zeros).
         components : list of int, optional
             **1-based** component indices to decompose over. ``None`` (default)
-            uses all components — appropriate for Hotelling's T² contributions.
+            uses all components - appropriate for Hotelling's T² contributions.
         weighted : bool, default=False
             If ``True``, divide the super-score delta by
             ``sqrt(explained_variance_)`` per component before back-projecting,

--- a/process_improve/regression/tools.py
+++ b/process_improve/regression/tools.py
@@ -28,7 +28,7 @@ def _register(name: str) -> None:
     description=(
         "Fit a robust simple linear regression between x and y variables using the repeated "
         "median slope estimator. Unlike ordinary least squares, the repeated median method is "
-        "highly resistant to outliers — up to ~29% of the data can be contaminated without "
+        "highly resistant to outliers - up to ~29% of the data can be contaminated without "
         "affecting the fit. "
         "Returns slope, intercept, R-squared, standard errors, prediction intervals, and "
         "fitted values. "
@@ -129,7 +129,7 @@ _register("robust_regression")
     name="repeated_median",
     description=(
         "Compute the repeated median slope between x and y vectors. "
-        "This is a highly robust slope estimator — the median of medians of all pairwise slopes. "
+        "This is a highly robust slope estimator - the median of medians of all pairwise slopes. "
         "It gives just the slope (no intercept, no full regression output). "
         "Use robust_regression if you need a complete regression analysis."
     ),

--- a/process_improve/simulation/__init__.py
+++ b/process_improve/simulation/__init__.py
@@ -5,11 +5,11 @@ Fake-data / process-simulator subpackage.
 Provides three agent-callable tools used to demonstrate DOE workflows
 against a synthetic (but deterministic) response surface:
 
-- ``create_simulator`` — records a hidden model from a seed + factor
+- ``create_simulator`` - records a hidden model from a seed + factor
   specs + structural hints.
-- ``simulate_process`` — evaluates the hidden surface at given factor
+- ``simulate_process`` - evaluates the hidden surface at given factor
   settings, adding fresh Gaussian noise each call.
-- ``reveal_simulator`` — returns the underlying coefficients, gated
+- ``reveal_simulator`` - returns the underlying coefficients, gated
   behind a ``confirmed`` flag that the host application enforces.
 
 The math itself lives in :mod:`process_improve.simulation.model`; the

--- a/process_improve/simulation/model.py
+++ b/process_improve/simulation/model.py
@@ -5,7 +5,7 @@ Deterministic fake-data simulator for DOE demonstrations.
 The simulator is fully specified by a JSON-serialisable ``private_state``
 dict containing:
 
-- ``seed``:             int  — base RNG seed for coefficient generation.
+- ``seed``:             int  - base RNG seed for coefficient generation.
 - ``factors``:          list of ``{name, low, high, units?}``.
 - ``outputs``:          list of ``{name, units?, direction?}``.
 - ``structural_hints``: list of free-text hints ("negative interaction
@@ -18,7 +18,7 @@ Given this state, :func:`materialize_model` regenerates the exact same
 response-surface coefficients on every call, across processes, across
 machines.  :func:`simulate` evaluates that surface at a given factor
 setting and adds *fresh* Gaussian noise each call so identical inputs
-yield similar-but-not-identical outputs — matching the behaviour of a
+yield similar-but-not-identical outputs - matching the behaviour of a
 real physical asset.
 """
 
@@ -286,7 +286,7 @@ def materialize_model(private_state: dict[str, Any]) -> dict[str, Any]:
 
     Deterministic: identical *private_state* always returns identical
     coefficients, across processes and machines.  This is the secret
-    the simulator hides from the LLM — callers that have *private_state*
+    the simulator hides from the LLM - callers that have *private_state*
     already have the model, so "revealing" is free.
     """
     seed = int(private_state["seed"])
@@ -421,7 +421,7 @@ def simulate(
         effective_settings[name] = val
         coded[name] = _coded_setting(val, low, high)
 
-    # Fresh (unseeded) RNG — noise is genuinely different on every call.
+    # Fresh (unseeded) RNG - noise is genuinely different on every call.
     noise_rng = np.random.default_rng()
     outputs: dict[str, float] = {
         out_name: float(_evaluate_surface(out_coefs, coded, timestamp_offset_days, noise_rng))

--- a/process_improve/simulation/tools.py
+++ b/process_improve/simulation/tools.py
@@ -4,17 +4,17 @@ Agent-callable tool wrappers for the fake-data simulator.
 
 Three tools are exposed:
 
-- ``create_simulator`` — records a hidden response-surface model.
-- ``simulate_process`` — evaluates the hidden model at given factor
+- ``create_simulator`` - records a hidden response-surface model.
+- ``simulate_process`` - evaluates the hidden model at given factor
   settings, with fresh Gaussian noise each call.
-- ``reveal_simulator`` — returns the underlying coefficients, gated
+- ``reveal_simulator`` - returns the underlying coefficients, gated
   behind a ``confirmed`` flag enforced by the host.
 
 The tools are intentionally stateless: the hidden model lives in a
 ``private_state`` dict that the host (e.g. the factorial web app)
 persists and injects on each call via a hidden ``simulator_state``
 kwarg. The JSON schema advertised to the LLM does not mention
-``simulator_state`` or ``confirmed`` — those are injected server-side
+``simulator_state`` or ``confirmed`` - those are injected server-side
 so the LLM cannot bypass the reveal policy or fabricate state.
 """
 
@@ -82,7 +82,7 @@ def _public_from_private(private: dict[str, Any], process_description: str, crea
         "response data. Use this when the user wants fake but realistic data to "
         "plan or demonstrate a designed experiment. "
         "Pick factor ranges silently from your domain knowledge; pass them in "
-        "the 'factors' list. The 'outputs' list must come from the user — "
+        "the 'factors' list. The 'outputs' list must come from the user - "
         "propose defaults if they are undecided but confirm before calling. "
         "The underlying model (intercepts, main effects, 2-factor interactions, "
         "quadratic terms) is generated internally and must NOT be disclosed to "
@@ -90,7 +90,7 @@ def _public_from_private(private: dict[str, Any], process_description: str, crea
         "'reveal_simulator'. "
         "Returns a 'sim_id' to pass to subsequent 'simulate_process' calls, plus "
         "a public summary of the declared factors, outputs, and noise level. "
-        "The host application persists the hidden state — do NOT try to store "
+        "The host application persists the hidden state - do NOT try to store "
         "or paraphrase it yourself."
     ),
     input_schema={
@@ -256,7 +256,7 @@ _register("create_simulator")
     description=(
         "Evaluate a previously created simulator at specific factor settings. "
         "Returns the simulated output values (with fresh Gaussian noise per call, "
-        "so identical settings yield similar but not identical outputs — this is "
+        "so identical settings yield similar but not identical outputs - this is "
         "intentional, matching real asset behaviour). "
         "Pass 'sim_id' from the 'create_simulator' response. Supply all declared "
         "factors in 'settings'; missing factors default to their mid-range value "

--- a/process_improve/tool_spec.py
+++ b/process_improve/tool_spec.py
@@ -149,7 +149,7 @@ def tool_spec(  # noqa: PLR0913
              "note": "<why no user seed>"}
 
         Omit entirely to leave the spec without an ``rng`` key (legacy
-        behavior; downstream consumers treat that as "unknown — assume
+        behavior; downstream consumers treat that as "unknown - assume
         deterministic"). The Anthropic API ignores unknown spec keys, so
         adding ``rng`` is safe.
 

--- a/process_improve/univariate/metrics.py
+++ b/process_improve/univariate/metrics.py
@@ -840,7 +840,7 @@ def variance_decomposition(df: pd.DataFrame, measured: str, repeat: str) -> dict
 
 
 # ---------------------------------------------------------------------------
-# Migration helpers — old names raise helpful errors
+# Migration helpers - old names raise helpful errors
 # ---------------------------------------------------------------------------
 
 _RENAMED = {

--- a/process_improve/univariate/tools.py
+++ b/process_improve/univariate/tools.py
@@ -293,7 +293,7 @@ _register("median_absolute_deviation")
         "using the Shapiro-Wilk test. "
         "Returns the test statistic, p-value, and a plain-language interpretation. "
         "A p-value below the significance threshold (default 0.05) provides evidence AGAINST "
-        "normality. Failure to reject does not prove normality — it merely means the data are "
+        "normality. Failure to reject does not prove normality - it merely means the data are "
         "not inconsistent with it. "
         "Use this to decide whether robust or classical statistics are more appropriate."
     ),

--- a/process_improve/visualization/adapters/echarts_adapter.py
+++ b/process_improve/visualization/adapters/echarts_adapter.py
@@ -2,7 +2,7 @@
 
 Produces raw Python dicts that match the `ECharts option specification
 <https://echarts.apache.org/en/option.html>`_.  No pyecharts dependency
-— dicts are JSON-serialisable and can be passed directly to
+- dicts are JSON-serialisable and can be passed directly to
 ``echarts.setOption()`` on the SvelteKit frontend.
 """
 

--- a/process_improve/visualization/adapters/plotly_adapter.py
+++ b/process_improve/visualization/adapters/plotly_adapter.py
@@ -327,7 +327,7 @@ class PlotlyAdapter(AbstractAdapter):
         """Build a Plotly box trace from pre-computed quartiles.
 
         Each row in ``layer.data`` provides ``group`` (category label)
-        and ``q_stats`` as ``[min, Q1, median, Q3, max]`` — matching
+        and ``q_stats`` as ``[min, Q1, median, Q3, max]`` - matching
         the wire format used by the ECharts adapter.
         """
         groups = [row["group"] for row in layer.data]

--- a/process_improve/visualization/charts/boxplot.py
+++ b/process_improve/visualization/charts/boxplot.py
@@ -32,12 +32,12 @@ class BoxStats:
     group : str
         Category label rendered on the x-axis.
     q_stats : list[float]
-        ``[lower_whisker, Q1, median, Q3, upper_whisker]`` — the order
+        ``[lower_whisker, Q1, median, Q3, upper_whisker]`` - the order
         used by both ECharts boxplot series and Plotly's pre-computed
         :class:`plotly.graph_objects.Box` (``lowerfence``, ``q1``,
         ``median``, ``q3``, ``upperfence``).
     outliers : list[dict]
-        Each entry has ``value`` (float) and optional ``id`` (str) — the
+        Each entry has ``value`` (float) and optional ``id`` (str) - the
         stable observation id used for cross-chart brushing.
     """
 

--- a/process_improve/visualization/spec.py
+++ b/process_improve/visualization/spec.py
@@ -1,7 +1,7 @@
 """Backend-agnostic chart specification (ChartSpec IR).
 
-The intermediate representation captures *what* to draw — data, visual
-encodings, annotations — while backend adapters handle *how* to draw it.
+The intermediate representation captures *what* to draw - data, visual
+encodings, annotations - while backend adapters handle *how* to draw it.
 Inspired by Vega-Lite's declarative approach, with DOE-specific
 primitives (significance thresholds, constraint regions) as first-class
 concepts.
@@ -60,7 +60,7 @@ class Encoding:
 
 @dataclass
 class LayerSpec:
-    """A single visual layer — one trace in Plotly, one series in ECharts.
+    """A single visual layer - one trace in Plotly, one series in ECharts.
 
     Parameters
     ----------
@@ -110,7 +110,7 @@ class Annotation:
     annotation_type : AnnotationType
         What kind of annotation this is.
     axis : str
-        ``"x"`` or ``"y"`` — which axis the annotation references.
+        ``"x"`` or ``"y"`` - which axis the annotation references.
     value : float or None
         Position for reference lines / thresholds.
     value_end : float or None
@@ -209,7 +209,7 @@ def constraint_region(
 
 @dataclass
 class PanelSpec:
-    """A single chart panel — becomes one Plotly subplot or ECharts grid.
+    """A single chart panel - becomes one Plotly subplot or ECharts grid.
 
     Parameters
     ----------
@@ -257,7 +257,7 @@ class PanelSpec:
 
 @dataclass
 class ChartSpec:
-    """Top-level chart specification — the IR that adapters consume.
+    """Top-level chart specification - the IR that adapters consume.
 
     A ``ChartSpec`` may contain one or more :class:`PanelSpec` panels.
     Single-panel charts (Pareto, contour, …) have ``len(panels) == 1``.
@@ -315,7 +315,7 @@ class ChartSpec:
         """Extract computed data arrays from the spec.
 
         Returns a lightweight dict containing just the raw data from each
-        panel's layers — useful when the consumer wants to render with a
+        panel's layers - useful when the consumer wants to render with a
         custom frontend.
         """
         panels_data: list[dict[str, Any]] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.13.1"
+version = "1.13.2"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/batch/test_tools.py
+++ b/tests/batch/test_tools.py
@@ -55,8 +55,8 @@ def test_extract_batch_features_default_features(two_batch_timeseries: list[dict
 # f_mad and f_robust_mad have pre-existing implementation issues in
 # `process_improve.batch.features` (mad: removed pandas API; robust_mad:
 # stub raises). The wrapper still surfaces them as `{"error": ...}` rather
-# than raising — that branch is covered by the unknown-feature and bad-data
-# tests below — so they're excluded here to keep this test focused on the
+# than raising - that branch is covered by the unknown-feature and bad-data
+# tests below - so they're excluded here to keep this test focused on the
 # working dispatch path.
 _WORKING_LOCATION_FEATURES = sorted(set(_FEATURE_MAP) - {"mad", "robust_mad"})
 

--- a/tests/test_augment_design.py
+++ b/tests/test_augment_design.py
@@ -192,7 +192,7 @@ class TestFoldover:
         # After foldover, even-length words survive
         df = _fractional_factorial_df(["D=ABC"], names="ABCD")
         result = augment_design(df, "foldover", generators=["D=ABC"])
-        # ABCD has length 4 (even) — it should survive
+        # ABCD has length 4 (even) - it should survive
         assert result["defining_relation"] is not None
         assert any("ABCD" in w for w in result["defining_relation"])
 
@@ -201,7 +201,7 @@ class TestFoldover:
         # 2^(3-1) with C=AB: I=ABC (length 3, odd)
         df = _fractional_factorial_df(["C=AB"], names="ABC")
         result = augment_design(df, "foldover", generators=["C=AB"])
-        # ABC has length 3 (odd) — should be eliminated
+        # ABC has length 3 (odd) - should be eliminated
         explanation = result["explanation"]
         assert "eliminated" in explanation.lower() or "de-alias" in explanation.lower()
 

--- a/tests/test_doe_knowledge.py
+++ b/tests/test_doe_knowledge.py
@@ -1,4 +1,4 @@
-"""Tests for Tool 7: doe_knowledge — DOE knowledge graph and query engine."""
+"""Tests for Tool 7: doe_knowledge - DOE knowledge graph and query engine."""
 
 from __future__ import annotations
 

--- a/tests/test_evaluate_design.py
+++ b/tests/test_evaluate_design.py
@@ -316,7 +316,7 @@ class TestPower:
         double = generate_design(factors, design_type="full_factorial", center_points=0, replicates=2)
         p1 = evaluate_design(single, model="main_effects", metric="power", effect_size=2.0, sigma=1.0)
         p2 = evaluate_design(double, model="main_effects", metric="power", effect_size=2.0, sigma=1.0)
-        # Pick any factor — power should be higher with 2x runs
+        # Pick any factor - power should be higher with 2x runs
         assert p2["power"]["A"] >= p1["power"]["A"] - 0.01
 
     def test_power_curve_when_no_effect_size(self) -> None:

--- a/tests/test_multiblock_oracles.py
+++ b/tests/test_multiblock_oracles.py
@@ -8,7 +8,7 @@ synthetic problem.
 
 If both reference paths agree, we have a trustworthy Python oracle that the
 production :class:`MBPCA` and :class:`MBPLS` classes can be validated against
-when they land in PR3 / PR6 — without ever needing to run MATLAB.
+when they land in PR3 / PR6 - without ever needing to run MATLAB.
 
 The MATLAB ``unit_tests.m`` MBPCA_tests / MBPLS_tests blocks structure their
 self-consistency checks the same way; this module is the Python equivalent.
@@ -28,7 +28,7 @@ from tests._multiblock_oracles import (
 
 
 def _preprocess(matrix: np.ndarray) -> np.ndarray:
-    """Mean-centre and unit-variance scale (ddof=1) — matches MCUVScaler."""
+    """Mean-centre and unit-variance scale (ddof=1) - matches MCUVScaler."""
     centred = matrix - matrix.mean(axis=0, keepdims=True)
     scale = centred.std(axis=0, ddof=1, keepdims=True)
     scale[scale == 0] = 1.0

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -109,7 +109,7 @@ def test_pca_foods() -> None:
                 axis=1,
             )
     except (urllib.error.URLError, TimeoutError):
-        pytest.skip("Cannot reach openmv.net — skipping network-dependent test")
+        pytest.skip("Cannot reach openmv.net - skipping network-dependent test")
     scaler = MCUVScaler().fit(foods)
     foods_mcuv = scaler.fit_transform(foods)
 
@@ -550,7 +550,7 @@ def test_pca_select_n_components() -> None:
 
     # 2 strong latent components driving 50 measured variables
     # N < K: the classic chemometrics scenario where PRESS cross-validation
-    # excels — noise components overfit because there aren't enough samples
+    # excels - noise components overfit because there aren't enough samples
     # to reliably estimate them.
     T_true = rng.standard_normal((N, 2)) * np.array([10.0, 6.0])
     P_true = rng.standard_normal((2, K))

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -24,7 +24,7 @@ from process_improve.experiments.tools import optimize_responses_tool
 from process_improve.tool_spec import get_tool_specs
 
 # ---------------------------------------------------------------------------
-# Fixtures — reusable model coefficient dicts
+# Fixtures - reusable model coefficient dicts
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_recommend_strategy.py
+++ b/tests/test_recommend_strategy.py
@@ -1,4 +1,4 @@
-"""Tests for Tool 8: recommend_strategy — multi-stage DOE strategy recommender."""
+"""Tests for Tool 8: recommend_strategy - multi-stage DOE strategy recommender."""
 
 from __future__ import annotations
 
@@ -444,14 +444,14 @@ class TestRealWorldScenarios:
         assert result["total_estimated_runs"] <= 40
 
     def test_q63_eight_factors_screening(self):
-        """Q63: 8 factors — screening to narrow to 2-3 in 16 runs."""
+        """Q63: 8 factors - screening to narrow to 2-3 in 16 runs."""
         factors = [Factor(name=chr(65 + i), low=0, high=100) for i in range(8)]
         result = recommend_strategy(factors=factors, budget=40)
         screening = [s for s in result["stages"] if s["stage_name"] == "Screening"]
         assert len(screening) == 1
 
     def test_q64_chemical_engineer_maximize_yield(self):
-        """Q64: T, P, catalyst% in ~20 runs — propose full strategy."""
+        """Q64: T, P, catalyst% in ~20 runs - propose full strategy."""
         factors = [
             Factor(name="Temperature", low=150, high=200, units="degC"),
             Factor(name="Pressure", low=1, high=5, units="bar"),


### PR DESCRIPTION
## Summary

- Replace em-dashes (`—`, U+2014) with hyphens across docs, docstrings, comments, and YAML prose content (~545 occurrences)
- Add a "Prose style" rule to `CLAUDE.md` so future sessions don't reintroduce them
- Bump PATCH version

Stylistic only; no behavioural change.

## Test plan

- [ ] `git grep '—' -- '*.py' '*.md' '*.rst' '*.yaml' '*.yml'` returns nothing
- [ ] `pytest -o "addopts=" -x` passes

https://claude.ai/code/session_015h2meo3ddHQHb3Z63CvkQR

---
_Generated by [Claude Code](https://claude.ai/code/session_015h2meo3ddHQHb3Z63CvkQR)_