### PR TITLE
Quick wins: t2_plot consistency + TODO.md cleanup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,10 +19,8 @@
 ## Multivariate (PCA / PLS / TPLS / MBPCA / MBPLS)
 
 - [ ] Add plotting routines on MV models: `model.plot_screeplot(...)` etc.; plots accept a `pc_depth` argument so a 3D plot is made instead. (TODO.txt)
-- [ ] PLS lacks an SPE limit - add it. (TODO.txt)
 - [ ] Fill in `R2*` attributes on MV models. (TODO.txt)
 - [ ] `print(model)` raises `'PCA_missing_values' object has no attribute 'copy'` - fix. (TODO.txt)
-- [ ] Implement sklearn-style `fit_transform` on `PCA`. (TODO.txt)
 - [ ] Add a post-filter helper: snap values within ±eps of zero to zero. (TODO.txt)
 - [ ] Add VIP for PCA, PLS, TPLS. (TODO.txt, #54 - unmerged)
 - [ ] Prediction intervals for PLS. (TODO.txt)
@@ -48,9 +46,6 @@
 - [ ] Re-derive `feature_importance["F"]` against deflated matrices `P(_^TP)^{-1}`. (multivariate/methods.py:2923)
 - [ ] Add missing-data support to MBPLS (currently raises `NotImplementedError`). (multivariate/methods.py:3405)
 - [ ] Add missing-data support to MBPCA (currently raises `NotImplementedError`). (multivariate/methods.py:4138)
-- [ ] Wire the `show_labels` flag through plot helpers. (multivariate/plots.py:103, multivariate/plots.py:629)
-- [ ] Decide what to plot when `with_a` is zero or > A. (multivariate/plots.py:619)
-- [ ] Constrain `conf_level` to < 1. (multivariate/plots.py:623)
 
 ## Batch
 

--- a/process_improve/multivariate/plots.py
+++ b/process_improve/multivariate/plots.py
@@ -100,7 +100,7 @@ def score_plot(  # noqa: C901, PLR0913
         title: str = (
             f"Score plot of component {pc_horiz} vs component {pc_vert} vs component {pc_depth}" if pc_depth > 0 else ""
         )
-        show_labels: bool = False  # TODO
+        show_labels: bool = False
         show_legend: bool = True
         html_image_height: float = 500.0
         html_aspect_ratio_w_over_h: float = 16 / 9.0
@@ -615,18 +615,31 @@ def t2_plot(
 
     if with_a < 0:
         with_a = model.hotellings_t2_.columns[with_a]
+    elif with_a == 0:
+        raise AssertionError("`with_a` must be >= 1, or specified with negative indexing")
 
-    # TODO: check `with_a`: what should it plot if `with_a` is zero, or > A?
+    assert with_a <= model.n_components, "`with_a` must be <= the number of components fitted"
 
     class Settings(BaseModel):
         show_limit: bool = True
-        conf_level: float = 0.95  # TODO: check constraint < 1
+        conf_level: float = 0.95
+
+        @field_validator("conf_level")
+        @classmethod
+        def check_conf_level(cls, val: float) -> float:
+            """Check confidence value is in range."""
+            if val >= 1:
+                raise ValueError("0.0 < `conf_level` < 1.0")
+            if val <= 0:
+                raise ValueError("0.0 < `conf_level` < 1.0")
+            return val
+
         title: str = (
             f"Hotelling's T2 plot after fitting {with_a} component{'s' if with_a > 1 else ''}"
             f", with the {conf_level * 100}% confidence limit"
         )
         default_marker: dict = dict(color="darkblue", symbol="circle", size=7)
-        show_labels: bool = False  # TODO
+        show_labels: bool = False
         show_legend: bool = False
         html_image_height: float = 500.0
         html_aspect_ratio_w_over_h: float = 16 / 9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.13.2"
+version = "1.13.3"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2516,6 +2516,27 @@ def test_t2_plot_with_highlights(fixture_pca_for_plots: PCA) -> None:
     assert len(fig.data) >= 2
 
 
+def test_t2_plot_rejects_zero_with_a(fixture_pca_for_plots: PCA) -> None:
+    """t2_plot should reject `with_a == 0`."""
+    with pytest.raises(AssertionError, match="with_a"):
+        fixture_pca_for_plots.t2_plot(with_a=0)
+
+
+def test_t2_plot_rejects_with_a_above_components(fixture_pca_for_plots: PCA) -> None:
+    """t2_plot should reject `with_a` larger than the number of fitted components."""
+    model = fixture_pca_for_plots
+    with pytest.raises(AssertionError, match="with_a"):
+        model.t2_plot(with_a=model.n_components + 1)
+
+
+def test_t2_plot_rejects_invalid_conf_level(fixture_pca_for_plots: PCA) -> None:
+    """t2_plot should reject `conf_level` outside the open interval (0, 1)."""
+    with pytest.raises(ValueError, match="conf_level"):
+        fixture_pca_for_plots.t2_plot(settings={"conf_level": 1.0})
+    with pytest.raises(ValueError, match="conf_level"):
+        fixture_pca_for_plots.t2_plot(settings={"conf_level": 0.0})
+
+
 # n_components = 3
 # data = fixture_tpls_example()
 # full_model = TPLS(n_components=n_components, d_matrix=data.pop("D"))

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2537,6 +2537,12 @@ def test_t2_plot_rejects_invalid_conf_level(fixture_pca_for_plots: PCA) -> None:
         fixture_pca_for_plots.t2_plot(settings={"conf_level": 0.0})
 
 
+def test_t2_plot_accepts_valid_conf_level(fixture_pca_for_plots: PCA) -> None:
+    """t2_plot should accept `conf_level` strictly inside (0, 1)."""
+    fig = fixture_pca_for_plots.t2_plot(settings={"conf_level": 0.99})
+    assert isinstance(fig, go.Figure)
+
+
 # n_components = 3
 # data = fixture_tpls_example()
 # full_model = TPLS(n_components=n_components, d_matrix=data.pop("D"))


### PR DESCRIPTION
## Summary

Coherent set of quick wins from `TODO.md`, all clustered around the
multivariate plot helpers in `process_improve/multivariate/plots.py`.

`spe_plot()` validates its inputs (rejecting `with_a == 0`, asserting
`with_a <= n_components`, validating `conf_level` is in `(0, 1)`).
`t2_plot()` does not, and three explicit `# TODO` comments in `t2_plot()`
flag the gap. This PR closes those.

A few other entries in `TODO.md` turned out to be already implemented and
just needed retiring from the list.

## Changes

- `process_improve/multivariate/plots.py`
  - `t2_plot()`: reject `with_a == 0`; assert `with_a <= n_components`.
  - `t2_plot()` `Settings`: add `@field_validator` for `conf_level` so
    values outside `(0, 1)` raise `ValueError`.
  - Drop three stale `# TODO` markers next to `show_labels` defaults
    (the flag is already wired through every plot helper).
- `tests/test_multivariate.py`
  - Add three tests covering `t2_plot` validation, mirroring existing
    `spe_plot` test style.
- `TODO.md`: strike completed multivariate items.
- `pyproject.toml`: bump `1.13.2` -> `1.13.3` (PATCH).

## Test plan

- [ ] `pytest tests/test_multivariate.py -v -k "plot" -o "addopts="`
- [ ] `pytest -o "addopts="` (full suite)
- [ ] `ruff check process_improve/multivariate/plots.py tests/test_multivariate.py`

https://claude.ai/code/session_01BfDguFfvVTMECJGuQpPwXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfDguFfvVTMECJGuQpPwXF)_