### PR TITLE
tests: push coverage from 87% to 88.02% (clear the 88% target)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.13.4"
+version = "1.13.5"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_echarts_multi_panel.py
+++ b/tests/test_echarts_multi_panel.py
@@ -1,0 +1,357 @@
+"""Tests for the multi-panel rendering path in EChartsAdapter.
+
+The ``_multi_panel`` method (visualization/adapters/echarts_adapter.py
+lines 138-188) and the constraint-region annotation arm (lines 432-447)
+were previously uncovered: every existing test built a single-panel
+ChartSpec and never used a constraint region.
+"""
+
+from __future__ import annotations
+
+from process_improve.visualization.adapters.echarts_adapter import EChartsAdapter
+from process_improve.visualization.spec import (
+    Annotation,
+    ChartSpec,
+    Encoding,
+    LayerSpec,
+    PanelSpec,
+)
+from process_improve.visualization.types import AnnotationType, MarkType
+
+
+def _scatter_panel(title: str = "panel") -> PanelSpec:
+    """Build a small single-layer scatter panel."""
+    layer = LayerSpec(
+        mark=MarkType.scatter,
+        data=[{"x": i, "y": 2 * i + 1} for i in range(5)],
+        x=Encoding(field="x", title="X"),
+        y=Encoding(field="y", title="Y"),
+        name="trace",
+    )
+    return PanelSpec(layers=[layer], title=title, x_title="X", y_title="Y")
+
+
+# ---------------------------------------------------------------------------
+# Multi-panel layout
+# ---------------------------------------------------------------------------
+
+
+def test_two_panel_grid_renders() -> None:
+    """A 2-panel ChartSpec should fan out into two grids / xAxes / yAxes."""
+    spec = ChartSpec(
+        panels=[_scatter_panel("p1"), _scatter_panel("p2")],
+        title="Two panels",
+        layout="grid",
+        columns=2,
+    )
+    option = EChartsAdapter().render(spec)
+
+    assert option["title"]["text"] == "Two panels"
+    # Multi-panel uses lists of grids / axes.
+    assert isinstance(option["grid"], list)
+    assert len(option["grid"]) == 2
+    assert isinstance(option["xAxis"], list)
+    assert len(option["xAxis"]) == 2
+    assert isinstance(option["yAxis"], list)
+    assert len(option["yAxis"]) == 2
+    # Each series should be tagged with the right xAxisIndex / yAxisIndex.
+    for idx, series in enumerate(option["series"]):
+        assert series["xAxisIndex"] == idx
+        assert series["yAxisIndex"] == idx
+
+
+def test_three_panel_grid_two_columns() -> None:
+    """A 3-panel grid with 2 columns should still render all 3 panels."""
+    spec = ChartSpec(
+        panels=[_scatter_panel(f"p{i}") for i in range(3)],
+        title="Three panels",
+        layout="grid",
+        columns=2,
+    )
+    option = EChartsAdapter().render(spec)
+    assert len(option["grid"]) == 3
+    assert len(option["series"]) == 3
+
+
+def test_multi_panel_with_annotations() -> None:
+    """Multi-panel rendering should also place annotations on each panel."""
+    panel = _scatter_panel("p")
+    panel.annotations = [
+        Annotation(
+            annotation_type=AnnotationType.reference_line,
+            value=1.5,
+            axis="y",
+            label="threshold",
+        ),
+    ]
+    spec = ChartSpec(
+        panels=[panel, _scatter_panel("p2")],
+        title="With annotations",
+    )
+    option = EChartsAdapter().render(spec)
+    # The first panel's series should carry the markLine.
+    assert "markLine" in option["series"][0]
+
+
+# ---------------------------------------------------------------------------
+# Constraint-region annotation
+# ---------------------------------------------------------------------------
+
+
+def test_constraint_region_x_only() -> None:
+    """A constraint_region with only x bounds should add an xAxis markArea."""
+    panel = _scatter_panel("p")
+    panel.annotations = [
+        Annotation(
+            annotation_type=AnnotationType.constraint_region,
+            value=None,
+            label="forbidden-x",
+            style={"x_min": 1.0, "x_max": 3.0},
+        ),
+    ]
+    spec = ChartSpec(panels=[panel], title="Constraint X")
+    option = EChartsAdapter().render(spec)
+
+    series = option["series"][0]
+    assert "markArea" in series
+    data = series["markArea"]["data"]
+    assert data[0][0]["xAxis"] == 1.0
+    assert data[0][1]["xAxis"] == 3.0
+
+
+def test_constraint_region_y_only() -> None:
+    """A constraint_region with only y bounds should add a yAxis markArea."""
+    panel = _scatter_panel("p")
+    panel.annotations = [
+        Annotation(
+            annotation_type=AnnotationType.constraint_region,
+            value=None,
+            label="forbidden-y",
+            style={"y_min": 0.0, "y_max": 2.5},
+        ),
+    ]
+    spec = ChartSpec(panels=[panel], title="Constraint Y")
+    option = EChartsAdapter().render(spec)
+    series = option["series"][0]
+    data = series["markArea"]["data"]
+    assert data[0][0]["yAxis"] == 0.0
+    assert data[0][1]["yAxis"] == 2.5
+
+
+def test_constraint_region_both_axes() -> None:
+    """A constraint_region with both x and y bounds should add two markAreas."""
+    panel = _scatter_panel("p")
+    panel.annotations = [
+        Annotation(
+            annotation_type=AnnotationType.constraint_region,
+            value=None,
+            label="forbidden-xy",
+            style={"x_min": 0, "x_max": 1, "y_min": 0, "y_max": 1},
+        ),
+    ]
+    spec = ChartSpec(panels=[panel], title="Constraint XY")
+    option = EChartsAdapter().render(spec)
+    series = option["series"][0]
+    assert len(series["markArea"]["data"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Reference band annotations
+# ---------------------------------------------------------------------------
+
+
+def test_reference_band_y() -> None:
+    """A reference_band annotation should populate a yAxis markArea."""
+    panel = _scatter_panel("p")
+    panel.annotations = [
+        Annotation(
+            annotation_type=AnnotationType.reference_band,
+            value=0.0,
+            value_end=1.0,
+            axis="y",
+            label="band",
+        ),
+    ]
+    option = EChartsAdapter().render(ChartSpec(panels=[panel]))
+    series = option["series"][0]
+    assert series["markArea"]["data"][0][0]["yAxis"] == 0.0
+    assert series["markArea"]["data"][0][1]["yAxis"] == 1.0
+
+
+def test_reference_band_x() -> None:
+    """A reference_band annotation on the x-axis should populate xAxis markArea."""
+    panel = _scatter_panel("p")
+    panel.annotations = [
+        Annotation(
+            annotation_type=AnnotationType.reference_band,
+            value=0.0,
+            value_end=2.0,
+            axis="x",
+            label="x-band",
+        ),
+    ]
+    option = EChartsAdapter().render(ChartSpec(panels=[panel]))
+    series = option["series"][0]
+    assert series["markArea"]["data"][0][0]["xAxis"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Empty / fallback rendering
+# ---------------------------------------------------------------------------
+
+
+def test_empty_chart_spec() -> None:
+    """A ChartSpec with zero panels should still produce a valid option dict."""
+    option = EChartsAdapter().render(ChartSpec(panels=[], title="Empty"))
+    assert option["title"]["text"] == "Empty"
+    assert option["series"] == []
+
+
+def test_render_panel_directly() -> None:
+    """``render_panel`` should produce the same option as a single-panel spec."""
+    panel = _scatter_panel("p")
+    option = EChartsAdapter().render_panel(panel)
+    assert option["title"]["text"] == "p"
+    assert len(option["series"]) == 1
+
+
+def test_link_group_injects_brush() -> None:
+    """A link_group on the spec should inject brush + __link_group keys."""
+    spec = ChartSpec(panels=[_scatter_panel("p")], link_group="grp1")
+    option = EChartsAdapter().render(spec)
+    assert option["__link_group"] == "grp1"
+    assert "brush" in option
+
+
+# ---------------------------------------------------------------------------
+# Bar / scatter / heatmap / wireframe series builders
+# ---------------------------------------------------------------------------
+
+
+def test_bar_series_with_layer_color() -> None:
+    """A bar layer with a single ``color`` should set itemStyle.color."""
+    layer = LayerSpec(
+        mark=MarkType.bar,
+        data=[{"x": "A", "y": 1.0}, {"x": "B", "y": 2.0}],
+        x=Encoding(field="x", title="X"),
+        y=Encoding(field="y", title="Y"),
+        color="#ff0000",
+    )
+    panel = PanelSpec(layers=[layer])
+    option = EChartsAdapter().render(ChartSpec(panels=[panel]))
+    assert option["series"][0]["itemStyle"] == {"color": "#ff0000"}
+
+
+def test_bar_series_with_error_bars() -> None:
+    """A bar layer with ``style['error_y']`` should add a markLine."""
+    layer = LayerSpec(
+        mark=MarkType.bar,
+        data=[{"x": "A", "y": 10.0}, {"x": "B", "y": 20.0}],
+        x=Encoding(field="x", title="X"),
+        y=Encoding(field="y", title="Y"),
+        style={"error_y": [1.0, 2.0]},
+    )
+    panel = PanelSpec(layers=[layer])
+    option = EChartsAdapter().render(ChartSpec(panels=[panel]))
+    series = option["series"][0]
+    assert "markLine" in series
+    assert len(series["markLine"]["data"]) == 2
+
+
+def test_bar_series_skips_zero_and_none_errors() -> None:
+    """Per-point ``error_y`` entries that are None or zero should be skipped."""
+    layer = LayerSpec(
+        mark=MarkType.bar,
+        data=[{"x": "A", "y": 1.0}, {"x": "B", "y": 2.0}, {"x": "C", "y": 3.0}],
+        x=Encoding(field="x", title="X"),
+        y=Encoding(field="y", title="Y"),
+        style={"error_y": [None, 0.0, 0.5]},
+    )
+    panel = PanelSpec(layers=[layer])
+    option = EChartsAdapter().render(ChartSpec(panels=[panel]))
+    series = option["series"][0]
+    # Only the third bar (err=0.5) should appear in markLine data.
+    assert len(series["markLine"]["data"]) == 1
+
+
+def test_scatter_series_with_per_point_colors() -> None:
+    """A scatter layer with ``style['colors']`` should embed per-point itemStyle."""
+    layer = LayerSpec(
+        mark=MarkType.scatter,
+        data=[{"x": 1, "y": 2}, {"x": 3, "y": 4}],
+        x=Encoding(field="x", title="X"),
+        y=Encoding(field="y", title="Y"),
+        style={"colors": ["#ff0000", "#00ff00"]},
+    )
+    panel = PanelSpec(layers=[layer])
+    option = EChartsAdapter().render(ChartSpec(panels=[panel]))
+    points = option["series"][0]["data"]
+    assert points[0]["itemStyle"]["color"] == "#ff0000"
+    assert points[1]["itemStyle"]["color"] == "#00ff00"
+
+
+def test_heatmap_series() -> None:
+    """A heatmap layer should produce [x, y, z] triples."""
+    layer = LayerSpec(
+        mark=MarkType.heatmap,
+        data=[],
+        style={
+            "z_matrix": [[1.0, 2.0], [3.0, 4.0]],
+            "x_grid": [10, 20],
+            "y_grid": [100, 200],
+        },
+    )
+    panel = PanelSpec(layers=[layer])
+    option = EChartsAdapter().render(ChartSpec(panels=[panel]))
+    series = option["series"][0]
+    assert series["type"] == "heatmap"
+    # 2 x 2 grid -> 4 cells.
+    assert len(series["data"]) == 4
+
+
+def test_wireframe_series_3d() -> None:
+    """A wireframe layer should switch the chart into 3D mode."""
+    layer = LayerSpec(
+        mark=MarkType.wireframe,
+        data=[{"x": 1, "y": 2, "z": 3}, {"x": 4, "y": 5, "z": 6}],
+        x=Encoding(field="x", title="X"),
+        y=Encoding(field="y", title="Y"),
+        z=Encoding(field="z", title="Z"),
+    )
+    panel = PanelSpec(layers=[layer])
+    option = EChartsAdapter().render(ChartSpec(panels=[panel]))
+    assert option["series"][0]["type"] == "scatter3D"
+    assert "xAxis3D" in option
+
+
+def test_boxplot_series_with_color() -> None:
+    """A boxplot layer with a color should set itemStyle.color."""
+    layer = LayerSpec(
+        mark=MarkType.boxplot,
+        data=[{"q_stats": [0.0, 1.0, 2.0, 3.0, 4.0]}],
+        color="#abc123",
+    )
+    panel = PanelSpec(layers=[layer])
+    option = EChartsAdapter().render(ChartSpec(panels=[panel]))
+    series = option["series"][0]
+    assert series["type"] == "boxplot"
+    assert series["itemStyle"] == {"color": "#abc123"}
+
+
+def test_line_series_basic() -> None:
+    """A line layer should build a line series with paired (x, y) data."""
+    layer = LayerSpec(
+        mark=MarkType.line,
+        data=[{"x": i, "y": i * i} for i in range(4)],
+        x=Encoding(field="x", title="X"),
+        y=Encoding(field="y", title="Y"),
+        color="#0066cc",
+        style={"smooth": True, "show_points": True, "dash": "dot"},
+    )
+    panel = PanelSpec(layers=[layer])
+    option = EChartsAdapter().render(ChartSpec(panels=[panel]))
+    series = option["series"][0]
+    assert series["type"] == "line"
+    assert series["smooth"] is True
+    # The dash mapping should turn "dot" into "dotted".
+    assert series["lineStyle"]["type"] == "dotted"

--- a/tests/test_multivariate_tpls_display.py
+++ b/tests/test_multivariate_tpls_display.py
@@ -1,0 +1,74 @@
+"""Smoke tests for ``TPLS.display_results``.
+
+The display_results method (multivariate.methods.TPLS.display_results,
+lines 2538-2604) was previously uncovered: the only reference in the
+test suite lives inside ``manual_cross_validation`` which is itself
+never invoked.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pandas as pd
+import pytest
+
+from process_improve.multivariate.methods import TPLS, DataFrameDict
+
+
+@pytest.fixture
+def tpls_pyphi_data() -> dict[str, dict[str, pd.DataFrame]]:
+    """Load the pyphi TPLS example dataset."""
+    folder = pathlib.Path(__file__).parents[1] / "process_improve" / "datasets" / "multivariate" / "tpls-pyphi"
+    properties = {
+        f"Group {i}": pd.read_csv(folder / f"properties_Group{i}.csv", sep=",", index_col=0, header=0).astype("float64")
+        for i in range(1, 6)
+    }
+    formulas = {
+        f"Group {i}": pd.read_csv(folder / f"formulas_Group{i}.csv", sep=",", index_col=0, header=0).astype("float64")
+        for i in range(1, 6)
+    }
+    process_conditions = {
+        "Conditions": pd.read_csv(folder / "process_conditions.csv", sep=",", index_col=0, header=0).astype("float64"),
+    }
+    quality_indicators = {
+        "Quality": pd.read_csv(folder / "quality_indicators.csv", sep=",", index_col=0, header=0).astype("float64"),
+    }
+    return {"Z": process_conditions, "D": properties, "F": formulas, "Y": quality_indicators}
+
+
+def test_tpls_display_results_cumulative(tpls_pyphi_data: dict) -> None:
+    """display_results should return a multi-line string with cumulative R-squared."""
+    n_components = 2
+    d_matrix = tpls_pyphi_data.pop("D")
+    model = TPLS(n_components=n_components, d_matrix=d_matrix)
+    model.fit(DataFrameDict(tpls_pyphi_data))
+
+    output = model.display_results(show_cumulative_stats=True)
+    assert isinstance(output, str)
+    # The header is rendered with the "sum(" prefix in cumulative mode.
+    assert "sum(R2:" in output
+    # Each LV row should appear in the output.
+    for a in range(1, n_components + 1):
+        assert f"LV {a}" in output
+
+
+def test_tpls_display_results_per_component(tpls_pyphi_data: dict) -> None:
+    """display_results should also render per-component (non-cumulative) stats."""
+    d_matrix = tpls_pyphi_data.pop("D")
+    model = TPLS(n_components=2, d_matrix=d_matrix)
+    model.fit(DataFrameDict(tpls_pyphi_data))
+
+    output = model.display_results(show_cumulative_stats=False)
+    # Non-cumulative header omits the "sum(" prefix.
+    assert "R2: D" in output
+    assert "sum(R2:" not in output
+
+
+def test_tpls_display_results_unfitted_raises(tpls_pyphi_data: dict) -> None:
+    """Calling display_results before fit() should raise RuntimeError."""
+    d_matrix = tpls_pyphi_data["D"]
+    model = TPLS(n_components=2, d_matrix=d_matrix)
+
+    with pytest.raises(RuntimeError, match="not fitted"):
+        model.display_results()

--- a/tests/test_tool_spec.py
+++ b/tests/test_tool_spec.py
@@ -697,3 +697,85 @@ class TestClean:
         """clean() should recurse into dicts and tuples."""
         result = clean({"a": (np.int64(1), np.float64(2.5)), "b": [np.int64(3)]})
         assert result == {"a": [1, 2.5], "b": [3]}
+
+
+# ---------------------------------------------------------------------------
+# scale_data and detect_multivariate_outliers wrappers in multivariate/tools.py
+# ---------------------------------------------------------------------------
+
+
+class TestScaleData:
+    """Cover the scale_data wrapper, including its except branch."""
+
+    def test_basic_mcuv_scaling(self) -> None:
+        result = execute_tool_call(
+            "scale_data",
+            {"data": [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0], [4.0, 40.0]]},
+        )
+        assert "error" not in result
+        # Means should be the column means of the input.
+        assert pytest.approx(result["means"][0], rel=1e-6) == 2.5
+        assert pytest.approx(result["means"][1], rel=1e-6) == 25.0
+        # All scaled column std-devs should be 1.
+        scaled = np.asarray(result["scaled_data"])
+        assert pytest.approx(scaled.std(axis=0, ddof=1), rel=1e-6) == np.array([1.0, 1.0])
+
+    def test_with_column_names(self) -> None:
+        result = execute_tool_call(
+            "scale_data",
+            {
+                "data": [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+                "column_names": ["temp", "pressure"],
+            },
+        )
+        assert "error" not in result
+        assert len(result["means"]) == 2
+        assert len(result["stds"]) == 2
+
+    def test_string_data_returns_error(self) -> None:
+        """Non-numeric input should be reported via the error key, not raised."""
+        result = execute_tool_call(
+            "scale_data",
+            {"data": [["x", "y"], ["a", "b"]]},
+        )
+        assert "error" in result
+
+
+class TestDetectMultivariateOutliers:
+    """Cover the detect_multivariate_outliers wrapper."""
+
+    def test_basic_outlier_detection(self) -> None:
+        rng = np.random.default_rng(42)
+        # Cluster of 50 normals + 1 obvious outlier.
+        clean_data = rng.standard_normal((50, 4)).tolist()
+        clean_data.append([100.0, 100.0, 100.0, 100.0])
+        result = execute_tool_call(
+            "detect_multivariate_outliers",
+            {"data": clean_data, "n_components": 2},
+        )
+        assert "error" not in result
+        assert "outlier_indices" in result
+        assert "t2_limit" in result
+        assert "spe_limit" in result
+
+    def test_custom_conf_level(self) -> None:
+        rng = np.random.default_rng(0)
+        data = rng.standard_normal((40, 3)).tolist()
+        result = execute_tool_call(
+            "detect_multivariate_outliers",
+            {"data": data, "n_components": 2, "conf_level": 0.99},
+        )
+        assert "error" not in result
+        # The 99% T2 limit must be larger than the 95% limit.
+        result_95 = execute_tool_call(
+            "detect_multivariate_outliers",
+            {"data": data, "n_components": 2, "conf_level": 0.95},
+        )
+        assert result["t2_limit"] >= result_95["t2_limit"]
+
+    def test_string_data_returns_error(self) -> None:
+        result = execute_tool_call(
+            "detect_multivariate_outliers",
+            {"data": [["x", "y"], ["a", "b"]], "n_components": 1},
+        )
+        assert "error" in result


### PR DESCRIPTION
## Summary

Follow-up to #130. After that PR landed, total coverage was **86.84%** - just over the 80% floor but short of the >88% target requested in the original task. This PR clears 88% with three small test files (~520 lines).

## What lifts coverage

- `tests/test_multivariate_tpls_display.py` (3 tests) - cover `TPLS.display_results` (cumulative + per-component formatting + unfitted-`RuntimeError` arm). `multivariate.methods` lines 2538-2604.
- `tests/test_echarts_multi_panel.py` (19 tests) - cover `EChartsAdapter._multi_panel`, `constraint_region` + `reference_band` annotations, `render_panel`, `link_group` brush injection, plus the bar / scatter / heatmap / wireframe / boxplot / line series builders. `visualization.adapters.echarts_adapter` multi-panel + annotation arms.
- `tests/test_tool_spec.py` (6 new tests) - cover `scale_data` and `detect_multivariate_outliers` wrappers (success + except arms). `multivariate.tools` lines 299-313 and 370-391.

Version bumped to **1.13.5** (PATCH; tests-only).

## Coverage delta

| Branch | Coverage |
| --- | --- |
| `main` (post-#130) | 86.8449% |
| this branch | **88.0205%** |

## Test plan

- [x] `uv run pytest --cov=. --cov-config=.coveragerc --cov-branch -q -o "addopts=" -n auto` reports `88%` (88.02% exact)
- [x] `uv run ruff check .` clean
- [x] All new tests pass on Python 3.11 and Python 3.13 (1022 passed, 10 skipped)
- [x] No production code touched

https://claude.ai/code/session_01Vmj69MiysAhoUjyNSKFp5y

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vmj69MiysAhoUjyNSKFp5y)_