### PR TITLE
docs: fix docstring/implementation mismatches in computational helpers

### DIFF
--- a/process_improve/batch/preprocessing.py
+++ b/process_improve/batch/preprocessing.py
@@ -559,7 +559,7 @@ def find_reference_batch(
         Batch data, in the standard format.
     columns_to_align : list
         Which columns to use. Others are ignored.
-    settings : dict
+    settings : dict, optional
         Default settings are::
 
             {
@@ -572,7 +572,11 @@ def find_reference_batch(
 
     Returns
     -------
-    One of the dictionary keys from `batches`.
+    str or list[str]
+        When ``settings["number_of_reference_batches"] == 1`` (the default), a
+        single dictionary key from ``batches`` is returned. When more than one
+        reference batch is requested, a list of that many keys is returned,
+        ordered from most to least central in the PCA model.
 
     """
     default_settings: dict[str, int | float | str | bool] = {

--- a/process_improve/bivariate/methods.py
+++ b/process_improve/bivariate/methods.py
@@ -20,10 +20,13 @@ def find_elbow_point(x: np.ndarray, y: np.ndarray, max_iter: int = 41) -> int | 
 
     Using a robust linear fit, sorts the samples in X (independent variable)
     and takes sample 1:5 from the left, and samples (end-5):end and fits two
-    linear regressions. Finds the angle between the two lines.
-    Adds a point to each regression, so (1:6) and (end-6:end) and repeats.
+    linear regressions, then computes the intersection of the two fitted lines.
+    Adds a point to each regression, so (1:6) and (end-6:end) and repeats,
+    accumulating one intersection point per iteration.
 
-    Find the median angle, which is where it should stabilize.
+    The elbow is taken as the data point whose (x, y) location is closest to
+    the median of the accumulated intersection points; the median location is
+    where the intersections should stabilise.
 
     Will probably not work well on few data points. If so, try fitting a spline
     to the raw data and then repeat with the interpolated data.

--- a/process_improve/regression/methods.py
+++ b/process_improve/regression/methods.py
@@ -12,11 +12,12 @@ from ..univariate.metrics import t_value
 __eps = np.finfo(np.float32).eps
 
 
-def fit_robust_lm(x: np.ndarray, y: np.ndarray) -> list:
+def fit_robust_lm(x: np.ndarray, y: np.ndarray) -> np.ndarray:
     """
     Fits a robust linear model between Numpy vectors `x` and `y`, with an
-    intercept. Returns a list: [intercept, slope] of the fit. No extra
-    checking on data consistency is done.
+    intercept. Returns a length-2 array ``[intercept, slope]`` (the
+    ``params`` attribute returned by ``statsmodels.RLM``); no extra checking
+    on data consistency is done.
 
     See also: regression.repeated_median_slope
     """

--- a/process_improve/univariate/metrics.py
+++ b/process_improve/univariate/metrics.py
@@ -104,15 +104,22 @@ def Sn(x: np.ndarray | pd.Series, constant: float = 1.1926) -> np.floating:  # n
     """
     Compute a robust scale estimator. The Sn metric is an efficient alternative to MAD.
 
-    Args:
-        x (iterable): A vector of values
+    Parameters
+    ----------
+    x : np.ndarray or pd.Series
+        A vector of values. NaN entries are ignored.
+    constant : float, optional
+        Multiplicative constant that makes the estimator consistent with iid values from a
+        Gaussian distribution with no outliers. Default is 1.1926.
 
-    Outputs:
-        a scalar value, the Sn estimate of spread
+    Returns
+    -------
+    np.floating
+        A scalar value, the Sn estimate of spread. Returns NaN if all entries are missing,
+        and 0.0 when only a single non-missing value is supplied.
 
-    The `constant` gives values which are consistent with iid values from a Gaussian distribution
-    and no outliers.
-
+    Notes
+    -----
     Tested against once of the most reliable open-source packages, written by some of the
     most respected names in the area of robust methods: [1]_ and [2]_.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.13.5"
+version = "1.13.6"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Audited public computational/user-facing functions in `process_improve/` and fixed four docstrings that disagreed with the actual implementation. No behavioural changes.

## Inconsistencies fixed

- **`process_improve/bivariate/methods.py:14` &mdash; `find_elbow_point`**
  Docstring claimed the algorithm "finds the angle between the two lines" and "find[s] the median angle, which is where it should stabilize". The reachable code only computes line *intersections* (via `find_line_intersection`) and returns the data point whose `(x, y)` is closest to the median intersection. The angle code lives in an unreachable `if False:` block. Updated the description to match what the code actually does.

- **`process_improve/batch/preprocessing.py:541` &mdash; `find_reference_batch`**
  Docstring said `Returns: One of the dictionary keys from `batches`.` (singular), but the signature is `-> str | list[str]` and the function returns a list of keys when `settings["number_of_reference_batches"] > 1` (see lines 638-641). Updated the Returns section to document both shapes. Also added the missing `optional` marker for `settings` (signature default is `None`).

- **`process_improve/univariate/metrics.py:103` &mdash; `Sn`**
  Docstring used non-NumPy `Args:` / `Outputs:` headings (CLAUDE.md mandates NumPy style throughout) and **never documented the `constant` parameter** even though it is in the signature with default `1.1926`. Rewrote the docstring in NumPy style and documented `constant` plus the NaN/single-value return behaviour that the implementation already handles.

- **`process_improve/regression/methods.py:15` &mdash; `fit_robust_lm`**
  Docstring and return annotation both said `list`, but `return rlm_results.params` returns a NumPy ndarray (from `statsmodels.RLM.fit()`). Updated the return annotation to `np.ndarray` and clarified the docstring.

## Inconsistencies considered and not fixed

- `ttest_paired` default `conflevel=0.995` &mdash; the docstring matches the signature; only "unusual default" was flagged, which is a code/API question, not a docstring bug.
- `calculate_cpk` `specifications` parameter &mdash; the prose docstring describes column-name support, and the implementation does support strings via `isinstance(... , str)`. The mismatch is in the *type annotation* (`tuple[float, float]` is too narrow); that is not a docstring/code mismatch and would be a separate API change.
- `repeated_median_slope` &mdash; minimal docstring (no Parameters section), but no false claims to fix.
- `confidence_interval` &mdash; uses non-NumPy bullet style, but no false claims about behaviour.

## Version bump

Per `CLAUDE.md`, bumped `pyproject.toml` from `1.13.5` &rarr; `1.13.6` (PATCH; docs-only).

## Test plan

- [x] No code/runtime behaviour changed; only docstrings, one return annotation, and the version string.
- [ ] CI runs `ruff check .` and `pytest` on push.

https://claude.ai/code/session_01NiUKGkGu3afbwz9B5BawyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiUKGkGu3afbwz9B5BawyH)_