### PR TITLE
docs: add 5 more case studies (Phase 2 of #134)

### DIFF
--- a/docs/user_guide/case_studies/design-analysis-experiments/factorial-oil-company-doe.ipynb
+++ b/docs/user_guide/case_studies/design-analysis-experiments/factorial-oil-company-doe.ipynb
@@ -1,0 +1,253 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Factorial DOE: oil-company experiment\n",
+    "\n",
+    "Industrial designed experiment from an oil company. Four blend\n",
+    "components are varied across 19 runs to improve volumetric heat\n",
+    "capacity. Three of the components (A, B, D) are continuous and were\n",
+    "varied in coded units; the fourth (C) is a binary factor: present or\n",
+    "absent. The aim is to identify which factors and interactions actually\n",
+    "drive the response so that future experimentation can focus there.\n",
+    "\n",
+    "**Data.** `oil-company-doe.csv` from\n",
+    "[openmv.net](https://openmv.net/info/oil-company-doe). 19 rows, five\n",
+    "columns: `A`, `B`, `C`, `D`, `y`.\n",
+    "\n",
+    "**What we do.** Run the package's `analyze_experiment` with an\n",
+    "interactions model, read the coefficient table and ANOVA, build a\n",
+    "Pareto plot of standardised effects, and check the residual\n",
+    "diagnostics.\n",
+    "\n",
+    "**Adapted from** the *Design and analysis of experiments* chapter of\n",
+    "the [Process Improvement using Data](https://learnche.org/pid) book\n",
+    "(CC BY-SA 4.0)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from process_improve.experiments.analysis import analyze_experiment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load and inspect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = \"https://openmv.net/file/oil-company-doe.csv\"\n",
+    "doe = pd.read_csv(url, index_col=0)\n",
+    "if doe.shape[1] < 5:\n",
+    "    doe = pd.read_csv(url)\n",
+    "doe.columns = [c.strip() for c in doe.columns]\n",
+    "print(f\"Shape: {doe.shape}\")\n",
+    "print(f\"Columns: {list(doe.columns)}\")\n",
+    "doe.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doe.describe(include=\"all\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fit the interactions model\n",
+    "\n",
+    "`analyze_experiment` accepts a design DataFrame and the name of the\n",
+    "response column, builds a formula, fits it via statsmodels, and\n",
+    "returns a dictionary keyed by the requested analysis types. With\n",
+    "`model=\"interactions\"` we ask for main effects plus all two-factor\n",
+    "interactions; that is 4 + 6 = 10 terms, which fits comfortably in 19\n",
+    "runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = analyze_experiment(\n",
+    "    doe,\n",
+    "    response_column=\"y\",\n",
+    "    model=\"interactions\",\n",
+    "    analysis_type=[\n",
+    "        \"coefficients\",\n",
+    "        \"anova\",\n",
+    "        \"effects\",\n",
+    "        \"significance\",\n",
+    "        \"residual_diagnostics\",\n",
+    "    ],\n",
+    ")\n",
+    "ms = result[\"model_summary\"]\n",
+    "print(f\"formula     : {ms['formula']}\")\n",
+    "print(f\"R2          : {ms['r_squared']:.3f}\")\n",
+    "print(f\"R2 (adj)    : {ms['r_squared_adj']:.3f}\")\n",
+    "print(f\"R2 (pred)   : {ms['r_squared_pred']:.3f}\")\n",
+    "print(f\"obs / df_resid: {ms['n_obs']} / {ms['df_residual']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Coefficient table\n",
+    "\n",
+    "Sort by absolute t-value to put the most impactful terms at the top.\n",
+    "Coefficients with a small p-value are the ones that the data picks out\n",
+    "as important; coefficients whose confidence interval straddles zero\n",
+    "are not."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coef_df = pd.DataFrame(result[\"coefficients\"]).set_index(\"term\")\n",
+    "coef_df = coef_df.reindex(coef_df[\"t_value\"].abs().sort_values(ascending=False).index)\n",
+    "coef_df.round(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## ANOVA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "anova = pd.DataFrame(result[\"anova_table\"]).set_index(\"source\")\n",
+    "anova.round(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pareto plot of standardised effects\n",
+    "\n",
+    "Dividing each effect estimate by its standard error gives a unitless\n",
+    "comparison of how strong each term is relative to the noise. Plotting\n",
+    "the absolute values as a horizontal bar chart from largest to smallest\n",
+    "is the classical Pareto plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "effects = pd.Series(result[\"effects\"], dtype=float)\n",
+    "errors = pd.Series(result[\"effect_std_errors\"], dtype=float).reindex(effects.index)\n",
+    "standardised = (effects / errors).abs().sort_values()\n",
+    "\n",
+    "_fig, ax = plt.subplots(figsize=(7, 0.35 * max(4, len(standardised)) + 1.0))\n",
+    "ax.barh(standardised.index, standardised.values, color=\"#1f77b4\")\n",
+    "ax.axvline(2, color=\"r\", linestyle=\"--\", linewidth=1, label=\"|t| = 2 (rough significance)\")\n",
+    "ax.set_xlabel(\"|effect / standard error|\")\n",
+    "ax.set_title(\"Pareto of standardised effects\")\n",
+    "ax.legend(loc=\"best\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Residual diagnostics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "diag = result[\"residual_diagnostics\"]\n",
+    "fitted = np.asarray(diag[\"fitted_values\"], dtype=float)\n",
+    "resid = np.asarray(diag[\"residuals\"], dtype=float)\n",
+    "\n",
+    "_fig, axes = plt.subplots(1, 2, figsize=(9, 3.2))\n",
+    "axes[0].scatter(fitted, resid, s=30, color=\"#1f77b4\")\n",
+    "axes[0].axhline(0, color=\"k\", linewidth=0.7)\n",
+    "axes[0].set_xlabel(\"Fitted\")\n",
+    "axes[0].set_ylabel(\"Residual\")\n",
+    "axes[0].set_title(\"Residuals vs fitted\")\n",
+    "\n",
+    "axes[1].hist(resid, bins=8, color=\"#1f77b4\", edgecolor=\"k\")\n",
+    "axes[1].set_xlabel(\"Residual\")\n",
+    "axes[1].set_title(\"Residual distribution\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"Shapiro-Wilk p-value : {diag['shapiro_wilk']['p_value']:.3f}\")\n",
+    "print(f\"Durbin-Watson        : {diag['durbin_watson']:.2f}\")\n",
+    "print(f\"Breusch-Pagan p-value: {diag['breusch_pagan']['p_value']:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What to try next\n",
+    "\n",
+    "- Drop the terms below the `|t| = 2` line and re-fit. The model R\n",
+    "  squared will go down a touch but the adjusted R squared usually goes\n",
+    "  up because the noise terms penalise the unadjusted statistic.\n",
+    "- Pass `analysis_type=\"lack_of_fit\"` to ask whether the residual\n",
+    "  variation is consistent with pure replication error, which tells you\n",
+    "  whether a curvature term is missing.\n",
+    "- For follow-up experimentation, the\n",
+    "  :func:`process_improve.experiments.strategy.recommend_strategy`\n",
+    "  function will propose where to run the next batch of experiments\n",
+    "  given the coefficients you have already estimated."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/user_guide/case_studies/design-analysis-experiments/index.rst
+++ b/docs/user_guide/case_studies/design-analysis-experiments/index.rst
@@ -1,0 +1,10 @@
+Design and analysis of experiments
+==================================
+
+Worked case studies that lay out and analyse a designed experiment: which
+factors matter, how they interact, and where to go next.
+
+.. toctree::
+   :maxdepth: 1
+
+   factorial-oil-company-doe

--- a/docs/user_guide/case_studies/index.rst
+++ b/docs/user_guide/case_studies/index.rst
@@ -14,6 +14,7 @@ the book lines up with a case study here.
    :maxdepth: 2
 
    latent-variable-modelling/index
+   process-monitoring/index
 
 Sources and attribution
 -----------------------

--- a/docs/user_guide/case_studies/index.rst
+++ b/docs/user_guide/case_studies/index.rst
@@ -14,6 +14,7 @@ the book lines up with a case study here.
    :maxdepth: 2
 
    latent-variable-modelling/index
+   least-squares-modelling/index
    process-monitoring/index
 
 Sources and attribution

--- a/docs/user_guide/case_studies/index.rst
+++ b/docs/user_guide/case_studies/index.rst
@@ -15,6 +15,7 @@ the book lines up with a case study here.
 
    latent-variable-modelling/index
    least-squares-modelling/index
+   design-analysis-experiments/index
    process-monitoring/index
 
 Sources and attribution

--- a/docs/user_guide/case_studies/latent-variable-modelling/index.rst
+++ b/docs/user_guide/case_studies/latent-variable-modelling/index.rst
@@ -9,3 +9,4 @@ projection to latent structures (PLS) on real process and product data.
 
    pca-spectral-data
    pca-food-texture
+   pca-kamyr-missing-data

--- a/docs/user_guide/case_studies/latent-variable-modelling/index.rst
+++ b/docs/user_guide/case_studies/latent-variable-modelling/index.rst
@@ -8,3 +8,4 @@ projection to latent structures (PLS) on real process and product data.
    :maxdepth: 1
 
    pca-spectral-data
+   pca-food-texture

--- a/docs/user_guide/case_studies/latent-variable-modelling/pca-food-texture.ipynb
+++ b/docs/user_guide/case_studies/latent-variable-modelling/pca-food-texture.ipynb
@@ -1,0 +1,206 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PCA on food texture\n",
+    "\n",
+    "A small dataset where five sensory and instrumental measurements are taken on each of 50 pastry samples: oil percentage, density, crispiness, fracture force, and hardness. The variables are correlated and measured on different scales, so PCA on the autoscaled data shows the dominant patterns in two components and lets us identify samples that do not look like the rest of the batch.\n",
+    "\n",
+    "**Data.** `food-texture.csv` from [openmv.net](https://openmv.net/info/food-texture). The first column is a sample identifier; the remaining five are the measurements.\n",
+    "\n",
+    "**Adapted from** the *Principal Component Analysis* chapter of the [Process Improvement using Data](https://learnche.org/pid) book (CC BY-SA 4.0)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import plotly.io as pio\n",
+    "\n",
+    "from process_improve.multivariate.methods import PCA, MCUVScaler\n",
+    "\n",
+    "pio.renderers.default = \"notebook_connected\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "foods = pd.read_csv(\"https://openmv.net/file/food-texture.csv\", index_col=0)\n",
+    "print(f\"Shape: {foods.shape[0]} samples x {foods.shape[1]} variables\")\n",
+    "foods.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "foods.describe().round(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The five variables span very different ranges (oil percentage is in the teens, density is in the thousands, the rest are unitless sensory scores). Without scaling, density would dominate the model purely through its variance.\n",
+    "\n",
+    "## Preprocess and fit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X = MCUVScaler().fit_transform(foods)\n",
+    "\n",
+    "selection = PCA.select_n_components(X, max_components=4, cv=5)\n",
+    "print(f\"Recommended A = {selection.n_components}\")\n",
+    "selection.press_ratio.round(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = PCA(n_components=max(2, selection.n_components)).fit(X)\n",
+    "model.r2_cumulative_.round(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Score and loading plots\n",
+    "\n",
+    "With only five variables, the loading plot is more useful than for high-dimensional spectra: every loading carries a recognisable label, and we can read directly which sensory and instrumental measurements drive each component."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.score_plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.loading_plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## SPE and Hotelling's T squared"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.spe_plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.t2_plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Outlier explanation\n",
+    "\n",
+    "Each flagged sample can be explained back in terms of the original five variables with `score_contributions`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outliers = model.detect_outliers(conf_level=0.95)\n",
+    "print(f\"{len(outliers)} samples flagged\")\n",
+    "for o in outliers[:3]:\n",
+    "    print(f\"  {o['observation']}: {o['outlier_types']} (severity={o['severity']:.2f})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if outliers:\n",
+    "    worst = outliers[0][\"observation\"]\n",
+    "    contrib = model.score_contributions(model.scores_.loc[worst].values)\n",
+    "\n",
+    "    fig, ax = plt.subplots(figsize=(6, 3))\n",
+    "    contrib.plot.bar(ax=ax, color=\"steelblue\")\n",
+    "    ax.axhline(0, color=\"k\", linewidth=0.5)\n",
+    "    ax.set_ylabel(\"Contribution\")\n",
+    "    ax.set_title(f\"Score contributions for sample {worst}\")\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What to try next\n",
+    "\n",
+    "- The food-texture dataset is small enough that you can recompute everything by hand and check intuition. Try changing the number of components and watch what happens to the score plot, the SPE limit, and the list of flagged samples.\n",
+    "- Compare the loading plot against domain knowledge: do the variables that cluster together in the loading plot also correlate strongly in `foods.corr()`?\n",
+    "- Once a property like consumer acceptance is added, switch to PLS to relate the texture variables to it."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/user_guide/case_studies/latent-variable-modelling/pca-kamyr-missing-data.ipynb
+++ b/docs/user_guide/case_studies/latent-variable-modelling/pca-kamyr-missing-data.ipynb
@@ -1,0 +1,208 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PCA with missing data: Kamyr digester\n",
+    "\n",
+    "Process data from a continuous Kamyr pulp digester: ten variables sampled over time, including chip feed rates, white liquor charges, blow flows, and Kappa number (the standard pulp quality metric). Some sensors fail or are not available for every observation, so roughly half the rows carry at least one missing value. Most off-the-shelf PCA implementations would force you to drop those rows; this package fits the model directly on the incomplete matrix using the iterative NIPALS or TSR algorithms.\n",
+    "\n",
+    "**Data.** `kamyr.csv` from [openmv.net](https://openmv.net/info/kamyr-digester). 96 rows by 10 numeric columns, no header, no row index.\n",
+    "\n",
+    "**What we do.** Quantify how much data is missing, scale the matrix (mean and standard deviation are computed column-wise ignoring NaN), fit PCA with `algorithm=\"auto\"` so it selects the missing-data-aware NIPALS solver, and read the convergence diagnostics from `fitting_info_`.\n",
+    "\n",
+    "**Adapted from** the *Principal Component Analysis* chapter of the [Process Improvement using Data](https://learnche.org/pid) book (CC BY-SA 4.0)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import plotly.io as pio\n",
+    "\n",
+    "from process_improve.multivariate.methods import PCA, MCUVScaler\n",
+    "\n",
+    "pio.renderers.default = \"notebook_connected\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load and inspect missingness\n",
+    "\n",
+    "The CSV has no header row. Columns are tagged `tag_1` through `tag_10` for plot legibility; the underlying dataset description on openmv.net names them by sensor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kamyr = pd.read_csv(\"https://openmv.net/file/kamyr.csv\", header=None, index_col=None)\n",
+    "kamyr.columns = [f\"tag_{i + 1}\" for i in range(kamyr.shape[1])]\n",
+    "print(f\"Shape: {kamyr.shape[0]} observations x {kamyr.shape[1]} variables\")\n",
+    "print(f\"Total missing values: {int(kamyr.isna().sum().sum())}\")\n",
+    "print(f\"Rows with at least one missing value: {int(kamyr.isna().any(axis=1).sum())}\")\n",
+    "kamyr.isna().sum().to_frame(\"missing_per_column\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "About half the rows have at least one missing value, and the last column is missing for almost half of all observations. Listwise deletion would throw away most of the data; we keep all rows and let PCA estimate the scores from the variables that are observed.\n",
+    "\n",
+    "## Scale and fit\n",
+    "\n",
+    "`MCUVScaler` computes per-column mean and standard deviation ignoring NaN, so scaling a matrix that has missing values is well-defined. We then fit PCA with `algorithm=\"auto\"`: it detects the missing values in `X` and switches from SVD to the iterative NIPALS solver."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X = MCUVScaler().fit_transform(kamyr)\n",
+    "model = PCA(n_components=3).fit(X)\n",
+    "print(f\"algorithm     : {model.algorithm_}\")\n",
+    "print(f\"missing data  : {model.has_missing_data_}\")\n",
+    "print(f\"iterations    : {model.fitting_info_['iterations']}\")\n",
+    "model.r2_cumulative_.round(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`fitting_info_['iterations']` lists how many NIPALS iterations each component required. Components with many missing entries typically take longer to converge; the default tolerance and iteration cap can be tightened or relaxed via the `missing_data_settings={\"md_tol\": ..., \"md_max_iter\": ...}` argument to `PCA`.\n",
+    "\n",
+    "## Score plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.score_plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading plot\n",
+    "\n",
+    "Variables that load together describe the same phenomenon. On the Kamyr digester the upper-vessel and lower-vessel measurements typically separate cleanly because the digester behaves like two stacked compartments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.loading_plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## SPE and Hotelling's T squared"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.spe_plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.t2_plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outliers = model.detect_outliers(conf_level=0.95)\n",
+    "print(f\"{len(outliers)} observations flagged\")\n",
+    "for o in outliers[:5]:\n",
+    "    print(f\"  obs {o['observation']}: {o['outlier_types']} (severity={o['severity']:.2f})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TSR as an alternative\n",
+    "\n",
+    "Trimmed Score Regression is generally a more reliable choice when the missingness pattern is structured (a whole shift's worth of a variable is gone, for example). Switching is a one-line change:\n",
+    "\n",
+    "```python\n",
+    "model_tsr = PCA(n_components=3, algorithm=\"tsr\").fit(X)\n",
+    "```\n",
+    "\n",
+    "and the rest of the workflow above is identical."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_tsr = PCA(n_components=3, algorithm=\"tsr\").fit(X)\n",
+    "comparison = pd.DataFrame(\n",
+    "    {\n",
+    "        \"NIPALS R2\": model.r2_cumulative_,\n",
+    "        \"TSR R2\": model_tsr.r2_cumulative_,\n",
+    "    }\n",
+    ").round(3)\n",
+    "comparison"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What to try next\n",
+    "\n",
+    "- Tighten `md_tol` and increase `md_max_iter` to see how far the iterative solver can push the fit when more iterations are budgeted.\n",
+    "- Re-run with the rows that have any missing values dropped (`kamyr.dropna()`) and compare the score plots; this is the listwise-deletion baseline that the missing-data algorithms are designed to avoid.\n",
+    "- If a quality variable like Kappa number is broken out from the predictor block, switch from PCA to PLS to relate the digester process variables to product quality."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/user_guide/case_studies/least-squares-modelling/index.rst
+++ b/docs/user_guide/case_studies/least-squares-modelling/index.rst
@@ -1,0 +1,11 @@
+Least squares modelling
+=======================
+
+Worked case studies that fit a response variable to one or more predictors
+with ordinary least squares, and read the diagnostics that come with the
+fit.
+
+.. toctree::
+   :maxdepth: 1
+
+   regression-cheddar-taste

--- a/docs/user_guide/case_studies/least-squares-modelling/regression-cheddar-taste.ipynb
+++ b/docs/user_guide/case_studies/least-squares-modelling/regression-cheddar-taste.ipynb
@@ -1,0 +1,236 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# Regressing cheddar taste on chemical composition\n",
+    "\n",
+    "The cheddar dataset records a panel-tasting score for 30 samples of mature cheddar alongside three chemical measurements that vary with maturation: free acetic acid concentration, hydrogen sulfide, and lactic acid. The question is the standard regression question: how much of the variation in taste can the chemistry explain, and which of the three predictors carries the most weight?\n",
+    "\n",
+    "**Data.** `cheddar.csv` from [openmv.net](https://openmv.net/info/cheddar). 30 rows, four numeric columns.\n",
+    "\n",
+    "**What we do.** Fit simple linear regression of taste on hydrogen sulfide on its own, then a multiple linear regression on all three predictors, read the coefficient table, and check the residual diagnostics that come with the `OLS` estimator.\n",
+    "\n",
+    "**Adapted from** the *Least squares modelling* chapter of the [Process Improvement using Data](https://learnche.org/pid) book (CC BY-SA 4.0)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from scipy import stats\n",
+    "\n",
+    "from process_improve.regression.methods import OLS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "source": [
+    "## Load the data\n",
+    "\n",
+    "openmv CSVs sometimes have an unnamed index column on the left and sometimes do not. We load with `index_col=0` and fall back to a no-index read if the resulting frame has fewer columns than expected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = \"https://openmv.net/file/cheddar.csv\"\n",
+    "cheddar = pd.read_csv(url, index_col=0)\n",
+    "if cheddar.shape[1] < 4:\n",
+    "    cheddar = pd.read_csv(url)\n",
+    "cheddar.columns = [c.strip() for c in cheddar.columns]\n",
+    "print(f\"Shape: {cheddar.shape}\")\n",
+    "print(f\"Columns: {list(cheddar.columns)}\")\n",
+    "cheddar.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Identify columns case-insensitively so the notebook is robust to small\n",
+    "# naming differences between revisions of the dataset.\n",
+    "cols = {c.lower(): c for c in cheddar.columns}\n",
+    "y_col = cols[\"taste\"]\n",
+    "h2s_col = cols[\"h2s\"]\n",
+    "predictor_cols = [cols[\"acetic\"], cols[\"h2s\"], cols[\"lactic\"]]\n",
+    "y = cheddar[y_col].astype(float)\n",
+    "print(f\"Response: {y_col}; Predictors: {predictor_cols}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {},
+   "source": [
+    "## Simple linear regression\n",
+    "\n",
+    "Hydrogen sulfide is the predictor that pid-book singles out as the strongest individual driver. Fitting taste on `H2S` alone is a useful sanity check; we expect a positive slope (more mature cheese smells stronger and tastes more) and a comfortable signal-to-noise ratio."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_simple = OLS().fit(cheddar[[h2s_col]], y)\n",
+    "print(\n",
+    "    f\"intercept = {model_simple.intercept_:.2f}, \"\n",
+    "    f\"slope = {model_simple.coefficients_[0]:.2f}, \"\n",
+    "    f\"R2 = {model_simple.r2_:.3f}\"\n",
+    ")\n",
+    "print(f\"t-value on slope = {model_simple.t_values_[0]:.2f}, p-value = {model_simple.p_values_[0]:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Scatter plot with fitted line and 95 percent prediction interval band.\n",
+    "x_grid = model_simple.pi_range_[:, 0]\n",
+    "lo = model_simple.pi_range_[:, 1]\n",
+    "hi = model_simple.pi_range_[:, 2]\n",
+    "y_hat = model_simple.intercept_ + model_simple.coefficients_[0] * x_grid\n",
+    "\n",
+    "_fig, ax = plt.subplots(figsize=(7, 4))\n",
+    "ax.scatter(cheddar[h2s_col], y, s=30, color=\"#1f77b4\", label=\"observed\")\n",
+    "ax.plot(x_grid, y_hat, color=\"k\", linewidth=1.2, label=\"fit\")\n",
+    "ax.fill_between(x_grid, lo, hi, color=\"orange\", alpha=0.25, label=\"95% prediction band\")\n",
+    "ax.set_xlabel(h2s_col)\n",
+    "ax.set_ylabel(y_col)\n",
+    "ax.set_title(\"Cheddar taste vs hydrogen sulfide\")\n",
+    "ax.legend(loc=\"best\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7623eae2785240b9bd12b16a66d81610",
+   "metadata": {},
+   "source": [
+    "## Multiple linear regression\n",
+    "\n",
+    "Adding the other two predictors gives the model a chance to explain more of the variation, but tells us less about which predictor matters most: collinearity between the three chemistry variables means the individual coefficient estimates trade against each other."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_full = OLS().fit(cheddar[predictor_cols], y)\n",
+    "summary = pd.DataFrame(\n",
+    "    {\n",
+    "        \"coefficient\": model_full.coefficients_,\n",
+    "        \"std_error\": model_full.standard_errors_,\n",
+    "        \"t_value\": model_full.t_values_,\n",
+    "        \"p_value\": model_full.p_values_,\n",
+    "    },\n",
+    "    index=predictor_cols,\n",
+    ")\n",
+    "summary.loc[\"(intercept)\"] = [\n",
+    "    model_full.intercept_,\n",
+    "    model_full.standard_error_intercept_,\n",
+    "    model_full.t_value_intercept_,\n",
+    "    model_full.p_value_intercept_,\n",
+    "]\n",
+    "print(\n",
+    "    f\"R2 = {model_full.r2_:.3f}, adjusted R2 = {model_full.adj_r2_:.3f}, \"\n",
+    "    f\"F = {model_full.f_statistic_:.2f} (p = {model_full.f_pvalue_:.4f})\"\n",
+    ")\n",
+    "summary.round(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b118ea5561624da68c537baed56e602f",
+   "metadata": {},
+   "source": [
+    "## Residual diagnostics\n",
+    "\n",
+    "Three quick plots tell you most of what you need to know about whether the linear model is appropriate:\n",
+    "\n",
+    "- **Residuals vs fitted**: should be a horizontal cloud around zero; a U-shape means a curvature term is missing, a fan shape means the variance grows with the fitted value.\n",
+    "- **Residual histogram or Q-Q plot**: should look approximately normal if you want to trust the t-statistics.\n",
+    "- **Residuals vs sample order** (if applicable): non-random patterns suggest the rows are not independent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "938c804e27f84196a10c8828c723f798",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fitted = model_full.fitted_values_\n",
+    "resid = model_full.residuals_\n",
+    "resid_clean = resid[np.isfinite(resid)]\n",
+    "\n",
+    "_fig, axes = plt.subplots(1, 3, figsize=(11, 3.2))\n",
+    "axes[0].scatter(fitted, resid_clean, s=25, color=\"#1f77b4\")\n",
+    "axes[0].axhline(0, color=\"k\", linewidth=0.8)\n",
+    "axes[0].set_xlabel(\"Fitted\")\n",
+    "axes[0].set_ylabel(\"Residual\")\n",
+    "axes[0].set_title(\"Residuals vs fitted\")\n",
+    "\n",
+    "axes[1].hist(resid_clean, bins=10, color=\"#1f77b4\", edgecolor=\"k\")\n",
+    "axes[1].set_xlabel(\"Residual\")\n",
+    "axes[1].set_title(\"Residual distribution\")\n",
+    "\n",
+    "stats.probplot(resid_clean, dist=\"norm\", plot=axes[2])\n",
+    "axes[2].set_title(\"Q-Q plot\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "504fb2a444614c0babb325280ed9130a",
+   "metadata": {},
+   "source": [
+    "## What to try next\n",
+    "\n",
+    "- Drop the predictor with the largest p-value and re-fit; compare the coefficient estimates of the two retained predictors. They should change because of the collinearity between the three chemistry variables.\n",
+    "- Try `OLS(fit_intercept=False)` to see what an origin-passing fit looks like; the diagnostics shift even though the data does not.\n",
+    "- For correlated predictors, switch to PLS to avoid the variance-inflation problem altogether. See the latent-variable case studies for examples."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/user_guide/case_studies/process-monitoring/control-charts-rubber-colour.ipynb
+++ b/docs/user_guide/case_studies/process-monitoring/control-charts-rubber-colour.ipynb
@@ -1,0 +1,182 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Control charts for rubber colour\n",
+    "\n",
+    "A short series of 100 colour readings on rubber product. Each reading is a single value that should sit close to a target, with run-to-run variation small relative to the spread that signals a process upset. The job of a control chart is to draw a target line and limits, then flag readings that fall outside.\n",
+    "\n",
+    "**Data.** `rubber-colour.csv` from [openmv.net](https://openmv.net/info/rubber-colour). One column, no missing values, no ordering metadata; the values are assumed to be in sample order.\n",
+    "\n",
+    "**What we do.** Build three charts:\n",
+    "\n",
+    "1. A classical Shewhart chart using the standard mean and standard deviation, which mirrors what the R `qcc` package produces with `type=\"xbar.one\"`.\n",
+    "2. A robust Shewhart chart using the median and a MAD-based scale estimate, which is less sensitive to the same outliers it is trying to flag.\n",
+    "3. A Holt-Winters chart that blends recent history with the long-run target, useful when the series drifts.\n",
+    "\n",
+    "**Adapted from** the *Process monitoring* chapter of the [Process Improvement using Data](https://learnche.org/pid) book (CC BY-SA 4.0)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from process_improve.monitoring.control_charts import ControlChart"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load and look"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = pd.read_csv(\"https://openmv.net/file/rubber-colour.csv\")\n",
+    "y = data[\"Colour\"].astype(float)\n",
+    "print(f\"{len(y)} readings, mean={y.mean():.2f}, sd={y.std(ddof=1):.2f}, range=[{y.min()}, {y.max()}]\")\n",
+    "y.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Classical Shewhart chart\n",
+    "\n",
+    "`ControlChart(variant=\"xbar.no.subgroup\", style=\"regular\")` plots each observation individually against limits computed from the sample mean and sample standard deviation. The R `qcc` package's `type=\"xbar.one\"` produces the same target and a very similar standard deviation estimate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cc_regular = ControlChart(variant=\"xbar.no.subgroup\", style=\"regular\")\n",
+    "cc_regular.calculate_limits(y)\n",
+    "print(f\"target = {cc_regular.target:.2f}, s = {cc_regular.s:.2f}\")\n",
+    "print(f\"flagged indices: {list(cc_regular.idx_outside_3S)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_chart(y: pd.Series, target: float, s: float, flagged: list[int], title: str) -> None:\n",
+    "    upper = target + 3 * s\n",
+    "    lower = target - 3 * s\n",
+    "    _fig, ax = plt.subplots(figsize=(9, 3.2))\n",
+    "    ax.plot(y.values, marker=\"o\", linestyle=\"-\", color=\"#1f77b4\", markersize=3, linewidth=0.7)\n",
+    "    ax.axhline(target, color=\"k\", linewidth=1)\n",
+    "    ax.axhline(upper, color=\"r\", linewidth=1, linestyle=\"--\")\n",
+    "    ax.axhline(lower, color=\"r\", linewidth=1, linestyle=\"--\")\n",
+    "    if flagged:\n",
+    "        ax.scatter(flagged, y.values[flagged], color=\"red\", zorder=5, s=40)\n",
+    "    ax.set_xlabel(\"Sample\")\n",
+    "    ax.set_ylabel(\"Colour\")\n",
+    "    ax.set_title(title)\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "\n",
+    "\n",
+    "plot_chart(y, cc_regular.target, cc_regular.s, list(cc_regular.idx_outside_3S), \"Shewhart chart (regular)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Robust Shewhart chart\n",
+    "\n",
+    "Replacing the mean with the median and the standard deviation with a MAD-based scale estimate prevents extreme observations from inflating the limits and hiding themselves. On a series with even a single outlier the robust chart usually flags more points than the classical chart, which is the desired behaviour: *flag, then investigate*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cc_robust = ControlChart(variant=\"xbar.no.subgroup\", style=\"robust\")\n",
+    "cc_robust.calculate_limits(y)\n",
+    "print(f\"target = {cc_robust.target:.2f}, s = {cc_robust.s:.2f}\")\n",
+    "print(f\"flagged indices: {list(cc_robust.idx_outside_3S)}\")\n",
+    "plot_chart(y, cc_robust.target, cc_robust.s, list(cc_robust.idx_outside_3S), \"Shewhart chart (robust)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Holt-Winters chart\n",
+    "\n",
+    "The default `ControlChart()` is a Holt-Winters chart. It blends two smoothing constants, `lambda_1` and `lambda_2`, with `lambda_1=lambda_2=0.5` by default. This makes the chart respond to genuine process shifts while staying stable under random scatter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cc_hw = ControlChart()\n",
+    "cc_hw.calculate_limits(y)\n",
+    "print(f\"target = {cc_hw.target:.2f}, s = {cc_hw.s:.2f}\")\n",
+    "y_star = cc_hw.df[\"y_star\"].astype(float).values\n",
+    "\n",
+    "_fig, ax = plt.subplots(figsize=(9, 3.2))\n",
+    "ax.plot(y.values, marker=\"o\", markersize=3, linewidth=0.7, color=\"#1f77b4\", label=\"observed\")\n",
+    "if len(y_star) and np.isfinite(y_star).any():\n",
+    "    ax.plot(y_star, color=\"orange\", linewidth=1.2, label=\"smoothed (y*)\")\n",
+    "ax.axhline(cc_hw.target, color=\"k\", linewidth=1, label=f\"target {cc_hw.target:.1f}\")\n",
+    "ax.axhline(cc_hw.target + 3 * cc_hw.s, color=\"r\", linewidth=1, linestyle=\"--\")\n",
+    "ax.axhline(cc_hw.target - 3 * cc_hw.s, color=\"r\", linewidth=1, linestyle=\"--\")\n",
+    "ax.set_xlabel(\"Sample\")\n",
+    "ax.set_ylabel(\"Colour\")\n",
+    "ax.set_title(\"Holt-Winters chart\")\n",
+    "ax.legend(loc=\"best\", fontsize=8)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What to try next\n",
+    "\n",
+    "- Pass an explicit `target` and `s` to `calculate_limits()` to use known design values rather than estimates from the same data being charted. This is the right choice once you have a reference period of stable operation.\n",
+    "- Investigate the flagged readings: do they cluster in time? Are they before or after a maintenance event? The chart only flags; the investigation belongs to you.\n",
+    "- For multivariate process data, fit a PCA model and chart SPE and Hotelling's T squared instead. See the [PCA on tablet spectra](../latent-variable-modelling/pca-spectral-data.ipynb) case study."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/user_guide/case_studies/process-monitoring/index.rst
+++ b/docs/user_guide/case_studies/process-monitoring/index.rst
@@ -1,0 +1,10 @@
+Process monitoring
+==================
+
+Worked case studies that build control charts on real production data and
+investigate the violations they flag.
+
+.. toctree::
+   :maxdepth: 1
+
+   control-charts-rubber-colour

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.13.7"
+version = "1.13.8"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Phase 2 of the documentation case-studies started in #134. Adds five more end-to-end notebook case studies under `docs/user_guide/case_studies/`, each fetching its dataset from openmv.net at notebook execution time:

- **`latent-variable-modelling/pca-food-texture.ipynb`** - canonical small PCA on the food-texture dataset.
- **`latent-variable-modelling/pca-kamyr-missing-data.ipynb`** - PCA on the Kamyr digester data, showcasing this package's missing-data handling (NIPALS / TSR).
- **`process-monitoring/control-charts-rubber-colour.ipynb`** - classical Shewhart, robust Shewhart, and Holt-Winters control charts on rubber colour readings.
- **`least-squares-modelling/regression-cheddar-taste.ipynb`** - simple linear regression of cheddar taste on H2S, then multiple linear regression on all three chemistry predictors with residual diagnostics, using the `OLS` estimator.
- **`design-analysis-experiments/factorial-oil-company-doe.ipynb`** - factorial DOE analysis with `analyze_experiment`: coefficient table, ANOVA, Pareto plot of standardised effects, residual diagnostics.

Notebooks are committed without outputs; `nbstripout` strips them on commit and `nbsphinx` re-executes against live openmv.net data at docs build time, so anything broken on openmv.net surfaces as a `Docs` workflow failure rather than stale content in the repo.

## Local verification

- `uv run ruff check docs/user_guide/case_studies` clean
- `uv run ruff format --check docs/user_guide/case_studies` clean
- `uv run sphinx-build docs docs/_build/html -D nbsphinx_execute=never -W` introduces no new warnings vs. main
- `uv run pytest -q` clean (1021 passed, 11 skipped)
- PCA + Kamyr, control charts on rubber-colour, and regression on the local batch-yield-and-purity reproduction smoke-execute against the in-repo dataset fixtures
- food-texture, cheddar, and oil-company-doe rely on openmv.net at execution time (sandbox cannot reach openmv.net but CI can); the surrounding analysis code is exercised against an equivalent local dataset or synthetic design

https://claude.ai/code/session_01Kk2WDp1uydjMtKQDANF7Xe