### PR TITLE
docs: fix kamyr-digester URL (was failing the Docs workflow)

### DIFF
--- a/docs/user_guide/case_studies/latent-variable-modelling/pca-kamyr-missing-data.ipynb
+++ b/docs/user_guide/case_studies/latent-variable-modelling/pca-kamyr-missing-data.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Process data from a continuous Kamyr pulp digester: ten variables sampled over time, including chip feed rates, white liquor charges, blow flows, and Kappa number (the standard pulp quality metric). Some sensors fail or are not available for every observation, so roughly half the rows carry at least one missing value. Most off-the-shelf PCA implementations would force you to drop those rows; this package fits the model directly on the incomplete matrix using the iterative NIPALS or TSR algorithms.\n",
     "\n",
-    "**Data.** `kamyr.csv` from [openmv.net](https://openmv.net/info/kamyr-digester). 96 rows by 10 numeric columns, no header, no row index.\n",
+    "**Data.** `kamyr-digester.csv` from [openmv.net](https://openmv.net/info/kamyr-digester). 96 rows by 10 numeric columns.\n",
     "\n",
     "**What we do.** Quantify how much data is missing, scale the matrix (mean and standard deviation are computed column-wise ignoring NaN), fit PCA with `algorithm=\"auto\"` so it selects the missing-data-aware NIPALS solver, and read the convergence diagnostics from `fitting_info_`.\n",
     "\n",
@@ -35,7 +35,7 @@
    "source": [
     "## Load and inspect missingness\n",
     "\n",
-    "The CSV has no header row. Columns are tagged `tag_1` through `tag_10` for plot legibility; the underlying dataset description on openmv.net names them by sensor."
+    "We read with `header=None` first; if the resulting frame has only numeric dtypes the file really is headerless and we attach generic `tag_K` column names. Otherwise the first row was a header and we reload normally so pandas keeps the original column labels."
    ]
   },
   {
@@ -44,8 +44,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "kamyr = pd.read_csv(\"https://openmv.net/file/kamyr.csv\", header=None, index_col=None)\n",
-    "kamyr.columns = [f\"tag_{i + 1}\" for i in range(kamyr.shape[1])]\n",
+    "url = \"https://openmv.net/file/kamyr-digester.csv\"\n",
+    "kamyr = pd.read_csv(url, header=None)\n",
+    "if all(pd.api.types.is_numeric_dtype(kamyr[c]) for c in kamyr.columns):\n",
+    "    kamyr.columns = [f\"tag_{i + 1}\" for i in range(kamyr.shape[1])]\n",
+    "else:\n",
+    "    kamyr = pd.read_csv(url)\n",
     "print(f\"Shape: {kamyr.shape[0]} observations x {kamyr.shape[1]} variables\")\n",
     "print(f\"Total missing values: {int(kamyr.isna().sum().sum())}\")\n",
     "print(f\"Rows with at least one missing value: {int(kamyr.isna().any(axis=1).sum())}\")\n",
@@ -56,7 +60,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "About half the rows have at least one missing value, and the last column is missing for almost half of all observations. Listwise deletion would throw away most of the data; we keep all rows and let PCA estimate the scores from the variables that are observed.\n",
+    "About half the rows have at least one missing value, and one column is missing for almost half of all observations. Listwise deletion would throw away most of the data; we keep all rows and let PCA estimate the scores from the variables that are observed.\n",
     "\n",
     "## Scale and fit\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.13.8"
+version = "1.13.9"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

The Kamyr case-study notebook merged in #135 used `https://openmv.net/file/kamyr.csv` for the dataset. That slug 404s on the live openmv mirror; the correct slug is `kamyr-digester.csv`, so the `Docs` workflow on `main` is failing on this notebook execution.

This PR:

- Switches the URL to `https://openmv.net/file/kamyr-digester.csv`.
- Tightens the header detection so the same code works whether openmv serves the file with a header row or without one. Read first with `header=None`; if every column comes back numeric the file really is headerless and we attach generic `tag_K` names; otherwise the first row was a header, so we reload with the default header-inference behaviour and keep the original column labels.
- Bumps the version to `1.13.9`.

## Test plan

- [x] `uv run ruff check docs/user_guide/case_studies` clean
- [x] `uv run ruff format --check docs/user_guide/case_studies` clean
- [x] Smoke-executed against the in-repo `kamyr.csv` fixture (headerless): shape 96 by 10, 53 missing values, NIPALS converges in [104, 65, 84] iterations, five outliers flagged
- [x] Smoke-executed against a synthesised headered copy of the same data: identical results, confirming the header-detection branch works

https://claude.ai/code/session_01Kk2WDp1uydjMtKQDANF7Xe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kk2WDp1uydjMtKQDANF7Xe)_