### PR TITLE
docs: run Docs build on PRs + drop non-numeric kamyr columns

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,8 @@ name: Docs
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: ['**']
   workflow_dispatch:  # allow manual trigger
 
 permissions:
@@ -11,7 +13,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -28,15 +30,18 @@ jobs:
       - name: Install pandoc (required by nbsphinx)
         run: sudo apt-get update && sudo apt-get install -y pandoc
       - name: Configure GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v6
       - name: Build docs
         run: uv run sphinx-build docs docs/_build/html -b html -W
       - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_build/html
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/docs/user_guide/case_studies/latent-variable-modelling/pca-kamyr-missing-data.ipynb
+++ b/docs/user_guide/case_studies/latent-variable-modelling/pca-kamyr-missing-data.ipynb
@@ -35,7 +35,9 @@
    "source": [
     "## Load and inspect missingness\n",
     "\n",
-    "We read with `header=None` first; if the resulting frame has only numeric dtypes the file really is headerless and we attach generic `tag_K` column names. Otherwise the first row was a header and we reload normally so pandas keeps the original column labels."
+    "We read with `header=None` first; if the resulting frame has only numeric dtypes the file really is headerless and we attach generic `tag_K` column names. Otherwise the first row was a header, so we reload with the default header-inference behaviour and keep the original column labels.\n",
+    "\n",
+    "Either way we then coerce every column to numeric (cells that cannot parse become NaN, which the missing-data PCA solver handles natively) and drop any column that becomes entirely NaN, which removes any non-numeric identifier or date column the dataset might carry alongside the process variables."
    ]
   },
   {
@@ -50,6 +52,7 @@
     "    kamyr.columns = [f\"tag_{i + 1}\" for i in range(kamyr.shape[1])]\n",
     "else:\n",
     "    kamyr = pd.read_csv(url)\n",
+    "kamyr = kamyr.apply(pd.to_numeric, errors=\"coerce\").dropna(axis=1, how=\"all\")\n",
     "print(f\"Shape: {kamyr.shape[0]} observations x {kamyr.shape[1]} variables\")\n",
     "print(f\"Total missing values: {int(kamyr.isna().sum().sum())}\")\n",
     "print(f\"Rows with at least one missing value: {int(kamyr.isna().any(axis=1).sum())}\")\n",

--- a/docs/user_guide/case_studies/least-squares-modelling/regression-cheddar-taste.ipynb
+++ b/docs/user_guide/case_studies/least-squares-modelling/regression-cheddar-taste.ipynb
@@ -4,17 +4,7 @@
    "cell_type": "markdown",
    "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
-   "source": [
-    "# Regressing cheddar taste on chemical composition\n",
-    "\n",
-    "The cheddar dataset records a panel-tasting score for 30 samples of mature cheddar alongside three chemical measurements that vary with maturation: free acetic acid concentration, hydrogen sulfide, and lactic acid. The question is the standard regression question: how much of the variation in taste can the chemistry explain, and which of the three predictors carries the most weight?\n",
-    "\n",
-    "**Data.** `cheddar.csv` from [openmv.net](https://openmv.net/info/cheddar). 30 rows, four numeric columns.\n",
-    "\n",
-    "**What we do.** Fit simple linear regression of taste on hydrogen sulfide on its own, then a multiple linear regression on all three predictors, read the coefficient table, and check the residual diagnostics that come with the `OLS` estimator.\n",
-    "\n",
-    "**Adapted from** the *Least squares modelling* chapter of the [Process Improvement using Data](https://learnche.org/pid) book (CC BY-SA 4.0)."
-   ]
+   "source": "# Regressing cheddar taste on chemical composition\n\nThe cheddar dataset records a panel-tasting score for 30 samples of mature cheddar alongside three chemical measurements that vary with maturation: free acetic acid concentration, hydrogen sulfide, and lactic acid. The question is the standard regression question: how much of the variation in taste can the chemistry explain, and which of the three predictors carries the most weight?\n\n**Data.** `cheddar-cheese.csv` from [openmv.net](https://openmv.net/info/cheddar-cheese). 30 rows, five columns: `Case` (a sample identifier) and the four numeric variables `Acetic`, `H2S`, `Lactic`, `Taste`.\n\n**What we do.** Fit simple linear regression of taste on hydrogen sulfide on its own, then a multiple linear regression on all three predictors, read the coefficient table, and check the residual diagnostics that come with the `OLS` estimator.\n\n**Adapted from** the *Least squares modelling* chapter of the [Process Improvement using Data](https://learnche.org/pid) book (CC BY-SA 4.0)."
   },
   {
    "cell_type": "code",
@@ -35,11 +25,7 @@
    "cell_type": "markdown",
    "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {},
-   "source": [
-    "## Load the data\n",
-    "\n",
-    "openmv CSVs sometimes have an unnamed index column on the left and sometimes do not. We load with `index_col=0` and fall back to a no-index read if the resulting frame has fewer columns than expected."
-   ]
+   "source": "## Load the data\n\nThe first column is a sample identifier (`Case`); the next four are the numeric variables we will model. We strip any whitespace from column names so case-insensitive lookups in the next cell are robust to small naming differences between revisions of the dataset."
   },
   {
    "cell_type": "code",
@@ -47,16 +33,7 @@
    "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "url = \"https://openmv.net/file/cheddar.csv\"\n",
-    "cheddar = pd.read_csv(url, index_col=0)\n",
-    "if cheddar.shape[1] < 4:\n",
-    "    cheddar = pd.read_csv(url)\n",
-    "cheddar.columns = [c.strip() for c in cheddar.columns]\n",
-    "print(f\"Shape: {cheddar.shape}\")\n",
-    "print(f\"Columns: {list(cheddar.columns)}\")\n",
-    "cheddar.head()"
-   ]
+   "source": "cheddar = pd.read_csv(\"https://openmv.net/file/cheddar-cheese.csv\")\ncheddar.columns = [c.strip() for c in cheddar.columns]\nprint(f\"Shape: {cheddar.shape}\")\nprint(f\"Columns: {list(cheddar.columns)}\")\ncheddar.head()"
   },
   {
    "cell_type": "code",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.13.10"
+version = "1.13.11"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.13.9"
+version = "1.13.10"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Two related fixes for the "openmv schema surprise breaks docs deploy after merge" pain you flagged.

### 1. Build docs on every PR (not just push-to-main)

`.github/workflows/docs.yml` previously triggered only on `push: main`, so notebook execution failures only surfaced **after** merge. This PR adds `pull_request: ['**']` to the triggers, gates the deploy and Pages-upload steps on `github.event_name == 'push' && github.ref == 'refs/heads/main'`, and updates `concurrency.group` to the standard `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}` pattern so PR runs cancel only their own previous runs, not the main-branch deploy.

After this lands, every PR that touches docs (or anything `sphinx-build -W` cares about) will get a `Docs / build` check, and you'll see whether nbsphinx can execute the notebooks against live openmv before merge.

### 2. Drop non-numeric Kamyr columns

The Docs build on `main` after #136 failed with `TypeError: Cannot perform reduction 'mean' with string dtype`, because openmv's `kamyr-digester.csv` has a header row plus at least one non-numeric column (a date or batch identifier) that my previous fix kept around. `MCUVScaler.fit` then choked on it.

Fix: after the headered-reload branch, coerce every column to numeric and drop any column that becomes entirely NaN. This removes identifier / date columns but leaves cells that are missing inside otherwise-numeric columns alone (the missing-data PCA solver handles them natively).

## Test plan

- [x] `uv run ruff check docs/user_guide/case_studies` clean
- [x] `uv run ruff format --check docs/user_guide/case_studies` clean
- [x] Smoke tested the headerless branch against the in-repo `kamyr.csv` fixture: 96 by 10, 53 missing, NIPALS [104, 65, 84], five outliers flagged
- [x] Smoke tested the headered branch against a synthesised `kamyr-digester.csv` with a leading `BatchID` text column: identical results, confirming the new coerce + dropna step removes the text column cleanly
- [ ] The new `Docs / build` check should appear on this PR itself, exercising the full nbsphinx pipeline against the live openmv data before merge

https://claude.ai/code/session_01Kk2WDp1uydjMtKQDANF7Xe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kk2WDp1uydjMtKQDANF7Xe)_