### PR TITLE
docs: promote case studies to top-level sidebar section (#138)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,3 +12,9 @@ monitoring. Companion to the online textbook
    quickstart
    user_guide/index
    api/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Case studies
+
+   user_guide/case_studies/index

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -7,4 +7,3 @@ User Guide
    multivariate
    cross_validation
    doe_strategy
-   case_studies/index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.13.11"
+version = "1.13.12"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Closes #138.

Promotes "Case studies" out of the User Guide toctree and into its own captioned section in the root `docs/index.rst` toctree, so the PyData Sphinx sidebar renders it as a separate top-level group alongside "Contents" (Quickstart / User Guide / API Reference).

Files stay at `docs/user_guide/case_studies/` so existing URLs and notebook execution paths are unchanged.

## Changes

- `docs/index.rst`: add a second toctree block with `:caption: Case studies` pointing at `user_guide/case_studies/index`.
- `docs/user_guide/index.rst`: drop the `case_studies/index` entry so it does not appear twice.
- `pyproject.toml`: bump patch version (1.13.11 → 1.13.12) per CLAUDE.md.

## Test plan

- [ ] `cd docs && make html` builds with no Sphinx warnings.
- [ ] Rendered `index.html` shows "Case studies" as its own captioned section in the left sidebar.
- [ ] All four case-study categories still render and link to their notebooks.
- [ ] "User Guide" no longer lists "Case studies" as a sub-entry.


---
_Generated by [Claude Code](https://claude.ai/code/session_017StDPvUYExherjy4Hj9krJ)_