### PR TITLE
docs(readme): link Applied DoE tutorial; fix examples-folder path

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,15 @@ for s in strategy["stages"]:
 
 Longer, fully-worked versions of each example live in the
 [Quickstart guide](https://kgdunn.github.io/process-improve/quickstart.html)
-and the `notebooks_examples/` folder.
+and the `process_improve/notebooks_examples/` folder.
+
+New to designed experiments? The
+[**Applied DoE tutorial**](https://kgdunn.github.io/process-improve/applied_doe/index.html)
+is an eight-module worked-solution series that mirrors the
+[12-week DoE short course](https://yint.org) and shows the same workflow
+in Python with `process-improve` end to end - from a 2x2 first design
+through factorial scaling, fractional factorials, blocking, and 1-D / 2-D
+response-surface optimization.
 
 ## API design
 
@@ -135,6 +143,8 @@ preserved through `fit` and `transform`.
 ## Documentation & learning resources
 
 - **API reference & user guide:** <https://kgdunn.github.io/process-improve/>
+- **Applied DoE tutorial (8 modules):**
+  <https://kgdunn.github.io/process-improve/applied_doe/index.html>
 - **Companion textbook:** [Process Improvement using Data](https://learnche.org/pid)
 - **Hosted experiment-design tool:** [factori.al](https://factori.al)
 - **Local docs build:** `cd docs && make html`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.16.2"
+version = "1.16.3"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Two small README updates plus a PATCH version bump:

1. **Link the Applied DoE tutorial.** The 8-module worked-solution series added in #146 / #147 / #148 had no entry from the README. Added two pointers:
   - a one-paragraph callout right after the DoE quick-start example, suitable for newcomers who land on the package via PyPI / GitHub and want a guided tour;
   - a dedicated bullet in the **Documentation & learning resources** section beside the API reference and the companion textbook.
2. **Fix examples-folder path.** The README pointed to a top-level `notebooks_examples/`; the folder is actually at `process_improve/notebooks_examples/` inside the package. Corrected.
3. Version bumped 1.16.2 -> 1.16.3 (PATCH; docs-only).

## Accuracy & consistency check

While in there I re-read the whole README against the current codebase:

| Claim in README | Verified |
|---|---|
| Python >= 3.10 | `pyproject.toml` ✓ |
| `Factor` / `Response` import from `process_improve.experiments.factor` | ✓ |
| `recommend_strategy(...)` returns dict with `stages` (each having `stage_number`, `design_type`, `estimated_runs`) | ✓ (ran the example block) |
| PLS `predict()` returns Bunch with `y_hat`, `spe`, `hotellings_t2` | ✓ |
| API design paragraph (sklearn conventions, trailing underscores, pandas index preservation) | ✓ |
| factori.al / learnche.org / kgdunn.github.io links | ✓ |
| Highlights bullet content (PCA SVD/NIPALS + TSR, PLS, TPLS, control charts, batch tooling, robust regression) | ✓ |

No other corrections needed.

## Test plan

- [x] DOE quick-start example block runs end-to-end and prints the documented output.
- [x] `pip install process-improve` line is unchanged.
- [x] All links resolve to the deployed site (the Applied DoE pages were deployed by the #148 merge).

---
_Generated by [Claude Code](https://claude.ai/code/session_012tE5PpJm6EQEko2EqeDH46)_