### PR TITLE
docs(applied_doe): correct the Ruggedness study description

### DIFF
--- a/docs/applied_doe/00_plan_your_experiment.rst
+++ b/docs/applied_doe/00_plan_your_experiment.rst
@@ -55,7 +55,7 @@ very different design choices:
      - Screening
      - Characterization
      - Optimization
-   * - Confirm robustness.
+   * - Test reliability and noise (variability) of the measurement system.
      - Eliminate factors.
      - Quantify which factors matter, by how much.
      - Find the operating point that best meets the objective.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.16.5"
+version = "1.16.6"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

User flagged that the "Type of study" table in the Plan-your-experiment page mis-states what a Ruggedness study does.

**Before:** "Confirm robustness."
**After:** "Test reliability and noise (variability) of the measurement system."

A ruggedness study is about characterizing the *measurement system's* noise / repeatability, not confirming that the *process* is robust to factor changes. The old wording conflated the two.

Version bumped 1.16.5 -> 1.16.6 (PATCH; docs-only).

## Test plan

- [x] `sphinx-build -W docs docs/_build/html` clean for the applied_doe pages.

---
_Generated by [Claude Code](https://claude.ai/code/session_012tE5PpJm6EQEko2EqeDH46)_