### PR TITLE
docs: align computational docstrings with actual function behavior

### DIFF
--- a/process_improve/batch/features.py
+++ b/process_improve/batch/features.py
@@ -243,6 +243,13 @@ def f_mad(
     Since the mean can be biased by outliers, the MAD can also be biased. If
     an unbiased estimate is required, see `f_robust_mad`.
 
+    .. warning::
+        This function calls ``DataFrameGroupBy.mad()``, which was
+        deprecated in pandas 1.5 and **removed in pandas 2.0**. On a
+        modern pandas it raises ``AttributeError``. Until the
+        implementation is rewritten in terms of ``apply``, callers on
+        pandas >= 2.0 cannot use this function.
+
     See also: f_std, f_iqr, f_robust_mad
     """
     base_name = "mad"

--- a/process_improve/experiments/optimal.py
+++ b/process_improve/experiments/optimal.py
@@ -7,7 +7,15 @@ IndexOrList = int | list
 
 
 def optimization_function(x: pd.DataFrame) -> float:
-    """Return the D-optimality of the design."""
+    """Score a design for the point-exchange D-optimal search (lower is better).
+
+    Returns ``log|det((X'X)^-1)|`` which is equivalent to the negative
+    log of the standard D-criterion ``log|det(X'X)|``. The point-exchange
+    routine in this module uses this convention and selects swaps that
+    decrease the returned value, i.e. that increase ``|det(X'X)|``.
+
+    Returns ``+inf`` when ``X'X`` is singular (no improvement possible).
+    """
     try:
         x = pd.DataFrame(x).drop_duplicates()
         xtx_i = np.linalg.inv(np.dot(np.transpose(x), x))

--- a/process_improve/monitoring/metrics.py
+++ b/process_improve/monitoring/metrics.py
@@ -23,10 +23,18 @@ def calculate_cpk(
         Raw data, at least one column is numeric.
     which_column : str
         Indicates which is the column of data that should be used for the Cpk calculation.
-    specifications : tuple, optional
-        Either a value, if the specification is constant over time; if the specification changes
-        over time, then use two column names here, one of which is the lower specification and
-        the second is the upper specification.
+    specifications : tuple of (lower, upper), optional
+        A 2-tuple ``(lower_spec, upper_spec)`` of the lower and upper specification limits.
+        Each element may be:
+
+        * a numeric value, when the specification is constant over time;
+        * a string, interpreted as a column name in ``df`` whose values give the
+          per-row specification (use this when the specification changes over time);
+        * ``None``, in which case the corresponding spec is estimated from the data
+          using ``trim_percentile`` (a percentile-based robust limit).
+
+        Default is ``(np.nan, np.nan)``, which treats both specs as numeric NaN
+        and yields NaN for the corresponding side of the Cpk calculation.
     trim_percentile : float, optional
         If non-zero, then robust alternatives are used. The value specified is the percentile of
         data that is trimmed away; by default 2.5 percent on the left, and 2.5% on the right.

--- a/process_improve/multivariate/methods.py
+++ b/process_improve/multivariate/methods.py
@@ -1633,10 +1633,19 @@ def terminate_check(t_a_guess: np.ndarray, t_a: np.ndarray, iterations: int, set
 
 def quick_regress(Y: np.ndarray, x: np.ndarray) -> np.ndarray:
     """
-    Regress vector `x` onto the columns in matrix ``Y`` one at a time.
-    Return the vector of regression coefficients, one for each column in `Y`.
-    There may be missing data in `Y`, but not in `x`.  The `x` vector
-    *must* be a column vector.
+    Quick least-squares regression with two shape-driven modes.
+
+    The mode is selected from the shapes of ``Y`` (``Ny`` x ``K``) and ``x`` (``Nx`` x 1):
+
+    * **Case A** (``Ny == Nx``): regress ``x`` onto each column of ``Y`` one at a
+      time. Returns a ``(K, 1)`` vector of coefficients ``b_k = (x' y_k) / (x' x)``,
+      one per column of ``Y``.
+    * **Case B** (``Nx == K``): regress ``x`` onto each row of ``Y`` one at a
+      time. Returns a ``(Ny, 1)`` vector of coefficients ``b_n = (y_n x) / (x' x)``,
+      one per row of ``Y``.
+
+    There may be missing data in ``Y``, but not in ``x``. The ``x`` vector
+    *must* be a column vector. Raises ``ValueError`` if neither case matches.
     """
     Ny, K = Y.shape
     Nx = x.shape[0]

--- a/process_improve/multivariate/plots.py
+++ b/process_improve/multivariate/plots.py
@@ -36,7 +36,11 @@ def score_plot(  # noqa: C901, PLR0913
     settings: dict | None = None,
     fig: go.Figure | None = None,
 ) -> go.Figure:
-    """Generate a 2-dimensional score plot for the given latent variable model.
+    """Generate a 2D or 3D score plot for the given latent variable model.
+
+    A 2D scatter on (``pc_horiz``, ``pc_vert``) is produced by default. Supplying
+    ``pc_depth >= 1`` adds a third score axis and switches the underlying trace
+    to ``Scatter3d``.
 
     Parameters
     ----------

--- a/process_improve/regression/methods.py
+++ b/process_improve/regression/methods.py
@@ -259,8 +259,9 @@ def multiple_linear_regression(  # noqa: PLR0913
         * does not handle weighting
         * N >= K at least as many rows as columns in X
 
-    Returns a dictionary of outputs with these keys::
+    Returns a dictionary of outputs. Keys always present::
 
+        N:                        number of observations actually used to fit
         coefficients:             a vector of K coefficients, one for each column in X
         intercept:                returned if fit_intercept==True
         standard_errors:          a vector of K standard errors, one per column in X
@@ -271,7 +272,15 @@ def multiple_linear_regression(  # noqa: PLR0913
         residuals:                the N residuals
         t_value:                  the t-values for the standard errors
         conf_intervals:           K rows x 2 columns (lower, upper) confidence intervals
-        pi_range:                 prediction intervals above and below, over the range of data
+
+    Keys present only for single-feature ``X`` (and only when ``fit_intercept``
+    is True and there is enough non-degenerate data)::
+
+        x_ssq:                    sum of squares of the centred predictor
+        leverage:                 hat-matrix diagonal
+        influence:                Cook-style influence values
+        pi_range:                 prediction interval above and below, over the
+                                  range of the predictor (``pi_resolution`` points)
     """
     model = OLS(
         fit_intercept=fit_intercept,

--- a/process_improve/univariate/metrics.py
+++ b/process_improve/univariate/metrics.py
@@ -504,7 +504,7 @@ def median_absolute_deviation(
         argument.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when input contains nan.
-        The following options are available (default is 'propagate'):
+        The following options are available (default is 'omit'):
         * 'propagate': returns nan
         * 'raise': throws an error
         * 'omit': performs the calculations ignoring nan values

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.16.8"
+version = "1.16.9"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Audit pass over computational and user-facing functions in the package to find docstrings that describe behavior the code does not implement (or describe behavior different from what the code does). Each finding is fixed in its own micro-commit on this branch.

## Inconsistencies addressed

- **`process_improve/univariate/metrics.py:466` `median_absolute_deviation`**: Parameters section claimed `nan_policy` default is `'propagate'`, but the signature default is `'omit'`.
- **`process_improve/monitoring/metrics.py:7` `calculate_cpk`**: `specifications` parameter description said "Either a value, ..." but the code unpacks a 2-tuple `(lower, upper)` where each element may be a numeric value, a column name, or `None`.
- **`process_improve/experiments/optimal.py:9` `optimization_function`**: Said it returns "the D-optimality of the design", but actually returns `log|det((X'X)^-1)|` (a quantity to MINIMIZE), opposite of the standard D-criterion convention.
- **`process_improve/multivariate/methods.py:1634` `quick_regress`**: Docstring described only Case A (regress `x` onto each column of `Y`); the code also has Case B that regresses each row of `Y` onto `x`.
- **`process_improve/multivariate/plots.py:30` `score_plot`**: First sentence said "2-dimensional", but the function supports 3D plots when `pc_depth >= 1`.
- **`process_improve/regression/methods.py:243` `multiple_linear_regression`**: Returned-keys block promised `pi_range` always, but `OLS.to_dict()` only includes it for single-feature inputs with intercept.
- **`process_improve/batch/features.py:225` `f_mad`**: Body calls `prepared.mad()`, which was removed in pandas 2.0; documented behavior is unreachable on supported pandas versions. Added a warning block matching the style of `f_robust_mad`.

## Test plan

- [ ] `pytest -o "addopts="`

https://claude.ai/code/session_01MUTiN2uJGQi5TjyGc66tyU

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUTiN2uJGQi5TjyGc66tyU)_