### PR TITLE
Set explicit Pygments code highlighting styles for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,4 +83,6 @@ html_theme_options = {
     "github_url": "https://github.com/kgdunn/process_improve",
     "show_toc_level": 2,
     "navigation_with_keys": True,
+    "pygments_light_style": "default",
+    "pygments_dark_style": "monokai",
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.16.8"
+version = "1.16.9"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

The Sphinx documentation had no Pygments syntax-highlighting style configured, so it fell back to the PyData Sphinx Theme default (the accessible high-contrast palette). This switches code blocks to an explicit, dark-forward pair:

- Light mode: `default` Pygments style
- Dark mode: `monokai` Pygments style

Both styles are built into Pygments, so no new dependency is added. They are wired up via the PyData theme's `pygments_light_style` / `pygments_dark_style` options in `html_theme_options`.

## Changes

- `docs/conf.py`: add `pygments_light_style` and `pygments_dark_style` to `html_theme_options`
- `pyproject.toml`: PATCH version bump `1.16.8` -> `1.16.9`

## Test plan

- [ ] `cd docs && make html` builds without warnings about unknown Pygments styles
- [ ] PCA/PLS example pages render code blocks with the Monokai palette in dark mode and the `default` palette in light mode (toggle via the theme switcher)


---
_Generated by [Claude Code](https://claude.ai/code/session_011DbEjgCtrUfwtq8oQihdBN)_