### PR TITLE
Add download badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![PyPI version](https://img.shields.io/pypi/v/process-improve.svg)](https://pypi.org/project/process-improve/)
 [![Python versions](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fkgdunn%2Fprocess-improve%2Fmain%2Fpyproject.toml&label=python)](https://pypi.org/project/process-improve/)
 [![License](https://img.shields.io/pypi/l/process-improve.svg)](LICENSE)
+[![Downloads](https://img.shields.io/pepy/dt/process-improve.svg?label=downloads)](https://pepy.tech/project/process-improve)
+[![Downloads per month](https://img.shields.io/pypi/dm/process-improve.svg?label=downloads%2Fmonth)](https://pypistats.org/packages/process-improve)
 [![CI](https://github.com/kgdunn/process-improve/actions/workflows/run-tests.yml/badge.svg?branch=main&event=push)](https://github.com/kgdunn/process-improve/actions/workflows/run-tests.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/kgdunn/process-improve/branch/main/graph/badge.svg)](https://codecov.io/gh/kgdunn/process-improve)
 [![Docs](https://img.shields.io/badge/docs-kgdunn.github.io-blue.svg)](https://kgdunn.github.io/process-improve/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.16.9"
+version = "1.16.10"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Add a **Downloads** badge (total PyPI downloads, via pepy.tech) to the README
- Add a **Downloads per month** badge (via shields.io `pypi/dm`) to the README
- Bump version `1.16.9` → `1.16.10` (PATCH, docs change)

Both badges use shields.io to match the style of the existing badges. The total-downloads badge links to pepy.tech and the monthly badge links to pypistats.org.

## Test plan

- [ ] Confirm both badges render correctly on the rendered README once merged to `main`

https://claude.ai/code/session_01Ua9DizknHc89GZzBq17Ldb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ua9DizknHc89GZzBq17Ldb)_