### PR TITLE
Scope CI cancel-in-progress to pull requests only

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Only cancel redundant in-progress runs for pull requests. Pushes to main
+  # share a single concurrency group (no pull_request.number), so a blanket
+  # cancel-in-progress would abort an earlier merge commit's run as soon as the
+  # next commit lands, leaving it marked as cancelled rather than tested.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.16.11"
+version = "1.16.12"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Scope the `run-tests.yml` workflow's `cancel-in-progress` to **pull request events only**.
- Pushes to `main` have no `github.event.pull_request.number`, so they all fall into one concurrency group keyed on `refs/heads/main`. With a blanket `cancel-in-progress: true`, merging a second PR cancels the still-running CI for the previous merge commit, which then shows as **cancelled** (gray icon) rather than tested.
- New behaviour: `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` - redundant PR runs are still cancelled (the useful case), but every commit on `main` runs to completion.
- Bump version `1.16.11` → `1.16.12` (PATCH, CI/workflow change).

## Test plan

- [ ] After merge, confirm the push-to-`main` run completes (green) even when another PR merges shortly after

https://claude.ai/code/session_01Ua9DizknHc89GZzBq17Ldb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ua9DizknHc89GZzBq17Ldb)_