### PR TITLE
Add per-observation diagnostics to PCA and PLS

### DIFF
--- a/docs/api/multivariate.rst
+++ b/docs/api/multivariate.rst
@@ -80,6 +80,29 @@ Diagnostics
 These functions work with fitted :class:`PCA` and :class:`PLS` models. Each is
 also bound as a convenience method on the model after :meth:`fit`.
 
+.. note::
+
+   **Two different "contributions" diagnostics.** The library has two methods
+   whose names both contain "contributions"; they are not interchangeable and
+   answer different questions about the same fitted score matrix.
+
+   * :meth:`PCA.score_contributions` (and :meth:`PLS.score_contributions`) is
+     *per-variable* and signed. It decomposes a single observation's movement
+     in score space back onto the original variables, answering "which
+     **variables** explain why this observation sits where it does?". It
+     returns one signed value per variable, and it takes an observation's
+     score vector as input.
+
+   * :func:`observation_contributions` is *per-observation* and non-negative.
+     It reports each observation's share of a component's total inertia
+     (:math:`t_{ia}^2 / \sum_i t_{ia}^2`), answering "which **observations**
+     most strongly shape this component?". It returns a sample-by-component
+     table whose columns each sum to 1, and it takes no input beyond the
+     fitted model.
+
+   In short, ``score_contributions`` decomposes *across variables* while
+   ``observation_contributions`` decomposes *across observations*.
+
 .. autofunction:: vip
 
 .. autofunction:: squared_cosine

--- a/docs/api/multivariate.rst
+++ b/docs/api/multivariate.rst
@@ -74,6 +74,22 @@ Preprocessing
 
 .. autofunction:: scale
 
+Diagnostics
+-----------
+
+These functions work with fitted :class:`PCA` and :class:`PLS` models. Each is
+also bound as a convenience method on the model after :meth:`fit`.
+
+.. autofunction:: vip
+
+.. autofunction:: squared_cosine
+
+.. autofunction:: observation_contributions
+
+.. autofunction:: eigenvalue_summary
+
+.. autofunction:: project_variables
+
 Plots
 -----
 

--- a/process_improve/multivariate/__init__.py
+++ b/process_improve/multivariate/__init__.py
@@ -6,7 +6,12 @@ from process_improve.multivariate.methods import (
     TPLS,
     MCUVScaler,
     center,
+    eigenvalue_summary,
+    observation_contributions,
+    project_variables,
     scale,
+    squared_cosine,
+    vip,
 )
 from process_improve.multivariate.plots import (
     loading_plot,
@@ -21,9 +26,14 @@ __all__ = [
     "TPLS",
     "MCUVScaler",
     "center",
+    "eigenvalue_summary",
     "loading_plot",
+    "observation_contributions",
+    "project_variables",
     "scale",
     "score_plot",
     "spe_plot",
+    "squared_cosine",
     "t2_plot",
+    "vip",
 ]

--- a/process_improve/multivariate/methods.py
+++ b/process_improve/multivariate/methods.py
@@ -143,6 +143,250 @@ def vip(model: PCA | PLS, n_components: int | None = None) -> pd.Series:
     return pd.Series(vip_values, index=weights.index, name="VIP")
 
 
+def squared_cosine(model: PCA | PLS, n_components: int | None = None) -> pd.DataFrame:
+    r"""Calculate the squared cosine (cos2): quality of representation of observations.
+
+    Works with fitted :class:`PCA` and :class:`PLS` models. The squared cosine
+    of observation :math:`i` on component :math:`a` is the squared score
+    divided by that observation's total variation budget:
+
+    .. math::
+
+        \\cos^2_{ia} = \\frac{t_{ia}^2}
+            {\\sum_{a=1}^{A} t_{ia}^2 + \\text{SPE}_i^2}
+
+    where :math:`t_{ia}` is the score and :math:`\\text{SPE}_i` the residual
+    (squared prediction error) of the observation. Across all components the
+    cos2 values plus the residual fraction sum to 1. A value close to 1 means
+    the observation is well represented on that component. For :class:`PCA`,
+    whose loadings are orthonormal, the denominator equals the squared distance
+    of the observation from the origin, matching the classical definition.
+
+    cos2 complements the existing diagnostics: Hotelling's T² measures distance
+    *within* the model plane, SPE measures distance *to* it, and cos2 reports
+    how much of an observation's total variation a given component captures.
+
+    Parameters
+    ----------
+    model : PCA or PLS
+        A fitted PCA or PLS model.
+    n_components : int or None, default=None
+        Number of components to return. ``None`` returns all fitted components.
+
+    Returns
+    -------
+    pd.DataFrame
+        cos2 values of shape (n_samples, n_components), indexed by sample.
+
+    Raises
+    ------
+    ValueError
+        If the model is not fitted, or if *n_components* is out of range.
+
+    Examples
+    --------
+    >>> pca = PCA(n_components=3).fit(X_scaled)
+    >>> pca.squared_cosine()              # bound convenience method after fit()
+    >>> squared_cosine(pca, n_components=2)  # or call the function directly
+    """
+    if not hasattr(model, "scores_") or not hasattr(model, "spe_"):
+        msg = "Model is not fitted. Call fit() before computing the squared cosine."
+        raise ValueError(msg)
+
+    scores = model.scores_
+    total_components = scores.shape[1]
+    if n_components is None:
+        n_components = total_components
+    elif not (1 <= n_components <= total_components):
+        msg = f"n_components must be between 1 and {total_components}, got {n_components}."
+        raise ValueError(msg)
+
+    score_ss = scores.to_numpy(dtype=float) ** 2
+    residual_ss = model.spe_.to_numpy(dtype=float)[:, -1] ** 2
+    total_ss = score_ss.sum(axis=1) + residual_ss
+
+    with np.errstate(invalid="ignore", divide="ignore"):
+        cos2 = score_ss[:, :n_components] / total_ss[:, None]
+    cos2[~np.isfinite(cos2)] = 0.0
+
+    return pd.DataFrame(cos2, index=scores.index, columns=scores.columns[:n_components])
+
+
+def observation_contributions(model: PCA | PLS, n_components: int | None = None) -> pd.DataFrame:
+    r"""Calculate the contribution of each observation to each component.
+
+    Works with fitted :class:`PCA` and :class:`PLS` models. The contribution of
+    observation :math:`i` to component :math:`a` is its squared score divided
+    by the sum of squared scores of all observations on that component:
+
+    .. math::
+
+        \\text{contribution}_{ia} = \\frac{t_{ia}^2}{\\sum_{i=1}^{N} t_{ia}^2}
+
+    Values lie between 0 and 1 and each column sums to 1, so a contribution
+    well above the average :math:`1/N` flags an observation that strongly
+    shapes that component. This is the per-observation counterpart of the
+    per-variable ``score_contributions`` and :func:`vip` diagnostics.
+
+    Parameters
+    ----------
+    model : PCA or PLS
+        A fitted PCA or PLS model.
+    n_components : int or None, default=None
+        Number of components to return. ``None`` returns all fitted components.
+
+    Returns
+    -------
+    pd.DataFrame
+        Contributions of shape (n_samples, n_components), indexed by sample.
+        Each column sums to 1.
+
+    Raises
+    ------
+    ValueError
+        If the model is not fitted, or if *n_components* is out of range.
+
+    Examples
+    --------
+    >>> pca = PCA(n_components=3).fit(X_scaled)
+    >>> pca.observation_contributions()
+    >>> observation_contributions(pca, n_components=2)
+    """
+    if not hasattr(model, "scores_"):
+        msg = "Model is not fitted. Call fit() before computing observation contributions."
+        raise ValueError(msg)
+
+    scores = model.scores_
+    total_components = scores.shape[1]
+    if n_components is None:
+        n_components = total_components
+    elif not (1 <= n_components <= total_components):
+        msg = f"n_components must be between 1 and {total_components}, got {n_components}."
+        raise ValueError(msg)
+
+    score_ss = scores.to_numpy(dtype=float) ** 2
+    column_ss = score_ss.sum(axis=0)
+
+    with np.errstate(invalid="ignore", divide="ignore"):
+        contributions = score_ss[:, :n_components] / column_ss[:n_components]
+    contributions[~np.isfinite(contributions)] = 0.0
+
+    return pd.DataFrame(contributions, index=scores.index, columns=scores.columns[:n_components])
+
+
+def eigenvalue_summary(model: PCA | PLS) -> pd.DataFrame:
+    """Summarize the variance captured by each component as a tidy table.
+
+    Works with fitted :class:`PCA` and :class:`PLS` models. Returns one row per
+    component, collecting ``explained_variance_``, ``r2_per_component_`` and
+    ``r2_cumulative_`` into a single table.
+
+    Parameters
+    ----------
+    model : PCA or PLS
+        A fitted PCA or PLS model.
+
+    Returns
+    -------
+    pd.DataFrame
+        Indexed by component, with columns ``eigenvalue`` (the variance of the
+        component scores), ``percent_variance`` and ``cumulative_percent``. For
+        PCA the percentages refer to variance in X; for PLS they refer to the
+        variance in Y explained by each component.
+
+    Raises
+    ------
+    ValueError
+        If the model is not fitted.
+
+    Examples
+    --------
+    >>> pca = PCA(n_components=3).fit(X_scaled)
+    >>> pca.eigenvalue_summary()
+    >>> eigenvalue_summary(pca)
+    """
+    if not hasattr(model, "r2_per_component_"):
+        msg = "Model is not fitted. Call fit() before computing the eigenvalue summary."
+        raise ValueError(msg)
+
+    summary = pd.DataFrame(
+        {
+            "eigenvalue": np.asarray(model.explained_variance_, dtype=float),
+            "percent_variance": model.r2_per_component_.to_numpy(dtype=float) * 100.0,
+            "cumulative_percent": model.r2_cumulative_.to_numpy(dtype=float) * 100.0,
+        },
+        index=model.r2_per_component_.index,
+    )
+    summary.index.name = "component"
+    return summary
+
+
+def project_variables(model: PCA | PLS, supplementary_data: DataMatrix) -> pd.DataFrame:
+    """Project supplementary (passive) variables onto a fitted model.
+
+    Works with fitted :class:`PCA` and :class:`PLS` models. Supplementary
+    variables are extra columns that did not take part in fitting the model but
+    were measured on the *same observations*. Each supplementary variable is
+    represented by its correlation with each component's scores, the standard
+    representation for passive quantitative variables. This is the column-wise
+    counterpart of ``transform``, which projects supplementary *rows* (new
+    observations).
+
+    Parameters
+    ----------
+    model : PCA or PLS
+        A fitted PCA or PLS model.
+    supplementary_data : array-like of shape (n_samples, n_supplementary)
+        Passive variables measured on the same observations used to fit the
+        model. Must have the same number of rows as the training data.
+
+    Returns
+    -------
+    pd.DataFrame
+        Correlations of shape (n_supplementary, n_components): the coordinate
+        of each supplementary variable on each component.
+
+    Raises
+    ------
+    ValueError
+        If the model is not fitted, or if *supplementary_data* does not have
+        the same number of rows as the training data.
+
+    Examples
+    --------
+    >>> pca = PCA(n_components=3).fit(X_scaled)
+    >>> pca.project_variables(passive_columns)
+    >>> project_variables(pca, passive_columns)
+    """
+    if not hasattr(model, "scores_"):
+        msg = "Model is not fitted. Call fit() before projecting variables."
+        raise ValueError(msg)
+
+    scores = model.scores_
+    if not isinstance(supplementary_data, pd.DataFrame):
+        supplementary_data = pd.DataFrame(supplementary_data)
+
+    if supplementary_data.shape[0] != scores.shape[0]:
+        msg = (
+            f"Supplementary data must have {scores.shape[0]} rows (the number of "
+            f"observations used to fit the model), got {supplementary_data.shape[0]}."
+        )
+        raise ValueError(msg)
+
+    xs = supplementary_data.to_numpy(dtype=float)
+    t = scores.to_numpy(dtype=float)
+    xs_centered = xs - xs.mean(axis=0, keepdims=True)
+    t_centered = t - t.mean(axis=0, keepdims=True)
+    xs_norm = np.sqrt((xs_centered**2).sum(axis=0))
+    t_norm = np.sqrt((t_centered**2).sum(axis=0))
+
+    with np.errstate(invalid="ignore", divide="ignore"):
+        correlations = (xs_centered.T @ t_centered) / np.outer(xs_norm, t_norm)
+    correlations[~np.isfinite(correlations)] = 0.0
+
+    return pd.DataFrame(correlations, index=supplementary_data.columns, columns=scores.columns)
+
+
 class PCA(TransformerMixin, BaseEstimator):
     """Principal Component Analysis with support for missing data.
 
@@ -346,6 +590,10 @@ class PCA(TransformerMixin, BaseEstimator):
         self.score_plot = partial(score_plot, model=self)
         self.spe_limit = partial(spe_limit, model=self)
         self.vip = partial(vip, model=self)
+        self.squared_cosine = partial(squared_cosine, model=self)
+        self.observation_contributions = partial(observation_contributions, model=self)
+        self.eigenvalue_summary = partial(eigenvalue_summary, model=self)
+        self.project_variables = partial(project_variables, self)
 
         # Clean up temporary numpy arrays
         del self._loadings_np, self._scores_np, self._r2_np, self._r2cum_np, self._r2_per_var_np, self._spe_np
@@ -1289,6 +1537,10 @@ class PLS(RegressorMixin, TransformerMixin, BaseEstimator):
         self.loading_plot = partial(loading_plot, model=self)
         self.score_plot = partial(score_plot, model=self)
         self.vip = partial(vip, model=self)
+        self.squared_cosine = partial(squared_cosine, model=self)
+        self.observation_contributions = partial(observation_contributions, model=self)
+        self.eigenvalue_summary = partial(eigenvalue_summary, model=self)
+        self.project_variables = partial(project_variables, self)
 
         return self
 

--- a/process_improve/multivariate/methods.py
+++ b/process_improve/multivariate/methods.py
@@ -225,8 +225,17 @@ def observation_contributions(model: PCA | PLS, n_components: int | None = None)
 
     Values lie between 0 and 1 and each column sums to 1, so a contribution
     well above the average :math:`1/N` flags an observation that strongly
-    shapes that component. This is the per-observation counterpart of the
-    per-variable ``score_contributions`` and :func:`vip` diagnostics.
+    shapes that component.
+
+    Note that this is *not* the same diagnostic as the ``score_contributions``
+    method, despite the similar name. ``score_contributions`` is *per-variable*
+    and signed: it decomposes one observation's position in score space back
+    onto the original variables ("which **variables** explain why this
+    observation sits where it does?"). ``observation_contributions`` is
+    *per-observation* and non-negative: it reports each observation's share of
+    a component's total inertia ("which **observations** most strongly shape
+    this component?"). The two are orthogonal views of the same score matrix
+    and are not interchangeable.
 
     Parameters
     ----------
@@ -251,6 +260,11 @@ def observation_contributions(model: PCA | PLS, n_components: int | None = None)
     >>> pca = PCA(n_components=3).fit(X_scaled)
     >>> pca.observation_contributions()
     >>> observation_contributions(pca, n_components=2)
+
+    See Also
+    --------
+    PCA.score_contributions : The per-variable counterpart - decomposes one
+        observation's score-space position back onto the original variables.
     """
     if not hasattr(model, "scores_"):
         msg = "Model is not fitted. Call fit() before computing observation contributions."
@@ -997,6 +1011,22 @@ class PCA(TransformerMixin, BaseEstimator):
         >>> contrib = pca.score_contributions(
         ...     pca.scores_.iloc[0].values, pca.scores_.iloc[5].values
         ... )
+
+        See Also
+        --------
+        observation_contributions : The per-observation counterpart. Despite
+            the similar name, the two answer different questions and are not
+            interchangeable. ``score_contributions`` is *per-variable*: it
+            decomposes a single observation's movement in score space back
+            onto the original variables, answering "which **variables**
+            explain why this observation sits where it does?". It returns one
+            signed value per variable. ``observation_contributions`` is
+            *per-observation*: it reports each observation's share of a
+            component's total inertia, answering "which **observations** most
+            strongly shape this component?". It returns a non-negative
+            sample-by-component table whose columns each sum to 1. The two are
+            orthogonal views of the same score matrix - one decomposes across
+            variables, the other across observations.
         """
         check_is_fitted(self, "loadings_")
         t_start = np.asarray(t_start, dtype=float)
@@ -1672,6 +1702,22 @@ class PLS(RegressorMixin, TransformerMixin, BaseEstimator):
         >>> pls = PLS(n_components=3).fit(X_scaled, Y_scaled)
         >>> contrib = pls.score_contributions(pls.scores_.iloc[0].values)
         >>> contrib.abs().sort_values(ascending=False).head()  # top contributors
+
+        See Also
+        --------
+        observation_contributions : The per-observation counterpart. Despite
+            the similar name, the two answer different questions and are not
+            interchangeable. ``score_contributions`` is *per-variable*: it
+            decomposes a single observation's movement in score space back
+            onto the original X variables, answering "which **variables**
+            explain why this observation sits where it does?". It returns one
+            signed value per variable. ``observation_contributions`` is
+            *per-observation*: it reports each observation's share of a
+            component's total inertia, answering "which **observations** most
+            strongly shape this component?". It returns a non-negative
+            sample-by-component table whose columns each sum to 1. The two are
+            orthogonal views of the same score matrix - one decomposes across
+            variables, the other across observations.
         """
         check_is_fitted(self, "x_loadings_")
         t_start = np.asarray(t_start, dtype=float)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.16.11"
+version = "1.17.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -23,12 +23,16 @@ from process_improve.multivariate.methods import (
     MCUVScaler,
     SpecificationWarning,
     center,
+    eigenvalue_summary,
     ellipse_coordinates,
     epsqrt,
     nan_to_zeros,
+    observation_contributions,
+    project_variables,
     quick_regress,
     regress_a_space_on_b_row,
     scale,
+    squared_cosine,
     ssq,
     vip,
 )
@@ -2541,6 +2545,174 @@ def test_t2_plot_accepts_valid_conf_level(fixture_pca_for_plots: PCA) -> None:
     """t2_plot should accept `conf_level` strictly inside (0, 1)."""
     fig = fixture_pca_for_plots.t2_plot(settings={"conf_level": 0.99})
     assert isinstance(fig, go.Figure)
+
+
+# ---- Per-observation diagnostics: cos2, contributions, eigenvalue summary, supplementary variables ----
+
+
+def test_squared_cosine_pca() -> None:
+    """cos2 for a fitted PCA model: shape, range, and agreement with the bound method."""
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame(rng.standard_normal((40, 6)), columns=[f"V{i}" for i in range(6)])
+    model = PCA(n_components=3).fit(MCUVScaler().fit_transform(X))
+
+    standalone = squared_cosine(model)
+    bound = model.squared_cosine()
+    assert standalone.equals(bound)
+
+    assert isinstance(standalone, pd.DataFrame)
+    assert standalone.shape == (40, 3)
+    assert standalone.index.equals(model.scores_.index)
+    assert list(standalone.columns) == list(model.scores_.columns)
+    assert ((standalone.to_numpy() >= 0) & (standalone.to_numpy() <= 1 + 1e-9)).all()
+
+    # cos2 over all components plus the residual fraction must sum to 1 per row.
+    residual_ss = model.spe_.iloc[:, -1].to_numpy() ** 2
+    score_ss = (model.scores_.to_numpy() ** 2).sum(axis=1)
+    residual_fraction = residual_ss / (score_ss + residual_ss)
+    assert standalone.sum(axis=1).to_numpy() + residual_fraction == pytest.approx(1.0, abs=1e-9)
+
+
+def test_squared_cosine_pls() -> None:
+    """cos2 works for PLS and matches the bound method."""
+    rng = np.random.default_rng(1)
+    X = pd.DataFrame(rng.standard_normal((40, 5)), columns=[f"X{i}" for i in range(5)])
+    beta = np.array([[2.0], [1.0], [-1.0], [0.5], [0.0]])
+    Y = pd.DataFrame(X.values @ beta + rng.standard_normal((40, 1)) * 0.3, columns=["y"])
+    model = PLS(n_components=2).fit(MCUVScaler().fit_transform(X), MCUVScaler().fit_transform(Y))
+
+    bound = model.squared_cosine()
+    assert squared_cosine(model).equals(bound)
+    assert bound.shape == (40, 2)
+    assert ((bound.to_numpy() >= 0) & (bound.to_numpy() <= 1 + 1e-9)).all()
+
+
+def test_squared_cosine_n_components() -> None:
+    """cos2 honours n_components and rejects out-of-range values."""
+    rng = np.random.default_rng(2)
+    X = pd.DataFrame(rng.standard_normal((30, 5)), columns=list("ABCDE"))
+    model = PCA(n_components=3).fit(MCUVScaler().fit_transform(X))
+
+    assert model.squared_cosine(n_components=2).shape == (30, 2)
+    # Restricting the number of components does not change the values that remain.
+    assert model.squared_cosine(n_components=2).equals(model.squared_cosine().iloc[:, :2])
+
+    with pytest.raises(ValueError, match="n_components"):
+        model.squared_cosine(n_components=0)
+    with pytest.raises(ValueError, match="n_components"):
+        model.squared_cosine(n_components=99)
+
+
+def test_observation_contributions_pca() -> None:
+    """Observation contributions for PCA: each component column sums to 1."""
+    rng = np.random.default_rng(3)
+    X = pd.DataFrame(rng.standard_normal((35, 6)), columns=[f"V{i}" for i in range(6)])
+    model = PCA(n_components=3).fit(MCUVScaler().fit_transform(X))
+
+    standalone = observation_contributions(model)
+    bound = model.observation_contributions()
+    assert standalone.equals(bound)
+
+    assert standalone.shape == (35, 3)
+    assert (standalone.to_numpy() >= 0).all()
+    assert standalone.sum(axis=0).to_numpy() == pytest.approx(1.0, abs=1e-9)
+
+
+def test_observation_contributions_pls() -> None:
+    """Observation contributions for PLS: each component column sums to 1."""
+    rng = np.random.default_rng(4)
+    X = pd.DataFrame(rng.standard_normal((35, 5)), columns=[f"X{i}" for i in range(5)])
+    beta = np.array([[1.5], [-0.5], [1.0], [0.0], [0.7]])
+    Y = pd.DataFrame(X.values @ beta + rng.standard_normal((35, 1)) * 0.2, columns=["y"])
+    model = PLS(n_components=2).fit(MCUVScaler().fit_transform(X), MCUVScaler().fit_transform(Y))
+
+    contributions = model.observation_contributions()
+    assert contributions.shape == (35, 2)
+    assert contributions.sum(axis=0).to_numpy() == pytest.approx(1.0, abs=1e-9)
+
+    with pytest.raises(ValueError, match="n_components"):
+        model.observation_contributions(n_components=5)
+
+
+def test_eigenvalue_summary_pca(fixture_tablet_spectra_data: tuple[pd.DataFrame, np.ndarray]) -> None:
+    """Eigenvalue summary for PCA on a real dataset: tidy table, monotone cumulative."""
+    spectra, _ = fixture_tablet_spectra_data
+    model = PCA(n_components=4).fit(MCUVScaler().fit_transform(spectra))
+
+    summary = eigenvalue_summary(model)
+    assert model.eigenvalue_summary().equals(summary)
+    assert list(summary.columns) == ["eigenvalue", "percent_variance", "cumulative_percent"]
+    assert summary.index.name == "component"
+    assert len(summary) == 4
+
+    # Cumulative percentage is non-decreasing and matches r2_cumulative_.
+    cumulative = summary["cumulative_percent"].to_numpy()
+    assert np.all(np.diff(cumulative) >= -1e-9)
+    assert cumulative == pytest.approx(model.r2_cumulative_.to_numpy() * 100.0)
+    # The R reference (prcomp) reports ~95.85% cumulative variance for 4 components.
+    assert cumulative[-1] == pytest.approx(95.846, abs=0.5)
+
+
+def test_eigenvalue_summary_pls() -> None:
+    """Eigenvalue summary works for PLS."""
+    rng = np.random.default_rng(5)
+    X = pd.DataFrame(rng.standard_normal((40, 5)), columns=[f"X{i}" for i in range(5)])
+    beta = np.array([[2.0], [1.0], [-1.0], [0.5], [0.0]])
+    Y = pd.DataFrame(X.values @ beta + rng.standard_normal((40, 1)) * 0.3, columns=["y"])
+    model = PLS(n_components=3).fit(MCUVScaler().fit_transform(X), MCUVScaler().fit_transform(Y))
+
+    summary = model.eigenvalue_summary()
+    assert list(summary.columns) == ["eigenvalue", "percent_variance", "cumulative_percent"]
+    assert len(summary) == 3
+    assert summary["cumulative_percent"].iloc[-1] == pytest.approx(model.r2_cumulative_.iloc[-1] * 100.0)
+
+
+def test_project_variables_recovers_scores() -> None:
+    """Projecting the score matrix as supplementary variables yields the identity."""
+    rng = np.random.default_rng(6)
+    X = pd.DataFrame(rng.standard_normal((50, 6)), columns=[f"V{i}" for i in range(6)])
+    model = PCA(n_components=3).fit(MCUVScaler().fit_transform(X))
+
+    # PCA scores are mutually orthogonal, so projecting them as supplementary
+    # variables must give an (almost) identity correlation matrix.
+    projected = model.project_variables(model.scores_)
+    assert projected.shape == (3, 3)
+    assert projected.to_numpy() == pytest.approx(np.eye(3), abs=1e-9)
+
+
+def test_project_variables_pls_and_errors() -> None:
+    """project_variables works for PLS and validates the row count."""
+    rng = np.random.default_rng(7)
+    X = pd.DataFrame(rng.standard_normal((40, 5)), columns=[f"X{i}" for i in range(5)])
+    beta = np.array([[2.0], [1.0], [-1.0], [0.5], [0.0]])
+    Y = pd.DataFrame(X.values @ beta + rng.standard_normal((40, 1)) * 0.3, columns=["y"])
+    model = PLS(n_components=2).fit(MCUVScaler().fit_transform(X), MCUVScaler().fit_transform(Y))
+
+    supplementary = pd.DataFrame(rng.standard_normal((40, 3)), columns=["s1", "s2", "s3"])
+    projected = model.project_variables(supplementary)
+    assert projected.shape == (3, 2)
+    assert list(projected.index) == ["s1", "s2", "s3"]
+    assert ((projected.to_numpy() >= -1 - 1e-9) & (projected.to_numpy() <= 1 + 1e-9)).all()
+
+    # The standalone function agrees with the bound method.
+    assert project_variables(model, supplementary).equals(projected)
+
+    # A supplementary block with the wrong number of rows must raise.
+    with pytest.raises(ValueError, match="rows"):
+        model.project_variables(pd.DataFrame(rng.standard_normal((10, 2))))
+
+
+def test_diagnostics_unfitted_raise() -> None:
+    """The new diagnostics raise a clear error on an unfitted model."""
+    for unfitted in (PCA(n_components=2), PLS(n_components=2)):
+        with pytest.raises(ValueError, match="not fitted"):
+            squared_cosine(unfitted)
+        with pytest.raises(ValueError, match="not fitted"):
+            observation_contributions(unfitted)
+        with pytest.raises(ValueError, match="not fitted"):
+            eigenvalue_summary(unfitted)
+        with pytest.raises(ValueError, match="not fitted"):
+            project_variables(unfitted, pd.DataFrame(np.zeros((3, 2))))
 
 
 # n_components = 3


### PR DESCRIPTION
## Summary

Adds four classical latent-variable diagnostics to the `PCA` and `PLS`
classes, exposed both as standalone functions and as convenience methods
bound after `fit()` (matching the existing `vip` pattern):

- **`squared_cosine`** (cos2): quality of representation of each observation
  on each component. Complements SPE and Hotelling's T2.
- **`observation_contributions`**: how strongly each observation drives each
  component (the per-observation counterpart to the existing per-variable
  `score_contributions` and VIP).
- **`eigenvalue_summary`**: a tidy table of eigenvalue, percent variance, and
  cumulative percent.
- **`project_variables`**: projects supplementary (passive) variables onto a
  fitted model as correlations with each component.

Also exports `vip` and the four new functions from the `multivariate`
package, documents them in the API reference, and bumps the version to
1.17.0 (new features).

## Test plan

- [x] New tests in `tests/test_multivariate.py` for each diagnostic on both
      PCA and PLS, using a real dataset (tablet spectra) and synthetic data
- [x] `pytest tests/test_multivariate.py -o "addopts="` - 77 passed, 2 skipped
- [x] `ruff check .` - all checks passed

https://claude.ai/code/session_01Gb56zS6tQW1Jdb64iaGAAb