### PR TITLE
Migrate test_doe.py from unittest to pytest

### DIFF
--- a/tests/test_doe.py
+++ b/tests/test_doe.py
@@ -1,9 +1,11 @@
-import pathlib
-import unittest
+"""Tests for design of experiments (DOE) module.
 
+This module was migrated from unittest to pytest format.
+"""
 import numpy as np
 import pandas as pd
 import pytest
+from pathlib import Path
 
 from process_improve.experiments.designs_factorial import full_factorial
 from process_improve.experiments.models import lm, predict, summary
@@ -11,251 +13,247 @@ from process_improve.experiments.optimal import optimization_function, point_exc
 from process_improve.experiments.structures import c, create_names, expand_grid, gather, supplement
 
 
-class TestStructures(unittest.TestCase):
-    """Test the data structures."""
-
-    def setUp(self) -> None:
-        """Set up test fixtures."""
-        self.A = [-1, +1, -1, +1, 0, +1]
-        self.B = [-1, -1, +1, +1, 0, 0]
-        self.C = [4, 5, 6, 4, 6]
-        self.D = [0, 1, "green"]
-        self.y = [52, 74, 62, 80, 50, 65]
-
-    def test_create_names(self) -> None:
-        """Create factor names."""
-        assert create_names(5) == ["A", "B", "C", "D", "E"]
-
-        assert create_names(3, letters=False) == ["X1", "X2", "X3"]
-
-        assert create_names(3, letters=False, prefix="Q", start_at=9, padded=True) == ["Q09", "Q10", "Q11"]
-
-        assert create_names(4, letters=False, prefix="Z", start_at=99, padded=True) == [
-            "Z099",
-            "Z100",
-            "Z101",
-            "Z102",
-        ]
-
-    def test_create_factors(self) -> None:
-        """Test creating factors with various options."""
-        A1 = c(*(self.A))
-        A2 = c(*(self.A), index=["lo", "hi", "lo", "hi", "cp", "hi"])
-        B = c(*(self.B), name="B")
-        C1 = c(*(self.C), range=(4, 6))
-        C2 = c(*(self.C), center=5, range=(4, 6))
-        C3 = c(*(self.C), lo=4, hi=6)
-        C4 = c(*(self.C), lo=4, hi=6, name="C4")
-        C5 = c([4, 5, 6, 4, 6], lo=4, hi=6, name="C5")
-        C6 = c(*(self.C), lo=5, hi=6, name="C6")
-        y = c(*(self.y), name="conversion", units="%")
-
-        assert isinstance(A1, pd.Series)
-        assert A1.shape == (6,)
-        assert hasattr(A1, "pi_index")
-        assert hasattr(A1, "name")
-
-        assert A1.name == "Unnamed [coded]"
-        assert hasattr(A1, "pi_lo")
-        assert A1.pi_lo == -1
-        assert hasattr(A1, "pi_hi")
-        assert A1.pi_hi == +1
-        assert hasattr(A1, "pi_range")
-        assert A1.pi_range[0] == -1
-        assert A1.pi_range[1] == +1
-        assert hasattr(A1, "pi_center")
-        assert A1.pi_center == 0
-
-        assert isinstance(A2.index, pd.Index)
-        assert hasattr(A2, "pi_index")
-        assert A2.name == "Unnamed [coded]"
-
-        with pytest.raises(IndexError):
-            A2 = c(*(self.A), index=["lo", "hi", "lo", "hi", "cp"])
-
-        assert B.shape == (6,)
-        assert B.name == "B [coded]"
-
-        assert C1.pi_range == (4, 6)
-        assert C2.pi_center == 5
-        assert C2.pi_range == (4, 6)
-        assert C3.pi_lo == 4
-        assert C3.pi_hi == 6
-        assert C4.pi_lo == 4
-        assert C4.pi_hi == 6
-        assert C5.pi_hi == 6
-        assert C5.name == "C5"
-
-        # User says the low is 5, but the minimum is actually different
-        assert C6.pi_lo == 5
-        assert C6.pi_range == (5, 6)
-
-        D = c(*(self.D))
-        assert D.pi_numeric is True
-
-        assert len(y) == 6
-        assert y.name == "conversion [%]"
-
-    def test_column_math(self) -> None:
-        """Test column multiplication."""
-        self.A = [-1, +1, -1, +1, 0, +1]
-        self.B = [-1, -1, +1, +1, 0, 0]
-        A = c(*(self.A))
-        B = c(*(self.B), name="B")
-        C1 = A * B
-        C2 = B * A
-
-        assert np.all(C1.values == [+1, -1, -1, +1, 0, 0])
-        assert np.all(C1.index == A.index)
-        assert np.all(C2.values == [+1, -1, -1, +1, 0, 0])
-        assert np.all(C2.index == A.index)
-
-    def test_gather(self) -> None:
-        """Test gathering factors into an experiment."""
-        A = c(*(self.A))
-        B = c(*(self.B))
-        y = c(*(self.y), name="conversion")
-
-        expt = gather(A=A, B=B, y=y)
-        assert expt.shape == (6, 3)
-
-        expt = gather(A=A, B=B, y=y, title="Testing expt name")
-
-        # Eventually this method must go to the "DF" class; currently in the
-        # model class; not really appropriate there.
-        assert expt.get_title() == "Testing expt name"
+# ============================================================================
+# Fixtures for TestStructures
+# ============================================================================
 
 
-class TestModels(unittest.TestCase):
-    """Test model fitting and results."""
-
-    def setUp(self) -> None:
-        """Set up test fixtures for model tests."""
-        A = c(-1, +1, -1, +1)
-        B = c(-1, -1, +1, +1)
-        C = A * B
-        y = c(41, 27, 35, 20, name="Stability", units="days")
-        self.expt = gather(A=A, B=B, C=C, y=y, title="Half-fraction, using C = A*B")
-        self.model_stability_poshalf = lm("y ~ A*B*C", self.expt)
-
-        """
-        Results from R:
-        A = c(-1, +1, -1, +1)
-        B = c(-1, -1, +1, +1)
-        C = A*B
-        y = c(41, 27, 35, 20)
-        data = data.frame(A=A, B=B, C=C, y=y)
-        model = lm(y ~ A*B*C, data=data)
-        summary(model)
-
-        Call:
-            lm(formula = y ~ A * B * C, data = data)
-
-            Residuals:
-            ALL 4 residuals are 0: no residual degrees of freedom!
-
-            Coefficients: (4 not defined because of singularities)
-                        Estimate Std. Error t value Pr(>|t|)
-            (Intercept)    30.75         NA      NA       NA
-            A              -7.25         NA      NA       NA
-            B              -3.25         NA      NA       NA
-            C              -0.25         NA      NA       NA
-            A:B               NA         NA      NA       NA
-            A:C               NA         NA      NA       NA
-            B:C               NA         NA      NA       NA
-            A:B:C             NA         NA      NA       NA
-
-            Residual standard error: NaN on 0 degrees of freedom
-            Multiple R-squared:      1,	Adjusted R-squared:    NaN
-            F-statistic:   NaN on 3 and 0 DF,  p-value: NA
-        """
-
-    def test_half_fraction(self) -> None:
-        """Testing attributes for the half-fraction model."""
-        assert self.model_stability_poshalf.nobs == 4
-        assert self.model_stability_poshalf.df_resid == 0
-        beta = self.model_stability_poshalf.get_parameters(drop_intercept=False)
-
-        assert beta["A"] == pytest.approx(-7.25)
-        assert beta["B"] == pytest.approx(-3.25)
-        assert beta["C"] == pytest.approx(-0.25)
-        assert beta["Intercept"] == pytest.approx(30.75)
-        assert self.model_stability_poshalf.get_aliases() == ["A + B:C", "B + A:C", "C + A:B"]
-
-        for resid in self.model_stability_poshalf.residuals:
-            assert resid == pytest.approx(0.0)
+@pytest.fixture
+def fixture_abcd_y():
+    """Common test data for structures tests."""
+    return {
+        "A": [-1, +1, -1, +1, 0, +1],
+        "B": [-1, -1, +1, +1, 0, 0],
+        "C": [4, 5, 6, 4, 6],
+        "D": [0, 1, "green"],
+        "y": [52, 74, 62, 80, 50, 65],
+    }
 
 
-class TestAPIUsage(unittest.TestCase):
-    """Test API usage patterns."""
-
-    def setUp(self) -> None:
-        """Set up test fixtures for API usage tests."""
-        # TODO: replace unittest -> pytest
-        # TODO: use path
-        folder = pathlib.Path(__file__).parents[1] / "process_improve" / "datasets" / "experiments"
-        self.df1 = pd.read_csv(folder / "test_doe1.csv").set_index("Run order")
-
-    @pytest.mark.skip(reason="Figure out StringArray in pandas")
-    def test_case_1(self) -> None:
-        """Test case 1 with real-world data."""
-        index = self.df1.index
-        C = c(
-            self.df1["C"],
-            lo=self.df1["C"].min(),
-            hi=self.df1["C"].max(),
-            index=index,
-            name="C",
-        )
-        M = c(self.df1["M"], levels=self.df1["M"].unique(), name="M")
-        V = c(self.df1["V"], lo=self.df1["V"].min(), hi=self.df1["V"].max(), name="V")
-        B = c(self.df1["B"], name="B")
-        assert B.pi_levels["B"] == ["Ard", "Eme"]
-
-        y = self.df1["y"]
-
-        expt = gather(C=C, M=M, V=V, B=B, y=y)
-        assert np.all(C.index == M.index)
-
-        _ = lm("np.log10(y) ~ C*M*B*V", expt)
-        # summary(model)
-        # pareto_plot(model)
-        # contour_plot(model, C, M)
-        # contour_plot(model, "C", "M")
-        # predict_plot(model)
-
-    def test_aliasing(self) -> None:
-        """Test aliasing detection in models."""
-        d4 = c(24, 48, 36, 36, 60, units="hours", lo=24, high=48)
-        y4 = c(31, 65, 52, 54, 69)
-        expt4 = gather(d=d4, y=y4, title="RW units")
-        model4 = lm("y ~ d + I(np.power(d, 2))", data=expt4)
-        assert len(model4.aliasing) == 0
-
-        model5 = lm("y ~ d + I(np.power(d, 2))", data=expt4, alias_threshold=0.99)
-        assert len(model5.aliasing) == 2
-
-    def test_realworld_coded(self) -> None:
-        """Test conversion between real-world and coded units."""
-        c1 = c(2.5, 3, 2.5, 3, center=2.75, range=[2.5, 3], name="cement")
-        c1_coded = c1.to_coded()
-        assert c1_coded.to_list() == [-1.0, 1.0, -1.0, 1.0]
-
-        c2 = c(
-            [-1.0, -1.0, +1.0, +1.0],
-            center=2.75,
-            range=[2.5, 3],
-            name="cement",
-            coded=True,
-        )
-        c2_rw = c2.to_realworld()
-        assert c2_rw.to_list() == [2.5, 2.5, 3.0, 3.0]
+# ============================================================================
+# TestStructures - Data structure tests
+# ============================================================================
 
 
-# ---- Model tests (improving experiments/models.py coverage) ----
+def test_create_names():
+    """Create factor names."""
+    assert create_names(5) == ["A", "B", "C", "D", "E"]
+    assert create_names(3, letters=False) == ["X1", "X2", "X3"]
+    assert create_names(3, letters=False, prefix="Q", start_at=9, padded=True) == ["Q09", "Q10", "Q11"]
+    assert create_names(4, letters=False, prefix="Z", start_at=99, padded=True) == [
+        "Z099",
+        "Z100",
+        "Z101",
+        "Z102",
+    ]
 
 
-def test_model_summary_output() -> None:
+def test_create_factors(fixture_abcd_y):
+    """Test creating factors with various options."""
+    data = fixture_abcd_y
+    A1 = c(*(data["A"]))
+    A2 = c(*(data["A"]), index=["lo", "hi", "lo", "hi", "cp", "hi"])
+    B = c(*(data["B"]), name="B")
+    C1 = c(*(data["C"]), range=(4, 6))
+    C2 = c(*(data["C"]), center=5, range=(4, 6))
+    C3 = c(*(data["C"]), lo=4, hi=6)
+    C4 = c(*(data["C"]), lo=4, hi=6, name="C4")
+    C5 = c([4, 5, 6, 4, 6], lo=4, hi=6, name="C5")
+    C6 = c(*(data["C"]), lo=5, hi=6, name="C6")
+    y = c(*(data["y"]), name="conversion", units="%")
+
+    assert isinstance(A1, pd.Series)
+    assert A1.shape == (6,)
+    assert hasattr(A1, "pi_index")
+    assert hasattr(A1, "name")
+
+    assert A1.name == "Unnamed [coded]"
+    assert hasattr(A1, "pi_lo")
+    assert A1.pi_lo == -1
+    assert hasattr(A1, "pi_hi")
+    assert A1.pi_hi == +1
+    assert hasattr(A1, "pi_range")
+    assert A1.pi_range[0] == -1
+    assert A1.pi_range[1] == +1
+    assert hasattr(A1, "pi_center")
+    assert A1.pi_center == 0
+
+    assert isinstance(A2.index, pd.Index)
+    assert hasattr(A2, "pi_index")
+    assert A2.name == "Unnamed [coded]"
+
+    with pytest.raises(IndexError):
+        A2 = c(*(data["A"]), index=["lo", "hi", "lo", "hi", "cp"])
+
+    assert B.shape == (6,)
+    assert B.name == "B [coded]"
+
+    assert C1.pi_range == (4, 6)
+    assert C2.pi_center == 5
+    assert C2.pi_range == (4, 6)
+    assert C3.pi_lo == 4
+    assert C3.pi_hi == 6
+    assert C4.pi_lo == 4
+    assert C4.pi_hi == 6
+    assert C5.pi_hi == 6
+    assert C5.name == "C5"
+
+    # User says the low is 5, but the minimum is actually different
+    assert C6.pi_lo == 5
+    assert C6.pi_range == (5, 6)
+
+    D = c(*(data["D"]))
+    assert D.pi_numeric is True
+
+    assert len(y) == 6
+    assert y.name == "conversion [%]"
+
+
+def test_column_math(fixture_abcd_y):
+    """Test column multiplication."""
+    data = fixture_abcd_y
+    A = c(*(data["A"]))
+    B = c(*(data["B"]), name="B")
+    C1 = A * B
+    C2 = B * A
+
+    assert np.all(C1.values == [+1, -1, -1, +1, 0, 0])
+    assert np.all(C1.index == A.index)
+    assert np.all(C2.values == [+1, -1, -1, +1, 0, 0])
+    assert np.all(C2.index == A.index)
+
+
+def test_gather(fixture_abcd_y):
+    """Test gathering factors into an experiment."""
+    data = fixture_abcd_y
+    A = c(*(data["A"]))
+    B = c(*(data["B"]))
+    y = c(*(data["y"]), name="conversion")
+
+    expt = gather(A=A, B=B, y=y)
+    assert expt.shape == (6, 3)
+
+    expt = gather(A=A, B=B, y=y, title="Testing expt name")
+
+    # Eventually this method must go to the "DF" class; currently in the
+    # model class; not really appropriate there.
+    assert expt.get_title() == "Testing expt name"
+
+
+# ============================================================================
+# Fixtures for TestModels
+# ============================================================================
+
+
+@pytest.fixture
+def model_stability_poshalf():
+    """Model for half-fraction design."""
+    A = c(-1, +1, -1, +1)
+    B = c(-1, -1, +1, +1)
+    C = A * B
+    y = c(41, 27, 35, 20, name="Stability", units="days")
+    expt = gather(A=A, B=B, C=C, y=y, title="Half-fraction, using C = A*B")
+    return lm("y ~ A*B*C", expt)
+
+
+# ============================================================================
+# TestModels - Model fitting and results tests
+# ============================================================================
+
+
+def test_half_fraction(model_stability_poshalf):
+    """Testing attributes for the half-fraction model."""
+    model = model_stability_poshalf
+    assert model.nobs == 4
+    assert model.df_resid == 0
+    beta = model.get_parameters(drop_intercept=False)
+
+    assert beta["A"] == pytest.approx(-7.25)
+    assert beta["B"] == pytest.approx(-3.25)
+    assert beta["C"] == pytest.approx(-0.25)
+    assert beta["Intercept"] == pytest.approx(30.75)
+    assert model.get_aliases() == ["A + B:C", "B + A:C", "C + A:B"]
+
+    for resid in model.residuals:
+        assert resid == pytest.approx(0.0)
+
+
+# ============================================================================
+# Fixtures for TestAPIUsage
+# ============================================================================
+
+
+@pytest.fixture
+def df1():
+    """Load test data for real-world tests."""
+    folder = Path(__file__).parents[1] / "process_improve" / "datasets" / "experiments"
+    return pd.read_csv(folder / "test_doe1.csv").set_index("Run order")
+
+
+# ============================================================================
+# TestAPIUsage - API usage patterns tests
+# ============================================================================
+
+
+@pytest.mark.skip(reason="Figure out StringArray in pandas")
+def test_case_1(df1):
+    """Test case 1 with real-world data."""
+    index = df1.index
+    C = c(
+        df1["C"],
+        lo=df1["C"].min(),
+        hi=df1["C"].max(),
+        index=index,
+        name="C",
+    )
+    M = c(df1["M"], levels=df1["M"].unique(), name="M")
+    V = c(df1["V"], lo=df1["V"].min(), hi=df1["V"].max(), name="V")
+    B = c(df1["B"], name="B")
+    assert B.pi_levels["B"] == ["Ard", "Eme"]
+
+    y = df1["y"]
+
+    expt = gather(C=C, M=M, V=V, B=B, y=y)
+    assert np.all(C.index == M.index)
+
+    _ = lm("np.log10(y) ~ C*M*B*V", expt)
+
+
+def test_aliasing():
+    """Test aliasing detection in models."""
+    d4 = c(24, 48, 36, 36, 60, units="hours", lo=24, high=48)
+    y4 = c(31, 65, 52, 54, 69)
+    expt4 = gather(d=d4, y=y4, title="RW units")
+    model4 = lm("y ~ d + I(np.power(d, 2))", data=expt4)
+    assert len(model4.aliasing) == 0
+
+    model5 = lm("y ~ d + I(np.power(d, 2))", data=expt4, alias_threshold=0.99)
+    assert len(model5.aliasing) == 2
+
+
+def test_realworld_coded():
+    """Test conversion between real-world and coded units."""
+    c1 = c(2.5, 3, 2.5, 3, center=2.75, range=[2.5, 3], name="cement")
+    c1_coded = c1.to_coded()
+    assert c1_coded.to_list() == [-1.0, 1.0, -1.0, 1.0]
+
+    c2 = c(
+        [-1.0, -1.0, +1.0, +1.0],
+        center=2.75,
+        range=[2.5, 3],
+        name="cement",
+        coded=True,
+    )
+    c2_rw = c2.to_realworld()
+    assert c2_rw.to_list() == [2.5, 2.5, 3.0, 3.0]
+
+
+# ============================================================================
+# Model tests (experiments/models.py coverage)
+# ============================================================================
+
+
+def test_model_summary_output():
     """Model.summary() should return a summary object with tables."""
     A = c(-1, +1, -1, +1)
     B = c(-1, -1, +1, +1)
@@ -267,7 +265,7 @@ def test_model_summary_output() -> None:
     assert len(smry.tables) >= 2
 
 
-def test_model_summary_with_name() -> None:
+def test_model_summary_with_name():
     """Model.summary() with a model name should include it in the title."""
     A = c(-1, +1, -1, +1)
     B = c(-1, -1, +1, +1)
@@ -279,7 +277,7 @@ def test_model_summary_with_name() -> None:
     assert "CustomName" in str(smry)
 
 
-def test_model_get_parameters() -> None:
+def test_model_get_parameters():
     """get_parameters should return coefficients, optionally without intercept."""
     A = c(-1, +1, -1, +1)
     B = c(-1, -1, +1, +1)
@@ -298,7 +296,7 @@ def test_model_get_parameters() -> None:
     assert params_with_intercept["B"] == pytest.approx(4.0, abs=1e-6)
 
 
-def test_model_get_factor_names() -> None:
+def test_model_get_factor_names():
     """get_factor_names should return factors at the requested interaction level."""
     A = c(-1, +1, -1, +1)
     B = c(-1, -1, +1, +1)
@@ -314,7 +312,7 @@ def test_model_get_factor_names() -> None:
     assert len(level2) == 1  # A:B interaction
 
 
-def test_model_get_response_name() -> None:
+def test_model_get_response_name():
     """get_response_name should return the response variable name."""
     A = c(-1, +1, -1, +1)
     B = c(-1, -1, +1, +1)
@@ -324,7 +322,7 @@ def test_model_get_response_name() -> None:
     assert model.get_response_name() == "y"
 
 
-def test_model_str() -> None:
+def test_model_str():
     """str(model) should return the formula description."""
     A = c(-1, +1, -1, +1)
     B = c(-1, -1, +1, +1)
@@ -336,7 +334,7 @@ def test_model_str() -> None:
     assert "B" in desc
 
 
-def test_predict_function() -> None:
+def test_predict_function():
     """predict() should make predictions from the model."""
     A = c(-1, +1, -1, +1)
     B = c(-1, -1, +1, +1)
@@ -351,7 +349,7 @@ def test_predict_function() -> None:
     assert pred_hi[0] == pytest.approx(81.0, abs=1e-6)
 
 
-def test_summary_function_with_aliasing() -> None:
+def test_summary_function_with_aliasing():
     """The standalone summary() function should include aliasing info."""
     A = c(-1, +1, -1, +1)
     B = c(-1, -1, +1, +1)
@@ -365,7 +363,7 @@ def test_summary_function_with_aliasing() -> None:
     assert "Aliasing pattern" in smry_str
 
 
-def test_model_get_aliases_websafe() -> None:
+def test_model_get_aliases_websafe():
     """get_aliases with websafe=True should return HTML-formatted strings."""
     A = c(-1, +1, -1, +1)
     B = c(-1, -1, +1, +1)
@@ -379,7 +377,7 @@ def test_model_get_aliases_websafe() -> None:
         assert "<span" in alias_str
 
 
-def test_model_get_aliases_empty() -> None:
+def test_model_get_aliases_empty():
     """get_aliases should return empty list when there is no aliasing."""
     A = c(-1, +1, -1, +1)
     B = c(-1, -1, +1, +1)
@@ -389,10 +387,12 @@ def test_model_get_aliases_empty() -> None:
     assert model.get_aliases() == []
 
 
-# ---- Structure tests (improving experiments/structures.py coverage) ----
+# ============================================================================
+# Structure tests (experiments/structures.py coverage)
+# ============================================================================
 
 
-def test_expand_grid_basic() -> None:
+def test_expand_grid_basic():
     """expand_grid should create all combinations of factor levels."""
     A = c(-1, +1)
     B = c(-1, +1)
@@ -401,7 +401,7 @@ def test_expand_grid_basic() -> None:
     assert len(result[0]) == 4  # 2^2 = 4 rows
 
 
-def test_expand_grid_three_factors() -> None:
+def test_expand_grid_three_factors():
     """expand_grid with 3 factors should produce 2^3 = 8 rows."""
     A = c(-1, +1)
     B = c(-1, +1)
@@ -411,7 +411,7 @@ def test_expand_grid_three_factors() -> None:
     assert len(result[0]) == 8
 
 
-def test_supplement_function() -> None:
+def test_supplement_function():
     """Supplement should carry over kwargs to a new Column from existing values."""
     A = c(-1, +1, -1, +1)
     A_supp = supplement(A, name="Feed rate", units="g/min", lo=-1, hi=1)
@@ -420,14 +420,14 @@ def test_supplement_function() -> None:
     assert len(A_supp) == 4
 
 
-def test_full_factorial_default_names() -> None:
+def test_full_factorial_default_names():
     """full_factorial should create a 2^k design with default factor names."""
     result = full_factorial(3)
     assert len(result) == 3  # 3 factors
     assert len(result[0]) == 8  # 2^3 = 8 runs
 
 
-def test_full_factorial_custom_names() -> None:
+def test_full_factorial_custom_names():
     """full_factorial with custom names should use provided names."""
     result = full_factorial(2, names=["Temp", "Pressure"])
     assert len(result) == 2
@@ -436,7 +436,7 @@ def test_full_factorial_custom_names() -> None:
     assert len(result[0]) == 4  # 2^2 = 4 runs
 
 
-def test_column_division() -> None:
+def test_column_division():
     """Column division should work element-wise."""
     A = c(2.0, 4.0, 6.0)
     B = c(1.0, 2.0, 3.0)
@@ -444,7 +444,7 @@ def test_column_division() -> None:
     assert np.allclose(result.values, [2.0, 2.0, 2.0])
 
 
-def test_column_addition() -> None:
+def test_column_addition():
     """Column addition should work element-wise."""
     A = c(-1, +1, -1, +1)
     B = c(-1, -1, +1, +1)
@@ -452,59 +452,59 @@ def test_column_addition() -> None:
     assert np.allclose(result.values, [-2, 0, 0, 2])
 
 
-def test_column_to_coded_already_coded() -> None:
+def test_column_to_coded_already_coded():
     """to_coded on already-coded column should return the same values."""
     A = c(-1, +1, 0, name="A")
     coded = A.to_coded()
     assert np.allclose(coded.values, A.values)
 
 
-def test_column_to_realworld_not_coded() -> None:
+def test_column_to_realworld_not_coded():
     """to_realworld on a real-world column should return the same values."""
     A = c(100, 200, 150, lo=100, hi=200, name="Temp", units="C")
     rw = A.to_realworld()
     assert np.allclose(rw.values, A.values)
 
 
-def test_column_with_units_name() -> None:
+def test_column_with_units_name():
     """Column with units should format name correctly."""
     A = c(100, 200, lo=100, hi=200, name="Temp", units="C")
     assert "C" in A.name
     assert "Temp" in A.name
 
 
-def test_column_categorical_with_levels() -> None:
+def test_column_categorical_with_levels():
     """Column with explicit levels should store them."""
     D = c(0, 1, 0, 1, levels=(0, 1))
     assert hasattr(D, "pi_levels")
 
 
-def test_column_categorical_levels_missing_value_raises() -> None:
+def test_column_categorical_levels_missing_value_raises():
     """c() must error if a value is not in the explicit levels list."""
     with pytest.raises(ValueError, match="not in levels"):
         c("A", "B", "C", levels=["A", "B"])
 
 
-def test_column_categorical_levels_all_present_ok() -> None:
+def test_column_categorical_levels_all_present_ok():
     """c() should accept input when every value is covered by levels."""
     D = c("A", "B", "A", levels=["A", "B", "C"])
     assert hasattr(D, "pi_levels")
     assert D.pi_levels[D.pi_name] == ["A", "B", "C"]
 
 
-def test_column_categorical_levels_list_arg_validated() -> None:
+def test_column_categorical_levels_list_arg_validated():
     """A list arg whose elements are not in levels should raise."""
     with pytest.raises(ValueError, match="not in levels"):
         c(["A", "B", "C"], levels=["A", "B"])
 
 
-def test_column_categorical_levels_skips_nan() -> None:
+def test_column_categorical_levels_skips_nan():
     """NaN entries should be ignored by the levels-membership check."""
     D = c(0, 1, float("nan"), levels=(0, 1))
     assert hasattr(D, "pi_levels")
 
 
-def test_gather_drops_missing_values() -> None:
+def test_gather_drops_missing_values():
     """Gather should drop rows with any NaN values."""
     A = c(-1, +1, -1, +1, float("nan"))
     B = c(-1, -1, +1, +1, 0)
@@ -512,7 +512,7 @@ def test_gather_drops_missing_values() -> None:
     assert expt.shape[0] == 4  # NaN row dropped
 
 
-def test_expt_repr() -> None:
+def test_expt_repr():
     """Expt repr should include title and dimensions."""
     A = c(-1, +1, -1, +1)
     B = c(-1, -1, +1, +1)
@@ -522,24 +522,26 @@ def test_expt_repr() -> None:
     assert "4 experiments" in r
 
 
-# ---- Optimal design tests (experiments/optimal.py) ----
+# ============================================================================
+# Optimal design tests (experiments/optimal.py)
+# ============================================================================
 
 
-def test_optimization_function_basic() -> None:
+def test_optimization_function_basic():
     """optimization_function should return log determinant of (X'X)^-1."""
     X = pd.DataFrame([[-1, -1], [1, -1], [-1, 1], [1, 1]])
     result = optimization_function(X)
     assert np.isfinite(result)
 
 
-def test_optimization_function_singular() -> None:
+def test_optimization_function_singular():
     """optimization_function should return inf for singular designs."""
     X = pd.DataFrame([[1, 1], [1, 1], [1, 1]])
     result = optimization_function(X)
     assert result == float(np.inf)
 
 
-def test_point_exchange_simple() -> None:
+def test_point_exchange_simple():
     """point_exchange should select a near-optimal subset of candidate points."""
     # Create a full factorial as the candidate set
     rng = np.random.default_rng(42)


### PR DESCRIPTION
## Summary
Migrate test_doe.py from unittest.TestCase to pytest functions and pathlib.

## Changes
- Convert 3 TestCase classes to pytest functions with fixtures
- Preserve all 35+ test functions
- Use @pytest.fixture for setUp methods
- Keep pathlib.Path usage
- Keep @pytest.mark.skip decorators

Fixes #214