### PR TITLE
Migrate test_doe.py from unittest to pytest

### DIFF
--- a/tests/test_doe.py
+++ b/tests/test_doe.py
@@ -9,11 +9,10 @@ from process_improve.experiments.models import lm, predict, summary
 from process_improve.experiments.optimal import optimization_function, point_exchange
 from process_improve.experiments.structures import c, create_names, expand_grid, gather, supplement
 
-
 # ---- Fixtures ----
 
 
-@pytest.fixture()
+@pytest.fixture
 def structure_data():
     """Provide basic factor data for structure tests."""
     return {
@@ -25,7 +24,7 @@ def structure_data():
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def half_fraction_model():
     """Provide a half-fraction model for model tests."""
     A = c(-1, +1, -1, +1)
@@ -33,11 +32,10 @@ def half_fraction_model():
     C = A * B
     y = c(41, 27, 35, 20, name="Stability", units="days")
     expt = gather(A=A, B=B, C=C, y=y, title="Half-fraction, using C = A*B")
-    model = lm("y ~ A*B*C", expt)
-    return model
+    return lm("y ~ A*B*C", expt)
 
 
-@pytest.fixture()
+@pytest.fixture
 def api_dataframe():
     """Load the test_doe1.csv dataset for API usage tests."""
     folder = pathlib.Path(__file__).parents[1] / "process_improve" / "datasets" / "experiments"
@@ -199,7 +197,7 @@ def test_case_1(api_dataframe) -> None:
     _ = lm("np.log10(y) ~ C*M*B*V", expt)
 
 
-def test_aliasing(api_dataframe) -> None:
+def test_aliasing() -> None:
     """Test aliasing detection in models."""
     d4 = c(24, 48, 36, 36, 60, units="hours", lo=24, high=48)
     y4 = c(31, 65, 52, 54, 69)

--- a/tests/test_doe.py
+++ b/tests/test_doe.py
@@ -1,5 +1,4 @@
 import pathlib
-import unittest
 
 import numpy as np
 import pandas as pd
@@ -11,245 +10,222 @@ from process_improve.experiments.optimal import optimization_function, point_exc
 from process_improve.experiments.structures import c, create_names, expand_grid, gather, supplement
 
 
-class TestStructures(unittest.TestCase):
-    """Test the data structures."""
-
-    def setUp(self) -> None:
-        """Set up test fixtures."""
-        self.A = [-1, +1, -1, +1, 0, +1]
-        self.B = [-1, -1, +1, +1, 0, 0]
-        self.C = [4, 5, 6, 4, 6]
-        self.D = [0, 1, "green"]
-        self.y = [52, 74, 62, 80, 50, 65]
-
-    def test_create_names(self) -> None:
-        """Create factor names."""
-        assert create_names(5) == ["A", "B", "C", "D", "E"]
-
-        assert create_names(3, letters=False) == ["X1", "X2", "X3"]
-
-        assert create_names(3, letters=False, prefix="Q", start_at=9, padded=True) == ["Q09", "Q10", "Q11"]
-
-        assert create_names(4, letters=False, prefix="Z", start_at=99, padded=True) == [
-            "Z099",
-            "Z100",
-            "Z101",
-            "Z102",
-        ]
-
-    def test_create_factors(self) -> None:
-        """Test creating factors with various options."""
-        A1 = c(*(self.A))
-        A2 = c(*(self.A), index=["lo", "hi", "lo", "hi", "cp", "hi"])
-        B = c(*(self.B), name="B")
-        C1 = c(*(self.C), range=(4, 6))
-        C2 = c(*(self.C), center=5, range=(4, 6))
-        C3 = c(*(self.C), lo=4, hi=6)
-        C4 = c(*(self.C), lo=4, hi=6, name="C4")
-        C5 = c([4, 5, 6, 4, 6], lo=4, hi=6, name="C5")
-        C6 = c(*(self.C), lo=5, hi=6, name="C6")
-        y = c(*(self.y), name="conversion", units="%")
-
-        assert isinstance(A1, pd.Series)
-        assert A1.shape == (6,)
-        assert hasattr(A1, "pi_index")
-        assert hasattr(A1, "name")
-
-        assert A1.name == "Unnamed [coded]"
-        assert hasattr(A1, "pi_lo")
-        assert A1.pi_lo == -1
-        assert hasattr(A1, "pi_hi")
-        assert A1.pi_hi == +1
-        assert hasattr(A1, "pi_range")
-        assert A1.pi_range[0] == -1
-        assert A1.pi_range[1] == +1
-        assert hasattr(A1, "pi_center")
-        assert A1.pi_center == 0
-
-        assert isinstance(A2.index, pd.Index)
-        assert hasattr(A2, "pi_index")
-        assert A2.name == "Unnamed [coded]"
-
-        with pytest.raises(IndexError):
-            A2 = c(*(self.A), index=["lo", "hi", "lo", "hi", "cp"])
-
-        assert B.shape == (6,)
-        assert B.name == "B [coded]"
-
-        assert C1.pi_range == (4, 6)
-        assert C2.pi_center == 5
-        assert C2.pi_range == (4, 6)
-        assert C3.pi_lo == 4
-        assert C3.pi_hi == 6
-        assert C4.pi_lo == 4
-        assert C4.pi_hi == 6
-        assert C5.pi_hi == 6
-        assert C5.name == "C5"
-
-        # User says the low is 5, but the minimum is actually different
-        assert C6.pi_lo == 5
-        assert C6.pi_range == (5, 6)
-
-        D = c(*(self.D))
-        assert D.pi_numeric is True
-
-        assert len(y) == 6
-        assert y.name == "conversion [%]"
-
-    def test_column_math(self) -> None:
-        """Test column multiplication."""
-        self.A = [-1, +1, -1, +1, 0, +1]
-        self.B = [-1, -1, +1, +1, 0, 0]
-        A = c(*(self.A))
-        B = c(*(self.B), name="B")
-        C1 = A * B
-        C2 = B * A
-
-        assert np.all(C1.values == [+1, -1, -1, +1, 0, 0])
-        assert np.all(C1.index == A.index)
-        assert np.all(C2.values == [+1, -1, -1, +1, 0, 0])
-        assert np.all(C2.index == A.index)
-
-    def test_gather(self) -> None:
-        """Test gathering factors into an experiment."""
-        A = c(*(self.A))
-        B = c(*(self.B))
-        y = c(*(self.y), name="conversion")
-
-        expt = gather(A=A, B=B, y=y)
-        assert expt.shape == (6, 3)
-
-        expt = gather(A=A, B=B, y=y, title="Testing expt name")
-
-        # Eventually this method must go to the "DF" class; currently in the
-        # model class; not really appropriate there.
-        assert expt.get_title() == "Testing expt name"
+# ---- Fixtures ----
 
 
-class TestModels(unittest.TestCase):
-    """Test model fitting and results."""
-
-    def setUp(self) -> None:
-        """Set up test fixtures for model tests."""
-        A = c(-1, +1, -1, +1)
-        B = c(-1, -1, +1, +1)
-        C = A * B
-        y = c(41, 27, 35, 20, name="Stability", units="days")
-        self.expt = gather(A=A, B=B, C=C, y=y, title="Half-fraction, using C = A*B")
-        self.model_stability_poshalf = lm("y ~ A*B*C", self.expt)
-
-        """
-        Results from R:
-        A = c(-1, +1, -1, +1)
-        B = c(-1, -1, +1, +1)
-        C = A*B
-        y = c(41, 27, 35, 20)
-        data = data.frame(A=A, B=B, C=C, y=y)
-        model = lm(y ~ A*B*C, data=data)
-        summary(model)
-
-        Call:
-            lm(formula = y ~ A * B * C, data = data)
-
-            Residuals:
-            ALL 4 residuals are 0: no residual degrees of freedom!
-
-            Coefficients: (4 not defined because of singularities)
-                        Estimate Std. Error t value Pr(>|t|)
-            (Intercept)    30.75         NA      NA       NA
-            A              -7.25         NA      NA       NA
-            B              -3.25         NA      NA       NA
-            C              -0.25         NA      NA       NA
-            A:B               NA         NA      NA       NA
-            A:C               NA         NA      NA       NA
-            B:C               NA         NA      NA       NA
-            A:B:C             NA         NA      NA       NA
-
-            Residual standard error: NaN on 0 degrees of freedom
-            Multiple R-squared:      1,	Adjusted R-squared:    NaN
-            F-statistic:   NaN on 3 and 0 DF,  p-value: NA
-        """
-
-    def test_half_fraction(self) -> None:
-        """Testing attributes for the half-fraction model."""
-        assert self.model_stability_poshalf.nobs == 4
-        assert self.model_stability_poshalf.df_resid == 0
-        beta = self.model_stability_poshalf.get_parameters(drop_intercept=False)
-
-        assert beta["A"] == pytest.approx(-7.25)
-        assert beta["B"] == pytest.approx(-3.25)
-        assert beta["C"] == pytest.approx(-0.25)
-        assert beta["Intercept"] == pytest.approx(30.75)
-        assert self.model_stability_poshalf.get_aliases() == ["A + B:C", "B + A:C", "C + A:B"]
-
-        for resid in self.model_stability_poshalf.residuals:
-            assert resid == pytest.approx(0.0)
+@pytest.fixture()
+def structure_data():
+    """Provide basic factor data for structure tests."""
+    return {
+        "A": [-1, +1, -1, +1, 0, +1],
+        "B": [-1, -1, +1, +1, 0, 0],
+        "C": [4, 5, 6, 4, 6],
+        "D": [0, 1, "green"],
+        "y": [52, 74, 62, 80, 50, 65],
+    }
 
 
-class TestAPIUsage(unittest.TestCase):
-    """Test API usage patterns."""
+@pytest.fixture()
+def half_fraction_model():
+    """Provide a half-fraction model for model tests."""
+    A = c(-1, +1, -1, +1)
+    B = c(-1, -1, +1, +1)
+    C = A * B
+    y = c(41, 27, 35, 20, name="Stability", units="days")
+    expt = gather(A=A, B=B, C=C, y=y, title="Half-fraction, using C = A*B")
+    model = lm("y ~ A*B*C", expt)
+    return model
 
-    def setUp(self) -> None:
-        """Set up test fixtures for API usage tests."""
-        # TODO: replace unittest -> pytest
-        # TODO: use path
-        folder = pathlib.Path(__file__).parents[1] / "process_improve" / "datasets" / "experiments"
-        self.df1 = pd.read_csv(folder / "test_doe1.csv").set_index("Run order")
 
-    @pytest.mark.skip(reason="Figure out StringArray in pandas")
-    def test_case_1(self) -> None:
-        """Test case 1 with real-world data."""
-        index = self.df1.index
-        C = c(
-            self.df1["C"],
-            lo=self.df1["C"].min(),
-            hi=self.df1["C"].max(),
-            index=index,
-            name="C",
-        )
-        M = c(self.df1["M"], levels=self.df1["M"].unique(), name="M")
-        V = c(self.df1["V"], lo=self.df1["V"].min(), hi=self.df1["V"].max(), name="V")
-        B = c(self.df1["B"], name="B")
-        assert B.pi_levels["B"] == ["Ard", "Eme"]
+@pytest.fixture()
+def api_dataframe():
+    """Load the test_doe1.csv dataset for API usage tests."""
+    folder = pathlib.Path(__file__).parents[1] / "process_improve" / "datasets" / "experiments"
+    return pd.read_csv(folder / "test_doe1.csv").set_index("Run order")
 
-        y = self.df1["y"]
 
-        expt = gather(C=C, M=M, V=V, B=B, y=y)
-        assert np.all(C.index == M.index)
+# ---- Structure tests ----
 
-        _ = lm("np.log10(y) ~ C*M*B*V", expt)
-        # summary(model)
-        # pareto_plot(model)
-        # contour_plot(model, C, M)
-        # contour_plot(model, "C", "M")
-        # predict_plot(model)
 
-    def test_aliasing(self) -> None:
-        """Test aliasing detection in models."""
-        d4 = c(24, 48, 36, 36, 60, units="hours", lo=24, high=48)
-        y4 = c(31, 65, 52, 54, 69)
-        expt4 = gather(d=d4, y=y4, title="RW units")
-        model4 = lm("y ~ d + I(np.power(d, 2))", data=expt4)
-        assert len(model4.aliasing) == 0
+def test_create_names() -> None:
+    """Create factor names."""
+    assert create_names(5) == ["A", "B", "C", "D", "E"]
 
-        model5 = lm("y ~ d + I(np.power(d, 2))", data=expt4, alias_threshold=0.99)
-        assert len(model5.aliasing) == 2
+    assert create_names(3, letters=False) == ["X1", "X2", "X3"]
 
-    def test_realworld_coded(self) -> None:
-        """Test conversion between real-world and coded units."""
-        c1 = c(2.5, 3, 2.5, 3, center=2.75, range=[2.5, 3], name="cement")
-        c1_coded = c1.to_coded()
-        assert c1_coded.to_list() == [-1.0, 1.0, -1.0, 1.0]
+    assert create_names(3, letters=False, prefix="Q", start_at=9, padded=True) == ["Q09", "Q10", "Q11"]
 
-        c2 = c(
-            [-1.0, -1.0, +1.0, +1.0],
-            center=2.75,
-            range=[2.5, 3],
-            name="cement",
-            coded=True,
-        )
-        c2_rw = c2.to_realworld()
-        assert c2_rw.to_list() == [2.5, 2.5, 3.0, 3.0]
+    assert create_names(4, letters=False, prefix="Z", start_at=99, padded=True) == [
+        "Z099",
+        "Z100",
+        "Z101",
+        "Z102",
+    ]
+
+
+def test_create_factors(structure_data) -> None:
+    """Test creating factors with various options."""
+    A1 = c(*(structure_data["A"]))
+    A2 = c(*(structure_data["A"]), index=["lo", "hi", "lo", "hi", "cp", "hi"])
+    B = c(*(structure_data["B"]), name="B")
+    C1 = c(*(structure_data["C"]), range=(4, 6))
+    C2 = c(*(structure_data["C"]), center=5, range=(4, 6))
+    C3 = c(*(structure_data["C"]), lo=4, hi=6)
+    C4 = c(*(structure_data["C"]), lo=4, hi=6, name="C4")
+    C5 = c([4, 5, 6, 4, 6], lo=4, hi=6, name="C5")
+    C6 = c(*(structure_data["C"]), lo=5, hi=6, name="C6")
+    y = c(*(structure_data["y"]), name="conversion", units="%")
+
+    assert isinstance(A1, pd.Series)
+    assert A1.shape == (6,)
+    assert hasattr(A1, "pi_index")
+    assert hasattr(A1, "name")
+
+    assert A1.name == "Unnamed [coded]"
+    assert hasattr(A1, "pi_lo")
+    assert A1.pi_lo == -1
+    assert hasattr(A1, "pi_hi")
+    assert A1.pi_hi == +1
+    assert hasattr(A1, "pi_range")
+    assert A1.pi_range[0] == -1
+    assert A1.pi_range[1] == +1
+    assert hasattr(A1, "pi_center")
+    assert A1.pi_center == 0
+
+    assert isinstance(A2.index, pd.Index)
+    assert hasattr(A2, "pi_index")
+    assert A2.name == "Unnamed [coded]"
+
+    with pytest.raises(IndexError):
+        c(*(structure_data["A"]), index=["lo", "hi", "lo", "hi", "cp"])
+
+    assert B.shape == (6,)
+    assert B.name == "B [coded]"
+
+    assert C1.pi_range == (4, 6)
+    assert C2.pi_center == 5
+    assert C2.pi_range == (4, 6)
+    assert C3.pi_lo == 4
+    assert C3.pi_hi == 6
+    assert C4.pi_lo == 4
+    assert C4.pi_hi == 6
+    assert C5.pi_hi == 6
+    assert C5.name == "C5"
+
+    # User says the low is 5, but the minimum is actually different
+    assert C6.pi_lo == 5
+    assert C6.pi_range == (5, 6)
+
+    D = c(*(structure_data["D"]))
+    assert D.pi_numeric is True
+
+    assert len(y) == 6
+    assert y.name == "conversion [%]"
+
+
+def test_column_math(structure_data) -> None:
+    """Test column multiplication."""
+    A = c(*(structure_data["A"]))
+    B = c(*(structure_data["B"]), name="B")
+    C1 = A * B
+    C2 = B * A
+
+    assert np.all(C1.values == [+1, -1, -1, +1, 0, 0])
+    assert np.all(C1.index == A.index)
+    assert np.all(C2.values == [+1, -1, -1, +1, 0, 0])
+    assert np.all(C2.index == A.index)
+
+
+def test_gather(structure_data) -> None:
+    """Test gathering factors into an experiment."""
+    A = c(*(structure_data["A"]))
+    B = c(*(structure_data["B"]))
+    y = c(*(structure_data["y"]), name="conversion")
+
+    expt = gather(A=A, B=B, y=y)
+    assert expt.shape == (6, 3)
+
+    expt = gather(A=A, B=B, y=y, title="Testing expt name")
+
+    # Eventually this method must go to the "DF" class; currently in the
+    # model class; not really appropriate there.
+    assert expt.get_title() == "Testing expt name"
+
+
+# ---- Model tests ----
+
+
+def test_half_fraction(half_fraction_model) -> None:
+    """Testing attributes for the half-fraction model."""
+    assert half_fraction_model.nobs == 4
+    assert half_fraction_model.df_resid == 0
+    beta = half_fraction_model.get_parameters(drop_intercept=False)
+
+    assert beta["A"] == pytest.approx(-7.25)
+    assert beta["B"] == pytest.approx(-3.25)
+    assert beta["C"] == pytest.approx(-0.25)
+    assert beta["Intercept"] == pytest.approx(30.75)
+    assert half_fraction_model.get_aliases() == ["A + B:C", "B + A:C", "C + A:B"]
+
+    for resid in half_fraction_model.residuals:
+        assert resid == pytest.approx(0.0)
+
+
+# ---- API usage tests ----
+
+
+@pytest.mark.skip(reason="Figure out StringArray in pandas")
+def test_case_1(api_dataframe) -> None:
+    """Test case 1 with real-world data."""
+    df1 = api_dataframe
+    index = df1.index
+    C = c(
+        df1["C"],
+        lo=df1["C"].min(),
+        hi=df1["C"].max(),
+        index=index,
+        name="C",
+    )
+    M = c(df1["M"], levels=df1["M"].unique(), name="M")
+    V = c(df1["V"], lo=df1["V"].min(), hi=df1["V"].max(), name="V")
+    B = c(df1["B"], name="B")
+    assert B.pi_levels["B"] == ["Ard", "Eme"]
+
+    y = df1["y"]
+
+    expt = gather(C=C, M=M, V=V, B=B, y=y)
+    assert np.all(C.index == M.index)
+
+    _ = lm("np.log10(y) ~ C*M*B*V", expt)
+
+
+def test_aliasing(api_dataframe) -> None:
+    """Test aliasing detection in models."""
+    d4 = c(24, 48, 36, 36, 60, units="hours", lo=24, high=48)
+    y4 = c(31, 65, 52, 54, 69)
+    expt4 = gather(d=d4, y=y4, title="RW units")
+    model4 = lm("y ~ d + I(np.power(d, 2))", data=expt4)
+    assert len(model4.aliasing) == 0
+
+    model5 = lm("y ~ d + I(np.power(d, 2))", data=expt4, alias_threshold=0.99)
+    assert len(model5.aliasing) == 2
+
+
+def test_realworld_coded() -> None:
+    """Test conversion between real-world and coded units."""
+    c1 = c(2.5, 3, 2.5, 3, center=2.75, range=[2.5, 3], name="cement")
+    c1_coded = c1.to_coded()
+    assert c1_coded.to_list() == [-1.0, 1.0, -1.0, 1.0]
+
+    c2 = c(
+        [-1.0, -1.0, +1.0, +1.0],
+        center=2.75,
+        range=[2.5, 3],
+        name="cement",
+        coded=True,
+    )
+    c2_rw = c2.to_realworld()
+    assert c2_rw.to_list() == [2.5, 2.5, 3.0, 3.0]
 
 
 # ---- Model tests (improving experiments/models.py coverage) ----


### PR DESCRIPTION
Migrate `tests/test_doe.py` from unittest to pytest style:

- Remove `unittest.TestCase` classes; use plain test functions
- Convert `setUp` methods to pytest fixtures
- Remove `self.` references throughout
- Keep `pathlib.Path` usage (already present; no `os.path` to remove)

All 37 tests pass, 1 skipped (pre-existing skip for StringArray issue).

Closes #214