### PR TITLE
Document PR #175 diagnostics in the PCA / PLS user guide

### DIFF
--- a/docs/user_guide/pca.rst
+++ b/docs/user_guide/pca.rst
@@ -135,6 +135,35 @@ where :math:`s_a^2` is the variance of the *a*-th score column.
 
 Use ``model.t2_plot()`` and ``model.hotellings_t2_limit()`` for monitoring.
 
+Quality of Representation (cos²)
+--------------------------------
+
+The squared cosine, or *cos²*, reports how well each observation is represented
+on each component. It is the squared score divided by that observation's total
+variation budget:
+
+.. math::
+
+   \cos^2_{i,a} = \frac{t_{i,a}^2}{\sum_{a=1}^{A} t_{i,a}^2 + \text{SPE}_i^2}
+
+- cos² lies between 0 and 1. A value close to 1 means the component captures
+  most of that observation's variation.
+- Summed across all components, the cos² values plus the residual fraction
+  add up to 1.
+- For PCA, where the loadings are orthonormal, the denominator equals the
+  squared distance of the observation from the origin, so cos² matches the
+  classical factor-analysis definition.
+
+cos² completes the trio of per-observation diagnostics: **Hotelling's T²**
+measures distance *within* the model plane, **SPE** measures distance *to* it,
+and **cos²** says how much of an observation's total variation a given
+component accounts for.
+
+.. code-block:: python
+
+   model.squared_cosine()                  # all components
+   model.squared_cosine(n_components=2)     # first two components only
+
 Score Contributions
 -------------------
 
@@ -163,6 +192,35 @@ The reference point matters: contributions always measure the difference
 
    # T²-weighted contributions (scale by 1/sqrt(eigenvalue))
    contrib = model.score_contributions(model.scores_.iloc[5].values, weighted=True)
+
+Observation Contributions
+-------------------------
+
+Observation contributions answer a different question: *"Which observations
+shaped this component?"* The contribution of observation *i* to component *a*
+is its squared score as a fraction of the total over all observations:
+
+.. math::
+
+   \text{contribution}_{i,a} = \frac{t_{i,a}^2}{\sum_{i=1}^{N} t_{i,a}^2}
+
+- Each component column sums to 1, so a contribution well above the average
+  :math:`1/N` flags an observation that strongly drives that component.
+- Use it to find which observations a component is built on, and whether a
+  single observation is dominating it.
+
+This is **not** the same as *Score Contributions*, despite the similar name.
+``score_contributions`` is *per-variable* and signed: it decomposes one
+observation's position back onto the original variables.
+``observation_contributions`` is *per-observation* and non-negative: it reports
+each observation's share of a component's variation. The two are orthogonal
+views of the same score matrix; one decomposes across variables, the other
+across observations.
+
+.. code-block:: python
+
+   model.observation_contributions()              # all components
+   model.observation_contributions(n_components=2)
 
 Outlier Detection
 -----------------
@@ -209,6 +267,46 @@ component.
 
    # Compute VIP using only the first 2 components
    vip_2 = model.vip(n_components=2)
+
+Supplementary Variables
+-----------------------
+
+A *supplementary* (or passive) variable is an extra column that did not take
+part in fitting the model but was measured on the same observations. Projecting
+it shows how it relates to the model without letting it influence the model.
+
+Each supplementary variable is represented by its correlation with each
+component's scores, the standard representation for passive quantitative
+variables. This is the column-wise counterpart of ``transform()``, which
+projects supplementary *rows* (new observations).
+
+A common use is to build a PCA on process variables and then project a quality
+or outcome variable onto it, to see which components, and therefore which
+process patterns, line up with that outcome.
+
+.. code-block:: python
+
+   # passive_columns: a DataFrame with the same rows as the training data
+   model.project_variables(passive_columns)
+
+Eigenvalue Summary
+------------------
+
+``model.eigenvalue_summary()`` collects the per-component variance information
+into one tidy table, with one row per component and three columns:
+
+- ``eigenvalue`` - the variance of that component's score column.
+- ``percent_variance`` - the share of variance the component explains.
+- ``cumulative_percent`` - the running total of ``percent_variance``.
+
+It gathers ``explained_variance_``, ``r2_per_component_`` and
+``r2_cumulative_`` into a single view, and is the numeric companion of
+``model.explained_variance_plot()``. The cumulative column is a quick input to
+the component-count decision discussed next.
+
+.. code-block:: python
+
+   model.eigenvalue_summary()
 
 Model Selection
 ---------------

--- a/docs/user_guide/pls.rst
+++ b/docs/user_guide/pls.rst
@@ -96,8 +96,8 @@ system (just artificially separated into cause and effect), their joint
 loading plot reveals the interconnections between process conditions and
 quality outcomes.
 
-SPE, T², Contributions, and Outlier Detection
-----------------------------------------------
+Diagnostics Shared with PCA
+---------------------------
 
 These diagnostics work identically to PCA (see :doc:`pca`):
 
@@ -108,6 +108,14 @@ These diagnostics work identically to PCA (see :doc:`pca`):
 - ``model.score_contributions()`` - decompose scores back to original
   variables.
 - ``model.detect_outliers()`` - combined statistical + robust ESD detection.
+- ``model.squared_cosine()`` - quality of representation of each observation,
+  computed on the X-scores.
+- ``model.observation_contributions()`` - each observation's share of a
+  component, computed on the X-scores.
+- ``model.eigenvalue_summary()`` - per-component variance table; for PLS the
+  ``percent_variance`` and ``cumulative_percent`` columns refer to Y-variance.
+- ``model.project_variables()`` - project supplementary variables as their
+  correlation with the X-scores.
 
 Variable Importance in Projection (VIP)
 ---------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.21.4"
+version = "1.21.5"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Adds narrative user-guide coverage for the four per-observation / model
diagnostics added in PR #175 (`squared_cosine`, `observation_contributions`,
`eigenvalue_summary`, `project_variables`).

These already have docstrings, API-reference entries, and tests, but
`docs/user_guide/pca.rst` had no conceptual sections for them - unlike every
peer diagnostic (SPE, Hotelling's T2, Score Contributions, VIP). This closes
that gap.

- **`docs/user_guide/pca.rst`** - four new sections: Quality of Representation
  (cos2), Observation Contributions, Supplementary Variables, Eigenvalue
  Summary.
- **`docs/user_guide/pls.rst`** - extends the existing shared-diagnostics
  section to reference the four, with PLS-specific notes.

Documentation-only; no source code or API behaviour changes.

## Test plan

- [ ] `cd docs && make html` builds with no new Sphinx warnings
- [ ] New section headings render and cross-references resolve

https://claude.ai/code/session_01Gb56zS6tQW1Jdb64iaGAAb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gb56zS6tQW1Jdb64iaGAAb)_