### PR TITLE
Fix batch animation pause target

### DIFF
--- a/process_improve/batch/plotting.py
+++ b/process_improve/batch/plotting.py
@@ -566,8 +566,8 @@ def plot_multitags(  # noqa: PLR0912, PLR0913, PLR0915
         method="animate",
         args=[
             # https://plotly.com/python/animations/
-            # Note the None is in a list!
-            [[None]],  # TODO: does not work at the moment.
+            # Note the None is in a list.
+            [None],
             dict(
                 frame=dict(duration=0, redraw=False),
                 transition=dict(duration=0),

--- a/tests/batch/test_plotting.py
+++ b/tests/batch/test_plotting.py
@@ -59,3 +59,22 @@ def test_plotting_tags(nylon_data: dict) -> None:
 
     fig = plot_multitags(df_dict=batches_scaled)
     assert len(fig["data"]) == len(batches_scaled) * batches_scaled[1].shape[1]
+
+
+def test_plot_multitags_pause_button_targets_current_animation(nylon_data: dict) -> None:
+    """Test the animation pause button uses Plotly's current animation sentinel."""
+    scale_df = determine_scaling(nylon_data, settings={"robust": False})
+    batches_scaled = apply_scaling(nylon_data, scale_df)
+
+    fig = plot_multitags(
+        df_dict=batches_scaled,
+        settings={
+            "animate": True,
+            "animate_batches_to_highlight": [1],
+            "animate_n_frames": 2,
+        },
+    )
+
+    buttons = fig.layout.updatemenus[0].buttons
+    pause_button = next(button for button in buttons if button.label == "Pause")
+    assert pause_button.args[0] == (None,)


### PR DESCRIPTION
## Summary
- Update the batch multitags animation Pause button to target the current animation with Plotly's `[None]` sentinel.
- Add a focused regression test for the generated Pause button args.

This addresses the broken `[[None]]` placeholder from #202. I left the broader pydantic settings cleanup for a separate change.

## Validation
- `uv run pytest -o addopts='' tests/batch/test_plotting.py -q`
- `uv run ruff check process_improve/batch/plotting.py tests/batch/test_plotting.py`
- `uv run python -m py_compile process_improve/batch/plotting.py tests/batch/test_plotting.py`