### PR TITLE
Add a shared Plotly base theme for all library plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ those changes.
 
 - A shared Plotly base theme. Four templates are registered with Plotly
   (`pi_tufte`, `pi_economist`, `pi_journal`, `pi_brand`) so every plot in
-  the library shares a consistent, professional look. `pi_brand` is
+  the library shares a consistent, professional look. `pi_journal` is
   applied as the default; switch the global default with
   `process_improve.visualization.set_theme(...)`, or override a single
   plot through its `template` setting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.0] - 2026-05-21
+
+### Added
+
+- A shared Plotly base theme. Four templates are registered with Plotly
+  (`pi_tufte`, `pi_economist`, `pi_journal`, `pi_brand`) so every plot in
+  the library shares a consistent, professional look. `pi_brand` is
+  applied as the default; switch the global default with
+  `process_improve.visualization.set_theme(...)`, or override a single
+  plot through its `template` setting.
+
+### Changed
+
+- The latent-variable plots (score, loadings, SPE, Hotelling's T2,
+  explained-variance, correlation-loadings, observed-vs-predicted,
+  coefficient), the batch plots and the DOE plots now inherit their
+  styling from the base theme instead of hard-coding margins, legends,
+  axes and marker colours.
+
 ## [1.21.7] - 2026-05-18
 
 ### Fixed
@@ -67,7 +86,8 @@ those changes.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.21.7...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.0...HEAD
+[1.22.0]: https://github.com/kgdunn/process-improve/compare/v1.21.7...v1.22.0
 [1.21.7]: https://github.com/kgdunn/process-improve/compare/v1.21.6...v1.21.7
 [1.21.6]: https://github.com/kgdunn/process-improve/compare/v1.21.4...v1.21.6
 [1.21.4]: https://github.com/kgdunn/process-improve/compare/v1.21.3...v1.21.4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.21.7
-date-released: "2026-05-18"
+version: 1.22.0
+date-released: "2026-05-21"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/process_improve/batch/plotting.py
+++ b/process_improve/batch/plotting.py
@@ -199,12 +199,12 @@ def plot_all_batches_per_tag(  # noqa: PLR0912, PLR0913
                     )
                 )
 
-    yaxis1_dict = dict(title=tag, gridwidth=2, matches="y1", showticklabels=True, side="left")
+    yaxis1_dict = dict(title=tag, matches="y1", showticklabels=True, side="left")
     if (y1_limits[0] is not None) or (y1_limits[1] is not None):
         yaxis1_dict["autorange"] = False
         yaxis1_dict["range"] = y1_limits
 
-    yaxis2_dict: dict[str, Any] = dict(title=tag_y2, gridwidth=2, matches="y2", showticklabels=True, side="right")
+    yaxis2_dict: dict[str, Any] = dict(title=tag_y2, matches="y2", showticklabels=True, side="right")
     if (y2_limits[0] is not None) or (y2_limits[1] is not None):
         yaxis2_dict["autorange"] = False
         yaxis2_dict["range"] = y2_limits
@@ -215,15 +215,8 @@ def plot_all_batches_per_tag(  # noqa: PLR0912, PLR0913
         + (f" [{extra_info}]" if extra_info else ""),
         hovermode="closest",
         showlegend=True,
-        legend=dict(
-            orientation="h",
-            traceorder="normal",
-            font=dict(family="sans-serif", size=12, color="#000"),
-            bordercolor="#DDDDDD",
-            borderwidth=1,
-        ),
         autosize=False,
-        xaxis=dict(title=x_axis_label, gridwidth=1),
+        xaxis=dict(title=x_axis_label),
         yaxis=yaxis1_dict,
         width=html_aspect_ratio_w_over_h * html_image_height,
         height=html_image_height,
@@ -320,7 +313,6 @@ def plot_multitags(  # noqa: PLR0912, PLR0913, PLR0915
     if batches_to_highlight is None:
         batches_to_highlight = {}
     font_size = 12
-    margin_dict = dict(l=10, r=10, b=5, t=80)  # Defaults: l=80, r=80, t=100, b=80
     hovertemplate = "Time: %{x}\ny: %{y}"
 
     # This will be clumsy, until we have Python 3.9. TODO: use pydantic instead
@@ -587,32 +579,9 @@ def plot_multitags(  # noqa: PLR0912, PLR0913, PLR0915
 
     fig.update_layout(
         title=settings["title"],
-        margin=margin_dict,
         hovermode="closest",
         showlegend=settings["show_legend"],
-        legend=dict(
-            orientation="h",
-            traceorder="normal",
-            font=dict(family="sans-serif", size=12, color="#000"),
-            bordercolor="#DDDDDD",
-            borderwidth=1,
-        ),
         autosize=False,
-        xaxis=dict(
-            gridwidth=1,
-            mirror=True,  # ticks are mirror at the top of the frame also
-            showspikes=True,
-            visible=True,
-        ),
-        yaxis=dict(
-            gridwidth=2,
-            type="linear",
-            autorange=True,
-            showspikes=True,
-            visible=True,
-            showline=True,  # show a separating line
-            side="left",  # show on the RHS
-        ),
         width=settings["html_aspect_ratio_w_over_h"] * settings["html_image_height"],
         height=settings["html_image_height"],
         sliders=[slider_baseline_dict] if settings["animate_show_slider"] else [],

--- a/process_improve/multivariate/methods.py
+++ b/process_improve/multivariate/methods.py
@@ -22,6 +22,7 @@ from sklearn.utils.validation import check_array, check_is_fitted
 from tqdm import tqdm
 
 from ..univariate.metrics import detect_outliers_esd
+from ..visualization.themes import REFERENCE_LINE_COLOR
 from .plots import (
     coefficient_plot,
     correlation_loadings_plot,
@@ -4792,7 +4793,7 @@ class MBPLS(RegressorMixin, BaseEstimator):
                     x=[lo - pad, hi + pad],
                     y=[lo - pad, hi + pad],
                     mode="lines",
-                    line={"color": "black", "dash": "dash"},
+                    line={"color": REFERENCE_LINE_COLOR, "dash": "dash"},
                     name="y = x",
                 ),
             ]

--- a/process_improve/multivariate/plots.py
+++ b/process_improve/multivariate/plots.py
@@ -80,7 +80,7 @@ def score_plot(  # noqa: C901, PLR0913
                 "show_legend": True,           # bool: show clickable legend
                 "html_image_height": 500,      # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 16/9,  # float: width as ratio of height
-                "template": "pi_brand",        # str: registered Plotly theme name
+                "template": "pi_journal",        # str: registered Plotly theme name
             }
 
     Examples
@@ -284,7 +284,7 @@ def loading_plot(  # noqa: PLR0913
                 "show_labels": True,           # bool: add a label for each variable
                 "html_image_height": 500,      # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 16/9,  # float: width as ratio of height
-                "template": "pi_brand",        # str: registered Plotly theme name
+                "template": "pi_journal",        # str: registered Plotly theme name
             }
 
     Examples
@@ -413,7 +413,7 @@ def spe_plot(
                 "show_legend": False,           # bool: show clickable legend
                 "html_image_height": 500,       # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 16/9,  # float: width as ratio of height
-                "template": "pi_brand",         # str: registered Plotly theme name
+                "template": "pi_journal",         # str: registered Plotly theme name
             }
 
     Examples
@@ -561,7 +561,7 @@ def t2_plot(
                 "show_legend": False,           # bool: show clickable legend
                 "html_image_height": 500,       # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 16/9,  # float: width as ratio of height
-                "template": "pi_brand",         # str: registered Plotly theme name
+                "template": "pi_journal",         # str: registered Plotly theme name
             }
 
     Examples
@@ -695,7 +695,7 @@ def explained_variance_plot(
                 "show_legend": True,            # bool: show clickable legend
                 "html_image_height": 500,       # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 16/9,  # float: width as ratio of height
-                "template": "pi_brand",         # str: registered Plotly theme name
+                "template": "pi_journal",         # str: registered Plotly theme name
             }
 
     fig : go.Figure, optional
@@ -834,7 +834,7 @@ def correlation_loadings_plot(  # noqa: C901, PLR0913
                 "show_legend": True,            # bool: show clickable legend (PLS only)
                 "html_image_height": 600,       # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 1.0,   # float: width as ratio of height
-                "template": "pi_brand",         # str: registered Plotly theme name
+                "template": "pi_journal",         # str: registered Plotly theme name
             }
 
     fig : go.Figure, optional
@@ -984,7 +984,7 @@ def predictions_vs_observed_plot(
                 "reference_color": "#9CA3AF",   # str: colour of the y = x line
                 "html_image_height": 500,       # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 1.0,   # float: width as ratio of height
-                "template": "pi_brand",         # str: registered Plotly theme name
+                "template": "pi_journal",         # str: registered Plotly theme name
             }
 
     fig : go.Figure, optional
@@ -1101,7 +1101,7 @@ def coefficient_plot(
                 "bar_color": None,              # str|None: bar colour; None uses the theme
                 "html_image_height": 500,       # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 16/9,  # float: width as ratio of height
-                "template": "pi_brand",         # str: registered Plotly theme name
+                "template": "pi_journal",         # str: registered Plotly theme name
             }
 
     fig : go.Figure, optional

--- a/process_improve/multivariate/plots.py
+++ b/process_improve/multivariate/plots.py
@@ -12,6 +12,12 @@ import plotly.graph_objects as go
 from pydantic import BaseModel, field_validator
 from sklearn.base import BaseEstimator
 
+from process_improve.visualization.themes import (
+    DEFAULT_THEME,
+    LIMIT_LINE_COLOR,
+    REFERENCE_LINE_COLOR,
+)
+
 
 def plot_pre_checks(model: BaseEstimator, pc_horiz: int, pc_vert: int, pc_depth: int) -> bool:
     """Check the inputs for the plot functions are valid."""
@@ -74,6 +80,7 @@ def score_plot(  # noqa: C901, PLR0913
                 "show_legend": True,           # bool: show clickable legend
                 "html_image_height": 500,      # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 16/9,  # float: width as ratio of height
+                "template": "pi_brand",        # str: registered Plotly theme name
             }
 
     Examples
@@ -84,7 +91,6 @@ def score_plot(  # noqa: C901, PLR0913
     >>> pca.score_plot(pc_horiz=1, pc_vert=2, pc_depth=3)  # 3D
     """
     plot_pre_checks(model, pc_horiz, pc_vert, pc_depth)
-    margin_dict: dict = dict(l=10, r=10, b=5, t=80)  # Defaults: l=80, r=80, t=100, b=80
     data_to_plot = model.scores_ if hasattr(model, "scores_") else model._parent.t_scores_super
     ellipse_coordinates = (
         model.ellipse_coordinates if hasattr(model, "ellipse_coordinates") else model._parent.ellipse_coordinates
@@ -113,6 +119,7 @@ def score_plot(  # noqa: C901, PLR0913
         show_legend: bool = True
         html_image_height: float = 500.0
         html_aspect_ratio_w_over_h: float = 16 / 9.0
+        template: str = DEFAULT_THEME
 
     setdict = Settings(**settings).model_dump() if settings else Settings().model_dump()
     if fig is None:
@@ -142,7 +149,6 @@ def score_plot(  # noqa: C901, PLR0913
                 name=name,
                 mode="markers+text" if setdict["show_labels"] else "markers",
                 marker=dict(
-                    color="darkblue",
                     symbol="circle",
                 ),
                 text=list(default_index),
@@ -173,7 +179,6 @@ def score_plot(  # noqa: C901, PLR0913
                 name=name,
                 mode="markers+text" if setdict["show_labels"] else "markers",
                 marker=dict(
-                    color="darkblue",
                     symbol="circle",
                     size=7,
                 ),
@@ -201,8 +206,8 @@ def score_plot(  # noqa: C901, PLR0913
                 score_vert=pc_vert,
                 conf_level=setdict["ellipse_conf_level"],
             )
-            fig.add_hline(y=0, line_color="black")
-            fig.add_vline(x=0, line_color="black")
+            fig.add_hline(y=0, line_color=REFERENCE_LINE_COLOR)
+            fig.add_vline(x=0, line_color=REFERENCE_LINE_COLOR)
             fig.add_trace(
                 go.Scatter(
                     x=ellipse[0],
@@ -210,40 +215,18 @@ def score_plot(  # noqa: C901, PLR0913
                     name=f"Hotelling's T^2 [{setdict['ellipse_conf_level'] * 100:.4g}%]",
                     mode="lines",
                     line=dict(
-                        color="red",
+                        color=LIMIT_LINE_COLOR,
                         width=2,
                     ),
                 )
             )
 
     fig.update_layout(
+        template=setdict["template"],
         title_text=setdict["title"],
-        margin=margin_dict,
         hovermode="closest",
         showlegend=setdict["show_legend"],
-        legend=dict(
-            orientation="h",
-            traceorder="normal",
-            font=dict(family="sans-serif", size=12, color="#000"),
-            bordercolor="#DDDDDD",
-            borderwidth=1,
-        ),
         autosize=False,
-        xaxis=dict(
-            gridwidth=1,
-            mirror=True,
-            showspikes=True,
-            visible=True,
-        ),
-        yaxis=dict(
-            gridwidth=2,
-            type="linear",
-            autorange=True,
-            showspikes=True,
-            visible=True,
-            showline=True,
-            side="left",
-        ),
         width=setdict["html_aspect_ratio_w_over_h"] * setdict["html_image_height"],
         height=setdict["html_image_height"],
     )
@@ -301,6 +284,7 @@ def loading_plot(  # noqa: PLR0913
                 "show_labels": True,           # bool: add a label for each variable
                 "html_image_height": 500,      # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 16/9,  # float: width as ratio of height
+                "template": "pi_brand",        # str: registered Plotly theme name
             }
 
     Examples
@@ -310,7 +294,6 @@ def loading_plot(  # noqa: PLR0913
     >>> pls.loading_plot(loadings_type="w", pc_vert=3)     # W loadings, PC1 vs PC3
     """
     plot_pre_checks(model, pc_horiz, pc_vert, pc_depth=0)
-    margin_dict: dict = dict(l=10, r=10, b=5, t=80)  # Defaults: l=80, r=80, t=100, b=80
 
     class Settings(BaseModel):
         """Validated display settings for the loadings plot."""
@@ -319,6 +302,7 @@ def loading_plot(  # noqa: PLR0913
         show_labels: bool = True
         html_image_height: float = 500.0
         html_aspect_ratio_w_over_h: float = 16 / 9.0
+        template: str = DEFAULT_THEME
 
     setdict = Settings(**settings).model_dump() if settings else Settings().model_dump()
     if fig is None:
@@ -348,7 +332,6 @@ def loading_plot(  # noqa: PLR0913
             name="X-space loadings W*",
             mode="markers+text" if setdict["show_labels"] else "markers",
             marker=dict(
-                color="darkblue",
                 symbol="circle",
                 size=7,
             ),
@@ -369,7 +352,6 @@ def loading_plot(  # noqa: PLR0913
                 name="Y-space loadings C",
                 mode="markers+text" if setdict["show_labels"] else "markers",
                 marker=dict(
-                    color="purple",
                     symbol="star",
                     size=8,
                 ),
@@ -379,29 +361,14 @@ def loading_plot(  # noqa: PLR0913
         )
 
     fig.update_layout(xaxis_title_text=f"PC {pc_horiz}", yaxis_title_text=f"PC {pc_vert}")
-    fig.add_hline(y=0, line_color="black")
-    fig.add_vline(x=0, line_color="black")
+    fig.add_hline(y=0, line_color=REFERENCE_LINE_COLOR)
+    fig.add_vline(x=0, line_color=REFERENCE_LINE_COLOR)
     fig.update_layout(
+        template=setdict["template"],
         title_text=setdict["title"],
-        margin=margin_dict,
         hovermode="closest",
         showlegend=add_legend,
         autosize=False,
-        xaxis=dict(
-            gridwidth=1,
-            mirror=True,
-            showspikes=True,
-            visible=True,
-        ),
-        yaxis=dict(
-            gridwidth=2,
-            type="linear",
-            autorange=True,
-            showspikes=True,
-            visible=True,
-            showline=True,
-            side="left",
-        ),
         width=setdict["html_aspect_ratio_w_over_h"] * setdict["html_image_height"],
         height=setdict["html_image_height"],
     )
@@ -441,11 +408,12 @@ def spe_plot(
                 "show_limit": True,            # bool: show the SPE confidence limit line
                 "conf_level": 0.95,            # float: confidence level for limit (< 1.00)
                 "title": "SPE plot ...",        # str: overall plot title
-                "default_marker": {...},        # dict: e.g. dict(color="darkblue", size=7)
+                "default_marker": {...},        # dict: e.g. dict(symbol="circle", size=7)
                 "show_labels": False,           # bool: add a label for each observation
                 "show_legend": False,           # bool: show clickable legend
                 "html_image_height": 500,       # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 16/9,  # float: width as ratio of height
+                "template": "pi_brand",         # str: registered Plotly theme name
             }
 
     Examples
@@ -454,8 +422,6 @@ def spe_plot(
     >>> pca.spe_plot(settings={"conf_level": 0.99, "show_labels": True})
     """
     # TO CONSIDER: allow a setting `as_line`: which connects the points with line segments
-    margin_dict: dict = dict(l=10, r=10, b=5, t=80)  # Defaults: l=80, r=80, t=100, b=80
-
     if with_a < 0:
         # Get the actual name of the last column in the model if negative indexing is used
         with_a = model.spe_.columns[with_a]
@@ -485,13 +451,14 @@ def spe_plot(
             f"fitting {with_a} component{'s' if with_a > 1 else ''}"
             f", with the {conf_level * 100}% confidence limit"
         )
-        default_marker: dict = dict(color="darkblue", symbol="circle", size=7)
+        default_marker: dict = dict(symbol="circle", size=7)
         show_labels: bool = False
         show_legend: bool = False
         html_image_height: float = 500.0
         html_aspect_ratio_w_over_h: float = 16 / 9.0
+        template: str = DEFAULT_THEME
 
-    setdict = Settings(**settings).model_dump() if settings else Settings().dict()
+    setdict = Settings(**settings).model_dump() if settings else Settings().model_dump()
     if fig is None:
         fig = go.Figure()
 
@@ -537,41 +504,19 @@ def spe_plot(
     name = f"{setdict['conf_level'] * 100:.3g}% limit"
     fig.add_hline(
         y=limit_SPE_conf_level,
-        line_color="red",
+        line_color=LIMIT_LINE_COLOR,
         annotation_text=name,
         annotation_position="bottom right",
         name=name,
     )
-    fig.add_hline(y=0, line_color="black")
+    fig.add_hline(y=0, line_color=REFERENCE_LINE_COLOR)
     fig.update_layout(
+        template=setdict["template"],
         title_text=setdict["title"],
-        margin=margin_dict,
         hovermode="closest",
         showlegend=setdict["show_legend"],
-        legend=dict(
-            orientation="h",
-            traceorder="normal",
-            font=dict(family="sans-serif", size=12, color="#000"),
-            bordercolor="#DDDDDD",
-            borderwidth=1,
-        ),
         autosize=False,
-        xaxis=dict(
-            gridwidth=1,
-            mirror=True,
-            showspikes=True,
-            visible=True,
-        ),
-        yaxis=dict(
-            title=name,
-            gridwidth=2,
-            type="linear",
-            autorange=True,
-            showspikes=True,
-            visible=True,
-            showline=True,  # show a separating line
-            side="left",  # show on the RHS
-        ),
+        yaxis_title_text=name,
         width=setdict["html_aspect_ratio_w_over_h"] * setdict["html_image_height"],
         height=setdict["html_image_height"],
     )
@@ -611,11 +556,12 @@ def t2_plot(
                 "show_limit": True,            # bool: show the T2 confidence limit line
                 "conf_level": 0.95,            # float: confidence level for limit (< 1.00)
                 "title": "T2 plot ...",         # str: overall plot title
-                "default_marker": {...},        # dict: e.g. dict(color="darkblue", size=7)
+                "default_marker": {...},        # dict: e.g. dict(symbol="circle", size=7)
                 "show_labels": False,           # bool: add a label for each observation
                 "show_legend": False,           # bool: show clickable legend
                 "html_image_height": 500,       # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 16/9,  # float: width as ratio of height
+                "template": "pi_brand",         # str: registered Plotly theme name
             }
 
     Examples
@@ -624,8 +570,6 @@ def t2_plot(
     >>> pca.t2_plot(settings={"conf_level": 0.99, "show_labels": True})
     """
     # TO CONSIDER: allow a setting `as_line`: which connects the points with line segments
-    margin_dict: dict = dict(l=10, r=10, b=5, t=80)  # Defaults: l=80, r=80, t=100, b=80
-
     if with_a < 0:
         with_a = model.hotellings_t2_.columns[with_a]
     elif with_a == 0:
@@ -653,13 +597,14 @@ def t2_plot(
             f"Hotelling's T2 plot after fitting {with_a} component{'s' if with_a > 1 else ''}"
             f", with the {conf_level * 100}% confidence limit"
         )
-        default_marker: dict = dict(color="darkblue", symbol="circle", size=7)
+        default_marker: dict = dict(symbol="circle", size=7)
         show_labels: bool = False
         show_legend: bool = False
         html_image_height: float = 500.0
         html_aspect_ratio_w_over_h: float = 16 / 9.0
+        template: str = DEFAULT_THEME
 
-    setdict = Settings(**settings).dict() if settings else Settings().dict()
+    setdict = Settings(**settings).model_dump() if settings else Settings().model_dump()
     if fig is None:
         fig = go.Figure()
 
@@ -705,41 +650,19 @@ def t2_plot(
     name = f"{setdict['conf_level'] * 100:.3g}% limit"
     fig.add_hline(
         y=limit_HT2_conf_level,
-        line_color="red",
+        line_color=LIMIT_LINE_COLOR,
         annotation_text=name,
         annotation_position="bottom right",
         name=name,
     )
-    fig.add_hline(y=0, line_color="black")
+    fig.add_hline(y=0, line_color=REFERENCE_LINE_COLOR)
     fig.update_layout(
+        template=setdict["template"],
         title_text=setdict["title"],
-        margin=margin_dict,
         hovermode="closest",
         showlegend=setdict["show_legend"],
-        legend=dict(
-            orientation="h",
-            traceorder="normal",
-            font=dict(family="sans-serif", size=12, color="#000"),
-            bordercolor="#DDDDDD",
-            borderwidth=1,
-        ),
         autosize=False,
-        xaxis=dict(
-            gridwidth=1,
-            mirror=True,
-            showspikes=True,
-            visible=True,
-        ),
-        yaxis=dict(
-            title_text=name,
-            gridwidth=2,
-            type="linear",
-            autorange=True,
-            showspikes=True,
-            visible=True,
-            showline=True,
-            side="left",
-        ),
+        yaxis_title_text=name,
         width=setdict["html_aspect_ratio_w_over_h"] * setdict["html_image_height"],
         height=setdict["html_image_height"],
     )
@@ -767,11 +690,12 @@ def explained_variance_plot(
             {
                 "as_percentage": True,         # bool: y-axis as a percentage, else a fraction
                 "title": "Variance explained ...",   # str: overall plot title
-                "bar_color": "darkblue",        # str: colour of the per-component bars
-                "line_color": "crimson",        # str: colour of the cumulative line
+                "bar_color": None,              # str|None: bar colour; None uses the theme
+                "line_color": None,             # str|None: line colour; None uses the theme
                 "show_legend": True,            # bool: show clickable legend
                 "html_image_height": 500,       # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 16/9,  # float: width as ratio of height
+                "template": "pi_brand",         # str: registered Plotly theme name
             }
 
     fig : go.Figure, optional
@@ -786,7 +710,6 @@ def explained_variance_plot(
         msg = "Model is not fitted. Call fit() before plotting the explained variance."
         raise ValueError(msg)
 
-    margin_dict: dict = dict(l=10, r=10, b=5, t=80)  # Defaults: l=80, r=80, t=100, b=80
     block_label = "Y-variance" if type(model).__name__ == "PLS" else "X-variance"
 
     class Settings(BaseModel):
@@ -794,11 +717,12 @@ def explained_variance_plot(
 
         as_percentage: bool = True
         title: str = f"{block_label} explained per component"
-        bar_color: str = "darkblue"
-        line_color: str = "crimson"
+        bar_color: str | None = None
+        line_color: str | None = None
         show_legend: bool = True
         html_image_height: float = 500.0
         html_aspect_ratio_w_over_h: float = 16 / 9.0
+        template: str = DEFAULT_THEME
 
     setdict = Settings(**settings).model_dump() if settings else Settings().model_dump()
     if fig is None:
@@ -830,34 +754,13 @@ def explained_variance_plot(
         )
     )
     fig.update_layout(
+        template=setdict["template"],
         title_text=setdict["title"],
-        margin=margin_dict,
         hovermode="x",
         showlegend=setdict["show_legend"],
-        legend=dict(
-            orientation="h",
-            traceorder="normal",
-            font=dict(family="sans-serif", size=12, color="#000"),
-            bordercolor="#DDDDDD",
-            borderwidth=1,
-        ),
         autosize=False,
-        xaxis=dict(
-            title_text="Component",
-            type="category",
-            gridwidth=1,
-            mirror=True,
-            visible=True,
-        ),
-        yaxis=dict(
-            title_text=f"Variance explained ({unit})",
-            gridwidth=2,
-            type="linear",
-            rangemode="tozero",
-            visible=True,
-            showline=True,
-            side="left",
-        ),
+        xaxis=dict(title_text="Component", type="category"),
+        yaxis=dict(title_text=f"Variance explained ({unit})", rangemode="tozero"),
         width=setdict["html_aspect_ratio_w_over_h"] * setdict["html_image_height"],
         height=setdict["html_image_height"],
     )
@@ -924,13 +827,14 @@ def correlation_loadings_plot(  # noqa: C901, PLR0913
 
             {
                 "title": "Correlation loadings ...",  # str: overall plot title
-                "x_marker_color": "darkblue",   # str: colour of the X-variable markers
-                "y_marker_color": "crimson",    # str: colour of the Y-variable markers (PLS)
+                "x_marker_color": None,         # str|None: X-variable marker colour; None uses the theme
+                "y_marker_color": None,         # str|None: Y-variable marker colour (PLS); None uses the theme
                 "ellipse_color": "grey",        # str: colour of the variance ellipses
                 "show_labels": True,            # bool: label each variable
                 "show_legend": True,            # bool: show clickable legend (PLS only)
                 "html_image_height": 600,       # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 1.0,   # float: width as ratio of height
+                "template": "pi_brand",         # str: registered Plotly theme name
             }
 
     fig : go.Figure, optional
@@ -960,7 +864,6 @@ def correlation_loadings_plot(  # noqa: C901, PLR0913
             msg = f"Each value in variance_ellipses must be a fraction in (0, 1]; got {level}."
             raise ValueError(msg)
 
-    margin_dict: dict = dict(l=10, r=10, b=5, t=80)  # Defaults: l=80, r=80, t=100, b=80
     is_pls = hasattr(model, "r2y_per_variable_")
     x_loadings = model.x_loadings_ if is_pls else model.loadings_
 
@@ -968,13 +871,14 @@ def correlation_loadings_plot(  # noqa: C901, PLR0913
         """Validated display settings for the correlation-loadings plot."""
 
         title: str = f"Correlation loadings: components {pc_horiz} and {pc_vert}"
-        x_marker_color: str = "darkblue"
-        y_marker_color: str = "crimson"
+        x_marker_color: str | None = None
+        y_marker_color: str | None = None
         ellipse_color: str = "grey"
         show_labels: bool = True
         show_legend: bool = True
         html_image_height: float = 600.0
         html_aspect_ratio_w_over_h: float = 1.0
+        template: str = DEFAULT_THEME
 
     setdict = Settings(**settings).model_dump() if settings else Settings().model_dump()
     if fig is None:
@@ -1001,8 +905,8 @@ def correlation_loadings_plot(  # noqa: C901, PLR0913
             yshift=9,
             font=dict(color=setdict["ellipse_color"], size=11),
         )
-    fig.add_hline(y=0, line_color="lightgrey", line_width=1)
-    fig.add_vline(x=0, line_color="lightgrey", line_width=1)
+    fig.add_hline(y=0, line_color=REFERENCE_LINE_COLOR, line_width=1)
+    fig.add_vline(x=0, line_color=REFERENCE_LINE_COLOR, line_width=1)
 
     mode = "markers+text" if setdict["show_labels"] else "markers"
     fig.add_trace(
@@ -1033,19 +937,12 @@ def correlation_loadings_plot(  # noqa: C901, PLR0913
         explained = float(model.r2_per_component_[component]) * 100.0
         return f"Component {component} ({explained:.1f}%)"
 
-    axis_common: dict = dict(range=[-1.08, 1.08], zeroline=False, gridwidth=1, mirror=True, visible=True)
+    axis_common: dict = dict(range=[-1.08, 1.08], zeroline=False)
     fig.update_layout(
+        template=setdict["template"],
         title_text=setdict["title"],
-        margin=margin_dict,
         hovermode="closest",
         showlegend=setdict["show_legend"] and is_pls,
-        legend=dict(
-            orientation="h",
-            traceorder="normal",
-            font=dict(family="sans-serif", size=12, color="#000"),
-            bordercolor="#DDDDDD",
-            borderwidth=1,
-        ),
         autosize=False,
         xaxis=dict(title_text=_axis_title(pc_horiz), **axis_common),
         yaxis=dict(title_text=_axis_title(pc_vert), scaleanchor="x", scaleratio=1, **axis_common),
@@ -1083,10 +980,11 @@ def predictions_vs_observed_plot(
 
             {
                 "title": "Observed vs predicted ...",  # str: overall plot title
-                "marker_color": "darkblue",     # str: colour of the data markers
-                "reference_color": "black",     # str: colour of the y = x line
+                "marker_color": None,           # str|None: data-marker colour; None uses the theme
+                "reference_color": "#9CA3AF",   # str: colour of the y = x line
                 "html_image_height": 500,       # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 1.0,   # float: width as ratio of height
+                "template": "pi_brand",         # str: registered Plotly theme name
             }
 
     fig : go.Figure, optional
@@ -1124,16 +1022,15 @@ def predictions_vs_observed_plot(
     hi = float(max(observed.max(), predicted.max()))
     pad = 0.05 * (hi - lo) if hi > lo else 1.0
 
-    margin_dict: dict = dict(l=10, r=10, b=5, t=80)
-
     class Settings(BaseModel):
         """Validated display settings for the predictions-vs-observed plot."""
 
         title: str = f"Observed vs predicted for {variable}"
-        marker_color: str = "darkblue"
-        reference_color: str = "black"
+        marker_color: str | None = None
+        reference_color: str = REFERENCE_LINE_COLOR
         html_image_height: float = 500.0
         html_aspect_ratio_w_over_h: float = 1.0
+        template: str = DEFAULT_THEME
 
     setdict = Settings(**settings).model_dump() if settings else Settings().model_dump()
     if fig is None:
@@ -1163,10 +1060,10 @@ def predictions_vs_observed_plot(
         text=f"RMSE = {rmse:.4g}",
         showarrow=False,
     )
-    axis_common: dict = dict(range=[lo - pad, hi + pad], gridwidth=1, mirror=True, visible=True)
+    axis_common: dict = dict(range=[lo - pad, hi + pad])
     fig.update_layout(
+        template=setdict["template"],
         title_text=setdict["title"],
-        margin=margin_dict,
         hovermode="closest",
         showlegend=False,
         autosize=False,
@@ -1201,9 +1098,10 @@ def coefficient_plot(
 
             {
                 "title": "Regression coefficients ...",  # str: overall plot title
-                "bar_color": "darkblue",        # str: colour of the coefficient bars
+                "bar_color": None,              # str|None: bar colour; None uses the theme
                 "html_image_height": 500,       # int: image height in pixels
                 "html_aspect_ratio_w_over_h": 16/9,  # float: width as ratio of height
+                "template": "pi_brand",         # str: registered Plotly theme name
             }
 
     fig : go.Figure, optional
@@ -1227,15 +1125,14 @@ def coefficient_plot(
     coefficients = model.beta_coefficients_[variable]
     features = [str(name) for name in coefficients.index]
 
-    margin_dict: dict = dict(l=10, r=10, b=5, t=80)
-
     class Settings(BaseModel):
         """Validated display settings for the regression-coefficient plot."""
 
         title: str = f"Regression coefficients for {variable}"
-        bar_color: str = "darkblue"
+        bar_color: str | None = None
         html_image_height: float = 500.0
         html_aspect_ratio_w_over_h: float = 16 / 9.0
+        template: str = DEFAULT_THEME
 
     setdict = Settings(**settings).model_dump() if settings else Settings().model_dump()
     if fig is None:
@@ -1249,15 +1146,15 @@ def coefficient_plot(
             name=f"beta: {variable}",
         )
     )
-    fig.add_hline(y=0, line_color="black", line_width=1)
+    fig.add_hline(y=0, line_color=REFERENCE_LINE_COLOR, line_width=1)
     fig.update_layout(
+        template=setdict["template"],
         title_text=setdict["title"],
-        margin=margin_dict,
         hovermode="x",
         showlegend=False,
         autosize=False,
-        xaxis=dict(title_text="X-variable", type="category", gridwidth=1, mirror=True, visible=True),
-        yaxis=dict(title_text=f"Coefficient ({variable})", gridwidth=2, visible=True, showline=True),
+        xaxis=dict(title_text="X-variable", type="category"),
+        yaxis=dict(title_text=f"Coefficient ({variable})"),
         width=setdict["html_aspect_ratio_w_over_h"] * setdict["html_image_height"],
         height=setdict["html_image_height"],
     )

--- a/process_improve/visualization/__init__.py
+++ b/process_improve/visualization/__init__.py
@@ -18,13 +18,33 @@ from process_improve.visualization.spec import (
     LayerSpec,
     PanelSpec,
 )
+from process_improve.visualization.themes import (
+    DEFAULT_THEME,
+    THEME_BRAND,
+    THEME_ECONOMIST,
+    THEME_JOURNAL,
+    THEME_NAMES,
+    THEME_TUFTE,
+    register_themes,
+    set_theme,
+)
 from process_improve.visualization.types import (
     AnnotationType,
     MarkType,
     ScaleType,
 )
 
+# Register the base themes and apply the package default on import.
+register_themes()
+set_theme(DEFAULT_THEME)
+
 __all__ = [
+    "DEFAULT_THEME",
+    "THEME_BRAND",
+    "THEME_ECONOMIST",
+    "THEME_JOURNAL",
+    "THEME_NAMES",
+    "THEME_TUFTE",
     "Annotation",
     "AnnotationType",
     "ChartSpec",
@@ -33,4 +53,6 @@ __all__ = [
     "MarkType",
     "PanelSpec",
     "ScaleType",
+    "register_themes",
+    "set_theme",
 ]

--- a/process_improve/visualization/adapters/plotly_adapter.py
+++ b/process_improve/visualization/adapters/plotly_adapter.py
@@ -23,6 +23,7 @@ from process_improve.visualization.spec import (
     LayerSpec,
     PanelSpec,
 )
+from process_improve.visualization.themes import DEFAULT_THEME
 from process_improve.visualization.types import AnnotationType, MarkType
 
 
@@ -97,8 +98,7 @@ class PlotlyAdapter(AbstractAdapter):
             xaxis=dict(title=panel.x_title),
             width=panel.width,
             height=panel.height,
-            template="plotly_white",
-            font=dict(size=12),
+            template=DEFAULT_THEME,
         )
 
         if panel.secondary_y:
@@ -140,8 +140,7 @@ class PlotlyAdapter(AbstractAdapter):
 
         fig.update_layout(
             title=dict(text=spec.title),
-            template="plotly_white",
-            font=dict(size=12),
+            template=DEFAULT_THEME,
             showlegend=True,
         )
 

--- a/process_improve/visualization/colors.py
+++ b/process_improve/visualization/colors.py
@@ -90,3 +90,19 @@ DESIRABILITY_COLORSCALE: list[list[float | str]] = [
     [0.5, "#F59E0B"],   # d = 0.5
     [1.0, "#059669"],   # d = 1 (best)
 ]
+
+# ---------------------------------------------------------------------------
+# Font stacks (shared by the registered Plotly base themes)
+# ---------------------------------------------------------------------------
+
+#: Serif stack - used by the Tufte theme.
+FONT_SERIF: str = "Georgia, 'Times New Roman', serif"
+
+#: Modern sans stack - used by the process-improve brand theme.
+FONT_SANS: str = "Inter, 'Helvetica Neue', Arial, sans-serif"
+
+#: Heavy sans stack - used by the Economist theme.
+FONT_SANS_HEAVY: str = "Verdana, Arial, sans-serif"
+
+#: Compact sans stack - used by the scientific-journal theme.
+FONT_SANS_COMPACT: str = "Helvetica, Arial, sans-serif"

--- a/process_improve/visualization/themes.py
+++ b/process_improve/visualization/themes.py
@@ -13,7 +13,7 @@ Four themes are provided:
 ``pi_economist``
     Editorial style after *The Economist*: a pale blue-grey panel,
     horizontal-only white gridlines, a heavy sans font and the
-    signature red corner tab.
+    signature Economist colourway (deep blue with a red accent).
 ``pi_journal``
     Scientific-journal style (Nature / IEEE): white background, light
     full grid, a black mirrored box and the Okabe-Ito colourblind-safe
@@ -111,11 +111,14 @@ def _tufte_template() -> go.layout.Template:
 
 
 def _economist_template() -> go.layout.Template:
+    # The Economist red leads the accent palette but is kept out of the first
+    # slot: the first colourway entry styles the primary data series, and a red
+    # series would clash with the red confidence-limit lines (LIMIT_LINE_COLOR).
     return go.layout.Template(
         layout=dict(
             paper_bgcolor="#FFFFFF",
             plot_bgcolor="#D9E9F1",
-            colorway=["#E3120B", "#006BA2", "#3EBCD2", "#379A8B", "#EBB434", "#9A607F"],
+            colorway=["#006BA2", "#E3120B", "#3EBCD2", "#379A8B", "#EBB434", "#9A607F"],
             font=dict(family=FONT_SANS_HEAVY, size=13, color="#121212"),
             title=dict(font=dict(family=FONT_SANS_HEAVY, size=20, color="#121212"), x=0.0, xanchor="left"),
             xaxis=dict(
@@ -148,23 +151,8 @@ def _economist_template() -> go.layout.Template:
                 bgcolor="rgba(0,0,0,0)",
                 borderwidth=0,
             ),
-            margin=dict(l=72, r=40, t=96, b=64),
+            margin=dict(l=72, r=40, t=84, b=64),
             hoverlabel=dict(font=dict(family=FONT_SANS_HEAVY, size=12)),
-            shapes=[
-                # Signature red corner tab in the top-left margin.
-                dict(
-                    type="rect",
-                    xref="paper",
-                    yref="paper",
-                    x0=0.0,
-                    x1=0.05,
-                    y0=1.06,
-                    y1=1.13,
-                    fillcolor="#E3120B",
-                    line=dict(width=0),
-                    layer="above",
-                ),
-            ],
         ),
     )
 

--- a/process_improve/visualization/themes.py
+++ b/process_improve/visualization/themes.py
@@ -1,0 +1,299 @@
+"""Plotly base themes for process-improve.
+
+This module registers a small family of Plotly templates so that every
+figure produced by the library shares a consistent, professional look.
+Importing :mod:`process_improve.visualization` registers the templates and
+sets the package default.
+
+Four themes are provided:
+
+``pi_tufte``
+    Minimal, maximum data-ink. White background, no gridlines,
+    range-frame axes, a muted colourway and a serif font.
+``pi_economist``
+    Editorial style after *The Economist*: a pale blue-grey panel,
+    horizontal-only white gridlines, a heavy sans font and the
+    signature red corner tab.
+``pi_journal``
+    Scientific-journal style (Nature / IEEE): white background, light
+    full grid, a black mirrored box and the Okabe-Ito colourblind-safe
+    palette.
+``pi_brand``
+    The process-improve house style, built on the existing
+    :data:`~process_improve.visualization.colors.FACTOR_COLORS` palette
+    so latent-variable plots and DOE plots match.
+
+Examples
+--------
+>>> from process_improve.visualization import set_theme
+>>> set_theme("pi_economist")          # change the global default
+>>> pca.score_plot()                    # now uses the Economist theme
+>>> pca.score_plot(settings={"template": "pi_tufte"})  # per-call override
+"""
+
+from __future__ import annotations
+
+import plotly.graph_objects as go
+import plotly.io as pio
+
+from process_improve.visualization.colors import (
+    FACTOR_COLORS,
+    FONT_SANS,
+    FONT_SANS_COMPACT,
+    FONT_SANS_HEAVY,
+    FONT_SERIF,
+)
+
+# ---------------------------------------------------------------------------
+# Theme names
+# ---------------------------------------------------------------------------
+
+THEME_TUFTE: str = "pi_tufte"
+THEME_ECONOMIST: str = "pi_economist"
+THEME_JOURNAL: str = "pi_journal"
+THEME_BRAND: str = "pi_brand"
+
+#: Names of every theme registered by :func:`register_themes`.
+THEME_NAMES: tuple[str, ...] = (THEME_TUFTE, THEME_ECONOMIST, THEME_JOURNAL, THEME_BRAND)
+
+#: Theme applied as the Plotly default when the package is imported.
+DEFAULT_THEME: str = THEME_BRAND
+
+# ---------------------------------------------------------------------------
+# Semantic line colours
+# ---------------------------------------------------------------------------
+# Reference and confidence-limit lines are drawn as layout shapes, so they are
+# not coloured by a template ``colorway``. These constants give plot code a
+# single, theme-agnostic source for those semantic colours.
+
+#: Colour for confidence-limit lines (SPE limit, Hotelling's T2 limit, ...).
+LIMIT_LINE_COLOR: str = "#DC2626"
+
+#: Colour for neutral reference lines (zero lines, parity diagonals, ...).
+REFERENCE_LINE_COLOR: str = "#9CA3AF"
+
+
+def _tufte_template() -> go.layout.Template:
+    axis = dict(
+        showgrid=False,
+        zeroline=False,
+        showline=True,
+        linecolor="#2A2A2A",
+        linewidth=1,
+        ticks="outside",
+        ticklen=6,
+        tickcolor="#2A2A2A",
+        mirror=False,
+    )
+    return go.layout.Template(
+        layout=dict(
+            paper_bgcolor="#FFFFFF",
+            plot_bgcolor="#FFFFFF",
+            colorway=["#5B7C99", "#B4543A", "#6B8F71", "#8A7A9B", "#A9883E"],
+            font=dict(family=FONT_SERIF, size=13, color="#2A2A2A"),
+            title=dict(font=dict(family=FONT_SERIF, size=18, color="#2A2A2A"), x=0.0, xanchor="left"),
+            xaxis=axis,
+            yaxis=axis,
+            legend=dict(
+                orientation="h",
+                yanchor="bottom",
+                y=1.02,
+                xanchor="left",
+                x=0.0,
+                font=dict(size=12),
+                bgcolor="rgba(0,0,0,0)",
+                borderwidth=0,
+            ),
+            margin=dict(l=72, r=36, t=84, b=64),
+            hoverlabel=dict(font=dict(family=FONT_SERIF, size=12)),
+        ),
+    )
+
+
+def _economist_template() -> go.layout.Template:
+    return go.layout.Template(
+        layout=dict(
+            paper_bgcolor="#FFFFFF",
+            plot_bgcolor="#D9E9F1",
+            colorway=["#E3120B", "#006BA2", "#3EBCD2", "#379A8B", "#EBB434", "#9A607F"],
+            font=dict(family=FONT_SANS_HEAVY, size=13, color="#121212"),
+            title=dict(font=dict(family=FONT_SANS_HEAVY, size=20, color="#121212"), x=0.0, xanchor="left"),
+            xaxis=dict(
+                showgrid=False,
+                zeroline=False,
+                showline=True,
+                linecolor="#121212",
+                linewidth=1,
+                ticks="outside",
+                ticklen=5,
+                tickcolor="#121212",
+                mirror=False,
+            ),
+            yaxis=dict(
+                showgrid=True,
+                gridcolor="#FFFFFF",
+                gridwidth=1,
+                zeroline=False,
+                showline=False,
+                ticks="",
+                mirror=False,
+            ),
+            legend=dict(
+                orientation="h",
+                yanchor="bottom",
+                y=1.02,
+                xanchor="left",
+                x=0.0,
+                font=dict(size=12),
+                bgcolor="rgba(0,0,0,0)",
+                borderwidth=0,
+            ),
+            margin=dict(l=72, r=40, t=96, b=64),
+            hoverlabel=dict(font=dict(family=FONT_SANS_HEAVY, size=12)),
+            shapes=[
+                # Signature red corner tab in the top-left margin.
+                dict(
+                    type="rect",
+                    xref="paper",
+                    yref="paper",
+                    x0=0.0,
+                    x1=0.05,
+                    y0=1.06,
+                    y1=1.13,
+                    fillcolor="#E3120B",
+                    line=dict(width=0),
+                    layer="above",
+                ),
+            ],
+        ),
+    )
+
+
+def _journal_template() -> go.layout.Template:
+    axis = dict(
+        showgrid=True,
+        gridcolor="#E8E8E8",
+        gridwidth=1,
+        zeroline=False,
+        showline=True,
+        linecolor="#000000",
+        linewidth=1,
+        mirror=True,
+        ticks="inside",
+        ticklen=4,
+        tickcolor="#000000",
+    )
+    return go.layout.Template(
+        layout=dict(
+            paper_bgcolor="#FFFFFF",
+            plot_bgcolor="#FFFFFF",
+            colorway=[
+                "#0072B2",
+                "#D55E00",
+                "#009E73",
+                "#CC79A7",
+                "#E69F00",
+                "#56B4E9",
+                "#F0E442",
+                "#000000",
+            ],
+            font=dict(family=FONT_SANS_COMPACT, size=11, color="#000000"),
+            title=dict(font=dict(family=FONT_SANS_COMPACT, size=15, color="#000000"), x=0.0, xanchor="left"),
+            xaxis=axis,
+            yaxis=axis,
+            legend=dict(
+                orientation="h",
+                yanchor="bottom",
+                y=1.02,
+                xanchor="left",
+                x=0.0,
+                font=dict(size=11),
+                bgcolor="rgba(255,255,255,0.85)",
+                bordercolor="#000000",
+                borderwidth=1,
+            ),
+            margin=dict(l=64, r=28, t=72, b=56),
+            hoverlabel=dict(font=dict(family=FONT_SANS_COMPACT, size=11)),
+        ),
+    )
+
+
+def _brand_template() -> go.layout.Template:
+    axis = dict(
+        showgrid=True,
+        gridcolor="#E5E7EB",
+        gridwidth=1,
+        zeroline=True,
+        zerolinecolor="#9CA3AF",
+        zerolinewidth=1,
+        showline=True,
+        linecolor="#D1D5DB",
+        linewidth=1,
+        mirror=False,
+        ticks="outside",
+        ticklen=4,
+        tickcolor="#D1D5DB",
+    )
+    return go.layout.Template(
+        layout=dict(
+            paper_bgcolor="#FFFFFF",
+            plot_bgcolor="#FAFAFA",
+            colorway=list(FACTOR_COLORS),
+            font=dict(family=FONT_SANS, size=13, color="#1F2937"),
+            title=dict(font=dict(family=FONT_SANS, size=18, color="#1F2937"), x=0.0, xanchor="left"),
+            xaxis=axis,
+            yaxis=axis,
+            legend=dict(
+                orientation="h",
+                yanchor="bottom",
+                y=1.02,
+                xanchor="left",
+                x=0.0,
+                font=dict(size=12),
+                bgcolor="rgba(255,255,255,0.6)",
+                bordercolor="#E5E7EB",
+                borderwidth=1,
+            ),
+            margin=dict(l=70, r=36, t=84, b=60),
+            hoverlabel=dict(font=dict(family=FONT_SANS, size=12)),
+        ),
+    )
+
+
+def _build_templates() -> dict[str, go.layout.Template]:
+    """Build the four base templates keyed by their registered name."""
+    return {
+        THEME_TUFTE: _tufte_template(),
+        THEME_ECONOMIST: _economist_template(),
+        THEME_JOURNAL: _journal_template(),
+        THEME_BRAND: _brand_template(),
+    }
+
+
+def register_themes() -> None:
+    """Register all process-improve themes in ``plotly.io.templates``.
+
+    Safe to call repeatedly; existing registrations are simply overwritten.
+    """
+    for name, template in _build_templates().items():
+        pio.templates[name] = template
+
+
+def set_theme(name: str = DEFAULT_THEME) -> None:
+    """Set ``name`` as the global default Plotly template.
+
+    Parameters
+    ----------
+    name : str, optional
+        One of :data:`THEME_NAMES`, by default :data:`DEFAULT_THEME`.
+
+    Raises
+    ------
+    ValueError
+        If ``name`` is not a registered process-improve theme.
+    """
+    if name not in THEME_NAMES:
+        raise ValueError(f"Unknown theme {name!r}. Choose one of {THEME_NAMES}.")
+    if name not in pio.templates:
+        register_themes()
+    pio.templates.default = name

--- a/process_improve/visualization/themes.py
+++ b/process_improve/visualization/themes.py
@@ -57,7 +57,7 @@ THEME_BRAND: str = "pi_brand"
 THEME_NAMES: tuple[str, ...] = (THEME_TUFTE, THEME_ECONOMIST, THEME_JOURNAL, THEME_BRAND)
 
 #: Theme applied as the Plotly default when the package is imported.
-DEFAULT_THEME: str = THEME_BRAND
+DEFAULT_THEME: str = THEME_JOURNAL
 
 # ---------------------------------------------------------------------------
 # Semantic line colours

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.21.7"
+version = "1.22.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/scripts/theme_gallery.py
+++ b/scripts/theme_gallery.py
@@ -19,6 +19,7 @@ import pathlib
 import sys
 
 import pandas as pd
+import plotly.graph_objects as go
 
 from process_improve.multivariate.methods import PCA, MCUVScaler
 from process_improve.multivariate.plots import loading_plot, score_plot, spe_plot
@@ -34,7 +35,7 @@ def _fit_model() -> PCA:
     return PCA(n_components=3).fit(x_scaled)
 
 
-def _render(model: PCA, theme: str, plot: str):
+def _render(model: PCA, theme: str, plot: str) -> go.Figure:
     settings = {"template": theme}
     if plot == "score":
         return score_plot(model, settings=settings)

--- a/scripts/theme_gallery.py
+++ b/scripts/theme_gallery.py
@@ -1,0 +1,78 @@
+"""Render the four Plotly base themes side by side for visual assessment.
+
+Fits a small PCA on the bundled Kamyr dataset and renders a score plot, an
+SPE plot and a loadings plot under each registered theme
+(``pi_tufte``, ``pi_economist``, ``pi_journal``, ``pi_brand``).
+
+Usage
+-----
+    python scripts/theme_gallery.py [output_dir]
+
+Writes ``index.html`` (always) and one PNG per theme-plot combination (when
+the optional ``kaleido`` package is installed) into ``output_dir`` - by
+default ``./theme_gallery``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pandas as pd
+
+from process_improve.multivariate.methods import PCA, MCUVScaler
+from process_improve.multivariate.plots import loading_plot, score_plot, spe_plot
+from process_improve.visualization.themes import THEME_NAMES
+
+PLOTS = ("score", "spe", "loading")
+
+
+def _fit_model() -> PCA:
+    folder = pathlib.Path(__file__).resolve().parents[1] / "process_improve" / "datasets" / "multivariate"
+    raw = pd.read_csv(folder / "kamyr.csv", index_col=None, header=None)
+    x_scaled = MCUVScaler().fit_transform(raw)
+    return PCA(n_components=3).fit(x_scaled)
+
+
+def _render(model: PCA, theme: str, plot: str):
+    settings = {"template": theme}
+    if plot == "score":
+        return score_plot(model, settings=settings)
+    if plot == "spe":
+        return spe_plot(model, settings=settings)
+    return loading_plot(model, settings=settings)
+
+
+def main() -> None:
+    out_dir = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else pathlib.Path("theme_gallery")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    model = _fit_model()
+    sections: list[str] = []
+    png_count = 0
+    for theme in THEME_NAMES:
+        blocks: list[str] = []
+        for plot in PLOTS:
+            fig = _render(model, theme, plot)
+            blocks.append(fig.to_html(full_html=False, include_plotlyjs="cdn"))
+            try:
+                fig.write_image(out_dir / f"{theme}_{plot}.png", scale=2)
+                png_count += 1
+            except Exception as exc:  # noqa: BLE001 - kaleido is optional
+                print(f"  (PNG skipped for {theme}/{plot}: {exc})")
+        sections.append(f"<h2>{theme}</h2>\n" + "\n".join(blocks))
+        print(f"Rendered theme: {theme}")
+
+    index = out_dir / "index.html"
+    index.write_text(
+        "<!doctype html><html><head><meta charset='utf-8'>"
+        "<title>process-improve theme gallery</title></head><body>"
+        "<h1>process-improve Plotly theme gallery</h1>\n" + "\n".join(sections) + "</body></html>",
+        encoding="utf-8",
+    )
+    print(f"\nWrote {index}")
+    print(f"Wrote {png_count} PNG file(s) to {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/theme_gallery.py
+++ b/scripts/theme_gallery.py
@@ -23,7 +23,7 @@ import plotly.graph_objects as go
 
 from process_improve.multivariate.methods import PCA, MCUVScaler
 from process_improve.multivariate.plots import loading_plot, score_plot, spe_plot
-from process_improve.visualization.themes import THEME_NAMES
+from process_improve.visualization.themes import REFERENCE_LINE_COLOR, THEME_NAMES
 
 PLOTS = ("score", "spe", "loading")
 
@@ -35,10 +35,48 @@ def _fit_model() -> PCA:
     return PCA(n_components=3).fit(x_scaled)
 
 
+def _decorate_score(fig: go.Figure, model: PCA) -> go.Figure:
+    """Label a few extreme observations and add a diagonal reference line.
+
+    These extras let the gallery show how text labels, callout arrows, a
+    shape line and an inline annotation look under each theme.
+    """
+    pc1, pc2 = model.scores_[1], model.scores_[2]
+    for obs in (pc1.pow(2) + pc2.pow(2)).nlargest(3).index:
+        fig.add_annotation(
+            x=float(pc1[obs]),
+            y=float(pc2[obs]),
+            text=f"obs {obs}",
+            showarrow=True,
+            arrowhead=2,
+            arrowwidth=1,
+            ax=24,
+            ay=-28,
+        )
+    extent = float(max(pc1.abs().max(), pc2.abs().max()))
+    fig.add_shape(
+        type="line",
+        x0=-extent,
+        y0=-extent,
+        x1=extent,
+        y1=extent,
+        line=dict(color=REFERENCE_LINE_COLOR, width=2, dash="dash"),
+    )
+    fig.add_annotation(
+        x=extent * 0.55,
+        y=extent * 0.55,
+        text="trend: PC2 = PC1",
+        showarrow=False,
+        textangle=-45,
+        yshift=12,
+    )
+    return fig
+
+
 def _render(model: PCA, theme: str, plot: str) -> go.Figure:
     settings = {"template": theme}
     if plot == "score":
-        return score_plot(model, settings=settings)
+        return _decorate_score(score_plot(model, settings=settings), model)
     if plot == "spe":
         return spe_plot(model, settings=settings)
     return loading_plot(model, settings=settings)

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -1,0 +1,76 @@
+"""Tests for the registered Plotly base themes."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+import plotly.io as pio
+import pytest
+
+from process_improve.multivariate.methods import PCA, MCUVScaler
+from process_improve.multivariate.plots import score_plot, spe_plot
+from process_improve.visualization.themes import (
+    DEFAULT_THEME,
+    THEME_NAMES,
+    register_themes,
+    set_theme,
+)
+
+
+@pytest.fixture
+def fitted_pca() -> PCA:
+    """Return a small fitted PCA model on synthetic data."""
+    rng = np.random.default_rng(0)
+    x = pd.DataFrame(rng.normal(size=(40, 6)), columns=[f"v{i}" for i in range(6)])
+    return PCA(n_components=2).fit(MCUVScaler().fit_transform(x))
+
+
+def test_all_themes_registered() -> None:
+    """Every theme name resolves to a registered Plotly template."""
+    register_themes()
+    for name in THEME_NAMES:
+        assert name in pio.templates
+        assert isinstance(pio.templates[name], go.layout.Template)
+
+
+def test_default_theme_applied_on_import() -> None:
+    """Importing the package sets the default Plotly template."""
+    assert pio.templates.default == DEFAULT_THEME
+
+
+def test_set_theme_changes_default() -> None:
+    """set_theme switches the global default; restored afterwards."""
+    try:
+        for name in THEME_NAMES:
+            set_theme(name)
+            assert pio.templates.default == name
+    finally:
+        set_theme(DEFAULT_THEME)
+
+
+def test_set_theme_rejects_unknown() -> None:
+    """An unknown theme name raises ValueError."""
+    with pytest.raises(ValueError, match="Unknown theme"):
+        set_theme("not_a_theme")
+
+
+def test_themes_define_distinct_backgrounds() -> None:
+    """Each theme carries its own plot-area background colour."""
+    backgrounds = {name: pio.templates[name].layout.plot_bgcolor for name in THEME_NAMES}
+    assert backgrounds["pi_economist"] == "#D9E9F1"
+    assert backgrounds["pi_brand"] == "#FAFAFA"
+    # Tufte and journal both keep a white plot area.
+    assert backgrounds["pi_tufte"] == "#FFFFFF"
+
+
+def test_score_plot_uses_default_theme(fitted_pca: PCA) -> None:
+    """A score plot carries the default theme by default."""
+    fig = score_plot(fitted_pca)
+    assert fig.layout.template.layout.plot_bgcolor == pio.templates[DEFAULT_THEME].layout.plot_bgcolor
+
+
+def test_plot_template_is_overridable(fitted_pca: PCA) -> None:
+    """The `template` setting overrides the default per call."""
+    fig = spe_plot(fitted_pca, settings={"template": "pi_economist"})
+    assert fig.layout.template.layout.plot_bgcolor == "#D9E9F1"


### PR DESCRIPTION
## Summary

Every Plotly figure in the library hand-rolled its own layout (duplicated
legend dicts, `margin=dict(l=10, ...)`, hard-coded `darkblue` markers and
`red`/`black` reference lines), with no shared template. This PR introduces
a family of registered Plotly templates so every plot - especially the
latent-variable plots - derives from one consistent, recognizable,
professional base theme.

## What's included

- New `process_improve/visualization/themes.py` registering four
  `go.layout.Template` objects in `plotly.io.templates`:
  - `pi_tufte` - minimal, maximum data-ink, serif, muted colourway.
  - `pi_economist` - pale blue-grey panel, horizontal-only white
    gridlines, heavy sans, deep-blue-with-red Economist colourway.
  - `pi_journal` - Nature/IEEE style, light full grid, black mirrored
    box, Okabe-Ito colourblind-safe palette. **Shipped as the default.**
  - `pi_brand` - house style built on the existing `FACTOR_COLORS` palette.
- The `visualization` package registers the themes and applies the
  default (`pi_journal`) on import. Default-on, overridable: switch
  globally with `set_theme(...)` or per call via the `template` setting.
- The latent-variable, batch and DOE plots no longer hard-code margins,
  legends, axes or marker colours; they inherit the theme. Reference and
  confidence-limit lines use shared semantic colour constants.
- `scripts/theme_gallery.py` renders all four themes on real score, SPE
  and loadings plots (the score plot also shows point labels, callout
  arrows, a diagonal reference line and an inline annotation).
- `tests/test_themes.py` covers registration, the default, `set_theme`
  and per-plot overrides.
- Version bumped to 1.22.0 (new feature); `CHANGELOG.md` and
  `CITATION.cff` updated.

## Test plan

- [x] `pytest tests/test_themes.py -o "addopts="`
- [x] `pytest tests/test_multivariate.py tests/batch/test_plotting.py tests/test_visualization.py tests/test_visualization_spec.py -o "addopts="`
- [x] `ruff check .`
- [x] Theme gallery rendered and reviewed visually

https://claude.ai/code/session_01CrrmXwhGEj1deGWDRPzQ4d