### PR TITLE
Fix batch animation pause target (supersedes #230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.1] - 2026-05-21
+
+### Fixed
+
+- Batch multitags animation: the Pause button now targets the currently
+  running animation with Plotly's `[None]` sentinel instead of the malformed
+  `[[None]]` placeholder, so pausing works.
+
 ## [1.22.0] - 2026-05-21
 
 ### Added
@@ -86,7 +94,8 @@ those changes.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.1...HEAD
+[1.22.1]: https://github.com/kgdunn/process-improve/compare/v1.22.0...v1.22.1
 [1.22.0]: https://github.com/kgdunn/process-improve/compare/v1.21.7...v1.22.0
 [1.21.7]: https://github.com/kgdunn/process-improve/compare/v1.21.6...v1.21.7
 [1.21.6]: https://github.com/kgdunn/process-improve/compare/v1.21.4...v1.21.6

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.0
+version: 1.22.1
 date-released: "2026-05-21"
 keywords:
   - chemometrics

--- a/process_improve/batch/plotting.py
+++ b/process_improve/batch/plotting.py
@@ -558,8 +558,8 @@ def plot_multitags(  # noqa: PLR0912, PLR0913, PLR0915
         method="animate",
         args=[
             # https://plotly.com/python/animations/
-            # Note the None is in a list!
-            [[None]],  # TODO: does not work at the moment.
+            # Note the None is in a list.
+            [None],
             dict(
                 frame=dict(duration=0, redraw=False),
                 transition=dict(duration=0),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.0"
+version = "1.22.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/batch/test_plotting.py
+++ b/tests/batch/test_plotting.py
@@ -59,3 +59,22 @@ def test_plotting_tags(nylon_data: dict) -> None:
 
     fig = plot_multitags(df_dict=batches_scaled)
     assert len(fig["data"]) == len(batches_scaled) * batches_scaled[1].shape[1]
+
+
+def test_plot_multitags_pause_button_targets_current_animation(nylon_data: dict) -> None:
+    """Test the animation pause button uses Plotly's current animation sentinel."""
+    scale_df = determine_scaling(nylon_data, settings={"robust": False})
+    batches_scaled = apply_scaling(nylon_data, scale_df)
+
+    fig = plot_multitags(
+        df_dict=batches_scaled,
+        settings={
+            "animate": True,
+            "animate_batches_to_highlight": [1],
+            "animate_n_frames": 2,
+        },
+    )
+
+    buttons = fig.layout.updatemenus[0].buttons
+    pause_button = next(button for button in buttons if button.label == "Pause")
+    assert pause_button.args[0] == (None,)


### PR DESCRIPTION
## Summary

This supersedes #230. It carries the original fix by @resolvicomai (commit cherry-picked with authorship preserved) and adds the release housekeeping that #230 omitted.

- Fix the batch multitags animation Pause button: target the currently running animation with Plotly's `[None]` sentinel instead of the malformed `[[None]]` placeholder from #202.
- Add a focused regression test for the generated Pause button args.
- Bump the version `1.22.0` -> `1.22.1` (PATCH, bug fix), with `CITATION.cff` synced.
- Add a `CHANGELOG.md` entry under a new `## [1.22.1]` section and update the link-reference footer.

## Why this PR instead of #230

The code change in #230 is correct and CI was fully green there, but per `CLAUDE.md` every code change needs a version bump (with `CITATION.cff` sync) and a changelog entry. The external contributor was not aware of those conventions. Rather than push to the contributor's fork, this branch reproduces their commit verbatim (same author) and adds the missing housekeeping so the PR is self-contained and mergeable.

Maintainer can merge this and close #230.

## Validation

- `pytest tests/batch/test_plotting.py -v -o "addopts="` - all 5 tests pass, including the new `test_plot_multitags_pause_button_targets_current_animation`.
- `ruff check process_improve/batch/plotting.py tests/batch/test_plotting.py` - clean.
- `pyproject.toml` and `CITATION.cff` both report `1.22.1`.

https://claude.ai/code/session_01RwbTvuzdjkW2UjDnxhv5DL

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwbTvuzdjkW2UjDnxhv5DL)_