### PR TITLE
Fix docstring/implementation inconsistencies across computational modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ those changes.
 
 ### Fixed
 
-- `f_elbow` (batch features): batches with no detectable elbow now record
+- `f_elbow` (batch features): the per-batch result was written through a
+  chained-indexing assignment that is a no-op under modern pandas, so the
+  function silently returned column sums instead of elbow values. It now
+  writes results correctly, and batches with no detectable elbow record
   `np.nan` instead of the `np.isnan` function object.
 - Docstring corrections so they match the implementation: the `TPLS` class
   and its `fit`/`predict` examples (the `X` input has the keys `F`, `Z`, `Y`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.2] - 2026-05-22
+
+### Fixed
+
+- `f_elbow` (batch features): batches with no detectable elbow now record
+  `np.nan` instead of the `np.isnan` function object.
+- Docstring corrections so they match the implementation: the `TPLS` class
+  and its `fit`/`predict` examples (the `X` input has the keys `F`, `Z`, `Y`;
+  `D` is passed at construction), `robust_regression` return-value keys,
+  `find_elbow_point` window-growth description, `f_count` (counts non-missing
+  observations), `ControlChart.calculate_limits` (supports both variants),
+  `_steepest_path` `n_steps`, `colours_per_batch_id` parameter name, and the
+  `extract_batch_features` tool no longer advertises unavailable `mad` /
+  `robust_mad` features.
+
 ## [1.22.1] - 2026-05-21
 
 ### Fixed
@@ -94,7 +109,8 @@ those changes.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.1...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.2...HEAD
+[1.22.2]: https://github.com/kgdunn/process-improve/compare/v1.22.1...v1.22.2
 [1.22.1]: https://github.com/kgdunn/process-improve/compare/v1.22.0...v1.22.1
 [1.22.0]: https://github.com/kgdunn/process-improve/compare/v1.21.7...v1.22.0
 [1.21.7]: https://github.com/kgdunn/process-improve/compare/v1.21.6...v1.21.7

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.1
-date-released: "2026-05-21"
+version: 1.22.2
+date-released: "2026-05-22"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/process_improve/batch/features.py
+++ b/process_improve/batch/features.py
@@ -448,12 +448,12 @@ def f_count(
     """
     Feature:    count.
 
-    The index number of the final value for each tag, for the given tags
+    The number of non-missing observations for each tag, for the given tags
     in ``tags``, for each unique batch in the ``batch_col`` indicator column,
     and within each unique phase, per batch, of the ``phase_col`` column.
 
-    Can be useful to get the 1-based index (it is a count!), and to then
-    use that index for other calculation purposes.
+    For data without internal gaps this count equals the 1-based index of the
+    final row, so it can also be used as that index for other calculations.
 
     See also: f_sum, f_last
     """
@@ -661,7 +661,7 @@ def f_elbow(  # noqa: PLR0913
                 if only_index:
                     output.loc[batch_id][tag] = elbow_index
                 elif np.isnan(elbow_index):
-                    output.loc[batch_id][tag] = np.isnan
+                    output.loc[batch_id][tag] = np.nan
                 else:
                     output.loc[batch_id][tag] = x_vals[elbow_index]
 

--- a/process_improve/batch/features.py
+++ b/process_improve/batch/features.py
@@ -659,10 +659,10 @@ def f_elbow(  # noqa: PLR0913
                     elbow_index = np.nan
 
                 if only_index:
-                    output.loc[batch_id][tag] = elbow_index
+                    output.loc[batch_id, tag] = elbow_index
                 elif np.isnan(elbow_index):
-                    output.loc[batch_id][tag] = np.nan
+                    output.loc[batch_id, tag] = np.nan
                 else:
-                    output.loc[batch_id][tag] = x_vals[elbow_index]
+                    output.loc[batch_id, tag] = x_vals[elbow_index]
 
     return output.rename(columns=dict(zip(tags, f_names, strict=False)))

--- a/process_improve/batch/plotting.py
+++ b/process_improve/batch/plotting.py
@@ -237,7 +237,7 @@ def colours_per_batch_id(
     Return a colour to use for each trace in the plot. A dictionary: keys are batch ids, and
     the value is a colour and line width setting for Plotly.
 
-    override_default_colour: bool
+    use_default_colour: bool
         If True, then the default colour is used (grey: 0.5, 0.5, 0.5)
     """
     if colour_map is None:

--- a/process_improve/batch/tools.py
+++ b/process_improve/batch/tools.py
@@ -53,7 +53,7 @@ _TIME_FEATURE_MAP = {
         "etc. for each batch and each measurement tag. "
         "The result is a feature matrix with one row per batch, suitable for multivariate "
         "analysis (e.g. PCA on batch data). "
-        "Available features: 'mean', 'median', 'std', 'iqr', 'mad', 'robust_mad', 'sum', "
+        "Available features: 'mean', 'median', 'std', 'iqr', 'sum', "
         "'min', 'max', 'last', 'count'. "
         "Time-dependent features (require time_column): 'area', 'slope'."
     ),
@@ -76,7 +76,7 @@ _TIME_FEATURE_MAP = {
                     "items": {
                         "type": "string",
                         "enum": [
-                            "mean", "median", "std", "iqr", "mad", "robust_mad",
+                            "mean", "median", "std", "iqr",
                             "sum", "min", "max", "last", "count", "area", "slope",
                         ],
                     },

--- a/process_improve/bivariate/methods.py
+++ b/process_improve/bivariate/methods.py
@@ -16,13 +16,14 @@ def find_elbow_point(x: np.ndarray, y: np.ndarray, max_iter: int = 41) -> int | 
     Find the elbow point when plotting numeric entries in `x` vs numeric values in list `y`.
 
     Return the index into the vectors `x` and `y` [the vectors must have the same length], where
-    the elbow point occurs.
+    the elbow point occurs. Returns -1 if every value in `x` or `y` is missing.
 
     Using a robust linear fit, sorts the samples in X (independent variable)
-    and takes sample 1:5 from the left, and samples (end-5):end and fits two
-    linear regressions, then computes the intersection of the two fitted lines.
-    Adds a point to each regression, so (1:6) and (end-6:end) and repeats,
-    accumulating one intersection point per iteration.
+    and takes the first 5 samples from the left, and the last 5 from the right,
+    then fits two linear regressions and computes the intersection of the two
+    fitted lines. The window size is then grown over `max_iter` (default 41)
+    evenly spaced steps, via `numpy.linspace`, up to roughly half the data,
+    accumulating one intersection point per step.
 
     The elbow is taken as the data point whose (x, y) location is closest to
     the median of the accumulated intersection points; the median location is

--- a/process_improve/experiments/optimization.py
+++ b/process_improve/experiments/optimization.py
@@ -359,7 +359,9 @@ def _steepest_path(  # noqa: PLR0913
     step_size : float
         Step magnitude in coded units (default 0.5).
     n_steps : int
-        Number of steps to generate (default 10).
+        Number of steps to take away from the design centre (default 10).
+        The returned ``steps`` list has ``n_steps + 1`` entries because it
+        also includes step 0 at the centre.
     direction : str
         ``"ascent"`` or ``"descent"``.
     factor_ranges : dict or None

--- a/process_improve/monitoring/control_charts.py
+++ b/process_improve/monitoring/control_charts.py
@@ -84,13 +84,15 @@ class ControlChart:
         """
         Find for a given vector `y`, the control chart target and limits.
 
-        Only for the Holt-Winters method, and only when there are more than
-            min(20, max(10, np.ceil(0.10 * N))))
+        Works for both the Holt-Winters ('hw') and 'xbar.no.subgroup' variants.
 
-        measurements, where N is the length of the input vector. In other words, the provided
-        target and standard deviation are only used if more than 10 to 20 measurements.
-        If `target` and `s` are numeric, then that target value and that standard deviation value
-        are used, otherwise these values are estimated.
+        For the Holt-Winters variant, when there are fewer than
+            min(20, max(10, np.ceil(0.10 * N)))
+        measurements (where N is the length of the input vector), the target and
+        standard deviation are estimated directly from the data and any provided
+        `target` / `s` are ignored for that small-sample case.
+        Otherwise, if `target` and `s` are numeric, those values are used;
+        if not, they are estimated.
         """
         self._given_target = target
         self._given_s = s
@@ -149,8 +151,8 @@ class ControlChart:
     def _xbar_no_subgroup_fit(self) -> None:
         """
         Fit the control chart from the data samples, assuming each sample is its own subgroup.
-        Variant = 'regulur' | 'robust' switchs how the average and standard deviation are
-        calculated.
+        The `style` attribute ('regular' | 'robust') switches how the average and standard
+        deviation are calculated.
 
         Control chart limits assume the data are normally distributed and independent. In
         particular, this last assumption can have consequences if not actually met. Limits may be

--- a/process_improve/monitoring/control_charts.py
+++ b/process_improve/monitoring/control_charts.py
@@ -87,7 +87,9 @@ class ControlChart:
         Works for both the Holt-Winters ('hw') and 'xbar.no.subgroup' variants.
 
         For the Holt-Winters variant, when there are fewer than
+
             min(20, max(10, np.ceil(0.10 * N)))
+
         measurements (where N is the length of the input vector), the target and
         standard deviation are estimated directly from the data and any provided
         `target` / `s` are ignored for that small-sample case.

--- a/process_improve/multivariate/methods.py
+++ b/process_improve/multivariate/methods.py
@@ -2972,16 +2972,21 @@ class TPLS(RegressorMixin, BaseEstimator):
     max_iter : int, optional
         The maximum number of iterations for the TPLS algorithm. Default is 500.
 
+    skip_f_matrix_preprocessing : bool, optional
+        If True, the F (formula) matrices are used as-is, skipping the internal
+        centering and scaling of the F block. Default is False.
+
     Notes
     -----
-    The input ``X`` is a dictionary with 4 keys:
+    The input ``X`` passed to :meth:`fit` and :meth:`predict` is a dictionary with 3 keys:
 
-    - ``D``: Database of DataFrames (properties in columns, materials in rows).
-      ``D = {"Group A": df_props_a, "Group B": df_props_b, ...}``
     - ``F``: Formula matrices (rows = blends, columns = materials).
       ``F = {"Group A": df_formulas_a, "Group B": df_formulas_b, ...}``
     - ``Z``: Process conditions - one row per blend, one column per condition.
     - ``Y``: Product quality indicators - one row per blend, one column per indicator.
+
+    The ``D`` matrix (database of material properties) is supplied once at
+    construction via the ``d_matrix`` argument; it is not part of ``X``.
 
     Attributes
     ----------
@@ -3014,8 +3019,8 @@ class TPLS(RegressorMixin, BaseEstimator):
     >>> }
     >>> process_conditions = {"Conditions": pd.DataFrame(rng.standard_normal((n_formulas, n_conditions)))}
     >>> quality_indicators = {"Quality":    pd.DataFrame(rng.standard_normal((n_formulas, n_outputs)))}
-    >>> all_data = {"Z": process_conditions, "D": properties, "F": formulas, "Y": quality_indicators}
-    >>> estimator = TPLS(n_components=4)
+    >>> all_data = {"Z": process_conditions, "F": formulas, "Y": quality_indicators}
+    >>> estimator = TPLS(n_components=4, d_matrix=properties)
     >>> estimator.fit(all_data)
     """
 
@@ -3063,7 +3068,7 @@ class TPLS(RegressorMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : {dictionary of dataframes}, keys that must be present: "D", "F", "Z", and "Y"
+        X : {dictionary of dataframes}, keys that must be present: "F", "Z", and "Y"
             The training input samples. See documentation in the class definition for more information on each matrix.
 
         Returns
@@ -3238,7 +3243,7 @@ class TPLS(RegressorMixin, BaseEstimator):
 
         # Testing/inference phase:
         new_data = {"Z": ..., "F": ...}  # you need at least the F block for a new prediction. "Z" is optional.
-        predictions = estimator.predict(new_data_pp)
+        predictions = estimator.predict(new_data)
 
         Parameters
         ----------

--- a/process_improve/multivariate/plots.py
+++ b/process_improve/multivariate/plots.py
@@ -29,7 +29,8 @@ def plot_pre_checks(model: BaseEstimator, pc_horiz: int, pc_vert: int, pc_depth:
         f"The model has {n_components} components. Ensure that 1 <= pc_vert<={n_components}."
     )
     assert -1 <= pc_depth <= n_components, (
-        f"The model has {n_components} components. Ensure that 1 <= pc_depth<={n_components}."
+        f"The model has {n_components} components. Ensure that pc_depth is -1 (no depth axis) "
+        f"or 1 <= pc_depth <= {n_components}."
     )
     assert len({pc_horiz, pc_vert, pc_depth}) == 3, "Specify distinct components for each axis"
 

--- a/process_improve/regression/methods.py
+++ b/process_improve/regression/methods.py
@@ -85,17 +85,23 @@ def robust_regression(  # noqa: PLR0913, PLR0915
 
     Returns a dictionary of outputs with these keys::
 
-        coefficients:             a vector of K coefficients, one for each column in X
+        N:                        the number of observations used to fit the model
+        coefficients:             a length-1 list containing the regression slope
         intercept:                returned if fit_intercept==True, otherwise 0
-        standard_errors:          a vector of K standard errors, one per column in X
+        standard_errors:          a length-1 list containing the standard error of the slope
         standard_error_intercept: standard error for the intercept (np.nan if fit_intercept=False)
         R2:                       the R^2 value
         SE:                       the model's standard error
+        x_ssq:                    the sum of squares of (x - mean(x))
+        k:                        the number of model parameters (2 if fit_intercept else 1)
         fitted_values:            the N predicted values, one per row in y
         residuals:                the N residuals
         t_value:                  the t-values for the standard errors
         conf_intervals:           K rows x 2 columns (lower, upper) confidence intervals
+        conf_interval_intercept:  (lower, upper) confidence interval for the intercept
         pi_range:                 prediction intervals above and below, over the range of data
+        leverage:                 the hat-matrix diagonal (leverage) for each observation
+        influence:                Cook-style influence values for each observation
     """
 
     out: dict[str, Any] = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.1"
+version = "1.22.2"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/batch/test_features.py
+++ b/tests/batch/test_features.py
@@ -246,3 +246,24 @@ def test_f_elbow_only_index(batch_data: pd.DataFrame) -> None:
         only_index=True,
     )
     assert result.shape[1] == 1
+
+
+def test_f_elbow_no_elbow_records_nan() -> None:
+    """A straight line has no elbow; f_elbow should record np.nan, not a function."""
+    n = 30
+    straight_line = pd.DataFrame(
+        {
+            "Batch": ["B1"] * n,
+            "time": np.arange(n, dtype=float),
+            "signal": np.arange(n, dtype=float),
+        }
+    )
+    result = features.f_elbow(
+        straight_line,
+        x_axis_tag="time",
+        tags=["signal"],
+        batch_col="Batch",
+    )
+    value = result.iloc[0, 0]
+    assert isinstance(value, float)
+    assert np.isnan(value)


### PR DESCRIPTION
## Summary

An audit of computational and user-facing functions compared each docstring against its implementation. This PR corrects the docstrings that had drifted, plus one clear code bug found along the way.

### Docstring corrections

- **`multivariate/methods.py` — `TPLS`**: the class Notes section, the class `Example`, and `fit`'s parameter description all said the `X` input dict has 4 keys including `D`. The code requires exactly `{F, Z, Y}` (`_input_data_checks` would raise an `AssertionError` otherwise); `D` is supplied once at construction via `d_matrix`. The runnable `Example` was doubly broken: it passed a 4-key dict to `fit` and called `TPLS(n_components=4)` without the required `d_matrix`. Also documented the previously-omitted `skip_f_matrix_preprocessing` parameter.
- **`multivariate/methods.py` — `TPLS.predict`**: example referenced an undefined `new_data_pp`; the variable defined just above is `new_data`.
- **`multivariate/plots.py` — `plot_pre_checks`**: the `pc_depth` assertion message said `1 <= pc_depth <= n_components` but the code accepts `-1` (no depth axis).
- **`regression/methods.py` — `robust_regression`**: the documented return-dict keys omitted `N`, `x_ssq`, `k`, `conf_interval_intercept`, `leverage`, and `influence`; `coefficients`/`standard_errors` are length-1 lists for this single-x model, not "K per column in X".
- **`bivariate/methods.py` — `find_elbow_point`**: the docstring described adding one point per iteration `(1:6)`, `(end-6:end)`...; the code grows the window over `max_iter` (default 41) evenly spaced `np.linspace` steps.
- **`monitoring/control_charts.py` — `calculate_limits`**: said "Only for the Holt-Winters method" but the method also fits the `xbar.no.subgroup` variant. Also fixed the `'regulur'` typo in `_xbar_no_subgroup_fit`.
- **`experiments/optimization.py` — `_steepest_path`**: `n_steps` produces `n_steps + 1` step entries (step 0 at the centre is included).
- **`batch/features.py` — `f_count`**: described as "the index number of the final value"; the code returns the count of non-missing observations.
- **`batch/tools.py` — `extract_batch_features`**: the tool description and input-schema `enum` advertised `mad` and `robust_mad`, which are not in the feature maps and have no implementation.
- **`batch/plotting.py` — `colours_per_batch_id`**: docstring documented `override_default_colour`; the actual parameter is `use_default_colour`.

### Code fix

- **`batch/features.py` — `f_elbow`**: when no elbow is detected the code assigned the `np.isnan` function object instead of `np.nan`. Now records `np.nan`.

Version bumped to `1.22.2` (`pyproject.toml`, `CITATION.cff`, `CHANGELOG.md`).

## Test plan

- [x] `ruff check` passes on all changed files
- [x] `pytest tests/batch/test_features.py tests/test_bivariate.py tests/test_regression.py` — 58 passed
- [x] All changed modules import cleanly

https://claude.ai/code/session_01TNhQhZRrr7UacjeFnjhhcN

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNhQhZRrr7UacjeFnjhhcN)_