### PR TITLE
Add experimental free-threaded Python CI jobs (tracks #43)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,8 +55,11 @@ jobs:
             os: ubuntu-latest
             experimental: false
           # Free-threaded (no-GIL) Python. numba 0.63+ ships free-threaded
-          # wheels but support is still upstream-experimental, so allow these
-          # rows to fail without blocking the workflow.
+          # wheels but llvmlite (a numba dependency) does not yet publish
+          # cp31Xt wheels on PyPI, and its sdist needs LLVM 20 which is not
+          # on the GitHub-hosted ubuntu image. Until llvmlite ships
+          # free-threaded wheels these rows are expected to fail at install
+          # time; allow them to fail without blocking the workflow.
           - python-version: "3.13t"
             os: ubuntu-latest
             experimental: true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,14 +43,28 @@ jobs:
        # Adjust for min and max supported Python versions
         python-version: ["3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        experimental: [false]
         include:
           - python-version: "3.10"
             os: ubuntu-latest
+            experimental: false
           - python-version: "3.11"
             os: ubuntu-latest
+            experimental: false
           - python-version: "3.12"
             os: ubuntu-latest
+            experimental: false
+          # Free-threaded (no-GIL) Python. numba 0.63+ ships free-threaded
+          # wheels but support is still upstream-experimental, so allow these
+          # rows to fail without blocking the workflow.
+          - python-version: "3.13t"
+            os: ubuntu-latest
+            experimental: true
+          - python-version: "3.14t"
+            os: ubuntu-latest
+            experimental: true
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     defaults:
       run:
         shell: bash -e {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.3] - 2026-05-27
+
+### Changed
+
+- CI now includes experimental, allow-failure jobs for free-threaded
+  Python 3.13t and 3.14t on ubuntu, since numba >= 0.63 ships
+  free-threaded wheels (#43).
+
 ## [1.22.2] - 2026-05-22
 
 ### Fixed
@@ -112,7 +120,8 @@ those changes.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.2...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.3...HEAD
+[1.22.3]: https://github.com/kgdunn/process-improve/compare/v1.22.2...v1.22.3
 [1.22.2]: https://github.com/kgdunn/process-improve/compare/v1.22.1...v1.22.2
 [1.22.1]: https://github.com/kgdunn/process-improve/compare/v1.22.0...v1.22.1
 [1.22.0]: https://github.com/kgdunn/process-improve/compare/v1.21.7...v1.22.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.2
-date-released: "2026-05-22"
+version: 1.22.3
+date-released: "2026-05-27"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.2"
+version = "1.22.3"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Tracks #43 — keeping that issue open intentionally so we periodically revisit free-threaded Python support as the upstream ecosystem matures (see "current upstream blocker" below).

## Why now

Issue #43 was filed as a reminder to test on free-threaded (no-GIL) Python and was blocked on numba upstream issue [numba/numba#9928](https://github.com/numba/numba/issues/9928). That numba-side blocker is now resolved:

- **numba 0.63.0** (8 Dec 2025) shipped initial, experimental support for free-threaded CPython.
- **numba 0.65.0** (31 Mar 2026) added Python 3.14t support with `cp314t` wheels on PyPI.
- `pyproject.toml` already pins `numba>=0.63.1`, so installed numba in CI is already free-threading-capable.

numba is the only native/JIT dependency in the codebase (`process_improve/batch/alignment_helpers.py`, two `@jit(nopython=True)` functions).

## What this PR does

Adds two new rows to the `test` job matrix in `.github/workflows/run-tests.yml`:

- `python-version: "3.13t"` on `ubuntu-latest`
- `python-version: "3.14t"` on `ubuntu-latest`

Both run with `continue-on-error: true` (driven by a new `experimental` matrix dimension), so they surface regressions without blocking PRs while upstream support is still labelled experimental. `astral-sh/setup-uv@v7` understands the `t` suffix directly, so no extra setup step is needed.

Existing matrix entries (3.10, 3.11, 3.12, 3.13 x three OSes) are unchanged and remain required.

## Current upstream blocker (why #43 stays open)

The experimental rows currently fail in CI. Root cause is **`llvmlite`** (transitive dep of numba), not numba itself:

```
× Failed to build `llvmlite==0.47.0`
CMake Error at CMakeLists.txt:46 (message):
  LLVM CMake export states LLVM version is 17, llvmlite only officially
  supports 20.
```

llvmlite has not yet published `cp313t` / `cp314t` wheels on PyPI, so uv falls back to a source build, which requires LLVM 20 while ubuntu-latest only ships LLVM 17. The matrix entries will go green automatically once llvmlite publishes free-threaded wheels (or PyPI mirrors them); until then they remain as an informational signal — which is why we're keeping #43 open as a periodic-revisit reminder.

## Out of scope

- Bumping the supported-Python floor or default CI Python version.
- Adding 3.13t / 3.14t to the lint or publish workflows.
- Marking the package as officially supporting free-threading.

## Test plan

- [x] All existing matrix entries stay green and required.
- [x] The two `*t` rows actually run (not silently skipped) and report status.
- [x] If a `*t` row fails, the overall workflow stays green (continue-on-error).
- [x] Root cause of the `*t` failures captured both in the workflow comment and in the PR conversation.
