### PR TITLE
docs: fix docstring inconsistencies in metrics, monitoring, and regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.4] - 2026-05-29
+
+### Fixed
+
+- Docstring corrections so they match the implementation:
+  - `ttest_paired` (`univariate/metrics.py`): the returned dict's
+    `"Standard deviation"` key actually holds the standard error of the
+    mean difference, not the sample standard deviation; the docstring now
+    documents every returned key and calls out the misnomer explicitly.
+  - `calculate_cpk` (`monitoring/metrics.py`): the `trim_percentile`
+    parameter is described accurately - it is used both as the percentile
+    for estimating missing specification limits and as the toggle between
+    classical and robust centre/spread.
+  - `repeated_median_slope` (`regression/methods.py`): added missing
+    Parameters and Returns sections documenting the signature and return
+    type.
+
 ## [1.22.3] - 2026-05-27
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.3
-date-released: "2026-05-27"
+version: 1.22.4
+date-released: "2026-05-29"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/process_improve/monitoring/metrics.py
+++ b/process_improve/monitoring/metrics.py
@@ -36,8 +36,13 @@ def calculate_cpk(
         Default is ``(np.nan, np.nan)``, which treats both specs as numeric NaN
         and yields NaN for the corresponding side of the Cpk calculation.
     trim_percentile : float, optional
-        If non-zero, then robust alternatives are used. The value specified is the percentile of
-        data that is trimmed away; by default 2.5 percent on the left, and 2.5% on the right.
+        Controls two things. (1) When a specification limit is missing, ``trim_percentile`` is
+        used as a percentile on the data (in percent) to estimate that limit: the lower spec is
+        set to ``np.nanpercentile(data, trim_percentile)`` and the upper spec to
+        ``np.nanpercentile(data, 100 - trim_percentile)``. Default ``2.5`` therefore yields the
+        2.5th and 97.5th percentiles. (2) When ``trim_percentile > 0`` the centre/spread used in
+        the Cpk formula switch from mean/std to robust alternatives (median and ``Sn``); when 0
+        the classical mean/std are used.
 
     Returns
     -------

--- a/process_improve/regression/methods.py
+++ b/process_improve/regression/methods.py
@@ -28,12 +28,32 @@ def fit_robust_lm(x: np.ndarray, y: np.ndarray) -> np.ndarray:
 
 def repeated_median_slope(x: np.ndarray, y: np.ndarray, nowarn: bool = False) -> float:
     """
-    Robust slope calculation.
+    Robust slope calculation via Siegel's repeated-median estimator.
 
     https://en.wikipedia.org/wiki/Repeated_median_regression
 
-    An elegant (simple) method to compute the robust slope between a vector `x` and `y`.
+    An elegant (simple) method to compute the robust slope between a vector ``x`` and ``y``.
+    For each point ``i`` the median of the pairwise slopes ``(y[j] - y[i]) / (x[j] - x[i])``
+    over all ``j != i`` is computed; the returned slope is the median of those per-point medians.
 
+    Parameters
+    ----------
+    x : np.ndarray or sequence
+        Independent variable. Coerced to a 1-D numpy array. Must have at least 3 elements
+        (unless ``nowarn=True``).
+    y : np.ndarray or sequence
+        Dependent variable. Must have the same length as ``x`` (unless ``nowarn=True``).
+    nowarn : bool, optional
+        If ``True``, skip the length and equal-length input assertions. Default ``False``.
+
+    Returns
+    -------
+    float
+        The repeated-median estimate of the slope. Returns ``np.nan`` if all inner medians
+        are undefined (e.g. all ``x`` values are equal).
+
+    Notes
+    -----
     INVESTIGATE: algorithm speed-ups via these articles:
     https://link.springer.com/article/10.1007/PL00009190
     http://www.sciencedirect.com/science/article/pii/S0020019003003508

--- a/process_improve/univariate/metrics.py
+++ b/process_improve/univariate/metrics.py
@@ -319,7 +319,17 @@ def ttest_paired(differences: pd.Series, conflevel: float = 0.995) -> dict:
     Returns
     -------
     dict
-        Outcomes from the statistical test.
+        Outcomes from the statistical test, with keys:
+
+        - ``"Differences mean"``: the mean of the input ``differences``.
+        - ``"z value"``: the test statistic (mean divided by its standard error).
+        - ``"ConfInt: Lo"``, ``"ConfInt: Hi"``: lower and upper bounds of the two-sided
+          confidence interval around the mean difference at the requested ``conflevel``.
+        - ``"p value"``: two-sided p-value from the t-distribution.
+        - ``"Degrees of freedom"``: ``n - 1`` for ``n`` paired observations.
+        - ``"Standard deviation"``: the **standard error of the mean difference**,
+          i.e. ``sample_std / sqrt(n)`` (the scale used to build the confidence interval),
+          NOT the sample standard deviation of ``differences``.
     """
     diff_mean = differences.mean()
     diff_svar = differences.std(ddof=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.3"
+version = "1.22.4"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Three computational functions had docstrings that did not match the implementation. All changes are documentation-only.

- **`ttest_paired`** (`process_improve/univariate/metrics.py:308`) - the returned dict has a key called `"Standard deviation"` but the value stored under it is `diff_svar * sqrt(1/(dof+1))`, which is the **standard error of the mean difference**, not the sample standard deviation. The docstring previously said only `"Outcomes from the statistical test"` and gave no key list. Now lists every returned key and calls out the misnomer explicitly so callers don't multiply the value by `sqrt(n)` thinking it's a sample SD. The key name itself is not renamed because it is part of the public return shape.
- **`calculate_cpk`** (`process_improve/monitoring/metrics.py:7`) - the `trim_percentile` doc said "the percentile of data that is trimmed away; by default 2.5 percent on the left, and 2.5% on the right", but the code does not trim data. `trim_percentile` is used as the percentile for estimating a missing spec limit (`np.nanpercentile(data, trim_percentile)` and `100 - trim_percentile`) and as the toggle between mean/std and the robust median/Sn for centre/spread. Rewritten to describe both effects.
- **`repeated_median_slope`** (`process_improve/regression/methods.py:29`) - the docstring documented no parameters and no return value. Added NumPy-style Parameters and Returns sections covering `x`, `y`, `nowarn`, and the float return (including the `np.nan` edge case when all inner medians are undefined).

Version bumped to `1.22.4`; `CITATION.cff` and `CHANGELOG.md` updated to match per `CLAUDE.md`.

## Test plan

- [ ] `pytest` continues to pass (no behaviour change).
- [ ] `ruff check` clean.
- [ ] Sphinx docs build still passes (`cd docs && make html`).


---
_Generated by [Claude Code](https://claude.ai/code/session_011DPDeVfett7hXxgsqqisug)_