### PR TITLE
Fix SEC-01: block arbitrary code execution via patsy formula in fit_linear_model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.5] - 2026-05-29
+
+### Security
+
+- `fit_linear_model` tool (`experiments/tools.py`): the user-supplied `formula`
+  was passed straight to statsmodels/patsy, which evaluates formula terms as
+  Python expressions; a crafted formula could execute arbitrary code (SEC-01).
+  Formulas are now validated against a strict Wilkinson-notation allowlist over
+  the data columns (new `validate_formula_is_safe` / `UnsafeFormulaError` in
+  `experiments/models.py`) before they reach patsy.
+
 ## [1.22.4] - 2026-05-29
 
 ### Added
@@ -144,7 +155,8 @@ those changes.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.4...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.5...HEAD
+[1.22.5]: https://github.com/kgdunn/process-improve/compare/v1.22.4...v1.22.5
 [1.22.4]: https://github.com/kgdunn/process-improve/compare/v1.22.3...v1.22.4
 [1.22.3]: https://github.com/kgdunn/process-improve/compare/v1.22.2...v1.22.3
 [1.22.2]: https://github.com/kgdunn/process-improve/compare/v1.22.1...v1.22.2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.4
+version: 1.22.5
 date-released: "2026-05-29"
 keywords:
   - chemometrics

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -22,7 +22,7 @@ therefore ranked under two models:
 
 | ID | Title | U | L | Status |
 |----|-------|---|---|--------|
-| SEC-01 | RCE via patsy formula in `fit_linear_model` | Critical | Low | open |
+| SEC-01 | RCE via patsy formula in `fit_linear_model` | Critical | Low | done (#238, v1.22.5) |
 | SEC-02 | Timeout does not terminate runaway worker | High | Low | open |
 | SEC-03 | No per-call worker-pool isolation | Medium | Low | open |
 | SEC-04 | Declared `input_schema` never enforced | High | Low | open |
@@ -37,7 +37,9 @@ therefore ranked under two models:
 
 ---
 
-## SEC-01 - Arbitrary code execution via patsy formula in `fit_linear_model`
+## SEC-01 - Arbitrary code execution via patsy formula in `fit_linear_model` [RESOLVED]
+- **Status:** Fixed in v1.22.5 (issue #238). `validate_formula_is_safe` now
+  rejects any non-Wilkinson formula before it reaches patsy.
 - **Severity:** U = Critical, L = Low
 - **Where:** `process_improve/experiments/tools.py:172` (`fit_linear_model`) ->
   `process_improve/experiments/models.py:178` (`lm`) ->

--- a/process_improve/experiments/models.py
+++ b/process_improve/experiments/models.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import re
 import warnings
 from collections import defaultdict
+from collections.abc import Iterable
 from typing import Any
 
 import numpy as np
@@ -11,6 +13,70 @@ import pandas as pd
 import statsmodels.formula.api as smf
 from patsy import ModelDesc
 from statsmodels.regression.linear_model import OLS
+
+
+class UnsafeFormulaError(ValueError):
+    """Raised when a model formula contains tokens outside the safe Wilkinson subset.
+
+    Patsy and statsmodels evaluate each formula term as a Python expression, so a
+    formula coming from an untrusted source (for example the ``fit_linear_model``
+    MCP tool) is a code-execution vector. :func:`validate_formula_is_safe` rejects
+    anything that is not a plain Wilkinson formula over known data columns before it
+    ever reaches patsy.
+    """
+
+
+# Characters permitted in a safe Wilkinson formula: column-name characters,
+# whitespace, and the structural operators (~ + - * : ^) plus grouping parens.
+# Notably excluded: quotes, '.', ',', '[', ']', '=', '!', '@', '%', backslash -
+# i.e. everything needed to build a Python expression, attribute access, string
+# literal, or function-call argument list.
+_FORMULA_ALLOWED_CHARS = re.compile(r"^[A-Za-z0-9_ \t\r\n~+\-*:^()]*$")
+_FORMULA_IDENTIFIER = re.compile(r"[A-Za-z_]\w*")
+
+
+def validate_formula_is_safe(formula: str, allowed_names: Iterable[str]) -> None:
+    """Reject a model ``formula`` that is not a plain Wilkinson formula over *allowed_names*.
+
+    This is the guard for untrusted callers (e.g. the ``fit_linear_model`` tool).
+    Patsy evaluates every formula term as a Python expression with builtins and
+    numpy in scope, so a string such as ``y ~ I(__import__('os').system('id'))``
+    would execute arbitrary code. We forbid that by allowing only:
+
+    * identifiers that name an actual data column,
+    * the operators ``~ + - * : ^`` and grouping parentheses,
+    * integer literals (for powers like ``(A + B)**2``) and whitespace.
+
+    Any quote, dot, comma, dunder, or unknown identifier (``np``, ``I``,
+    ``__import__``, ...) is rejected.
+
+    Parameters
+    ----------
+    formula:
+        The model formula in Wilkinson notation, e.g. ``"y ~ A*B"``.
+    allowed_names:
+        The legal identifier names, i.e. the columns present in the data.
+
+    Raises
+    ------
+    UnsafeFormulaError
+        If *formula* is not a string, contains forbidden characters or a
+        ``__`` dunder, or references an identifier that is not a data column.
+    """
+    if not isinstance(formula, str):
+        raise UnsafeFormulaError(f"formula must be a string, got {type(formula).__name__}.")
+    if "__" in formula:
+        raise UnsafeFormulaError("formula may not contain '__' (dunder access is forbidden).")
+    if not _FORMULA_ALLOWED_CHARS.match(formula):
+        forbidden = sorted({c for c in formula if not _FORMULA_ALLOWED_CHARS.match(c)})
+        raise UnsafeFormulaError(f"formula contains forbidden characters: {forbidden}.")
+    allowed = {str(name) for name in allowed_names}
+    unknown = sorted({tok for tok in _FORMULA_IDENTIFIER.findall(formula) if tok not in allowed})
+    if unknown:
+        raise UnsafeFormulaError(
+            f"formula references unknown name(s) {unknown}; only data columns are allowed: "
+            f"{sorted(allowed)}."
+        )
 
 
 def forg(x: float, prec: int = 3) -> str:

--- a/process_improve/experiments/tools.py
+++ b/process_improve/experiments/tools.py
@@ -176,10 +176,16 @@ def fit_linear_model(
 ) -> dict[str, Any]:
     """Fit a linear model to experimental data; see tool spec for details."""
     try:
-        from process_improve.experiments.models import lm  # noqa: PLC0415
+        from process_improve.experiments.models import lm, validate_formula_is_safe  # noqa: PLC0415
         from process_improve.experiments.structures import Expt  # noqa: PLC0415
 
         df = pd.DataFrame(data)
+
+        # Patsy evaluates formula terms as Python expressions, so a formula from an
+        # untrusted caller is a code-execution vector. Only allow a plain Wilkinson
+        # formula over the columns actually present in the data.
+        validate_formula_is_safe(formula, df.columns)
+
         expt_data = Expt(df)
         expt_data.pi_title = None
         expt_data.pi_source = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.4"
+version = "1.22.5"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_experiments_models_formula.py
+++ b/tests/test_experiments_models_formula.py
@@ -1,0 +1,60 @@
+"""Unit tests for the SEC-01 formula guard in ``experiments/models.py``.
+
+``validate_formula_is_safe`` is the boundary that stops an untrusted model
+formula from reaching patsy, which evaluates formula terms as arbitrary
+Python expressions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from process_improve.experiments.models import UnsafeFormulaError, validate_formula_is_safe
+
+_COLUMNS = ["A", "B", "C", "y"]
+
+
+class TestValidateFormulaIsSafe:
+    @pytest.mark.parametrize(
+        "formula",
+        [
+            "y ~ A*B*C",
+            "y ~ A + B + C",
+            "y ~ A*B",
+            "y ~ A:B + C",
+            "y ~ (A + B)^2",
+            "y ~ A + B - 1",
+            "  y ~ A + B  ",
+        ],
+    )
+    def test_legitimate_wilkinson_formulas_pass(self, formula: str) -> None:
+        # Should not raise.
+        validate_formula_is_safe(formula, _COLUMNS)
+
+    @pytest.mark.parametrize(
+        "formula",
+        [
+            "y ~ I(__import__('os').system('id'))",  # classic RCE payload
+            "y ~ A + __import__('os')",               # dunder
+            "y ~ A + np.sin(B)",                       # attribute access + unknown name
+            "y ~ A + open('secret')",                  # string literal + unknown call
+            "y ~ A + eval('1')",                       # eval
+            "y ~ A; import os",                         # statement injection char ';'
+            "y ~ A + B == C",                           # '=' not permitted
+        ],
+    )
+    def test_malicious_formulas_are_rejected(self, formula: str) -> None:
+        with pytest.raises(UnsafeFormulaError):
+            validate_formula_is_safe(formula, _COLUMNS)
+
+    def test_unknown_column_is_rejected(self) -> None:
+        with pytest.raises(UnsafeFormulaError, match="unknown name"):
+            validate_formula_is_safe("y ~ A + Z", _COLUMNS)
+
+    def test_non_string_is_rejected(self) -> None:
+        with pytest.raises(UnsafeFormulaError, match="must be a string"):
+            validate_formula_is_safe(["y ~ A"], _COLUMNS)  # type: ignore[arg-type]
+
+    def test_dunder_is_rejected_first(self) -> None:
+        with pytest.raises(UnsafeFormulaError, match="dunder"):
+            validate_formula_is_safe("y ~ A.__class__", _COLUMNS)

--- a/tests/test_experiments_tools.py
+++ b/tests/test_experiments_tools.py
@@ -52,6 +52,14 @@ class TestCreateFactorialDesign:
 # ---------------------------------------------------------------------------
 
 
+_SAFE_FIT_DATA = [
+    {"A": -1, "B": -1, "y": 28.0},
+    {"A": 1, "B": -1, "y": 36.0},
+    {"A": -1, "B": 1, "y": 18.0},
+    {"A": 1, "B": 1, "y": 31.0},
+]
+
+
 class TestFitLinearModel:
     def test_two_factor_factorial_fit(self) -> None:
         """A 2^2 factorial should fit cleanly."""
@@ -73,11 +81,49 @@ class TestFitLinearModel:
         assert "summary_text" in result
         assert isinstance(result["summary_text"], str)
 
-    # Note: tests that intentionally trigger a patsy formula error are skipped.
-    # On Python 3.13 the traceback formatter calls ``list(frame.f_locals)``
-    # over patsy's eval namespace, which raises ``KeyError: 0`` and triggers
-    # an INTERNALERROR even when the user-level assertion would pass. The
-    # success-path test above already exercises the wrapper's try block.
+    def test_main_effects_only(self) -> None:
+        """A '+' main-effects formula should still fit."""
+        result = execute_tool_call(
+            "fit_linear_model",
+            {
+                "formula": "y ~ A + B",
+                "data": [
+                    {"A": -1, "B": -1, "y": 28.0},
+                    {"A": 1, "B": -1, "y": 36.0},
+                    {"A": -1, "B": 1, "y": 18.0},
+                    {"A": 1, "B": 1, "y": 31.0},
+                ],
+            },
+        )
+        assert "error" not in result
+        assert "coefficients" in result
+
+    # ---- SEC-01: patsy-formula code-execution guard -----------------------
+    # Patsy evaluates formula terms as Python, so an untrusted formula is an
+    # RCE vector. The wrapper now rejects anything that is not a plain
+    # Wilkinson formula over the data columns, *before* it reaches patsy, so
+    # these never hit patsy's eval (which also avoids the Python 3.13
+    # traceback INTERNALERROR seen previously).
+
+    def test_rce_formula_is_rejected_without_side_effect(self, tmp_path) -> None:
+        """A malicious formula must return an error and must not execute code."""
+        sentinel = tmp_path / "pwned"
+        malicious = f"y ~ A + I(__import__('os').system('touch {sentinel}'))"
+        result = execute_tool_call(
+            "fit_linear_model",
+            {"formula": malicious, "data": _SAFE_FIT_DATA},
+        )
+        assert "error" in result
+        assert not sentinel.exists(), "formula was evaluated - RCE guard failed"
+
+    def test_unknown_identifier_is_rejected(self) -> None:
+        """A formula referencing a non-column name (e.g. numpy) is rejected."""
+        result = execute_tool_call(
+            "fit_linear_model",
+            {"formula": "y ~ A + np", "data": _SAFE_FIT_DATA},
+        )
+        assert "error" in result
+        assert "unknown name" in result["error"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #238. First fix from the `SECURITY_AUDIT.md` series.

## Problem
The `fit_linear_model` MCP tool passed its user-supplied `formula` straight to statsmodels/patsy:

`experiments/tools.py` (`fit_linear_model`) -> `experiments/models.py` (`lm`) -> `smf.ols(formula, data)`.

Patsy evaluates each formula term as a Python expression with builtins/numpy in scope, so a formula such as `y ~ I(__import__('os').system('id'))` executes arbitrary code. The `safe_execute_tool_call` sandbox caps time/memory but does not restrict what code runs, so it is not a boundary against this. **Severity: Critical under the untrusted threat model, Low local-trusted.**

## Fix
New `validate_formula_is_safe(formula, allowed_names)` + `UnsafeFormulaError` in `experiments/models.py`, called at the `fit_linear_model` boundary before anything reaches patsy. It permits only:
- identifiers that name an actual data column,
- the Wilkinson operators `~ + - * : ^` and grouping parentheses,
- integer literals (for powers) and whitespace.

Quotes, `.` (attribute access), `__` dunders, and any unknown identifier (`np`, `I`, `open`, `__import__`, ...) are rejected. The guard is applied at the untrusted tool boundary; internal trusted callers of `lm()` are unchanged (no behaviour change for them).

## Tests
- `tests/test_experiments_models_formula.py`: unit tests for the validator (legitimate Wilkinson formulas pass; RCE/dunder/attribute/quote/unknown-name payloads raise).
- `tests/test_experiments_tools.py`: a malicious formula returns an `error` dict and does **not** create a sentinel file (proves no evaluation); an unknown identifier is rejected; main-effects and factorial fits still succeed.
- Full `tests/test_doe.py` still green (37 passed, 1 skipped).

This also lets us re-enable the previously-skipped patsy-error tests: rejection now happens before patsy, avoiding the Python 3.13 traceback INTERNALERROR that motivated the skip.

## Versioning
PATCH bump to `1.22.5`; `CITATION.cff` and `CHANGELOG.md` (new `### Security` entry) synced; SEC-01 struck off `SECURITY_AUDIT.md`.

https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp)_