### PR TITLE
Fix SEC-04: enforce tool input_schema on the untrusted dispatch path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.6] - 2026-05-29
+
+### Security
+
+- Tool dispatch now enforces each tool's declared JSON `input_schema` on the
+  untrusted path (`safe_execute_tool_call`): types, `minimum`/`maximum`,
+  `minItems`/`maxItems`, `enum`, `required`, and rejection of unknown
+  parameters (SEC-04). Previously the schema was advisory and inputs were
+  passed straight through as `**kwargs`. New dependency-free
+  `validate_against_schema` in `tool_safety.py`; the in-process
+  `execute_tool_call` fast path is unchanged.
+
 ## [1.22.5] - 2026-05-29
 
 ### Security
@@ -155,7 +167,8 @@ those changes.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.5...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.6...HEAD
+[1.22.6]: https://github.com/kgdunn/process-improve/compare/v1.22.5...v1.22.6
 [1.22.5]: https://github.com/kgdunn/process-improve/compare/v1.22.4...v1.22.5
 [1.22.4]: https://github.com/kgdunn/process-improve/compare/v1.22.3...v1.22.4
 [1.22.3]: https://github.com/kgdunn/process-improve/compare/v1.22.2...v1.22.3

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.5
+version: 1.22.6
 date-released: "2026-05-29"
 keywords:
   - chemometrics

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -25,7 +25,7 @@ therefore ranked under two models:
 | SEC-01 | RCE via patsy formula in `fit_linear_model` | Critical | Low | done (#238, v1.22.5) |
 | SEC-02 | Timeout does not terminate runaway worker | High | Low | open |
 | SEC-03 | No per-call worker-pool isolation | Medium | Low | open |
-| SEC-04 | Declared `input_schema` never enforced | High | Low | open |
+| SEC-04 | Declared `input_schema` never enforced | High | Low | done (#240, v1.22.6) |
 | SEC-05 | Div-by-zero in NIPALS / multiblock methods | High | High | open |
 | SEC-06 | Non-convergence not flagged; `fractional()` 1/0 | Medium | Medium | open |
 | SEC-07 | Matrix inversion without conditioning checks | Medium | Medium | open |
@@ -89,7 +89,10 @@ therefore ranked under two models:
   calls) so each tool call gets a clean process; document the isolation
   guarantee. Can be implemented together with SEC-02 as "pool hardening."
 
-## SEC-04 - Declared `input_schema` is never enforced at dispatch
+## SEC-04 - Declared `input_schema` is never enforced at dispatch [RESOLVED]
+- **Status:** Fixed in v1.22.6 (issue #240). `safe_execute_tool_call` now calls
+  `validate_against_schema` (types, bounds, item counts, enum, required, unknown
+  keys) before dispatch; the in-process `execute_tool_call` fast path is unchanged.
 - **Severity:** U = High, L = Low
 - **Where:** `process_improve/tool_spec.py:310-335` (`execute_tool_call`) and
   `process_improve/tool_safety.py:293-339` (`safe_execute_tool_call`), both ending

--- a/process_improve/tool_safety.py
+++ b/process_improve/tool_safety.py
@@ -30,6 +30,7 @@ import contextlib
 import multiprocessing
 import os
 import sys
+from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from concurrent.futures.process import BrokenProcessPool
@@ -210,6 +211,138 @@ def validate_input(
 
 
 # ---------------------------------------------------------------------------
+# JSON-schema enforcement
+# ---------------------------------------------------------------------------
+#
+# Each tool ships an ``input_schema`` (JSON Schema), but the dispatch path
+# passes the input straight through as ``**kwargs`` without checking it. For an
+# untrusted transport that means types, bounds, enums and ``required`` are
+# unenforced and unknown keys reach the function. ``validate_against_schema``
+# enforces the subset of JSON Schema actually used by the tool specs. It is
+# deliberately dependency-free (no ``jsonschema``) so it adds no install/lockfile
+# churn.
+
+# A JSON "number" accepts ints; "integer" rejects floats. ``bool`` is excluded
+# from the numeric types because ``True``/``False`` are ints in Python.
+_JSON_TYPE_CHECKS: dict[str, Callable[[Any], bool]] = {
+    "number": lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
+    "integer": lambda v: isinstance(v, int) and not isinstance(v, bool),
+    "string": lambda v: isinstance(v, str),
+    "boolean": lambda v: isinstance(v, bool),
+    "array": lambda v: isinstance(v, list),
+    "object": lambda v: isinstance(v, dict),
+}
+
+
+def _validate_value(key: str, value: Any, subschema: dict[str, Any]) -> None:  # noqa: ANN401
+    """Validate a single parameter *value* against its property *subschema*."""
+    # Optional parameters may be supplied as an explicit ``null``; the tool
+    # function then falls back to its own default, so do not type-check None.
+    if value is None:
+        return
+
+    expected = subschema.get("type")
+    check = _JSON_TYPE_CHECKS.get(expected) if isinstance(expected, str) else None
+    if check is not None and not check(value):
+        raise ToolInputInvalidError(
+            f"Parameter {key!r} must be of type {expected!r}, got {type(value).__name__}.",
+            details={"key": key, "expected_type": expected, "observed_type": type(value).__name__},
+        )
+
+    enum = subschema.get("enum")
+    if enum is not None and value not in enum:
+        raise ToolInputInvalidError(
+            f"Parameter {key!r}={value!r} is not one of {enum}.",
+            details={"key": key, "enum": list(enum)},
+        )
+
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        minimum = subschema.get("minimum")
+        if minimum is not None and value < minimum:
+            raise ToolInputInvalidError(
+                f"Parameter {key!r}={value} is below the minimum of {minimum}.",
+                details={"key": key, "minimum": minimum, "observed": value},
+            )
+        maximum = subschema.get("maximum")
+        if maximum is not None and value > maximum:
+            raise ToolInputInvalidError(
+                f"Parameter {key!r}={value} exceeds the maximum of {maximum}.",
+                details={"key": key, "maximum": maximum, "observed": value},
+            )
+
+    if isinstance(value, list):
+        min_items = subschema.get("minItems")
+        if min_items is not None and len(value) < min_items:
+            raise ToolInputInvalidError(
+                f"Parameter {key!r} has {len(value)} items; minimum is {min_items}.",
+                details={"key": key, "min_items": min_items, "observed": len(value)},
+            )
+        max_items = subschema.get("maxItems")
+        if max_items is not None and len(value) > max_items:
+            raise ToolInputInvalidError(
+                f"Parameter {key!r} has {len(value)} items; maximum is {max_items}.",
+                details={"key": key, "max_items": max_items, "observed": len(value)},
+            )
+
+
+def validate_against_schema(tool_input: dict[str, Any], schema: dict[str, Any]) -> None:
+    """Validate *tool_input* against a tool's JSON ``input_schema``.
+
+    Enforces the subset of JSON Schema used by process-improve tool specs:
+    the object's ``required`` keys must be present, parameters not declared in
+    ``properties`` are rejected (no additional keys), and each supplied value is
+    checked against its property ``type``, ``enum``, ``minimum``/``maximum``
+    (numbers) and ``minItems``/``maxItems`` (arrays).
+
+    Parameters
+    ----------
+    tool_input:
+        The ``input`` dict that would be passed as keyword arguments to the tool.
+    schema:
+        The tool's ``input_schema`` (a JSON Schema object).
+
+    Raises
+    ------
+    ToolInputInvalidError
+        On any missing-required, unknown-key, type, enum, bound, or item-count
+        violation.
+    """
+    if schema.get("type") != "object":
+        return
+
+    properties: dict[str, Any] = schema.get("properties", {})
+    required = schema.get("required", [])
+
+    for req_key in required:
+        if req_key not in tool_input:
+            raise ToolInputInvalidError(
+                f"Missing required parameter {req_key!r}.",
+                details={"key": req_key, "required": list(required)},
+            )
+
+    if properties:
+        unknown = sorted(set(tool_input) - set(properties))
+        if unknown:
+            raise ToolInputInvalidError(
+                f"Unknown parameter(s): {unknown}. Allowed: {sorted(properties)}.",
+                details={"unknown": unknown, "allowed": sorted(properties)},
+            )
+
+    for key, value in tool_input.items():
+        subschema = properties.get(key)
+        if isinstance(subschema, dict):
+            _validate_value(key, value, subschema)
+
+
+def _lookup_input_schema(tool_name: str) -> dict[str, Any] | None:
+    """Return the ``input_schema`` for *tool_name*, or None if not registered."""
+    from process_improve.tool_spec import get_tool_specs  # noqa: PLC0415
+
+    specs = get_tool_specs(names=[tool_name])
+    return specs[0]["input_schema"] if specs else None
+
+
+# ---------------------------------------------------------------------------
 # Subprocess worker
 # ---------------------------------------------------------------------------
 
@@ -323,7 +456,9 @@ def safe_execute_tool_call(  # noqa: PLR0913
     Raises
     ------
     ToolInputInvalidError, ToolInputTooLargeError:
-        Synchronous rejection before any subprocess work.
+        Synchronous rejection before any subprocess work. ``ToolInputInvalidError``
+        also covers JSON-schema violations (wrong type, out-of-bounds value,
+        bad enum, missing required key, or an unknown parameter).
     ToolTimeoutError:
         Wall-clock overrun.
     ToolMemoryExceededError:
@@ -337,6 +472,14 @@ def safe_execute_tool_call(  # noqa: PLR0913
         max_string=max_string,
         max_depth=max_depth,
     )
+
+    # Enforce the tool's declared JSON schema (types, bounds, enums, required,
+    # no unknown keys). Done after the size check so an oversize payload is still
+    # reported as ToolInputTooLargeError. Unknown tools fall through to the
+    # worker, which raises the canonical "Unknown tool" ValueError.
+    schema = _lookup_input_schema(tool_name)
+    if schema is not None:
+        validate_against_schema(tool_input, schema)
 
     pool = executor if executor is not None else get_pool(memory_mb=memory_mb)
     future = pool.submit(_worker_run, tool_name, tool_input)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.5"
+version = "1.22.6"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_tool_safety.py
+++ b/tests/test_tool_safety.py
@@ -31,6 +31,7 @@ from process_improve.tool_safety import (
     ToolTimeoutError,
     _apply_memory_limit,
     _count_numeric_leaves,
+    _lookup_input_schema,
     _pool_initializer,
     _worker_run,
     get_pool,
@@ -232,6 +233,25 @@ class TestValidateAgainstSchema:
         validate_against_schema(
             {"data": [1, 2, 3], "n_components": 2, "name": None}, _DEMO_SCHEMA
         )
+
+    def test_non_object_schema_is_noop(self) -> None:
+        # Schemas that are not object-typed are not enforced (no raise).
+        validate_against_schema({"anything": 1}, {"type": "array"})
+
+    def test_property_without_recognised_type_is_skipped(self) -> None:
+        # A property whose subschema declares no (or an unknown) type is accepted
+        # as-is; only enum/bounds, if present, still apply.
+        schema = {"type": "object", "properties": {"x": {"description": "free-form"}}}
+        validate_against_schema({"x": ["whatever", 1, {"k": "v"}]}, schema)
+
+    def test_lookup_input_schema_unknown_returns_none(self) -> None:
+        assert _lookup_input_schema("definitely_not_a_registered_tool") is None
+
+    def test_lookup_input_schema_known_returns_schema(self) -> None:
+        schema = _lookup_input_schema("_safety_test_echo")
+        assert schema is not None
+        assert schema["type"] == "object"
+        assert "value" in schema["properties"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_safety.py
+++ b/tests/test_tool_safety.py
@@ -36,6 +36,7 @@ from process_improve.tool_safety import (
     get_pool,
     safe_execute_tool_call,
     shutdown_pool,
+    validate_against_schema,
     validate_input,
 )
 from process_improve.tool_spec import _TOOL_REGISTRY, tool_spec
@@ -149,6 +150,91 @@ class TestValidateInput:
 
 
 # ---------------------------------------------------------------------------
+# validate_against_schema: SEC-04, synchronous, in-process
+# ---------------------------------------------------------------------------
+
+
+_DEMO_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "data": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 5},
+        "n_components": {"type": "integer", "minimum": 1},
+        "conf_level": {"type": "number", "minimum": 0.8, "maximum": 0.999},
+        "method": {"type": "string", "enum": ["a", "b"]},
+        "name": {"type": "string"},
+    },
+    "required": ["data", "n_components"],
+}
+
+
+class TestValidateAgainstSchema:
+    def test_valid_input_passes(self) -> None:
+        validate_against_schema(
+            {"data": [1, 2, 3], "n_components": 2, "conf_level": 0.95, "method": "a"},
+            _DEMO_SCHEMA,
+        )
+
+    def test_int_accepted_for_number_type(self) -> None:
+        # JSON "number" accepts integers.
+        validate_against_schema(
+            {"x": 5},
+            {"type": "object", "properties": {"x": {"type": "number"}}},
+        )
+
+    def test_missing_required_rejected(self) -> None:
+        with pytest.raises(ToolInputInvalidError, match="required"):
+            validate_against_schema({"data": [1, 2, 3]}, _DEMO_SCHEMA)
+
+    def test_unknown_key_rejected(self) -> None:
+        with pytest.raises(ToolInputInvalidError, match="Unknown parameter"):
+            validate_against_schema(
+                {"data": [1, 2, 3], "n_components": 2, "bogus": 1}, _DEMO_SCHEMA
+            )
+
+    def test_wrong_type_rejected(self) -> None:
+        with pytest.raises(ToolInputInvalidError, match="type 'integer'"):
+            validate_against_schema({"data": [1, 2, 3], "n_components": "two"}, _DEMO_SCHEMA)
+
+    def test_float_rejected_for_integer(self) -> None:
+        with pytest.raises(ToolInputInvalidError):
+            validate_against_schema({"data": [1, 2, 3], "n_components": 2.5}, _DEMO_SCHEMA)
+
+    def test_bool_rejected_for_number(self) -> None:
+        with pytest.raises(ToolInputInvalidError):
+            validate_against_schema({"data": [1, 2, 3], "n_components": True}, _DEMO_SCHEMA)
+
+    def test_below_minimum_rejected(self) -> None:
+        with pytest.raises(ToolInputInvalidError, match="minimum"):
+            validate_against_schema({"data": [1, 2, 3], "n_components": 0}, _DEMO_SCHEMA)
+
+    def test_above_maximum_rejected(self) -> None:
+        with pytest.raises(ToolInputInvalidError, match="maximum"):
+            validate_against_schema(
+                {"data": [1, 2, 3], "n_components": 2, "conf_level": 2.0}, _DEMO_SCHEMA
+            )
+
+    def test_too_few_items_rejected(self) -> None:
+        with pytest.raises(ToolInputInvalidError, match="minimum is 3"):
+            validate_against_schema({"data": [1, 2], "n_components": 2}, _DEMO_SCHEMA)
+
+    def test_too_many_items_rejected(self) -> None:
+        with pytest.raises(ToolInputInvalidError, match="maximum is 5"):
+            validate_against_schema({"data": [1, 2, 3, 4, 5, 6], "n_components": 2}, _DEMO_SCHEMA)
+
+    def test_bad_enum_rejected(self) -> None:
+        with pytest.raises(ToolInputInvalidError, match="not one of"):
+            validate_against_schema(
+                {"data": [1, 2, 3], "n_components": 2, "method": "z"}, _DEMO_SCHEMA
+            )
+
+    def test_explicit_null_for_optional_allowed(self) -> None:
+        # An optional parameter passed as null falls back to the tool's default.
+        validate_against_schema(
+            {"data": [1, 2, 3], "n_components": 2, "name": None}, _DEMO_SCHEMA
+        )
+
+
+# ---------------------------------------------------------------------------
 # Subprocess-based tests
 # ---------------------------------------------------------------------------
 
@@ -171,6 +257,16 @@ class TestSafeExecuteToolCall:
                 timeout=10,
                 max_cells=100,
             )
+
+    def test_schema_violation_rejected_before_subprocess(self) -> None:
+        # SEC-04: wrong type for a declared parameter is rejected synchronously,
+        # before any worker runs.
+        with pytest.raises(ToolInputInvalidError):
+            safe_execute_tool_call("_safety_test_echo", {"value": "not-a-number"}, timeout=10)
+
+    def test_schema_unknown_key_rejected_before_subprocess(self) -> None:
+        with pytest.raises(ToolInputInvalidError, match="Unknown parameter"):
+            safe_execute_tool_call("_safety_test_echo", {"value": 1, "rogue": 2}, timeout=10)
 
     def test_timeout_raises_structured_error(self) -> None:
         with pytest.raises(ToolTimeoutError) as exc_info:


### PR DESCRIPTION
Closes #240. PR 2 of the `SECURITY_AUDIT.md` series.

## Problem
`execute_tool_call` and `safe_execute_tool_call` ended in `_TOOL_REGISTRY[tool_name](**tool_input)`, so each tool's declared JSON `input_schema` (types, `minimum`/`maximum`, `minItems`, `enum`, `required`, `additionalProperties`) was advisory only. `_SCALAR_CAPS` capped just a hard-coded handful of keys; other cost-driving params were unbounded and types were unchecked (type confusion, silent wrong results, or expensive work below the cell cap). **Severity: High under the untrusted threat model, Low local-trusted.**

## Fix
New dependency-free `validate_against_schema(tool_input, schema)` in `tool_safety.py`, wired into `safe_execute_tool_call` **after** the size check (so an oversize payload is still reported as `ToolInputTooLargeError`). It enforces the JSON-Schema subset the specs actually use:
- `required` keys present; unknown keys rejected;
- per-property `type` (JSON `number` accepts ints; `integer` rejects floats; `bool` excluded from numeric types), `enum`, `minimum`/`maximum`, `minItems`/`maxItems`.

Optional params passed as explicit `null` are allowed (the tool function falls back to its own default). Unknown tool names fall through to the worker's canonical `ValueError`.

### Scope / why no new dependency
Validation is added only to `safe_execute_tool_call` — the untrusted boundary (`PROCESS_IMPROVE_MCP_SAFE_MODE`). The in-process `execute_tool_call` fast path used by local/trusted callers and most tests is unchanged. Implemented without `jsonschema` to avoid a new runtime dependency and lockfile churn (and the schemas are simple, in-house).

## Tests
- `TestValidateAgainstSchema` (13 cases): valid input; int-for-number; missing-required; unknown-key; wrong type; float-for-integer; bool-for-number; below-min; above-max; too-few/too-many items; bad enum; explicit-null optional.
- Two end-to-end cases through `safe_execute_tool_call`: a wrong-type value and an unknown key are both rejected synchronously before any worker runs.
- Verified all 35 real tool schemas are object-type and that representative valid inputs pass while a bad `fit_pca` input is rejected.
- `tests/test_tool_safety.py` + `tests/test_tool_spec.py` green (108 passed).

## Versioning
PATCH bump to `1.22.6`; `CITATION.cff` and `CHANGELOG.md` (`### Security`) synced; SEC-04 struck off `SECURITY_AUDIT.md`.

https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp)_