### PR TITLE
Fix SEC-02/SEC-03: kill runaway workers on timeout, recycle pool per call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.7] - 2026-05-29
+
+### Security
+
+- `safe_execute_tool_call` now actually terminates a runaway worker on timeout
+  (SEC-02). Previously it called `shutdown(wait=False)`, which does not
+  interrupt a worker already running a task, so a CPU-bound or infinite-loop
+  tool kept holding a core after `ToolTimeoutError` was raised. Workers are now
+  force-terminated (`terminate()` then `kill()`).
+- The module-managed worker pool is recycled after every call (SEC-03), so each
+  call runs in a fresh worker with isolated process-global state and reclaimed
+  memory. Caller-provided executors are left untouched.
+
 ## [1.22.6] - 2026-05-29
 
 ### Security
@@ -167,7 +180,8 @@ those changes.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.6...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.7...HEAD
+[1.22.7]: https://github.com/kgdunn/process-improve/compare/v1.22.6...v1.22.7
 [1.22.6]: https://github.com/kgdunn/process-improve/compare/v1.22.5...v1.22.6
 [1.22.5]: https://github.com/kgdunn/process-improve/compare/v1.22.4...v1.22.5
 [1.22.4]: https://github.com/kgdunn/process-improve/compare/v1.22.3...v1.22.4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.6
+version: 1.22.7
 date-released: "2026-05-29"
 keywords:
   - chemometrics

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -23,8 +23,8 @@ therefore ranked under two models:
 | ID | Title | U | L | Status |
 |----|-------|---|---|--------|
 | SEC-01 | RCE via patsy formula in `fit_linear_model` | Critical | Low | done (#238, v1.22.5) |
-| SEC-02 | Timeout does not terminate runaway worker | High | Low | open |
-| SEC-03 | No per-call worker-pool isolation | Medium | Low | open |
+| SEC-02 | Timeout does not terminate runaway worker | High | Low | done (#239, v1.22.7) |
+| SEC-03 | No per-call worker-pool isolation | Medium | Low | done (#239, v1.22.7) |
 | SEC-04 | Declared `input_schema` never enforced | High | Low | done (#240, v1.22.6) |
 | SEC-05 | Div-by-zero in NIPALS / multiblock methods | High | High | open |
 | SEC-06 | Non-convergence not flagged; `fractional()` 1/0 | Medium | Medium | open |
@@ -59,7 +59,9 @@ therefore ranked under two models:
   `experiments/evaluate.py:95`). Add tests asserting malicious formulas are
   rejected before reaching patsy.
 
-## SEC-02 - Timeout guard does not terminate runaway workers (CPU-exhaustion DoS)
+## SEC-02 - Timeout guard does not terminate runaway workers (CPU-exhaustion DoS) [RESOLVED]
+- **Status:** Fixed in v1.22.7 (issue #239). `shutdown_pool` now force-terminates
+  workers; `safe_execute_tool_call` recycles the pool after every call.
 - **Severity:** U = High, L = Low
 - **Where:** `process_improve/tool_safety.py:344-353` (`safe_execute_tool_call`),
   `shutdown_pool` (`tool_safety.py:279-285`).
@@ -76,7 +78,10 @@ therefore ranked under two models:
   then join) before raising. Correct the docstring. Add a regression test that
   submits a busy-loop tool and asserts the child process is gone after timeout.
 
-## SEC-03 - Worker pool has no per-call isolation / memory reset
+## SEC-03 - Worker pool has no per-call isolation / memory reset [RESOLVED]
+- **Status:** Fixed in v1.22.7 (issue #239). The module pool is recycled after
+  every call. (`max_tasks_per_child=1` is incompatible with the `fork` start
+  method this module uses, so per-call recycling is used instead.)
 - **Severity:** U = Medium, L = Low
 - **Where:** `process_improve/tool_safety.py:259-276` (`get_pool`),
   `_pool_initializer`, `_apply_memory_limit`.

--- a/process_improve/tool_safety.py
+++ b/process_improve/tool_safety.py
@@ -409,10 +409,42 @@ def get_pool(memory_mb: int = DEFAULT_MEMORY_MB, max_workers: int = 1) -> Proces
     return _pool
 
 
+def _terminate_workers(pool: ProcessPoolExecutor) -> None:
+    """Force-kill a pool's worker processes (best-effort).
+
+    ``ProcessPoolExecutor.shutdown(wait=False, cancel_futures=True)`` does not
+    interrupt a worker that is *already running* a task: ``cancel_futures`` only
+    drops not-yet-started futures. So a runaway tool (infinite loop, pathological
+    input) would keep a CPU core busy after a timeout. Here we reach into the
+    CPython-internal process table and terminate each worker, escalating to
+    ``kill()`` if ``terminate()`` does not take. Guarded with ``suppress`` so that
+    an internal-API change degrades to the old (non-killing) behaviour instead of
+    raising.
+    """
+    processes = getattr(pool, "_processes", None)
+    if not processes:
+        return
+    workers = list(processes.values())
+    for proc in workers:
+        with contextlib.suppress(Exception):
+            if proc.is_alive():
+                proc.terminate()
+    for proc in workers:
+        with contextlib.suppress(Exception):
+            proc.join(timeout=1.0)
+            if proc.is_alive():
+                proc.kill()
+
+
 def shutdown_pool() -> None:
-    """Shut down the module-level pool, if any. Safe to call repeatedly."""
+    """Shut down the module-level pool, if any. Safe to call repeatedly.
+
+    Worker processes are force-terminated first so a runaway task cannot keep
+    holding a CPU after the executor is torn down.
+    """
     global _pool, _pool_memory_mb  # noqa: PLW0603
     if _pool is not None:
+        _terminate_workers(_pool)
         _pool.shutdown(wait=False, cancel_futures=True)
         _pool = None
         _pool_memory_mb = None
@@ -441,8 +473,9 @@ def safe_execute_tool_call(  # noqa: PLR0913
     tool_name, tool_input:
         Same meaning as :func:`process_improve.tool_spec.execute_tool_call`.
     timeout:
-        Wall-clock seconds. On overrun, the current subprocess is terminated
-        and a fresh pool is started; :class:`ToolTimeoutError` is raised.
+        Wall-clock seconds. On overrun the runaway worker is force-terminated
+        (``terminate()`` then ``kill()``) so it cannot keep holding a CPU, and
+        :class:`ToolTimeoutError` is raised.
     max_cells, max_string, max_depth:
         Input-size limits. See :func:`validate_input`.
     memory_mb:
@@ -451,7 +484,10 @@ def safe_execute_tool_call(  # noqa: PLR0913
         is raised.
     executor:
         Optional caller-provided pool. When *None* (default) a module-level
-        singleton is used.
+        singleton is used and is recycled after every call, so each call runs
+        in a fresh worker with isolated process-global state and reclaimed
+        memory. A caller-provided executor is never recycled or terminated by
+        this function - the caller owns its lifecycle.
 
     Raises
     ------
@@ -487,16 +523,11 @@ def safe_execute_tool_call(  # noqa: PLR0913
     try:
         return future.result(timeout=timeout)
     except FuturesTimeoutError as exc:
-        # Kill the whole pool so the runaway worker cannot hold the CPU.
-        if executor is None:
-            shutdown_pool()
         raise ToolTimeoutError(
             f"Tool {tool_name!r} exceeded {timeout}s timeout",
             details={"tool_name": tool_name, "timeout": timeout},
         ) from exc
     except BrokenProcessPool as exc:
-        if executor is None:
-            shutdown_pool()
         raise ToolMemoryExceededError(
             f"Tool {tool_name!r} worker died (likely exceeded memory limit of {memory_mb} MB)",
             details={"tool_name": tool_name, "memory_mb": memory_mb},
@@ -509,3 +540,12 @@ def safe_execute_tool_call(  # noqa: PLR0913
             f"Tool {tool_name!r} exceeded memory limit of {memory_mb} MB",
             details={"tool_name": tool_name, "memory_mb": memory_mb},
         ) from exc
+    finally:
+        # Recycle the module-managed pool after every call: each call then runs in
+        # a fresh worker with clean process-global state (RNG, matplotlib, cached
+        # imports) and reclaimed memory, and any worker that overran the timeout
+        # or hit the memory cap is force-terminated here rather than left holding
+        # a CPU. A caller-provided executor is left untouched - the caller owns
+        # its lifecycle.
+        if executor is None:
+            shutdown_pool()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.6"
+version = "1.22.7"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_tool_safety.py
+++ b/tests/test_tool_safety.py
@@ -17,6 +17,7 @@ Windows these tests are skipped.
 from __future__ import annotations
 
 import contextlib
+import os
 import sys
 import time
 
@@ -88,6 +89,27 @@ def _safety_test_memory_bomb(*, megabytes: int) -> dict:
     size = int(megabytes) * 1024 * 1024 // 8
     _ = np.zeros(size, dtype=np.float64)
     return {"allocated_mb": megabytes}
+
+
+@tool_spec(
+    name="_safety_test_busy_loop",
+    description="Spin on the CPU forever. Test-only.",
+    input_schema={"json": {"type": "object", "properties": {}}},
+)
+def _safety_test_busy_loop() -> dict:
+    while True:
+        pass
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True if a process with *pid* still exists."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
 
 
 @pytest.fixture(autouse=True)
@@ -293,6 +315,33 @@ class TestSafeExecuteToolCall:
             safe_execute_tool_call("_safety_test_sleep", {"seconds": 5}, timeout=0.2)
         assert exc_info.value.code == "timeout"
         assert exc_info.value.details["tool_name"] == "_safety_test_sleep"
+
+    def test_timeout_force_terminates_runaway_worker(self) -> None:
+        # SEC-02: a CPU-bound runaway must actually be killed on timeout, not
+        # left spinning. Warm the module pool (workers spawn lazily) so we can
+        # record its worker pids, then run an infinite-loop tool through the same
+        # pool and confirm those workers are gone afterwards.
+        pool = get_pool()
+        pool.submit(_worker_run, "_safety_test_echo", {"value": 0}).result(timeout=10)
+        pids = list(getattr(pool, "_processes", {}).keys())
+        assert pids, "expected at least one worker process"
+
+        with pytest.raises(ToolTimeoutError):
+            safe_execute_tool_call("_safety_test_busy_loop", {}, timeout=0.3)
+
+        deadline = time.time() + 5
+        while time.time() < deadline and any(_pid_alive(p) for p in pids):
+            time.sleep(0.05)
+        assert not any(_pid_alive(p) for p in pids), "runaway worker still alive after timeout"
+
+    def test_module_pool_recycled_after_each_call(self) -> None:
+        # SEC-03: the module-managed pool is recycled after every call so each
+        # call runs in a fresh, isolated worker.
+        import process_improve.tool_safety as ts
+
+        result = safe_execute_tool_call("_safety_test_echo", {"value": 1}, timeout=10)
+        assert result == {"value": 1}
+        assert ts._pool is None
 
     def test_error_has_json_serialisable_dict(self) -> None:
         err: ToolSafetyError = ToolTimeoutError("boom", details={"tool_name": "x", "timeout": 1})

--- a/tests/test_tool_safety.py
+++ b/tests/test_tool_safety.py
@@ -34,6 +34,7 @@ from process_improve.tool_safety import (
     _count_numeric_leaves,
     _lookup_input_schema,
     _pool_initializer,
+    _terminate_workers,
     _worker_run,
     get_pool,
     safe_execute_tool_call,
@@ -274,6 +275,70 @@ class TestValidateAgainstSchema:
         assert schema is not None
         assert schema["type"] == "object"
         assert "value" in schema["properties"]
+
+
+# ---------------------------------------------------------------------------
+# _terminate_workers: SEC-02 helper, no real subprocesses (runs everywhere)
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    """A multiprocessing.Process double recording terminate()/kill() calls.
+
+    ``alive`` is a list of booleans consumed by successive ``is_alive()`` calls
+    (first in the terminate loop, then after ``join`` in the kill loop).
+    """
+
+    def __init__(self, alive: list[bool]) -> None:
+        self._alive = alive
+        self.terminated = False
+        self.killed = False
+
+    def is_alive(self) -> bool:
+        return self._alive.pop(0) if self._alive else False
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def join(self, timeout: float | None = None) -> None:
+        pass
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+class _FakePool:
+    def __init__(self, procs: list[_FakeProc]) -> None:
+        self._processes = dict(enumerate(procs))
+
+
+class TestTerminateWorkers:
+    def test_no_processes_attr_is_noop(self) -> None:
+        # A pool object without a _processes table is handled gracefully.
+        _terminate_workers(object())  # type: ignore[arg-type]
+
+    def test_empty_process_table_is_noop(self) -> None:
+        _terminate_workers(_FakePool([]))  # type: ignore[arg-type]
+
+    def test_alive_worker_is_terminated_then_killed(self) -> None:
+        # Still alive after terminate() + join -> escalate to kill().
+        proc = _FakeProc(alive=[True, True])
+        _terminate_workers(_FakePool([proc]))  # type: ignore[arg-type]
+        assert proc.terminated
+        assert proc.killed
+
+    def test_terminate_suffices_when_worker_exits(self) -> None:
+        # Alive at first, dead after terminate() -> no kill().
+        proc = _FakeProc(alive=[True, False])
+        _terminate_workers(_FakePool([proc]))  # type: ignore[arg-type]
+        assert proc.terminated
+        assert not proc.killed
+
+    def test_already_dead_worker_untouched(self) -> None:
+        proc = _FakeProc(alive=[False, False])
+        _terminate_workers(_FakePool([proc]))  # type: ignore[arg-type]
+        assert not proc.terminated
+        assert not proc.killed
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #239. PR 3 of the `SECURITY_AUDIT.md` series (SEC-02 + SEC-03, grouped pool hardening).

## SEC-02 - Timeout did not terminate runaway workers (High under untrusted)
`safe_execute_tool_call`'s timeout handler called `shutdown_pool()` -> `ProcessPoolExecutor.shutdown(wait=False, cancel_futures=True)`, which does **not** interrupt a worker already running a task (`cancel_futures` only drops not-yet-started futures). A CPU-bound or infinite-loop tool kept a core pegged after `ToolTimeoutError` was raised, contradicting the docstring; repeated timeouts accumulated live busy processes.

**Fix:** `shutdown_pool` now force-terminates the workers (`terminate()`, then `kill()` if that does not take) before tearing down the executor. Best-effort and guarded with `suppress` so an internal-API change degrades to the old behaviour instead of raising. Docstring corrected.

## SEC-03 - No per-call worker isolation / memory reset (Medium under untrusted)
The forked module pool reused one long-lived worker across calls and clients, so process-global state (numpy RNG, matplotlib, cached imports) leaked between unrelated calls and memory was never reclaimed (`RLIMIT_AS` is cumulative, and Python does not reliably return memory to the OS).

**Fix:** the module-managed pool is recycled after **every** call (in a `finally`), so each call runs in a fresh, isolated worker. `max_tasks_per_child=1` (the audit's first suggestion) is **incompatible with the `fork` start method** this module uses (verified: `ValueError: max_tasks_per_child is incompatible with the 'fork' multiprocessing start method`), so per-call recycling is used instead. A fork is cheap and the parent already has the tool modules imported (children inherit them), so the overhead is small - and `safe_execute_tool_call` is the opt-in untrusted/hosted path, where isolation matters more than raw throughput. Caller-provided executors are never recycled or terminated; the caller owns their lifecycle.

The two `except` branches no longer duplicate shutdown logic; the single `finally` both force-terminates a runaway and recycles the pool.

## Tests
- SEC-02: warm the module pool, record its worker pid, run an infinite-loop tool with a short timeout, and assert that worker is gone afterwards.
- SEC-03: after a successful call the module `_pool` is `None` (recycled).
- All existing safety tests (timeout, memory-cap, unknown-tool, happy path) still pass: `tests/test_tool_safety.py` + `tests/test_tool_spec.py` = 114 passed.

## Versioning
PATCH bump to `1.22.7`; `CITATION.cff` and `CHANGELOG.md` (`### Security`) synced; SEC-02 and SEC-03 struck off `SECURITY_AUDIT.md`.

https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp)_