### PR TITLE
Fix SEC-05/SEC-06: guard multivariate NIPALS division, flag non-convergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.8] - 2026-05-29
+
+### Fixed
+
+- MBPLS / MBPCA NIPALS no longer silently produce `inf`/`nan` when a score or
+  loading vector collapses (a degenerate or perfectly collinear block, or a
+  fully-deflated component): the sum-of-squares and norm denominators are now
+  floored away from zero (SEC-05). R-squared for a zero-variance block or
+  column is reported as `NaN` (undefined) rather than a misleading `1.0` or a
+  divide-by-zero warning.
+- MBPLS / MBPCA record per-component convergence in `fitting_info_["converged"]`
+  and emit a `SpecificationWarning` when `max_iter` is reached without
+  converging (SEC-06); previously a non-converged solution was returned
+  silently.
+- `Resampler.fractional` re-validates `fraction_excluded` (must be in the open
+  interval `(0, 1)`), so mutating it to `0` after construction raises a clear
+  error instead of `ZeroDivisionError` (SEC-06).
+
 ## [1.22.7] - 2026-05-29
 
 ### Security
@@ -180,7 +198,8 @@ those changes.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.7...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.8...HEAD
+[1.22.8]: https://github.com/kgdunn/process-improve/compare/v1.22.7...v1.22.8
 [1.22.7]: https://github.com/kgdunn/process-improve/compare/v1.22.6...v1.22.7
 [1.22.6]: https://github.com/kgdunn/process-improve/compare/v1.22.5...v1.22.6
 [1.22.5]: https://github.com/kgdunn/process-improve/compare/v1.22.4...v1.22.5

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.7
+version: 1.22.8
 date-released: "2026-05-29"
 keywords:
   - chemometrics

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -26,8 +26,8 @@ therefore ranked under two models:
 | SEC-02 | Timeout does not terminate runaway worker | High | Low | done (#239, v1.22.7) |
 | SEC-03 | No per-call worker-pool isolation | Medium | Low | done (#239, v1.22.7) |
 | SEC-04 | Declared `input_schema` never enforced | High | Low | done (#240, v1.22.6) |
-| SEC-05 | Div-by-zero in NIPALS / multiblock methods | High | High | open |
-| SEC-06 | Non-convergence not flagged; `fractional()` 1/0 | Medium | Medium | open |
+| SEC-05 | Div-by-zero in NIPALS / multiblock methods | High | High | done (#241, v1.22.8) |
+| SEC-06 | Non-convergence not flagged; `fractional()` 1/0 | Medium | Medium | done (#241, v1.22.8) |
 | SEC-07 | Matrix inversion without conditioning checks | Medium | Medium | open |
 | SEC-08 | `assert` used for validation (stripped by `-O`) | Medium | Low | open |
 | SEC-09 | Exception suppression; tool errors leak internals | Medium | Low | open |
@@ -115,7 +115,9 @@ therefore ranked under two models:
   `additionalProperties`. This also closes the `_SCALAR_CAPS` bypass. Add tests
   for type/bounds rejection and unknown-key rejection.
 
-## SEC-05 - Unguarded division by zero in multivariate NIPALS / multiblock methods
+## SEC-05 - Unguarded division by zero in multivariate NIPALS / multiblock methods [RESOLVED]
+- **Status:** Fixed in v1.22.8 (issue #241). NIPALS denominators are floored via
+  `_nz`; zero-variance R-squared is reported as NaN.
 - **Severity:** U = High, L = High (correctness)
 - **Where:** `process_improve/multivariate/methods.py` around lines 4444-4458,
   5277-5283, 5435-5439 (e.g. `/(p_b @ p_b)`, `/(t_super @ t_super)`,
@@ -130,7 +132,9 @@ therefore ranked under two models:
   in `fitting_info_` instead of silently substituting `1.0`. Add tests with
   collinear / all-constant columns.
 
-## SEC-06 - Iterative algorithms do not flag non-convergence; `fractional()` divide-by-zero
+## SEC-06 - Iterative algorithms do not flag non-convergence; `fractional()` divide-by-zero [RESOLVED]
+- **Status:** Fixed in v1.22.8 (issue #241). `fitting_info_["converged"]` plus a
+  `SpecificationWarning`; `fractional()` re-validates `fraction_excluded`.
 - **Severity:** U = Medium, L = Medium (correctness)
 - **Where:** `process_improve/multivariate/methods.py:4434`, `5258` (NIPALS
   `while ... and itern < self.max_iter`), `5740`

--- a/process_improve/multivariate/methods.py
+++ b/process_improve/multivariate/methods.py
@@ -38,6 +38,24 @@ DataMatrix: TypeAlias = np.ndarray | pd.DataFrame
 
 epsqrt = np.sqrt(np.finfo(float).eps)
 
+#: Smallest positive float; used to floor NIPALS denominators away from zero.
+_DENOM_FLOOR = float(np.finfo(float).tiny)
+
+
+def _nz(denominator: float) -> float:
+    """Floor a non-negative NIPALS denominator away from zero.
+
+    Sum-of-squares and vector-norm denominators (``v @ v``, ``norm(v)``) are
+    non-negative. When a score or loading vector collapses to (near) zero during
+    NIPALS - a fully-deflated component, or a degenerate / perfectly collinear
+    block - the denominator is ~0 and the division would yield ``inf``/``nan``
+    that silently poisons the fitted model. Flooring to the smallest positive
+    float leaves every well-conditioned value untouched (real denominators are
+    far larger) while turning the degenerate ``0/0`` into a finite (~0)
+    projection, since the numerator collapses with the same vector.
+    """
+    return max(_DENOM_FLOOR, denominator)
+
 
 class SpecificationWarning(UserWarning):
     """Parent warning class."""
@@ -4432,30 +4450,30 @@ class MBPLS(RegressorMixin, BaseEstimator):
                     u_a_col = u_a.reshape(-1, 1)
                     for b_idx, name in enumerate(self.block_names_):
                         w_b = quick_regress(x_def[name], u_a_col).flatten()
-                        w_b = w_b / np.sqrt(ssq(w_b.reshape(-1, 1)))
+                        w_b = w_b / _nz(np.sqrt(ssq(w_b.reshape(-1, 1))))
                         t_b = quick_regress(x_def[name], w_b.reshape(-1, 1)).flatten() / sqrt_kb[name]
                         local_w[name] = w_b
                         local_t[name] = t_b
                         t_b_summary[:, b_idx] = t_b
                 else:
                     for b_idx, name in enumerate(self.block_names_):
-                        w_b = x_def[name].T @ u_a / (u_a @ u_a)
-                        w_b = w_b / np.linalg.norm(w_b)
-                        t_b = x_def[name] @ w_b / (w_b @ w_b) / sqrt_kb[name]
+                        w_b = x_def[name].T @ u_a / _nz(u_a @ u_a)
+                        w_b = w_b / _nz(np.linalg.norm(w_b))
+                        t_b = x_def[name] @ w_b / _nz(w_b @ w_b) / sqrt_kb[name]
                         local_w[name] = w_b
                         local_t[name] = t_b
                         t_b_summary[:, b_idx] = t_b
 
-                w_s = t_b_summary.T @ u_a / (u_a @ u_a)
-                w_s = w_s / np.linalg.norm(w_s)
-                t_super = t_b_summary @ w_s / (w_s @ w_s)
+                w_s = t_b_summary.T @ u_a / _nz(u_a @ u_a)
+                w_s = w_s / _nz(np.linalg.norm(w_s))
+                t_super = t_b_summary @ w_s / _nz(w_s @ w_s)
                 if algo == "nipals":
                     t_super_col = t_super.reshape(-1, 1)
                     c_a = quick_regress(y_def, t_super_col).flatten()
                     u_a = quick_regress(y_def, c_a.reshape(-1, 1)).flatten()
                 else:
-                    c_a = y_def.T @ t_super / (t_super @ t_super)
-                    u_a = y_def @ c_a / (c_a @ c_a)
+                    c_a = y_def.T @ t_super / _nz(t_super @ t_super)
+                    u_a = y_def @ c_a / _nz(c_a @ c_a)
                 itern += 1
 
             # Sign convention: largest |w_super| element positive
@@ -4475,7 +4493,7 @@ class MBPLS(RegressorMixin, BaseEstimator):
                 if algo == "nipals":
                     p_b = quick_regress(x_def[name], t_super_col).flatten()
                 else:
-                    p_b = x_def[name].T @ t_super / (t_super @ t_super)
+                    p_b = x_def[name].T @ t_super / _nz(t_super @ t_super)
                 x_def[name] = x_def[name] - np.outer(t_super, p_b)
                 block_loadings_np[name][:, a] = p_b
                 block_weights_np[name][:, a] = local_w[name]
@@ -4490,15 +4508,24 @@ class MBPLS(RegressorMixin, BaseEstimator):
             # Track per-block cumulative R^2_X and per-Y-variable cumulative R^2_Y
             for b_idx, name in enumerate(self.block_names_):
                 ssq_remain_per_var = np.nansum(x_def[name] ** 2, axis=0)
-                r2_x_block_cum[b_idx, a] = 1 - np.sum(ssq_remain_per_var) / ssq_x_init[name]
-                r2_x_var_cum[name][:, a] = 1 - ssq_remain_per_var / np.where(
-                    ssq_x_init_per_var[name] > 0, ssq_x_init_per_var[name], 1.0
+                # R^2 is undefined for a zero-variance block/column; report NaN
+                # rather than dividing by zero (inf/nan + warning) or returning a
+                # misleading 1.0.
+                r2_x_block_cum[b_idx, a] = (
+                    1 - np.sum(ssq_remain_per_var) / ssq_x_init[name] if ssq_x_init[name] > 0 else np.nan
+                )
+                r2_x_var_cum[name][:, a] = np.where(
+                    ssq_x_init_per_var[name] > 0,
+                    1 - ssq_remain_per_var / np.where(ssq_x_init_per_var[name] > 0, ssq_x_init_per_var[name], 1.0),
+                    np.nan,
                 )
                 block_spe_np[name][:, a] = np.sqrt(np.nansum(x_def[name] ** 2, axis=1))
             ssq_y_remain_per_var = np.nansum(y_def ** 2, axis=0)
-            r2_y_cum[a] = 1 - np.sum(ssq_y_remain_per_var) / ssq_y_init
-            r2_y_var_cum[:, a] = 1 - ssq_y_remain_per_var / np.where(
-                ssq_y_init_per_var > 0, ssq_y_init_per_var, 1.0
+            r2_y_cum[a] = 1 - np.sum(ssq_y_remain_per_var) / ssq_y_init if ssq_y_init > 0 else np.nan
+            r2_y_var_cum[:, a] = np.where(
+                ssq_y_init_per_var > 0,
+                1 - ssq_y_remain_per_var / np.where(ssq_y_init_per_var > 0, ssq_y_init_per_var, 1.0),
+                np.nan,
             )
 
             timing[a] = time.time() - start
@@ -4537,7 +4564,16 @@ class MBPLS(RegressorMixin, BaseEstimator):
         self.scaling_factor_for_super_scores_ = pd.Series(
             np.sqrt(self.explained_variance_), index=component_names, name="Standard deviation per super-score"
         )
-        self.fitting_info_ = {"timing": timing, "iterations": iterations}
+        converged = iterations < self.max_iter
+        self.fitting_info_ = {"timing": timing, "iterations": iterations, "converged": converged}
+        if not np.all(converged):
+            failed = [int(i + 1) for i, ok in enumerate(converged) if not ok]
+            warnings.warn(
+                f"MBPLS NIPALS did not converge within max_iter={self.max_iter} for "
+                f"component(s) {failed}; results for those components may be unreliable.",
+                SpecificationWarning,
+                stacklevel=2,
+            )
 
         # --- Per-component (incremental) R^2 from cumulative ---
         r2_x_block_per_a = np.zeros_like(r2_x_block_cum)
@@ -5265,22 +5301,22 @@ class MBPCA(TransformerMixin, BaseEstimator):
                     t_super_col = t_super.reshape(-1, 1)
                     for b_idx, name in enumerate(self.block_names_):
                         p_b = quick_regress(x_def[name], t_super_col).flatten()
-                        p_b = p_b / np.sqrt(ssq(p_b.reshape(-1, 1)))
+                        p_b = p_b / _nz(np.sqrt(ssq(p_b.reshape(-1, 1))))
                         t_b = quick_regress(x_def[name], p_b.reshape(-1, 1)).flatten() / sqrt_kb[name]
                         local_loadings[name] = p_b
                         local_scores[name] = t_b
                         t_b_summary[:, b_idx] = t_b
                 else:
                     for b_idx, name in enumerate(self.block_names_):
-                        p_b = x_def[name].T @ t_super / (t_super @ t_super)
-                        p_b = p_b / np.linalg.norm(p_b)
-                        t_b = x_def[name] @ p_b / (p_b @ p_b) / sqrt_kb[name]
+                        p_b = x_def[name].T @ t_super / _nz(t_super @ t_super)
+                        p_b = p_b / _nz(np.linalg.norm(p_b))
+                        t_b = x_def[name] @ p_b / _nz(p_b @ p_b) / sqrt_kb[name]
                         local_loadings[name] = p_b
                         local_scores[name] = t_b
                         t_b_summary[:, b_idx] = t_b
-                p_s = t_b_summary.T @ t_super / (t_super @ t_super)
-                p_s = p_s / np.linalg.norm(p_s)
-                t_super = t_b_summary @ p_s / (p_s @ p_s)
+                p_s = t_b_summary.T @ t_super / _nz(t_super @ t_super)
+                p_s = p_s / _nz(np.linalg.norm(p_s))
+                t_super = t_b_summary @ p_s / _nz(p_s @ p_s)
                 itern += 1
 
             # Sign convention: largest |super_loading| element positive
@@ -5305,9 +5341,15 @@ class MBPCA(TransformerMixin, BaseEstimator):
             # Per-block cumulative R²X and SPE
             for b_idx, name in enumerate(self.block_names_):
                 ssq_remain_per_var = np.nansum(x_def[name] ** 2, axis=0)
-                r2_x_block_cum[b_idx, a] = 1 - np.sum(ssq_remain_per_var) / ssq_x_init[name]
-                r2_x_var_cum[name][:, a] = 1 - ssq_remain_per_var / np.where(
-                    ssq_x_init_per_var[name] > 0, ssq_x_init_per_var[name], 1.0
+                # R^2 is undefined for a zero-variance block/column; report NaN
+                # rather than dividing by zero (inf/nan + warning) or 1.0.
+                r2_x_block_cum[b_idx, a] = (
+                    1 - np.sum(ssq_remain_per_var) / ssq_x_init[name] if ssq_x_init[name] > 0 else np.nan
+                )
+                r2_x_var_cum[name][:, a] = np.where(
+                    ssq_x_init_per_var[name] > 0,
+                    1 - ssq_remain_per_var / np.where(ssq_x_init_per_var[name] > 0, ssq_x_init_per_var[name], 1.0),
+                    np.nan,
                 )
                 block_spe_np[name][:, a] = np.sqrt(np.nansum(x_def[name] ** 2, axis=1))
 
@@ -5335,7 +5377,16 @@ class MBPCA(TransformerMixin, BaseEstimator):
         self.scaling_factor_for_super_scores_ = pd.Series(
             np.sqrt(self.explained_variance_), index=component_names, name="Standard deviation per super-score"
         )
-        self.fitting_info_ = {"timing": timing, "iterations": iterations}
+        converged = iterations < self.max_iter
+        self.fitting_info_ = {"timing": timing, "iterations": iterations, "converged": converged}
+        if not np.all(converged):
+            failed = [int(i + 1) for i, ok in enumerate(converged) if not ok]
+            warnings.warn(
+                f"MBPCA NIPALS did not converge within max_iter={self.max_iter} for "
+                f"component(s) {failed}; results for those components may be unreliable.",
+                SpecificationWarning,
+                stacklevel=2,
+            )
 
         # Per-component (incremental) R²X
         r2_x_block_per_a = np.zeros_like(r2_x_block_cum)
@@ -5432,11 +5483,11 @@ class MBPCA(TransformerMixin, BaseEstimator):
             t_b_row = np.zeros((n_new, len(self.block_names_)))
             for b_idx, name in enumerate(self.block_names_):
                 p_b = self.block_loadings_[name].values[:, a]
-                t_b = x_def[name] @ p_b / (p_b @ p_b) / sqrt_kb[name]
+                t_b = x_def[name] @ p_b / _nz(p_b @ p_b) / sqrt_kb[name]
                 block_scores[name][:, a] = t_b
                 t_b_row[:, b_idx] = t_b
             p_s = self.super_loadings_.values[:, a]
-            t_super = t_b_row @ p_s / (p_s @ p_s)
+            t_super = t_b_row @ p_s / _nz(p_s @ p_s)
             super_scores[:, a] = t_super
             for b_idx, name in enumerate(self.block_names_):
                 p_b = self.block_loadings_[name].values[:, a]
@@ -5737,6 +5788,13 @@ class Resampler:
 
         # Generate fractional samples, resample with replacement, in a loop of self.bootstrap_rounds iterations
         rng = np.random.default_rng()
+        # Re-validate here: the __init__ guard can be bypassed by mutating
+        # ``fraction_excluded`` to 0 (or out of range) before calling fractional().
+        if not 0.0 < self.fraction_excluded < 1.0:
+            raise ValueError(
+                f"`fraction_excluded` must be in the open interval (0, 1) to perform fractional "
+                f"resampling, got {self.fraction_excluded}."
+            )
         n_groups = int(1 / self.fraction_excluded)
         for _ in tqdm(range(len(self.x)), desc="Fractional Resampling", disable=not show_progress):
             # Find the indices to leave out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.7"
+version = "1.22.8"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_multivariate_robustness.py
+++ b/tests/test_multivariate_robustness.py
@@ -1,0 +1,187 @@
+"""Robustness regression tests for SEC-05 and SEC-06 (multivariate methods).
+
+SEC-05: NIPALS / multiblock divisions are guarded so a degenerate or
+fully-deflated block yields finite (~0) projections instead of silently
+producing ``inf``/``nan``.
+
+SEC-06: MBPLS / MBPCA record per-component convergence in ``fitting_info_``
+and warn when ``max_iter`` is hit; ``Resampler.fractional`` re-validates
+``fraction_excluded`` so a mutated-to-zero value raises rather than dividing
+by zero.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.base import BaseEstimator
+
+from process_improve.multivariate.methods import (
+    MBPCA,
+    MBPLS,
+    DataFrameDict,
+    Resampler,
+    SpecificationWarning,
+    _nz,
+)
+
+_DENOM_FLOOR = float(np.finfo(float).tiny)
+
+
+# ---------------------------------------------------------------------------
+# _nz helper
+# ---------------------------------------------------------------------------
+
+
+class TestNzHelper:
+    def test_passes_through_normal_values(self) -> None:
+        assert _nz(5.0) == 5.0
+        assert _nz(1e-6) == 1e-6
+
+    def test_floors_zero(self) -> None:
+        assert _nz(0.0) == _DENOM_FLOOR
+
+    def test_unguarded_zero_division_is_nan(self) -> None:
+        # Documents the bug this guard prevents.
+        v = np.zeros(3)
+        with np.errstate(invalid="ignore"):
+            assert np.all(np.isnan(v / np.linalg.norm(v)))
+        # Guarded form is finite.
+        assert np.all(np.isfinite(v / _nz(np.linalg.norm(v))))
+
+
+# ---------------------------------------------------------------------------
+# SEC-05: degenerate block must not poison the model with inf/nan
+# ---------------------------------------------------------------------------
+
+
+def _blocks_with_constant_block(n: int = 15) -> dict[str, pd.DataFrame]:
+    """One normal block plus one entirely-constant block.
+
+    A constant block centres to exactly zero, so its loading vector collapses
+    and the normalisation ``p_b / norm(p_b)`` would be ``0/0`` without the guard.
+    """
+    rng = np.random.default_rng(0)
+    return {
+        "A": pd.DataFrame(rng.normal(size=(n, 3)), columns=["a1", "a2", "a3"]),
+        "B": pd.DataFrame(np.full((n, 2), 7.0), columns=["b1", "b2"]),
+    }
+
+
+class TestDegenerateBlockStaysFinite:
+    def test_mbpca_constant_block_finite(self) -> None:
+        model = MBPCA(n_components=2).fit(_blocks_with_constant_block())
+        assert np.all(np.isfinite(model.super_scores_.values))
+        for loadings in model.block_loadings_.values():
+            assert np.all(np.isfinite(loadings.values))
+        for scores in model.block_scores_.values():
+            assert np.all(np.isfinite(scores.values))
+
+    def test_mbpls_constant_block_finite(self) -> None:
+        blocks = _blocks_with_constant_block()
+        rng = np.random.default_rng(1)
+        y = pd.DataFrame(rng.normal(size=(15, 1)), columns=["y"])
+        model = MBPLS(n_components=2).fit(blocks, y)
+        assert np.all(np.isfinite(model.super_scores_.values))
+        assert np.all(np.isfinite(model.predictions_.values))
+        for loadings in model.block_loadings_.values():
+            assert np.all(np.isfinite(loadings.values))
+
+
+# ---------------------------------------------------------------------------
+# SEC-06: convergence reporting
+# ---------------------------------------------------------------------------
+
+
+def _clean_blocks(n: int = 20) -> dict[str, pd.DataFrame]:
+    rng = np.random.default_rng(3)
+    latent = rng.normal(size=(n, 2))
+    a = latent @ rng.normal(size=(2, 3)) + 0.05 * rng.normal(size=(n, 3))
+    b = latent @ rng.normal(size=(2, 2)) + 0.05 * rng.normal(size=(n, 2))
+    return {
+        "A": pd.DataFrame(a, columns=["a1", "a2", "a3"]),
+        "B": pd.DataFrame(b, columns=["b1", "b2"]),
+    }
+
+
+class TestConvergenceFlag:
+    def test_mbpca_reports_converged_on_clean_fit(self) -> None:
+        model = MBPCA(n_components=2).fit(_clean_blocks())
+        converged = model.fitting_info_["converged"]
+        assert converged.dtype == bool
+        assert len(converged) == 2
+        assert np.all(converged)
+
+    def test_mbpca_flags_non_convergence_and_warns(self) -> None:
+        with pytest.warns(SpecificationWarning, match="did not converge"):
+            model = MBPCA(n_components=2, max_iter=1).fit(_clean_blocks())
+        assert not np.all(model.fitting_info_["converged"])
+
+    def test_mbpls_reports_converged_on_clean_fit(self) -> None:
+        rng = np.random.default_rng(5)
+        y = pd.DataFrame(rng.normal(size=(20, 1)), columns=["y"])
+        model = MBPLS(n_components=2).fit(_clean_blocks(), y)
+        assert "converged" in model.fitting_info_
+        assert np.all(model.fitting_info_["converged"])
+
+    def test_mbpls_flags_non_convergence_and_warns(self) -> None:
+        rng = np.random.default_rng(6)
+        y = pd.DataFrame(rng.normal(size=(20, 1)), columns=["y"])
+        with pytest.warns(SpecificationWarning, match="did not converge"):
+            model = MBPLS(n_components=2, max_iter=1).fit(_clean_blocks(), y)
+        assert not np.all(model.fitting_info_["converged"])
+
+
+# ---------------------------------------------------------------------------
+# SEC-06: Resampler.fractional re-validates fraction_excluded
+# ---------------------------------------------------------------------------
+
+
+class _StubEstimator(BaseEstimator):
+    def __init__(self, dummy: int = 1) -> None:
+        self.dummy = dummy
+
+    def fit(self, X: DataFrameDict, y: object | None = None) -> _StubEstimator:  # noqa: ARG002
+        self.n_train_samples_ = len(X)
+        return self
+
+
+def _accessor(estimator: _StubEstimator) -> dict[str, float]:
+    return {"n": float(estimator.n_train_samples_)}
+
+
+@pytest.fixture
+def tiny_dfd() -> DataFrameDict:
+    n = 10
+    rng = np.random.default_rng(0)
+    return DataFrameDict(
+        {
+            "F": {"main": pd.DataFrame(rng.standard_normal((n, 2)), columns=["f1", "f2"])},
+            "Z": {"conds": pd.DataFrame(rng.standard_normal((n, 1)), columns=["z1"])},
+            "Y": {"out": pd.DataFrame(rng.standard_normal((n, 1)), columns=["y1"])},
+        }
+    )
+
+
+class TestFractionalGuard:
+    def test_fraction_excluded_zero_raises(self, tiny_dfd: DataFrameDict) -> None:
+        # Default fraction_excluded is 0.0; calling fractional() directly must
+        # not divide by zero.
+        r = Resampler(estimator=_StubEstimator(), x=tiny_dfd, accessor=_accessor, use_jackknife=False)
+        with pytest.raises(ValueError, match="fraction_excluded"):
+            r.fractional(show_progress=False)
+
+    def test_mutated_to_zero_after_init_raises(self, tiny_dfd: DataFrameDict) -> None:
+        # The __init__ guard can be bypassed by mutating the attribute; the
+        # method-level guard catches it.
+        r = Resampler(
+            estimator=_StubEstimator(),
+            x=tiny_dfd,
+            accessor=_accessor,
+            use_jackknife=False,
+            fraction_excluded=0.5,
+        )
+        r.fraction_excluded = 0.0
+        with pytest.raises(ValueError, match="fraction_excluded"):
+            r.fractional(show_progress=False)


### PR DESCRIPTION
Closes #241. PR 4 of the `SECURITY_AUDIT.md` series (SEC-05 + SEC-06, grouped multivariate numerical robustness).

## SEC-05 - Unguarded division by zero in NIPALS / multiblock methods (High, correctness)
MBPLS/MBPCA hierarchical NIPALS divided by score/loading sum-of-squares and vector norms (`v @ v`, `norm(v)`) without guarding against zero. A degenerate or perfectly collinear block, or a fully-deflated component, collapses a vector to ~0, so the division produced `inf`/`nan` that silently poisoned the fitted model (scores, loadings, predictions).

**Fix:** a new `_nz()` helper floors these non-negative denominators to the smallest positive float (`np.finfo(float).tiny`). Because the numerator collapses with the same vector, the projection becomes ~0 instead of non-finite, and every well-conditioned value is untouched (real denominators are far larger). Applied at all the NIPALS division/normalisation sites in MBPLS `fit`, MBPCA `fit`, and MBPCA `transform`.

Also: R-squared for a zero-variance block or column is now reported as `NaN` (undefined) rather than a misleading `1.0` (the old `np.where(..., 1.0)` fallback) or a divide-by-zero `nan` + RuntimeWarning.

## SEC-06 - Non-convergence not flagged; `fractional()` divide-by-zero (Medium)
- MBPLS/MBPCA now record per-component convergence in `fitting_info_["converged"]` (derived as `iterations < max_iter`) and emit a `SpecificationWarning` listing the components that hit `max_iter`. Previously a non-converged solution was returned silently.
- `Resampler.fractional` re-validates `fraction_excluded` is in the open interval `(0, 1)`. The `__init__` guard could be bypassed by mutating the attribute to `0`, giving `ZeroDivisionError`; now it raises a clear `ValueError`.

## Tests (`tests/test_multivariate_robustness.py`)
- `_nz` passes normal values through and floors zero (with a test documenting that the unguarded form is `nan`).
- MBPCA and MBPLS fit on data containing an all-constant block and produce **finite** scores/loadings/predictions.
- `fitting_info_["converged"]` is all-`True` on a clean fit; with `max_iter=1` it is `False` and a `SpecificationWarning` is raised (both classes).
- `fractional()` raises `ValueError` when `fraction_excluded` is `0` (default) or mutated to `0` after construction.
- Full multivariate suite green: 235 passed, 1 skipped across `test_multivariate*`, `test_multiblock_*`, `test_pca_nipals_*`.

## Versioning
PATCH bump to `1.22.8`; `CITATION.cff` and `CHANGELOG.md` synced; SEC-05 and SEC-06 struck off `SECURITY_AUDIT.md`.

https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp)_