### PR TITLE
Fix SEC-07: guard matrix inversions against singular/ill-conditioned input

### DIFF
--- a/process_improve/_linalg.py
+++ b/process_improve/_linalg.py
@@ -1,0 +1,76 @@
+"""(c) Kevin Dunn, 2010-2026. MIT License.
+
+Small numerical-linear-algebra guards shared across the package.
+
+``np.linalg.inv`` does not raise on an ill-conditioned (near-singular) matrix:
+it returns overflow-driven garbage. These helpers detect singular and
+ill-conditioned matrices up front so callers can either fail with a clear
+message or fall back to a pseudo-inverse, instead of silently propagating
+``inf``/``nan`` into a fitted model or a plot.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+#: A matrix whose 2-norm condition number exceeds this is treated as singular.
+#: ``1 / eps`` (~4.5e15) is the standard threshold beyond which a double-precision
+#: solve has effectively no significant digits left.
+DEFAULT_COND_LIMIT: float = 1.0 / np.finfo(float).eps
+
+
+def is_singular(matrix: np.ndarray, *, cond_limit: float = DEFAULT_COND_LIMIT) -> bool:
+    """Return True if *matrix* is non-square, non-finite, singular, or ill-conditioned.
+
+    Parameters
+    ----------
+    matrix:
+        The matrix to test. Coerced to a float array.
+    cond_limit:
+        Condition-number threshold; above this the matrix is considered
+        numerically singular. Defaults to :data:`DEFAULT_COND_LIMIT`.
+    """
+    a = np.asarray(matrix, dtype=float)
+    if a.ndim != 2 or a.shape[0] != a.shape[1]:
+        return True
+    if not np.all(np.isfinite(a)):
+        return True
+    cond = np.linalg.cond(a)
+    return (not np.isfinite(cond)) or cond > cond_limit
+
+
+def safe_inverse(
+    matrix: np.ndarray,
+    *,
+    what: str = "matrix",
+    cond_limit: float = DEFAULT_COND_LIMIT,
+) -> np.ndarray:
+    """Invert *matrix*, raising a clear error if it is singular or ill-conditioned.
+
+    For a well-conditioned matrix this returns exactly ``np.linalg.inv(matrix)``
+    (no numerical change versus a bare ``inv``). For a singular or
+    ill-conditioned matrix it raises :class:`numpy.linalg.LinAlgError` with an
+    actionable message instead of returning ``inf``/``nan`` garbage.
+
+    Parameters
+    ----------
+    matrix:
+        The square matrix to invert.
+    what:
+        Human-readable description of the matrix, used in the error message.
+    cond_limit:
+        Condition-number threshold; see :func:`is_singular`.
+
+    Raises
+    ------
+    numpy.linalg.LinAlgError
+        If *matrix* is non-square, non-finite, singular, or ill-conditioned.
+    """
+    a = np.asarray(matrix, dtype=float)
+    if is_singular(a, cond_limit=cond_limit):
+        raise np.linalg.LinAlgError(
+            f"{what} is singular or ill-conditioned (condition number exceeds "
+            f"{cond_limit:.2e}); cannot invert reliably. Reduce the number of "
+            "components/terms or remove collinear columns."
+        )
+    return np.linalg.inv(a)

--- a/process_improve/experiments/visualization/plots/design_quality.py
+++ b/process_improve/experiments/visualization/plots/design_quality.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from process_improve._linalg import is_singular
 from process_improve.experiments.visualization.plots.registry import BasePlot, register_plot
 from process_improve.visualization.colors import DOE_PALETTE
 from process_improve.visualization.spec import (
@@ -39,7 +40,7 @@ class FDSPlot(BasePlot):
     Requires ``design_data`` with factor columns (coded values).
     """
 
-    def to_spec(self) -> ChartSpec:  # noqa: C901, PLR0912
+    def to_spec(self) -> ChartSpec:  # noqa: C901
         """Build an FDS ChartSpec.
 
         Returns
@@ -73,10 +74,11 @@ class FDSPlot(BasePlot):
 
         x_model = np.column_stack(x_terms)
 
-        try:
-            xtx_inv = np.linalg.inv(x_model.T @ x_model)
-        except np.linalg.LinAlgError:
-            xtx_inv = np.linalg.pinv(x_model.T @ x_model)
+        # Fall back to the pseudo-inverse not just for an exactly-singular X'X but
+        # also for an ill-conditioned one, where np.linalg.inv would silently
+        # return overflow-driven garbage.
+        xtx = x_model.T @ x_model
+        xtx_inv = np.linalg.pinv(xtx) if is_singular(xtx) else np.linalg.inv(xtx)
 
         # Sample random points in the design space and compute SPV
         n_samples = 5000

--- a/process_improve/experiments/visualization/plots/surfaces.py
+++ b/process_improve/experiments/visualization/plots/surfaces.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import numpy as np
 
+from process_improve._linalg import is_singular
 from process_improve.experiments.visualization.plots.registry import BasePlot, register_plot
 from process_improve.visualization.spec import (
     Annotation,
@@ -470,10 +471,11 @@ class PredictionVariancePlot(BasePlot):
 
         X_model = np.column_stack(X_terms)
 
-        try:
-            XtX_inv = np.linalg.inv(X_model.T @ X_model)
-        except np.linalg.LinAlgError:
-            XtX_inv = np.linalg.pinv(X_model.T @ X_model)
+        # Fall back to the pseudo-inverse not just for an exactly-singular X'X but
+        # also for an ill-conditioned one, where np.linalg.inv would silently
+        # return overflow-driven garbage.
+        XtX = X_model.T @ X_model
+        XtX_inv = np.linalg.pinv(XtX) if is_singular(XtX) else np.linalg.inv(XtX)
 
         # Evaluate scaled prediction variance on a grid
         n_grid = 40

--- a/process_improve/multivariate/methods.py
+++ b/process_improve/multivariate/methods.py
@@ -21,6 +21,7 @@ from sklearn.utils import Bunch
 from sklearn.utils.validation import check_array, check_is_fitted
 from tqdm import tqdm
 
+from .._linalg import safe_inverse
 from ..univariate.metrics import detect_outliers_esd
 from ..visualization.themes import REFERENCE_LINE_COLOR
 from .plots import (
@@ -1633,7 +1634,9 @@ class PLS(RegressorMixin, TransformerMixin, BaseEstimator):
         # --- Common post-fit path: wrap numpy arrays into pandas ---
 
         # R = W(P'W)^{-1} [KxA]; useful since T = XR
-        direct_weights = self.x_weights_ @ np.linalg.inv(self.x_loadings_.T @ self.x_weights_)
+        direct_weights = self.x_weights_ @ safe_inverse(
+            self.x_loadings_.T @ self.x_weights_, what="(x_loadings' @ x_weights)"
+        )
         # beta = RC' [KxM]: direct link from k-th X variable to m-th Y variable
         beta_coefficients = direct_weights @ self.y_loadings_.T
 
@@ -3856,7 +3859,8 @@ class TPLS(RegressorMixin, BaseEstimator):
         # Calculate the Hotelling's T2 values, and limits. Could do a ddof correction (n-1) for the variance matrix.
         variance_matrix = self.t_scores_super.T @ self.t_scores_super / self.t_scores_super.shape[0]
         t2_values = np.sum(
-            (self.t_scores_super.values @ np.linalg.inv(variance_matrix)) * self.t_scores_super.values,
+            (self.t_scores_super.values @ safe_inverse(variance_matrix, what="super-score covariance"))
+            * self.t_scores_super.values,
             axis=1,
         )
         self.hotellings_t2 = pd.DataFrame(

--- a/tests/test_linalg_guards.py
+++ b/tests/test_linalg_guards.py
@@ -1,0 +1,69 @@
+"""Tests for the SEC-07 matrix-conditioning guards in ``process_improve._linalg``.
+
+``np.linalg.inv`` returns overflow-driven garbage on an ill-conditioned matrix
+without raising. ``safe_inverse`` / ``is_singular`` detect that up front.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from process_improve._linalg import DEFAULT_COND_LIMIT, is_singular, safe_inverse
+
+
+class TestIsSingular:
+    def test_well_conditioned_identity(self) -> None:
+        assert not is_singular(np.eye(3))
+
+    def test_well_conditioned_random(self) -> None:
+        rng = np.random.default_rng(0)
+        a = rng.normal(size=(4, 4)) + 4 * np.eye(4)
+        assert not is_singular(a)
+
+    def test_exactly_singular(self) -> None:
+        a = np.array([[1.0, 2.0], [2.0, 4.0]])  # rank 1
+        assert is_singular(a)
+
+    def test_ill_conditioned(self) -> None:
+        # A nearly rank-deficient matrix that np.linalg.inv would not reject.
+        a = np.array([[1.0, 1.0], [1.0, 1.0 + 1e-16]])
+        assert is_singular(a)
+
+    def test_non_square(self) -> None:
+        assert is_singular(np.ones((2, 3)))
+
+    def test_non_finite(self) -> None:
+        assert is_singular(np.array([[np.nan, 0.0], [0.0, 1.0]]))
+
+
+class TestSafeInverse:
+    def test_matches_inv_for_well_conditioned(self) -> None:
+        rng = np.random.default_rng(1)
+        a = rng.normal(size=(3, 3)) + 3 * np.eye(3)
+        # Bit-identical to a bare inv for well-conditioned input.
+        np.testing.assert_array_equal(safe_inverse(a), np.linalg.inv(a))
+
+    def test_raises_on_singular(self) -> None:
+        a = np.array([[1.0, 2.0], [2.0, 4.0]])
+        with pytest.raises(np.linalg.LinAlgError, match="singular or ill-conditioned"):
+            safe_inverse(a, what="X'X")
+
+    def test_error_message_includes_what_and_limit(self) -> None:
+        a = np.zeros((2, 2))
+        with pytest.raises(np.linalg.LinAlgError) as exc:
+            safe_inverse(a, what="super-score covariance")
+        msg = str(exc.value)
+        assert "super-score covariance" in msg
+        assert f"{DEFAULT_COND_LIMIT:.2e}" in msg
+
+    def test_unguarded_inv_of_singular_is_not_finite(self) -> None:
+        # Documents the failure mode the guard prevents: inv of a singular
+        # matrix is non-finite (or raises), never a usable result.
+        a = np.array([[1.0, 2.0], [2.0, 4.0]])
+        with np.errstate(all="ignore"):
+            try:
+                inv = np.linalg.inv(a)
+                assert not np.all(np.isfinite(inv))
+            except np.linalg.LinAlgError:
+                pass  # exactly-singular path: inv raises, also fine


### PR DESCRIPTION
Closes #242. Part of the SEC-07..SEC-12 hardening series, re-cut as **independent code-only PRs** that target `main` and can merge in any order.

`np.linalg.inv` does not raise on an ill-conditioned matrix; it returns overflow-driven garbage. New internal `process_improve/_linalg.py` (`safe_inverse` + `is_singular`) guards the two unguarded `multivariate/methods.py` sites (PLS direct-weights inverse, TPLS Hotelling's T2 covariance inverse); the response-surface and design-quality plots fall back to `pinv` for ill-conditioned `X'X`. For well-conditioned input `safe_inverse` returns exactly `np.linalg.inv`, so there is no numerical change.

**This PR is code + tests only.** The version bump, `CHANGELOG.md`, `CITATION.cff`, and `SECURITY_AUDIT.md` updates for SEC-07..SEC-12 are in a single follow-up PR (`claude/sec-07-12-release-metadata`).

Tests: `tests/test_linalg_guards.py` plus the existing PLS/TPLS suites (120 passed) exercise it.

https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp