### PR TITLE
Fix SEC-09: stop silent exception swallowing and error-message leakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.10] - 2026-05-29
+
+### Changed
+
+- The Breusch-Pagan diagnostic (`experiments/analysis.py`) and design metric
+  evaluation (`experiments/augment.py`) no longer swallow every exception: they
+  catch only the expected failure types and log a warning, so unexpected errors
+  surface instead of being silently discarded (SEC-09).
+
+### Security
+
+- The MCP server no longer returns the raw text of an unexpected exception to
+  the caller (SEC-09). Unexpected errors may contain internal detail (file
+  paths, library internals); the full traceback is now logged server-side and a
+  generic message is returned. Structured `ToolSafetyError`s keep their curated
+  payload.
+
 ## [1.22.9] - 2026-05-29
 
 ### Fixed
@@ -212,7 +229,8 @@ those changes.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.9...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.10...HEAD
+[1.22.10]: https://github.com/kgdunn/process-improve/compare/v1.22.9...v1.22.10
 [1.22.9]: https://github.com/kgdunn/process-improve/compare/v1.22.8...v1.22.9
 [1.22.8]: https://github.com/kgdunn/process-improve/compare/v1.22.7...v1.22.8
 [1.22.7]: https://github.com/kgdunn/process-improve/compare/v1.22.6...v1.22.7

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.9
+version: 1.22.10
 date-released: "2026-05-29"
 keywords:
   - chemometrics

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -30,7 +30,7 @@ therefore ranked under two models:
 | SEC-06 | Non-convergence not flagged; `fractional()` 1/0 | Medium | Medium | done (#241, v1.22.8) |
 | SEC-07 | Matrix inversion without conditioning checks | Medium | Medium | done (#242, v1.22.9) |
 | SEC-08 | `assert` used for validation (stripped by `-O`) | Medium | Low | open |
-| SEC-09 | Exception suppression; tool errors leak internals | Medium | Low | open |
+| SEC-09 | Exception suppression; tool errors leak internals | Medium | Low | done (#244, v1.22.10) |
 | SEC-10 | Latent path traversal; unverified remote fetch | Low | Low | open |
 | SEC-11 | `discover_tools` swallows all `ImportError`s | Low | Low | open |
 | SEC-12 | `DataFrame.query` built with f-strings | Low | Low | open |
@@ -186,7 +186,12 @@ therefore ranked under two models:
   prefer explicit raises at API boundaries. Tests: invalid input raises even
   under `-O`.
 
-## SEC-09 - Broad exception suppression hides errors; tool errors leak internals
+## SEC-09 - Broad exception suppression hides errors; tool errors leak internals [RESOLVED]
+- **Status:** Fixed in v1.22.10 (issue #244). `analysis.py` and `augment.py`
+  narrow their `except` and log; the MCP server logs unexpected exceptions
+  server-side and returns a generic message instead of `str(exc)`. (Individual
+  tool wrappers already log server-side and mostly carry domain-validation
+  messages; SEC-04 now rejects malformed inputs before dispatch.)
 - **Severity:** U = Medium (information disclosure), L = Low
 - **Where:** `process_improve/experiments/analysis.py:191` (`except Exception` ->
   `None, None`), `process_improve/experiments/augment.py:69` (`except Exception`

--- a/process_improve/experiments/analysis.py
+++ b/process_improve/experiments/analysis.py
@@ -12,6 +12,7 @@ precision, and confirmation run testing.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -21,6 +22,8 @@ import statsmodels.api as sm
 import statsmodels.formula.api as smf
 from scipy import stats
 from statsmodels.regression.linear_model import RegressionResultsWrapper
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Formula builder
@@ -183,12 +186,15 @@ def _run_residual_diagnostics(ols_result: RegressionResultsWrapper) -> dict[str,
 
     dw = float(durbin_watson(residuals))
 
-    # Breusch-Pagan (homoscedasticity)
+    # Breusch-Pagan (homoscedasticity). The test can legitimately fail to compute
+    # (singular exog, too few residuals); record None but log so the failure is
+    # not silent, and do not swallow unexpected error types.
     try:
         from statsmodels.stats.diagnostic import het_breuschpagan  # noqa: PLC0415
 
         bp_stat, bp_p, _bp_f, _bp_fp = het_breuschpagan(residuals, ols_result.model.exog)
-    except Exception:  # noqa: BLE001
+    except (ImportError, ValueError, ZeroDivisionError, np.linalg.LinAlgError) as exc:
+        logger.warning("Breusch-Pagan test could not be computed: %s", exc)
         bp_stat, bp_p = None, None
 
     # Cook's distance

--- a/process_improve/experiments/augment.py
+++ b/process_improve/experiments/augment.py
@@ -20,6 +20,7 @@ Example
 from __future__ import annotations
 
 import itertools
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -34,6 +35,8 @@ from process_improve.experiments.evaluate import (
     _word_to_str,
     evaluate_design,
 )
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Internal context shared across augmentation handlers
@@ -66,7 +69,10 @@ def _safe_evaluate(design: pd.DataFrame, generators: list[str] | None, model: st
         if generators:
             metrics.extend(["alias_structure", "resolution"])
         return evaluate_design(design, model=model, metric=metrics)
-    except Exception:  # noqa: BLE001
+    except (ValueError, KeyError, np.linalg.LinAlgError) as exc:
+        # Evaluation may not apply to every design; return no metrics but log so
+        # the failure is not silent, and let unexpected error types propagate.
+        logger.warning("Design evaluation skipped: %s", exc)
         return {}
 
 

--- a/process_improve/mcp_server.py
+++ b/process_improve/mcp_server.py
@@ -58,6 +58,20 @@ mcp = FastMCP(
 )
 
 
+def _serialise_tool_error(exc: Exception, tool_name: str) -> str:
+    """Return a JSON error string that does not leak internal detail.
+
+    An unexpected exception's message may carry internal detail (filesystem
+    paths, library internals). Over an untrusted MCP transport that is an
+    information-disclosure risk, so the full traceback is logged server-side and
+    only a generic message is returned to the caller. (Structured
+    :class:`ToolSafetyError`s, which have a curated payload, are handled by the
+    caller before reaching here.)
+    """
+    logger.exception("Tool %r raised an unexpected error", tool_name)
+    return json.dumps({"error": "internal error while executing tool", "tool": tool_name})
+
+
 def _register_all_tools() -> None:
     """Register every ``@tool_spec`` tool as an MCP tool."""
     discover_tools()
@@ -89,9 +103,10 @@ def _create_mcp_tool(
                 return json.dumps(result, indent=2, default=str)
             return str(result)
         except ToolSafetyError as exc:
+            # Structured safety errors carry a curated, non-sensitive payload.
             return json.dumps(exc.to_dict())
         except Exception as exc:  # noqa: BLE001
-            return json.dumps({"error": str(exc)})
+            return _serialise_tool_error(exc, tool_name)
 
     # Set proper function metadata for FastMCP
     handler.__name__ = tool_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.9"
+version = "1.22.10"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_sec09_error_handling.py
+++ b/tests/test_sec09_error_handling.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -32,6 +33,34 @@ class TestSafeEvaluateLogsAndNarrows:
         monkeypatch.setattr(augment, "evaluate_design", _boom)
         with pytest.raises(RuntimeError, match="genuine bug"):
             augment._safe_evaluate(self._design(), generators=None)
+
+
+class TestBreuschPaganFailureLogged:
+    def test_failure_is_logged_and_not_raised(self, monkeypatch, caplog) -> None:
+        import statsmodels.api as sm
+
+        from process_improve.experiments.analysis import _run_residual_diagnostics
+
+        def _raise(*_args, **_kwargs):
+            raise ValueError("singular exog")
+
+        # The diagnostic imports het_breuschpagan from this module at call time,
+        # so patching the module attribute is picked up.
+        monkeypatch.setattr("statsmodels.stats.diagnostic.het_breuschpagan", _raise)
+
+        # Fit with pandas inputs so resid/fittedvalues are Series (the function
+        # accesses ``.values`` on them).
+        x = sm.add_constant(pd.DataFrame({"x": np.arange(1.0, 8.0)}))
+        y = pd.Series([1.0, 2.0, 2.5, 4.0, 4.5, 6.0, 7.0], name="y")
+        ols_result = sm.OLS(y, x).fit()
+
+        with caplog.at_level(logging.WARNING):
+            out = _run_residual_diagnostics(ols_result)
+
+        assert "Breusch-Pagan" in caplog.text
+        bp = out["residual_diagnostics"]["breusch_pagan"]
+        assert bp["statistic"] is None
+        assert bp["p_value"] is None
 
 
 class TestMcpErrorSanitisation:

--- a/tests/test_sec09_error_handling.py
+++ b/tests/test_sec09_error_handling.py
@@ -1,0 +1,46 @@
+"""SEC-09: exception handling no longer swallows silently or leaks internals."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pandas as pd
+import pytest
+
+from process_improve.experiments import augment
+
+
+class TestSafeEvaluateLogsAndNarrows:
+    def _design(self) -> pd.DataFrame:
+        return pd.DataFrame({"A": [-1, 1, -1, 1], "B": [-1, -1, 1, 1]})
+
+    def test_expected_failure_returns_empty_and_logs(self, monkeypatch, caplog) -> None:
+        def _boom(*_args, **_kwargs):
+            raise ValueError("not applicable to this design")
+
+        monkeypatch.setattr(augment, "evaluate_design", _boom)
+        with caplog.at_level(logging.WARNING):
+            result = augment._safe_evaluate(self._design(), generators=None)
+        assert result == {}
+        assert "Design evaluation skipped" in caplog.text
+
+    def test_unexpected_error_propagates(self, monkeypatch) -> None:
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("genuine bug, should not be swallowed")
+
+        monkeypatch.setattr(augment, "evaluate_design", _boom)
+        with pytest.raises(RuntimeError, match="genuine bug"):
+            augment._safe_evaluate(self._design(), generators=None)
+
+
+class TestMcpErrorSanitisation:
+    def test_unexpected_error_is_generic_no_leak(self) -> None:
+        pytest.importorskip("mcp")
+        from process_improve.mcp_server import _serialise_tool_error
+
+        internal_detail = "/home/app/internal/path/module.py line 42"
+        out = _serialise_tool_error(RuntimeError(internal_detail), "fit_pca")
+        payload = json.loads(out)
+        assert payload == {"error": "internal error while executing tool", "tool": "fit_pca"}
+        assert internal_detail not in out


### PR DESCRIPTION
Closes #244. PR 6 of the `SECURITY_AUDIT.md` series.

> **Stacked PR.** Base is `claude/sec-07-matrix-conditioning` (PR #252); GitHub retargets to `main` as the chain merges.

## Problem
- `experiments/analysis.py` (Breusch-Pagan) and `experiments/augment.py` (`_safe_evaluate`) caught bare `Exception` and silently discarded it (`None, None` / `{}`), masking genuine bugs.
- The MCP server returned the raw `str(exc)` of an unexpected exception to the caller. Over an untrusted transport that is an information-disclosure risk (file paths, library internals). **Severity: Medium (info disclosure) untrusted, Low local-trusted.**

## Fix
- `analysis.py` / `augment.py`: catch only the expected failure types (`ImportError`/`ValueError`/`LinAlgError`/...), log a warning, and let unexpected error types propagate so real bugs surface.
- `mcp_server.py`: unexpected exceptions are logged server-side (full traceback) and a generic message is returned, via a new testable `_serialise_tool_error` helper. Structured `ToolSafetyError`s keep their curated `to_dict()` payload.

## Scope note
Individual tool wrappers already log server-side (e.g. `experiments/tools.py` uses `logger.exception`) and mostly return domain-validation messages rather than internal detail; with SEC-04 now rejecting malformed inputs before dispatch, the residual exposure was the two silent swallows and the MCP catch-all addressed here. Tightening every per-tool error string to a generic message is noted in the audit as an optional follow-up.

## Tests (`tests/test_sec09_error_handling.py`)
- `_safe_evaluate` returns `{}` and logs a warning on an expected failure, but **propagates** an unexpected error type (no longer swallowed).
- `_serialise_tool_error` returns `{"error": "internal error while executing tool", "tool": ...}` and does **not** contain the original exception message (skipped locally when the `mcp` extra is absent; runs in CI under `--all-extras`).
- `test_evaluate_design` / `test_augment_design` regression suites still green.

## Versioning
PATCH bump to `1.22.10`; `CITATION.cff` and `CHANGELOG.md` synced; SEC-09 struck off `SECURITY_AUDIT.md`.

https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp)_