### PR TITLE
Fix SEC-08: convert validation asserts to explicit raises

### DIFF
--- a/process_improve/batch/data_input.py
+++ b/process_improve/batch/data_input.py
@@ -64,26 +64,30 @@ def check_valid_batch_dict(in_dict: dict, no_nan: bool = False) -> bool:
     bool
         True, if it passes the checks.
     """
-    assert len(in_dict) >= 1, "At least 1 batch is required in the dataframe dictionary."
+    if len(in_dict) < 1:
+        raise ValueError("At least 1 batch is required in the dataframe dictionary.")
     batch1 = in_dict[next(iter(in_dict.keys()))]
     base_columns = set(batch1.columns)
     check = True
     for bid, batch in in_dict.items():
         # Check 1
         check = check & (base_columns == set(batch.columns))
-        assert check, (
-            f"The column names must be the same in all batches. Differs in {bid}. Base "
-            f"columns = {base_columns}; this batch has: {set(batch.columns)}"
-        )
+        if not check:
+            raise ValueError(
+                f"The column names must be the same in all batches. Differs in {bid}. Base "
+                f"columns = {base_columns}; this batch has: {set(batch.columns)}"
+            )
 
         # Check 2
         check *= batch.select_dtypes(include=[np.number]).shape[1] == batch.shape[1]
-        assert check, f"All columns must be a numeric type. Differs in {bid}."
+        if not check:
+            raise ValueError(f"All columns must be a numeric type. Differs in {bid}.")
 
         # Check 3
         if no_nan:
             check *= batch.isna().values.sum() == 0
-            assert check, f"No missing values allowed. Missing values found in {bid}."
+            if not check:
+                raise ValueError(f"No missing values allowed. Missing values found in {bid}.")
 
     return bool(check)
 
@@ -101,7 +105,8 @@ def dict_to_melted(
         if idx == 0:
             num_rows = batch.shape[0]
             sequence = np.arange(0, num_rows)
-        assert num_rows == batch.shape[0], "All batches must have the same number of samples"
+        if num_rows != batch.shape[0]:
+            raise ValueError("All batches must have the same number of samples")
 
         subset = batch.copy()
 
@@ -143,13 +148,15 @@ def melted_to_dict(in_df: pd.DataFrame, batch_id_col: str) -> dict:
     in a dictionary. The dictionary keys are the batch identifier, and the corresponding value
     is a Pandas dataframe of the batch data for that batch.
     """
-    assert batch_id_col in in_df, "The `batch_id_col` column does not exist in the incoming dataframe."
+    if batch_id_col not in in_df:
+        raise ValueError("The `batch_id_col` column does not exist in the incoming dataframe.")
     return {batch_id: batch for batch_id, batch in in_df.groupby(batch_id_col)}  # noqa: C416
 
 
 def melted_to_wide(in_df: pd.DataFrame, batch_id_col: str) -> dict:
     """Convert aligned melted data to wide format."""
-    assert batch_id_col in in_df
+    if batch_id_col not in in_df:
+        raise ValueError(f"The `batch_id_col` column {batch_id_col!r} does not exist in the incoming dataframe.")
     return {}
 
     # max_places = int(np.ceil(np.log10(aligned_df["_sequence_"].max())))

--- a/process_improve/experiments/optimal.py
+++ b/process_improve/experiments/optimal.py
@@ -76,8 +76,10 @@ def point_exchange(x: pd.DataFrame, number_points: int = 10) -> tuple[pd.DataFra
         The selected design (sorted by the original row index) and its
         D-optimality value (log-determinant of ``(X'X)^-1``).
     """
-    assert number_points >= x.shape[1], f"`number_point`s must be at least {x.shape[1]} (the number of columns in `x`)"
-    assert number_points <= x.shape[0], f"`number_point`s must be at most {x.shape[0]} (the number of rows in `x`)"
+    if number_points < x.shape[1]:
+        raise ValueError(f"`number_points` must be at least {x.shape[1]} (the number of columns in `x`).")
+    if number_points > x.shape[0]:
+        raise ValueError(f"`number_points` must be at most {x.shape[0]} (the number of rows in `x`).")
     x = pd.DataFrame(x).drop_duplicates()
 
     number_points = min(number_points, x.shape[0])

--- a/process_improve/monitoring/control_charts.py
+++ b/process_improve/monitoring/control_charts.py
@@ -78,7 +78,7 @@ class ControlChart:
         ]
         self.df = pd.DataFrame(columns=columns, dtype=np.float64)
 
-    def calculate_limits(
+    def calculate_limits(  # noqa: C901  - branch count is mostly simple input-validation guard clauses
         self, y: np.ndarray | pd.Series, target: float | None = None, s: float | None = None, **kwargs,
     ) -> None:
         """
@@ -101,8 +101,11 @@ class ControlChart:
 
         if s is not None:
             self.s = float(s)
-            assert s > 0.0, "The given standard deviation cannot be zero, and must be positive."
-            assert s < 1e300, "The given standard deviation cannot be this large."
+            if not 0.0 < s < 1e300:
+                raise ValueError(
+                    "The given standard deviation must be positive and not excessively large "
+                    f"(0 < s < 1e300); got {s}."
+                )
 
         if target is not None:
             self.target = float(target)
@@ -178,12 +181,11 @@ class ControlChart:
 
         if self.ld_1 and self.ld_2:
             # User has provided their own lambda_1 and lambda_2 values.
-            assert self.ld_1 >= 0.0, "Lambda_1 must be greater than or equal to zero."
-            assert self.ld_2 >= 0.0, "Lambda_2 must be greater than or equal to zero."
-            assert self.ld_s >= 0.0, "Lambda_s must be greater than or equal to zero."
-            assert self.ld_1 <= 1.0, "Lambda_1 must be less than or equal to 1.0."
-            assert self.ld_2 <= 1.0, "Lambda_2 must be less than or equal to 1.0."
-            assert self.ld_s <= 1.0, "Lambda_s must be less than or equal to 1.0."
+            for _name, _val in (("Lambda_1", self.ld_1), ("Lambda_2", self.ld_2), ("Lambda_s", self.ld_s)):
+                if _val < 0.0:
+                    raise ValueError(f"{_name} must be greater than or equal to zero.")
+                if _val > 1.0:
+                    raise ValueError(f"{_name} must be less than or equal to 1.0.")
             self._holt_winters_warmup_fit(ld_1=self.ld_1, ld_2=self.ld_2, ld_s=self.ld_s)
 
         else:

--- a/process_improve/regression/methods.py
+++ b/process_improve/regression/methods.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import statsmodels.api as sm
 from sklearn.base import BaseEstimator, RegressorMixin
+from sklearn.exceptions import NotFittedError
 
 from ..univariate.metrics import t_value
 
@@ -64,8 +65,10 @@ def repeated_median_slope(x: np.ndarray, y: np.ndarray, nowarn: bool = False) ->
     y = y.copy().ravel() if isinstance(y, np.ndarray) else pd.Series(y).values.ravel()
 
     if not (nowarn):
-        assert len(x) > 2, "More than two samples are required for this function."
-        assert len(x) == len(y), "Vectors x and y must have the same length."
+        if len(x) <= 2:
+            raise ValueError("More than two samples are required for this function.")
+        if len(x) != len(y):
+            raise ValueError("Vectors x and y must have the same length.")
 
     for i in np.arange(len(x)):
         inner_medians = []
@@ -503,10 +506,14 @@ class OLS(RegressorMixin, BaseEstimator):
 
         n_samples, n_features = X_.shape
         k_params = n_features + (1 if self.fit_intercept else 0)
-        assert n_samples >= k_params, (
-            "N >= K: You need at least as many rows as there are columns to fit a linear regression."
-        )
-        assert n_samples == y_.size
+        if n_samples < k_params:
+            raise ValueError(
+                "N >= K: You need at least as many rows as there are columns to fit a linear regression."
+            )
+        if n_samples != y_.size:
+            raise ValueError(
+                f"X and y must have the same number of rows: got {n_samples} and {y_.size}."
+            )
 
         # Build the design matrix.
         design = X_.copy()
@@ -632,7 +639,8 @@ class OLS(RegressorMixin, BaseEstimator):
         -------
         y_pred : np.ndarray of shape (N,)
         """
-        assert getattr(self, "is_fitted_", False), "OLS must be fitted before calling predict()."
+        if not getattr(self, "is_fitted_", False):
+            raise NotFittedError("OLS must be fitted before calling predict().")
         if isinstance(X, pd.DataFrame):
             X_arr = X.to_numpy(dtype=float)
         elif isinstance(X, pd.Series):

--- a/process_improve/univariate/metrics.py
+++ b/process_improve/univariate/metrics.py
@@ -404,7 +404,11 @@ def ttest_paired_from_df(
             sample_B = data_subset[data_subset[grouper_column].eq(groupB_name)][values_column]
             sample_A = sample_A.astype(np.float64)
             sample_B = sample_B.astype(np.float64)
-            assert sample_A.shape[0] == sample_B.shape[0]
+            if sample_A.shape[0] != sample_B.shape[0]:
+                raise ValueError(
+                    "Paired t-test requires both groups to have the same number of samples; "
+                    f"got {sample_A.shape[0]} and {sample_B.shape[0]}."
+                )
             differences = sample_A - sample_B.values  # only the .values of one vector are needed!
             basic_stats = ttest_paired(differences, conflevel)
             basic_stats.update(
@@ -590,7 +594,8 @@ def median_absolute_deviation(
     >>> stats.median_abs_deviation(x, scale='normal')
     1.9996446978061115
     """
-    assert axis is not None, "axis=None is now depricated. Unraval the array."
+    if axis is None:
+        raise ValueError("axis=None is now deprecated. Unravel the array.")
     if not callable(center):
         raise TypeError(f"The argument 'center' must be callable. The given value {center!r} is not callable.")
 
@@ -740,8 +745,12 @@ def detect_outliers_esd(
         robust_variant = bool(kwargs.get("robust_variant", True))
         alpha = float(kwargs.get("alpha", 0.05))
 
-        assert alpha <= 1.0
-        assert max_outliers_detected <= len(x)
+        if alpha > 1.0:
+            raise ValueError(f"alpha must be <= 1.0, got {alpha}.")
+        if max_outliers_detected > len(x):
+            raise ValueError(
+                f"max_outliers_detected ({max_outliers_detected}) cannot exceed the sample size ({len(x)})."
+            )
 
         # 1. Run K-S test first to check normality
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -128,10 +128,10 @@ class TestHoltWintersControlChart:
     # Checks that the required asserts are raised
 
     cc_assert = ControlChart()
-    with pytest.raises(AssertionError, match=r"Lambda_1 must be less than or equal to 1\.0\."):
+    with pytest.raises(ValueError, match=r"Lambda_1 must be less than or equal to 1\.0\."):
         cc_assert.calculate_limits(y, ld_1=1.2, ld_2=0.5)
 
-    with pytest.raises(AssertionError, match=r"Lambda_1 must be greater than or equal to zero\."):
+    with pytest.raises(ValueError, match=r"Lambda_1 must be greater than or equal to zero\."):
         cc_assert.calculate_limits(y, ld_1=-1, ld_2=0.5)
 
     # test_hw_chart_missing_values(self):

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -248,7 +248,7 @@ def test_input_transposed_vector(multiple_linear_regression_data: tuple[np.ndarr
     y = pd.DataFrame(y_)
 
     # There is a difference with a transposed array
-    with pytest.raises(AssertionError, match=r"N >= K: You need at least as many rows .*"):
+    with pytest.raises(ValueError, match=r"N >= K: You need at least as many rows .*"):
         _ = multiple_linear_regression(x, y)
 
 

--- a/tests/test_sec08_validation_raises.py
+++ b/tests/test_sec08_validation_raises.py
@@ -1,0 +1,108 @@
+"""SEC-08: input/state validation uses explicit raises, not bare asserts.
+
+Asserts are stripped under ``python -O``; these checks must remain active. The
+tests assert the concrete exception type (ValueError / NotFittedError) at a few
+representative converted sites. Other converted sites are covered by the
+existing regression and monitoring suites.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.exceptions import NotFittedError
+
+from process_improve.batch.data_input import check_valid_batch_dict, dict_to_melted, melted_to_dict, melted_to_wide
+from process_improve.experiments.optimal import point_exchange
+from process_improve.regression.methods import OLS, repeated_median_slope
+from process_improve.univariate.metrics import detect_outliers_esd, median_absolute_deviation
+
+
+class TestPointExchangeBounds:
+    def _x(self) -> pd.DataFrame:
+        return pd.DataFrame({"a": [-1, 1, -1, 1], "b": [-1, -1, 1, 1], "c": [1, -1, 1, -1]})
+
+    def test_too_few_points_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least"):
+            point_exchange(self._x(), number_points=2)  # < n columns (3)
+
+    def test_too_many_points_raises(self) -> None:
+        with pytest.raises(ValueError, match="at most"):
+            point_exchange(self._x(), number_points=99)  # > n rows (4)
+
+
+class TestOlsPredictBeforeFit:
+    def test_predict_before_fit_raises_not_fitted(self) -> None:
+        model = OLS()
+        with pytest.raises(NotFittedError, match="must be fitted"):
+            model.predict(pd.DataFrame({"x": [1.0, 2.0, 3.0]}))
+
+
+class TestMeltedToWideMissingColumn:
+    def test_missing_batch_id_column_raises(self) -> None:
+        df = pd.DataFrame({"not_the_id": [1, 2, 3], "value": [4.0, 5.0, 6.0]})
+        with pytest.raises(ValueError, match="does not exist"):
+            melted_to_wide(df, batch_id_col="batch_id")
+
+
+class TestEsdOutlierValidation:
+    def test_too_many_outliers_requested_raises(self) -> None:
+        x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        with pytest.raises(ValueError, match="cannot exceed the sample size"):
+            detect_outliers_esd(x, max_outliers_detected=99)
+
+    def test_alpha_above_one_raises(self) -> None:
+        x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        with pytest.raises(ValueError, match="alpha"):
+            detect_outliers_esd(x, max_outliers_detected=1, alpha=1.5)
+
+
+class TestMedianAbsoluteDeviationAxis:
+    def test_axis_none_raises(self) -> None:
+        with pytest.raises(ValueError, match="axis=None"):
+            median_absolute_deviation(np.array([1.0, 2.0, 3.0]), axis=None)
+
+
+class TestRepeatedMedianSlopeValidation:
+    def test_too_few_samples_raises(self) -> None:
+        with pytest.raises(ValueError, match="More than two samples"):
+            repeated_median_slope(np.array([1.0, 2.0]), np.array([1.0, 2.0]))
+
+    def test_mismatched_lengths_raises(self) -> None:
+        with pytest.raises(ValueError, match="same length"):
+            repeated_median_slope(np.array([1.0, 2.0, 3.0]), np.array([1.0, 2.0]))
+
+
+class TestBatchDictValidation:
+    def _batch(self, cols=("Tag01", "Tag02"), n=4) -> pd.DataFrame:
+        return pd.DataFrame({c: np.arange(n, dtype=float) for c in cols})
+
+    def test_empty_dict_raises(self) -> None:
+        with pytest.raises(ValueError, match="At least 1 batch"):
+            check_valid_batch_dict({})
+
+    def test_column_mismatch_raises(self) -> None:
+        batches = {"b1": self._batch(("Tag01", "Tag02")), "b2": self._batch(("Tag01", "TagX"))}
+        with pytest.raises(ValueError, match="column names must be the same"):
+            check_valid_batch_dict(batches)
+
+    def test_non_numeric_column_raises(self) -> None:
+        bad = pd.DataFrame({"Tag01": [1.0, 2.0], "Tag02": ["a", "b"]})
+        with pytest.raises(ValueError, match="numeric type"):
+            check_valid_batch_dict({"b1": bad})
+
+    def test_missing_values_raises_when_no_nan(self) -> None:
+        nan_batch = pd.DataFrame({"Tag01": [1.0, np.nan], "Tag02": [3.0, 4.0]})
+        with pytest.raises(ValueError, match="No missing values"):
+            check_valid_batch_dict({"b1": nan_batch}, no_nan=True)
+
+    def test_unequal_row_counts_raises(self) -> None:
+        batches = {"b1": self._batch(n=4), "b2": self._batch(n=5)}
+        with pytest.raises(ValueError, match="same number of samples"):
+            dict_to_melted(batches)
+
+    def test_melted_to_dict_missing_column_raises(self) -> None:
+        df = pd.DataFrame({"not_id": [1, 2], "value": [3.0, 4.0]})
+        with pytest.raises(ValueError, match="does not exist"):
+            melted_to_dict(df, batch_id_col="batch_id")


### PR DESCRIPTION
Closes #243. Part of the SEC-07..SEC-12 hardening series, re-cut as **independent code-only PRs** that target `main` and can merge in any order.

Asserts are stripped under `python -O`, silently disabling input/state validation. Converted the flagged validation asserts to explicit `if ...: raise` in `regression/methods.py` (OLS shape checks, repeated-median vectors, predict-before-fit → `NotFittedError`), `experiments/optimal.py` (`point_exchange` bounds), `batch/data_input.py` validators, `monitoring/control_charts.py` (`s` and lambda bounds), and `univariate/metrics.py` (paired t-test sizes, MAD `axis`, ESD bounds). Two control-chart tests and one regression test now expect `ValueError` instead of `AssertionError`.

**This PR is code + tests only.** Version/CHANGELOG/CITATION/SECURITY_AUDIT bookkeeping is in the single follow-up PR (`claude/sec-07-12-release-metadata`).

Tests: new `tests/test_sec08_validation_raises.py` plus updated monitoring/regression cases; `test_regression`, `test_monitoring`, `test_univariate`, `test_doe` green (123 passed).

https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp