### PR TITLE
Fix SEC-11: don't silently swallow all ImportErrors in discover_tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.12] - 2026-05-29
+
+### Fixed
+
+- `discover_tools` no longer silently swallows every `ImportError` (SEC-11). A
+  missing optional dependency (`ModuleNotFoundError`) is tolerated but logged so
+  the dropped tool category is visible; any other `ImportError` (for example a
+  bad name imported inside a tools module) now propagates instead of making the
+  whole category vanish without a trace.
+
 ## [1.22.11] - 2026-05-29
 
 ### Changed
@@ -243,7 +253,8 @@ those changes.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.11...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.12...HEAD
+[1.22.12]: https://github.com/kgdunn/process-improve/compare/v1.22.11...v1.22.12
 [1.22.11]: https://github.com/kgdunn/process-improve/compare/v1.22.10...v1.22.11
 [1.22.10]: https://github.com/kgdunn/process-improve/compare/v1.22.9...v1.22.10
 [1.22.9]: https://github.com/kgdunn/process-improve/compare/v1.22.8...v1.22.9

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.11
+version: 1.22.12
 date-released: "2026-05-29"
 keywords:
   - chemometrics

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -32,7 +32,7 @@ therefore ranked under two models:
 | SEC-08 | `assert` used for validation (stripped by `-O`) | Medium | Low | done (#243, v1.22.11) |
 | SEC-09 | Exception suppression; tool errors leak internals | Medium | Low | done (#244, v1.22.10) |
 | SEC-10 | Latent path traversal; unverified remote fetch | Low | Low | open |
-| SEC-11 | `discover_tools` swallows all `ImportError`s | Low | Low | open |
+| SEC-11 | `discover_tools` swallows all `ImportError`s | Low | Low | done (#246, v1.22.12) |
 | SEC-12 | `DataFrame.query` built with f-strings | Low | Low | open |
 
 ---
@@ -228,7 +228,9 @@ therefore ranked under two models:
   document the trust assumption (optionally checksum-pin). Tests: traversal
   filename rejected.
 
-## SEC-11 - `discover_tools` silently swallows all `ImportError`s
+## SEC-11 - `discover_tools` silently swallows all `ImportError`s [RESOLVED]
+- **Status:** Fixed in v1.22.12 (issue #246). Only `ModuleNotFoundError` is
+  tolerated (and logged); other `ImportError`s propagate.
 - **Severity:** U = Low, L = Low (robustness)
 - **Where:** `process_improve/tool_spec.py:255-269`
   (`contextlib.suppress(ImportError)` around each `import_module`).

--- a/process_improve/tool_spec.py
+++ b/process_improve/tool_spec.py
@@ -29,11 +29,14 @@ Import the decorated tools and pass the specs to the Anthropic client::
 
 from __future__ import annotations
 
+import logging
 import math
 from collections.abc import Callable
 from typing import Any
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Registry
@@ -239,6 +242,24 @@ def clean(value: Any) -> Any:  # noqa: PLR0911, ANN401
 # ---------------------------------------------------------------------------
 
 
+def _import_tool_module(module: str) -> None:
+    """Import a single ``tools.py`` module for discovery.
+
+    A genuinely missing module - typically an uninstalled optional third-party
+    dependency that the tools module imports - is tolerated but logged, so the
+    dropped tool category is visible rather than silent. Any other
+    :class:`ImportError` (for example a bad name imported inside the module) is a
+    real bug and is allowed to propagate rather than being silently swallowed,
+    which would make the whole tool category vanish without a trace.
+    """
+    import importlib  # noqa: PLC0415
+
+    try:
+        importlib.import_module(module)
+    except ModuleNotFoundError as exc:
+        logger.warning("Tool module %r not loaded (missing dependency): %s", module, exc)
+
+
 def discover_tools() -> None:
     """Import all ``tools.py`` modules to populate the tool registry.
 
@@ -248,9 +269,6 @@ def discover_tools() -> None:
     global _discovery_done  # noqa: PLW0603
     if _discovery_done:
         return
-
-    import contextlib  # noqa: PLC0415
-    import importlib  # noqa: PLC0415
 
     for module in [
         "process_improve.univariate.tools",
@@ -263,8 +281,7 @@ def discover_tools() -> None:
         "process_improve.visualization.tools",
         "process_improve.simulation.tools",
     ]:
-        with contextlib.suppress(ImportError):
-            importlib.import_module(module)
+        _import_tool_module(module)
 
     _discovery_done = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.11"
+version = "1.22.12"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_sec08_validation_raises.py
+++ b/tests/test_sec08_validation_raises.py
@@ -13,9 +13,10 @@ import pandas as pd
 import pytest
 from sklearn.exceptions import NotFittedError
 
-from process_improve.batch.data_input import melted_to_wide
+from process_improve.batch.data_input import check_valid_batch_dict, dict_to_melted, melted_to_dict, melted_to_wide
 from process_improve.experiments.optimal import point_exchange
-from process_improve.regression.methods import OLS
+from process_improve.regression.methods import OLS, repeated_median_slope
+from process_improve.univariate.metrics import detect_outliers_esd, median_absolute_deviation
 
 
 class TestPointExchangeBounds:
@@ -47,8 +48,61 @@ class TestMeltedToWideMissingColumn:
 
 class TestEsdOutlierValidation:
     def test_too_many_outliers_requested_raises(self) -> None:
-        from process_improve.univariate.metrics import detect_outliers_esd
-
         x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
         with pytest.raises(ValueError, match="cannot exceed the sample size"):
             detect_outliers_esd(x, max_outliers_detected=99)
+
+    def test_alpha_above_one_raises(self) -> None:
+        x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        with pytest.raises(ValueError, match="alpha"):
+            detect_outliers_esd(x, max_outliers_detected=1, alpha=1.5)
+
+
+class TestMedianAbsoluteDeviationAxis:
+    def test_axis_none_raises(self) -> None:
+        with pytest.raises(ValueError, match="axis=None"):
+            median_absolute_deviation(np.array([1.0, 2.0, 3.0]), axis=None)
+
+
+class TestRepeatedMedianSlopeValidation:
+    def test_too_few_samples_raises(self) -> None:
+        with pytest.raises(ValueError, match="More than two samples"):
+            repeated_median_slope(np.array([1.0, 2.0]), np.array([1.0, 2.0]))
+
+    def test_mismatched_lengths_raises(self) -> None:
+        with pytest.raises(ValueError, match="same length"):
+            repeated_median_slope(np.array([1.0, 2.0, 3.0]), np.array([1.0, 2.0]))
+
+
+class TestBatchDictValidation:
+    def _batch(self, cols=("Tag01", "Tag02"), n=4) -> pd.DataFrame:
+        return pd.DataFrame({c: np.arange(n, dtype=float) for c in cols})
+
+    def test_empty_dict_raises(self) -> None:
+        with pytest.raises(ValueError, match="At least 1 batch"):
+            check_valid_batch_dict({})
+
+    def test_column_mismatch_raises(self) -> None:
+        batches = {"b1": self._batch(("Tag01", "Tag02")), "b2": self._batch(("Tag01", "TagX"))}
+        with pytest.raises(ValueError, match="column names must be the same"):
+            check_valid_batch_dict(batches)
+
+    def test_non_numeric_column_raises(self) -> None:
+        bad = pd.DataFrame({"Tag01": [1.0, 2.0], "Tag02": ["a", "b"]})
+        with pytest.raises(ValueError, match="numeric type"):
+            check_valid_batch_dict({"b1": bad})
+
+    def test_missing_values_raises_when_no_nan(self) -> None:
+        nan_batch = pd.DataFrame({"Tag01": [1.0, np.nan], "Tag02": [3.0, 4.0]})
+        with pytest.raises(ValueError, match="No missing values"):
+            check_valid_batch_dict({"b1": nan_batch}, no_nan=True)
+
+    def test_unequal_row_counts_raises(self) -> None:
+        batches = {"b1": self._batch(n=4), "b2": self._batch(n=5)}
+        with pytest.raises(ValueError, match="same number of samples"):
+            dict_to_melted(batches)
+
+    def test_melted_to_dict_missing_column_raises(self) -> None:
+        df = pd.DataFrame({"not_id": [1, 2], "value": [3.0, 4.0]})
+        with pytest.raises(ValueError, match="does not exist"):
+            melted_to_dict(df, batch_id_col="batch_id")

--- a/tests/test_sec11_discover_tools.py
+++ b/tests/test_sec11_discover_tools.py
@@ -1,0 +1,52 @@
+"""SEC-11: discover_tools no longer silently swallows every ImportError.
+
+A missing optional dependency (ModuleNotFoundError) is tolerated but logged; a
+genuine bug inside a tools module (any other ImportError, e.g. a bad name) now
+propagates instead of making the whole tool category vanish silently.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+
+import pytest
+
+import process_improve.tool_spec as ts
+
+_TARGET = "process_improve.univariate.tools"
+
+
+class TestDiscoverToolsImportHandling:
+    def test_missing_dependency_is_logged_and_tolerated(self, monkeypatch, caplog) -> None:
+        real_import = importlib.import_module
+
+        def fake(name: str, *args, **kwargs):
+            if name == _TARGET:
+                raise ModuleNotFoundError("No module named 'some_optional_dep'", name="some_optional_dep")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(ts, "_discovery_done", False)
+        monkeypatch.setattr(importlib, "import_module", fake)
+
+        with caplog.at_level(logging.WARNING):
+            ts.discover_tools()
+
+        assert "not loaded" in caplog.text
+        assert _TARGET in caplog.text
+        # Discovery still completed for the other modules.
+        assert ts._discovery_done is True
+
+    def test_unexpected_import_error_propagates(self, monkeypatch) -> None:
+        real_import = importlib.import_module
+
+        def fake(name: str, *args, **kwargs):
+            if name == _TARGET:
+                raise ImportError("cannot import name 'foo' from 'process_improve.univariate.tools'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(ts, "_discovery_done", False)
+        monkeypatch.setattr(importlib, "import_module", fake)
+
+        with pytest.raises(ImportError, match="cannot import name"):
+            ts.discover_tools()


### PR DESCRIPTION
Closes #246. PR 8 of the `SECURITY_AUDIT.md` series.

> **Stacked PR.** Base is `claude/sec-08-assert-validation` (PR #254); GitHub retargets to `main` as the chain merges.

## Problem
`discover_tools` wrapped each `tools.py` import in `contextlib.suppress(ImportError)`, so a genuine bug inside a module (e.g. a bad name imported deep in it) silently dropped that entire tool category from the registry with no signal - a hard-to-diagnose "missing tool" failure. **Severity: Low (robustness).**

## Fix
Only `ModuleNotFoundError` (a genuinely missing module, typically an uninstalled optional third-party dependency) is tolerated - and now **logged** so the dropped category is visible. Any other `ImportError` (e.g. `cannot import name ...`) propagates. The per-module import was extracted into a small `_import_tool_module` helper to keep the loop clean (and avoid a try/except in the loop body).

## Tests (`tests/test_sec11_discover_tools.py`)
- A simulated `ModuleNotFoundError` for one module is logged ("not loaded") and discovery still completes (`_discovery_done` becomes True).
- A simulated nested `ImportError` propagates out of `discover_tools` instead of being swallowed.
- `test_tool_spec.py` / `test_tool_safety.py` still green (121 passed together with the new tests).

## Versioning
PATCH bump to `1.22.12`; `CITATION.cff` and `CHANGELOG.md` synced; SEC-11 struck off `SECURITY_AUDIT.md`.

https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp)_