### PR TITLE
Fix SEC-10: confine knowledge YAML loader path; clear remote-fetch errors

### DIFF
--- a/process_improve/experiments/datasets.py
+++ b/process_improve/experiments/datasets.py
@@ -9,6 +9,23 @@ import pandas as pd
 _DATASETS_DIR = Path(__file__).resolve().parents[1] / "datasets" / "experiments"
 
 
+def _read_remote_csv(url: str) -> pd.DataFrame:
+    """Fetch a sample-dataset CSV from a (hard-coded, trusted) remote host.
+
+    The URL is not user-supplied. Network or parse failures are surfaced as a
+    clear ``RuntimeError`` rather than a lower-level ``URLError`` / parser error,
+    so callers get an actionable message. Note that the content is fetched over
+    the network and is therefore trusted only as far as the remote host is.
+    """
+    try:
+        return pd.read_csv(url)
+    except (OSError, ValueError) as exc:
+        raise RuntimeError(
+            f"Could not download the sample dataset from {url!r}: {exc}. "
+            "Check your network connection; this dataset is fetched from a remote host."
+        ) from exc
+
+
 def distillateflow() -> pd.DataFrame:
     """Return the flow rate of distillate from the top of a distillation column.
 
@@ -27,7 +44,7 @@ def distillateflow() -> pd.DataFrame:
 
 
     """
-    return pd.read_csv("https://openmv.net/file/distillate-flow.csv")
+    return _read_remote_csv("https://openmv.net/file/distillate-flow.csv")
 
 
 def pollutant() -> None:
@@ -91,7 +108,7 @@ def oildoe() -> pd.DataFrame:
     Data from a confidential industrial source.
 
     """
-    return pd.read_csv("https://openmv.net/file/oil-company-doe.csv")
+    return _read_remote_csv("https://openmv.net/file/oil-company-doe.csv")
 
 
 def golf() -> None:

--- a/process_improve/experiments/knowledge/engine.py
+++ b/process_improve/experiments/knowledge/engine.py
@@ -33,8 +33,16 @@ _GRAPH: KnowledgeGraph | None = None
 
 
 def _load_yaml(filename: str) -> list[dict[str, Any]]:
-    """Load a YAML file from the data directory and return its contents."""
-    path = _DATA_DIR / filename
+    """Load a YAML file from the data directory and return its contents.
+
+    *filename* is resolved against :data:`_DATA_DIR` and must stay inside it; a
+    value containing ``..`` (or an absolute path) that escapes the data
+    directory raises :class:`ValueError` rather than reading an arbitrary file.
+    """
+    base = _DATA_DIR.resolve()
+    path = (base / filename).resolve()
+    if not path.is_relative_to(base):
+        raise ValueError(f"Refusing to load {filename!r}: path escapes the data directory.")
     if not path.exists():
         return []
     with path.open(encoding="utf-8") as fh:

--- a/tests/test_sec10_path_and_fetch.py
+++ b/tests/test_sec10_path_and_fetch.py
@@ -1,0 +1,42 @@
+"""SEC-10: path-traversal guard in the knowledge YAML loader, and clear errors
+for the remote sample-dataset fetch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from process_improve.experiments import datasets
+from process_improve.experiments.knowledge import engine
+
+
+class TestLoadYamlTraversal:
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "../../../etc/passwd",
+            "../secrets.yaml",
+            "/etc/passwd",
+        ],
+    )
+    def test_traversal_paths_rejected(self, bad: str) -> None:
+        with pytest.raises(ValueError, match="escapes the data directory"):
+            engine._load_yaml(bad)
+
+    def test_legitimate_filename_loads(self) -> None:
+        # A real data file ships with the package and loads as a list.
+        result = engine._load_yaml("design_types.yaml")
+        assert isinstance(result, list)
+
+    def test_safe_missing_filename_returns_empty(self) -> None:
+        assert engine._load_yaml("does_not_exist.yaml") == []
+
+
+class TestRemoteCsvErrorHandling:
+    def test_network_failure_raises_clear_error(self, monkeypatch) -> None:
+        def _boom(_url):
+            raise OSError("name resolution failed")
+
+        monkeypatch.setattr(datasets.pd, "read_csv", _boom)
+        with pytest.raises(RuntimeError, match="Could not download the sample dataset"):
+            datasets._read_remote_csv("https://openmv.net/file/distillate-flow.csv")


### PR DESCRIPTION
Closes #245. Part of the SEC-07..SEC-12 hardening series, re-cut as **independent code-only PRs** that target `main` and can merge in any order.

- `experiments/knowledge/engine._load_yaml` resolves the filename and rejects paths that escape its data directory (`..` / absolute), closing a latent path-traversal footgun.
- The remote sample-dataset loaders (`experiments/datasets`) go through a new `_read_remote_csv` that raises a clear `RuntimeError` on fetch/parse failure.
- `plot_to_HTML` is an explicit save-to-path API and is intentionally left as-is.

**This PR is code + tests only.** Version/CHANGELOG/CITATION/SECURITY_AUDIT bookkeeping is in the single follow-up PR (`claude/sec-07-12-release-metadata`).

Tests: `tests/test_sec10_path_and_fetch.py` plus `test_doe_knowledge`/`test_experiments_datasets` (64 passed).

https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp