### PR TITLE
Fix SEC-12: replace DataFrame.query f-string with boolean-mask indexing

### DIFF
--- a/process_improve/batch/preprocessing.py
+++ b/process_improve/batch/preprocessing.py
@@ -634,9 +634,11 @@ def find_reference_batch(
     )
     metrics = metrics.sort_values(by=["HT2", "SPE"])
     start_cutoff = 0.5
-    spe_metrics = metrics.query(f"SPE < {pca_second.spe_limit(conf_level=0.5)}")
+    # Boolean-mask indexing instead of a DataFrame.query() expression string built
+    # by f-string (no expression is assembled or evaluated).
+    spe_metrics = metrics[metrics["SPE"] < pca_second.spe_limit(conf_level=0.5)]
     while spe_metrics.shape[0] < int(settings["number_of_reference_batches"]):
-        spe_metrics = metrics.query(f"SPE < {pca_second.spe_limit(conf_level=start_cutoff)}")
+        spe_metrics = metrics[metrics["SPE"] < pca_second.spe_limit(conf_level=start_cutoff)]
         start_cutoff += 0.05
 
     if settings["number_of_reference_batches"] == 1:


### PR DESCRIPTION
Closes #247. Part of the SEC-07..SEC-12 hardening series, re-cut as **independent code-only PRs** that target `main` and can merge in any order.

`find_reference_batch` (`batch/preprocessing.py`) built a `DataFrame.query()` expression string via f-string. Replaced both occurrences with boolean-mask indexing (`metrics[metrics["SPE"] < limit]`); behaviour is identical, no expression is evaluated.

**This PR is code only.** Version/CHANGELOG/CITATION/SECURITY_AUDIT bookkeeping is in the single follow-up PR (`claude/sec-07-12-release-metadata`).

Tests: behaviour-preserving; `tests/batch/test_preprocessing.py` exercises `find_reference_batch` (8 passed).

https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp