### PR TITLE
Fix SEC-09: stop silent exception swallowing and error-message leakage

### DIFF
--- a/process_improve/experiments/analysis.py
+++ b/process_improve/experiments/analysis.py
@@ -12,6 +12,7 @@ precision, and confirmation run testing.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -21,6 +22,8 @@ import statsmodels.api as sm
 import statsmodels.formula.api as smf
 from scipy import stats
 from statsmodels.regression.linear_model import RegressionResultsWrapper
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Formula builder
@@ -183,12 +186,15 @@ def _run_residual_diagnostics(ols_result: RegressionResultsWrapper) -> dict[str,
 
     dw = float(durbin_watson(residuals))
 
-    # Breusch-Pagan (homoscedasticity)
+    # Breusch-Pagan (homoscedasticity). The test can legitimately fail to compute
+    # (singular exog, too few residuals); record None but log so the failure is
+    # not silent, and do not swallow unexpected error types.
     try:
         from statsmodels.stats.diagnostic import het_breuschpagan  # noqa: PLC0415
 
         bp_stat, bp_p, _bp_f, _bp_fp = het_breuschpagan(residuals, ols_result.model.exog)
-    except Exception:  # noqa: BLE001
+    except (ImportError, ValueError, ZeroDivisionError, np.linalg.LinAlgError) as exc:
+        logger.warning("Breusch-Pagan test could not be computed: %s", exc)
         bp_stat, bp_p = None, None
 
     # Cook's distance

--- a/process_improve/experiments/augment.py
+++ b/process_improve/experiments/augment.py
@@ -20,6 +20,7 @@ Example
 from __future__ import annotations
 
 import itertools
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -34,6 +35,8 @@ from process_improve.experiments.evaluate import (
     _word_to_str,
     evaluate_design,
 )
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Internal context shared across augmentation handlers
@@ -66,7 +69,10 @@ def _safe_evaluate(design: pd.DataFrame, generators: list[str] | None, model: st
         if generators:
             metrics.extend(["alias_structure", "resolution"])
         return evaluate_design(design, model=model, metric=metrics)
-    except Exception:  # noqa: BLE001
+    except (ValueError, KeyError, np.linalg.LinAlgError) as exc:
+        # Evaluation may not apply to every design; return no metrics but log so
+        # the failure is not silent, and let unexpected error types propagate.
+        logger.warning("Design evaluation skipped: %s", exc)
         return {}
 
 

--- a/process_improve/mcp_server.py
+++ b/process_improve/mcp_server.py
@@ -58,6 +58,20 @@ mcp = FastMCP(
 )
 
 
+def _serialise_tool_error(exc: Exception, tool_name: str) -> str:
+    """Return a JSON error string that does not leak internal detail.
+
+    An unexpected exception's message may carry internal detail (filesystem
+    paths, library internals). Over an untrusted MCP transport that is an
+    information-disclosure risk, so the full traceback is logged server-side and
+    only a generic message is returned to the caller. (Structured
+    :class:`ToolSafetyError`s, which have a curated payload, are handled by the
+    caller before reaching here.)
+    """
+    logger.exception("Tool %r raised an unexpected error", tool_name)
+    return json.dumps({"error": "internal error while executing tool", "tool": tool_name})
+
+
 def _register_all_tools() -> None:
     """Register every ``@tool_spec`` tool as an MCP tool."""
     discover_tools()
@@ -89,9 +103,10 @@ def _create_mcp_tool(
                 return json.dumps(result, indent=2, default=str)
             return str(result)
         except ToolSafetyError as exc:
+            # Structured safety errors carry a curated, non-sensitive payload.
             return json.dumps(exc.to_dict())
         except Exception as exc:  # noqa: BLE001
-            return json.dumps({"error": str(exc)})
+            return _serialise_tool_error(exc, tool_name)
 
     # Set proper function metadata for FastMCP
     handler.__name__ = tool_name

--- a/tests/test_sec09_error_handling.py
+++ b/tests/test_sec09_error_handling.py
@@ -1,0 +1,75 @@
+"""SEC-09: exception handling no longer swallows silently or leaks internals."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from process_improve.experiments import augment
+
+
+class TestSafeEvaluateLogsAndNarrows:
+    def _design(self) -> pd.DataFrame:
+        return pd.DataFrame({"A": [-1, 1, -1, 1], "B": [-1, -1, 1, 1]})
+
+    def test_expected_failure_returns_empty_and_logs(self, monkeypatch, caplog) -> None:
+        def _boom(*_args, **_kwargs):
+            raise ValueError("not applicable to this design")
+
+        monkeypatch.setattr(augment, "evaluate_design", _boom)
+        with caplog.at_level(logging.WARNING):
+            result = augment._safe_evaluate(self._design(), generators=None)
+        assert result == {}
+        assert "Design evaluation skipped" in caplog.text
+
+    def test_unexpected_error_propagates(self, monkeypatch) -> None:
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("genuine bug, should not be swallowed")
+
+        monkeypatch.setattr(augment, "evaluate_design", _boom)
+        with pytest.raises(RuntimeError, match="genuine bug"):
+            augment._safe_evaluate(self._design(), generators=None)
+
+
+class TestBreuschPaganFailureLogged:
+    def test_failure_is_logged_and_not_raised(self, monkeypatch, caplog) -> None:
+        import statsmodels.api as sm
+
+        from process_improve.experiments.analysis import _run_residual_diagnostics
+
+        def _raise(*_args, **_kwargs):
+            raise ValueError("singular exog")
+
+        # The diagnostic imports het_breuschpagan from this module at call time,
+        # so patching the module attribute is picked up.
+        monkeypatch.setattr("statsmodels.stats.diagnostic.het_breuschpagan", _raise)
+
+        # Fit with pandas inputs so resid/fittedvalues are Series (the function
+        # accesses ``.values`` on them).
+        x = sm.add_constant(pd.DataFrame({"x": np.arange(1.0, 8.0)}))
+        y = pd.Series([1.0, 2.0, 2.5, 4.0, 4.5, 6.0, 7.0], name="y")
+        ols_result = sm.OLS(y, x).fit()
+
+        with caplog.at_level(logging.WARNING):
+            out = _run_residual_diagnostics(ols_result)
+
+        assert "Breusch-Pagan" in caplog.text
+        bp = out["residual_diagnostics"]["breusch_pagan"]
+        assert bp["statistic"] is None
+        assert bp["p_value"] is None
+
+
+class TestMcpErrorSanitisation:
+    def test_unexpected_error_is_generic_no_leak(self) -> None:
+        pytest.importorskip("mcp")
+        from process_improve.mcp_server import _serialise_tool_error
+
+        internal_detail = "/home/app/internal/path/module.py line 42"
+        out = _serialise_tool_error(RuntimeError(internal_detail), "fit_pca")
+        payload = json.loads(out)
+        assert payload == {"error": "internal error while executing tool", "tool": "fit_pca"}
+        assert internal_detail not in out


### PR DESCRIPTION
Closes #244. Part of the SEC-07..SEC-12 hardening series, re-cut as **independent code-only PRs** that target `main` and can merge in any order. (Replaces the earlier #253, which was accidentally merged into a sibling branch rather than `main`.)

- `experiments/analysis.py` (Breusch-Pagan) and `experiments/augment.py` (`_safe_evaluate`) now catch only expected failure types and log, instead of swallowing every `Exception` and masking real bugs.
- The MCP server logs unexpected exceptions server-side and returns a generic message (via `_serialise_tool_error`) rather than the raw `str(exc)`, avoiding internal-detail leakage over an untrusted transport. Structured `ToolSafetyError`s keep their curated payload.

**This PR is code + tests only.** Version/CHANGELOG/CITATION/SECURITY_AUDIT bookkeeping is in the single follow-up PR (`claude/sec-07-12-release-metadata`).

Tests: `tests/test_sec09_error_handling.py` (the MCP-sanitisation case is skipped unless the `mcp` extra is installed; CI installs `--all-extras`) plus `test_evaluate_design`/`test_augment_design` (127 passed).

https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp)_