### PR TITLE
Fix SEC-11: don't silently swallow all ImportErrors in discover_tools

### DIFF
--- a/process_improve/tool_spec.py
+++ b/process_improve/tool_spec.py
@@ -29,11 +29,14 @@ Import the decorated tools and pass the specs to the Anthropic client::
 
 from __future__ import annotations
 
+import logging
 import math
 from collections.abc import Callable
 from typing import Any
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Registry
@@ -239,6 +242,24 @@ def clean(value: Any) -> Any:  # noqa: PLR0911, ANN401
 # ---------------------------------------------------------------------------
 
 
+def _import_tool_module(module: str) -> None:
+    """Import a single ``tools.py`` module for discovery.
+
+    A genuinely missing module - typically an uninstalled optional third-party
+    dependency that the tools module imports - is tolerated but logged, so the
+    dropped tool category is visible rather than silent. Any other
+    :class:`ImportError` (for example a bad name imported inside the module) is a
+    real bug and is allowed to propagate rather than being silently swallowed,
+    which would make the whole tool category vanish without a trace.
+    """
+    import importlib  # noqa: PLC0415
+
+    try:
+        importlib.import_module(module)
+    except ModuleNotFoundError as exc:
+        logger.warning("Tool module %r not loaded (missing dependency): %s", module, exc)
+
+
 def discover_tools() -> None:
     """Import all ``tools.py`` modules to populate the tool registry.
 
@@ -248,9 +269,6 @@ def discover_tools() -> None:
     global _discovery_done  # noqa: PLW0603
     if _discovery_done:
         return
-
-    import contextlib  # noqa: PLC0415
-    import importlib  # noqa: PLC0415
 
     for module in [
         "process_improve.univariate.tools",
@@ -263,8 +281,7 @@ def discover_tools() -> None:
         "process_improve.visualization.tools",
         "process_improve.simulation.tools",
     ]:
-        with contextlib.suppress(ImportError):
-            importlib.import_module(module)
+        _import_tool_module(module)
 
     _discovery_done = True
 

--- a/tests/test_sec11_discover_tools.py
+++ b/tests/test_sec11_discover_tools.py
@@ -1,0 +1,52 @@
+"""SEC-11: discover_tools no longer silently swallows every ImportError.
+
+A missing optional dependency (ModuleNotFoundError) is tolerated but logged; a
+genuine bug inside a tools module (any other ImportError, e.g. a bad name) now
+propagates instead of making the whole tool category vanish silently.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+
+import pytest
+
+import process_improve.tool_spec as ts
+
+_TARGET = "process_improve.univariate.tools"
+
+
+class TestDiscoverToolsImportHandling:
+    def test_missing_dependency_is_logged_and_tolerated(self, monkeypatch, caplog) -> None:
+        real_import = importlib.import_module
+
+        def fake(name: str, *args, **kwargs):
+            if name == _TARGET:
+                raise ModuleNotFoundError("No module named 'some_optional_dep'", name="some_optional_dep")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(ts, "_discovery_done", False)
+        monkeypatch.setattr(importlib, "import_module", fake)
+
+        with caplog.at_level(logging.WARNING):
+            ts.discover_tools()
+
+        assert "not loaded" in caplog.text
+        assert _TARGET in caplog.text
+        # Discovery still completed for the other modules.
+        assert ts._discovery_done is True
+
+    def test_unexpected_import_error_propagates(self, monkeypatch) -> None:
+        real_import = importlib.import_module
+
+        def fake(name: str, *args, **kwargs):
+            if name == _TARGET:
+                raise ImportError("cannot import name 'foo' from 'process_improve.univariate.tools'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(ts, "_discovery_done", False)
+        monkeypatch.setattr(importlib, "import_module", fake)
+
+        with pytest.raises(ImportError, match="cannot import name"):
+            ts.discover_tools()


### PR DESCRIPTION
Closes #246. Part of the SEC-07..SEC-12 hardening series, re-cut as **independent code-only PRs** that target `main` and can merge in any order. (Replaces the earlier #255, which was accidentally merged into a sibling branch rather than `main`.)

`discover_tools` wrapped each `tools.py` import in `contextlib.suppress(ImportError)`, so a genuine bug inside a module silently dropped that whole tool category. Now only `ModuleNotFoundError` (a missing optional dependency) is tolerated - and logged - while any other `ImportError` propagates. The per-module import was extracted into a small `_import_tool_module` helper.

**This PR is code + tests only.** Version/CHANGELOG/CITATION/SECURITY_AUDIT bookkeeping is in the single follow-up PR (`claude/sec-07-12-release-metadata`).

Tests: `tests/test_sec11_discover_tools.py` plus `test_tool_spec` (75 passed).

https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoTKMjQbJXJkfQq9efzpEp)_