### PR TITLE
Fix TPLS.score NameError on empty Y dict (SEC-16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.10] - 2026-06-01
+
+### Fixed
+
+- `TPLS.score` no longer raises `NameError` when the `Y` block (`X["Y"]`) is an
+  empty dict (SEC-16). The method now raises a clear `ValueError` instead of
+  crashing on a malformed test bundle, and the per-block averaging uses an
+  explicit counter rather than the loop index.
+
 ## [1.22.9] - 2026-05-29
 
 This release lands the second half of the `SECURITY_AUDIT.md` hardening series
@@ -241,7 +250,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.9...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.10...HEAD
+[1.22.10]: https://github.com/kgdunn/process-improve/compare/v1.22.9...v1.22.10
 [1.22.9]: https://github.com/kgdunn/process-improve/compare/v1.22.8...v1.22.9
 [1.22.8]: https://github.com/kgdunn/process-improve/compare/v1.22.7...v1.22.8
 [1.22.7]: https://github.com/kgdunn/process-improve/compare/v1.22.6...v1.22.7

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.9
-date-released: "2026-05-29"
+version: 1.22.10
+date-released: "2026-06-01"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/process_improve/multivariate/methods.py
+++ b/process_improve/multivariate/methods.py
@@ -3492,11 +3492,16 @@ class TPLS(RegressorMixin, BaseEstimator):
         predictions = self.predict(X)
         y_pred = predictions.hat
         y_actual = X["Y"]
+        if not y_actual:
+            msg = "y_actual is empty: X['Y'] must contain at least one block to compute a score."
+            raise ValueError(msg)
         r2_key = 0.0
-        for _idx, key in enumerate(y_actual):
+        count = 0
+        for key in y_actual:
             r2_key += r2_score(y_true=y_actual[key], y_pred=y_pred[key], sample_weight=sample_weight)
             _ = np.corrcoef(y_actual[key].values.ravel(), y_pred[key].values.ravel())
-        return r2_key / (_idx + 1)
+            count += 1
+        return r2_key / count
 
     def help(self) -> str:
         """Help for the TPLS Estimator.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.9"
+version = "1.22.10"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2466,6 +2466,33 @@ def test_tpls_cross_validation(fixture_tpls_example: dict) -> None:
     # TODO: tests on the output
 
 
+def test_tpls_score_single_block_y(fixture_tpls_example: dict) -> None:
+    """`TPLS.score` on a single-block `Y` returns a finite float."""
+    n_components = 3
+    d_matrix = fixture_tpls_example.pop("D")
+    tpls_test = TPLS(n_components=n_components, d_matrix=d_matrix)
+    tpls_test.fit(DataFrameDict(fixture_tpls_example))
+
+    # The fixture's Y block has a single block ("Quality"); scoring on the training data
+    # should return a finite float.
+    score = tpls_test.score(DataFrameDict(fixture_tpls_example))
+    assert isinstance(score, float)
+    assert np.isfinite(score)
+
+
+def test_tpls_score_empty_y_raises(fixture_tpls_example: dict) -> None:
+    """`TPLS.score` on an empty `Y` dict raises a clear `ValueError` (not `NameError`)."""
+    n_components = 3
+    d_matrix = fixture_tpls_example.pop("D")
+    tpls_test = TPLS(n_components=n_components, d_matrix=d_matrix)
+    tpls_test.fit(DataFrameDict(fixture_tpls_example))
+
+    # Build a test bundle whose "Y" block is an empty dict; the loop body never runs.
+    malformed = DataFrameDict({**fixture_tpls_example, "Y": {}})
+    with pytest.raises(ValueError, match="y_actual is empty"):
+        tpls_test.score(malformed)
+
+
 def manual_cross_validation(tpls_model: TPLS, full_datadict: dict, cv: int = 5, scoring: str = "r2") -> np.ndarray:
     """Perform manual cross-validation for a TPLS model."""
     kfold = KFold(n_splits=cv, shuffle=True)


### PR DESCRIPTION
Closes #265.

## Problem

`TPLS.score` (`process_improve/multivariate/methods.py`) computed its
per-block average using the loop index:

```python
for _idx, key in enumerate(y_actual):
    r2_key += r2_score(...)
return r2_key / (_idx + 1)
```

When `y_actual` (`X["Y"]`) is an empty dict the loop body never runs,
`_idx` is never bound, and the `return` line raises
`NameError: name '_idx' is not defined`. Any malformed test bundle
triggers it.

## Fix

- Raise a clear `ValueError("y_actual is empty: ...")` up front when the
  `Y` block is empty, instead of crashing with `NameError`.
- Replace the loop-index divisor with an explicit `count` accumulated
  inside the loop, so the averaging no longer depends on a leaked loop
  variable.

## Tests

Added two tests in `tests/test_multivariate.py`:

- `test_tpls_score_empty_y_raises` - scoring with an empty `Y` dict raises
  a clear `ValueError` (not `NameError`).
- `test_tpls_score_single_block_y` - scoring with a single-block `Y`
  returns a finite float.

Both pass; the full TPLS suite (6 tests) and `ruff check` are green.

## Housekeeping

- Version bumped 1.22.9 -> 1.22.10 (PATCH; bug fix) in `pyproject.toml`
  and `CITATION.cff`.
- `CHANGELOG.md` updated with a `Fixed` entry under a new `1.22.10`
  heading and refreshed compare links.

Note: SEC-16 is not yet present in `SECURITY_AUDIT.md` (the tracked table
currently ends at SEC-12), so that file was left unchanged to avoid an
inconsistent single-row addition; it can be batch-updated alongside
SEC-13 through SEC-15.

https://claude.ai/code/session_01Pyxyx1X83R9oywe1epCRjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pyxyx1X83R9oywe1epCRjR)_