### PR TITLE
Fix SEC-22 and SEC-23: control-chart and OLS predict robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.13] - 2026-06-01
+
+### Fixed
+
+- The Holt-Winters control chart now raises a clear `ValueError` when the
+  warm-up window has zero (or non-finite) variance, instead of silently
+  dividing by `sigma_0 = 0` and returning `0`/`NaN` control limits (SEC-22).
+- `regression.OLS.predict` now validates that `X` has the same number of
+  features as the fitted model and raises a clear `ValueError` otherwise,
+  rather than relying on a confusing numpy error or silently broadcasting to a
+  wrong-shaped result (SEC-23).
+
 ## [1.22.12] - 2026-06-01
 
 ### Security
@@ -280,7 +292,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.12...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.13...HEAD
+[1.22.13]: https://github.com/kgdunn/process-improve/compare/v1.22.12...v1.22.13
 [1.22.12]: https://github.com/kgdunn/process-improve/compare/v1.22.11...v1.22.12
 [1.22.11]: https://github.com/kgdunn/process-improve/compare/v1.22.10...v1.22.11
 [1.22.10]: https://github.com/kgdunn/process-improve/compare/v1.22.9...v1.22.10

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.12
+version: 1.22.13
 date-released: "2026-06-01"
 keywords:
   - chemometrics

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -36,6 +36,8 @@ therefore ranked under two models:
 | SEC-12 | `DataFrame.query` built with f-strings | Low | Low | done (#247, v1.22.9) |
 | SEC-14 | RCE via patsy formula in analyze/evaluate/augment/`lm` | Critical | Low | done (#314, v1.22.11) |
 | SEC-15 | `reveal_simulator` gate bypassable via kwarg injection | Critical | Low | done (#264, v1.22.12) |
+| SEC-22 | Holt-Winters chart divides by zero on constant warm-up | High | High | done (#271, v1.22.13) |
+| SEC-23 | `regression.OLS.predict` accepts wrong-shape `X` silently | High | Medium | done (#272, v1.22.13) |
 
 ---
 
@@ -322,6 +324,36 @@ therefore ranked under two models:
   forwarding `confirmed` / `simulator_state` through dispatch is dropped (or
   raises `ToolInputInvalidError` on the safe path), and the gate still fires for
   legitimate host calls.
+
+## SEC-22 - Holt-Winters control chart divides by zero on constant warm-up window [RESOLVED]
+- **Status:** Fixed in v1.22.13 (issue #271). `_holt_winters_warmup_fit` now
+  raises a clear `ValueError` when the warm-up `sigma_0` is zero or non-finite,
+  instead of propagating `inf`/`NaN` into the control limits.
+- **Severity:** U = High, L = High (silent wrong control-chart limits)
+- **Where:** `process_improve/monitoring/control_charts.py` (`_holt_winters_warmup_fit`,
+  around the `rho_input` / `rho_i = error_i / sigma_hat` divisions).
+- **Issue:** A constant (zero-variance) warm-up window makes
+  `sigma_0 = MAD = 0`, so `rho_i = +/-inf` propagates into every downstream
+  control-chart limit, which silently become `0` / `NaN`. No guard existed.
+- **Fix direction:** Validate `sigma_0` immediately after it is computed; raise
+  `ValueError("...variance is zero in warm-up window; supply more representative
+  data...")` rather than dividing by it. Test: a constant warm-up series raises a
+  clear error instead of producing NaN limits.
+
+## SEC-23 - `regression.OLS.predict` accepts wrong-shape `X` silently [RESOLVED]
+- **Status:** Fixed in v1.22.13 (issue #272). `OLS.predict` now checks the
+  feature count against `n_features_in_` and raises a clear `ValueError`.
+- **Severity:** U = High, L = Medium
+- **Where:** `process_improve/regression/methods.py` (`OLS.predict`,
+  `return intercept + X_arr @ self.coefficients_`).
+- **Issue:** `n_features_in_` is stored at fit time but never checked at predict.
+  A wrong column count either raised a confusing numpy `ValueError` or, worse,
+  broadcast shapes (e.g. a 1-column `X` against a scalar coefficient) and
+  produced silently wrong output.
+- **Fix direction:** Validate `X_arr.shape[1] == self.n_features_in_` and raise a
+  clear `ValueError`, mirroring the sklearn-style shape check used by PCA / PLS.
+  Tests: predict with the wrong column count raises a clear `ValueError`; predict
+  with the correct shape still returns finite values.
 
 ---
 

--- a/process_improve/monitoring/control_charts.py
+++ b/process_improve/monitoring/control_charts.py
@@ -277,6 +277,16 @@ class ControlChart:
             self.warm_up["sigma_0"] = median_absolute_deviation(warm_up_residuals, nan_policy="omit")
             self.warm_up["residuals"] = warm_up_residuals
 
+        # A constant (zero-variance) warm-up window gives sigma_0 = MAD = 0, which
+        # would make rho/psi infinite and silently poison every downstream control
+        # limit with 0/NaN. Fail loudly instead of returning meaningless limits.
+        if not np.isfinite(self.warm_up["sigma_0"]) or self.warm_up["sigma_0"] <= 0:
+            raise ValueError(
+                "The Holt-Winters warm-up window has zero (or non-finite) variance "
+                "(sigma_0 = 0), so the control-chart limits would be undefined. "
+                "Supply more representative warm-up data, or pass a positive 's'."
+            )
+
         df.loc[0, "rho_input"] = (
             self.warm_up["y_zero_robust"] - self.warm_up["alpha_0"] - self.warm_up["beta_0"]
         ) / self.warm_up["sigma_0"]

--- a/process_improve/regression/methods.py
+++ b/process_improve/regression/methods.py
@@ -649,6 +649,12 @@ class OLS(RegressorMixin, BaseEstimator):
             X_arr = np.asarray(X, dtype=float)
             if X_arr.ndim == 1:
                 X_arr = X_arr.reshape(-1, 1)
+        n_features = X_arr.shape[1]
+        if n_features != self.n_features_in_:
+            raise ValueError(
+                f"X has {n_features} feature(s), but OLS was fitted with "
+                f"{self.n_features_in_} feature(s)."
+            )
         intercept = 0.0 if not self.fit_intercept else self.intercept_
         return intercept + X_arr @ self.coefficients_
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.12"
+version = "1.22.13"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -157,6 +157,17 @@ class TestHoltWintersControlChart:
     assert len(cc_medium.idx_outside_3S) == 0
 
 
+def test_hw_constant_warmup_raises_value_error() -> None:
+    """A constant warm-up window must raise instead of giving NaN limits (SEC-22).
+
+    With sigma_0 = MAD = 0 the control limits would silently collapse to 0/NaN.
+    """
+    cc = ControlChart()
+    constant = np.full(12, 42.0)
+    with pytest.raises(ValueError, match=r"zero.*variance"):
+        cc.calculate_limits(constant, ld_1=0.4, ld_2=0.7)
+
+
 def test_cpk_well_centered_process() -> None:
     """Cpk for a well-centered process with wide specs should be high."""
     rng = np.random.default_rng(42)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -528,6 +528,23 @@ def test_ols_predict_matches_fitted_values(
     np.testing.assert_allclose(model.predict(x_new), expected, rtol=1e-12)
 
 
+def test_ols_predict_wrong_shape_raises(
+    multiple_linear_regression_data: tuple[np.ndarray, np.ndarray],
+) -> None:
+    """predict() must reject an X whose feature count differs from fit (SEC-23)."""
+    X, y = multiple_linear_regression_data
+    model = OLS().fit(X, y)  # fitted with a single feature
+    assert model.n_features_in_ == 1
+
+    with pytest.raises(ValueError, match=r"X has 2 feature\(s\), but OLS was fitted with 1"):
+        model.predict(np.ones((3, 2)))
+
+    # The correct shape still returns finite predictions.
+    good = model.predict(np.array([[0.05], [0.10]]))
+    assert good.shape == (2,)
+    assert np.all(np.isfinite(good))
+
+
 def test_ols_no_intercept(multiple_linear_regression_data: tuple[np.ndarray, np.ndarray]) -> None:
     """OLS with fit_intercept=False should match R's summary(lm(y~x+0))."""
     X, y = multiple_linear_regression_data


### PR DESCRIPTION
Closes #271. Closes #272.

Two small, independent robustness fixes from the `SECURITY_AUDIT.md` series, bundled in one PR.

## SEC-22 (#271) — Holt-Winters control chart divides by zero on constant warm-up

`process_improve/monitoring/control_charts.py`

A constant (zero-variance) warm-up window makes `sigma_0 = MAD = 0`, so `rho_i = error_i / sigma_hat` becomes `±inf` and propagates into every downstream control-chart limit, which silently collapse to `0`/`NaN` (confirmed locally: the un-patched code emits `RuntimeWarning: invalid value encountered in scalar divide`).

`_holt_winters_warmup_fit` now validates `sigma_0` right after it is computed and raises a clear `ValueError` ("...zero (or non-finite) variance ... supply more representative warm-up data, or pass a positive 's'.") instead of dividing by it.

## SEC-23 (#272) — `OLS.predict` accepts wrong-shape `X` silently

`process_improve/regression/methods.py`

`n_features_in_` was stored at fit time but never checked at predict, so a wrong column count either raised a confusing numpy error or broadcast shapes (e.g. a 1-column `X` against a scalar coefficient) into silently wrong output.

`predict` now checks `X_arr.shape[1] == self.n_features_in_` and raises a clear, sklearn-style `ValueError` ("X has N feature(s), but OLS was fitted with M feature(s).").

## Tests

- `test_hw_constant_warmup_raises_value_error`: a constant warm-up series raises rather than producing NaN limits.
- `test_ols_predict_wrong_shape_raises`: wrong feature count raises a clear `ValueError`; correct shape still returns finite predictions.

Both tests were confirmed to **fail before** the fixes and **pass after**. Full `tests/test_regression.py` + `tests/test_monitoring.py` (53 tests) pass; `ruff check` clean.

## Housekeeping

- Version `1.22.12` → `1.22.13` (patch — bug fixes); `CITATION.cff` kept in sync.
- `CHANGELOG.md` (new `1.22.13` section + footer links) and `SECURITY_AUDIT.md` (SEC-22 / SEC-23 rows + detail sections) updated.

https://claude.ai/code/session_0188U9vww7XM4n2QAUM2JXm2

---
_Generated by [Claude Code](https://claude.ai/code/session_0188U9vww7XM4n2QAUM2JXm2)_