### PR TITLE
docs: Wave 1 policy enablers (ENG-08, ENG-11, ENG-22, ENG-28)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,99 @@ The line length is 120 characters.
 - Open a pull request against `main` with a clear description of the change
   and why it is needed.
 - The version in `pyproject.toml` is bumped with every PR that changes code
-  or configuration (PATCH for fixes and small changes, MINOR for new
-  features).
+  or configuration (see "Versioning policy" below).
 - Bugs and feature requests can also be filed on the
   [issue tracker](https://github.com/kgdunn/process-improve/issues).
+
+## Versioning policy
+
+The package uses three-part semantic versioning: `MAJOR.MINOR.PATCH`.
+
+- **PATCH** (`1.22.8 -> 1.22.9`): bug fixes, CI / workflow changes,
+  documentation updates, dependency bumps, small refactors. Public
+  signatures are unchanged. Behaviour changes are only allowed when
+  fixing a documented bug.
+- **MINOR** (`1.22.9 -> 1.23.0`): new features, new modules,
+  significant API additions, or meaningful behavioural changes.
+  Backwards-compatible by default; deprecations follow the schedule
+  in [`docs/development/deprecation_policy.rst`](docs/development/deprecation_policy.rst).
+- **MAJOR** (`1.x.x -> 2.0.0`): incompatible removals. Anything
+  previously deprecated under the policy can be removed here.
+
+Reset rules:
+
+- Bumping MINOR resets PATCH to 0 (`1.22.9 -> 1.23.0`).
+- Bumping MAJOR resets MINOR and PATCH to 0 (`1.23.4 -> 2.0.0`).
+
+If you are unsure whether a change is a PATCH or a MINOR, ask in the
+PR; the maintainer decides on the boundary case.
+
+### What counts as a breaking change
+
+A change is breaking if any of these are true:
+
+- A documented public name (function, class, attribute, kwarg) is
+  removed, renamed, or moved.
+- A public function's signature changes in a way that fails
+  existing valid call sites (a positional becomes keyword-only,
+  a required kwarg is added without a default, a kwarg default
+  changes meaning).
+- A `Bunch` return type loses or renames a field.
+- A `@tool_spec` tool is renamed, has a schema field removed, or
+  changes the meaning of an existing field.
+- A documented behaviour (e.g. "PCA returns sign-flipped loadings
+  by the Wold convention") is silently changed.
+
+A change is **not** breaking if:
+
+- A new optional kwarg is added with a default that preserves the
+  previous behaviour.
+- A new public function or attribute is added.
+- A `Bunch` return type gains a field.
+- A documented bug is fixed.
+- Internal (`_`-prefixed) code is refactored without affecting any
+  public surface.
+
+Breaking changes always require a deprecation cycle; see the
+linked policy below.
+
+## Performance-regression policy
+
+Public-API algorithms (PCA fit, PLS fit/predict, ``analyze_experiment``,
+``evaluate_design``, batch alignment) are expected not to regress in
+wall-clock time. The rule of thumb:
+
+- A PR that knowingly slows a hot path by more than ~10% must say
+  so in the PR description and justify the trade-off (correctness
+  fix, security guard, deprecation prep).
+- Unknowing regressions are caught by the perf-baseline CI job
+  (planned: [ENG-15](https://github.com/kgdunn/process-improve/issues/297)).
+  Until that job lands, the maintainer eyeballs perf on the hot
+  paths during review.
+- Internal refactors (private modules, internal classes) carry no
+  perf SLA.
+
+If a perf regression is unavoidable, the CHANGELOG entry says so
+under "Changed".
+
+## Policies referenced from this guide
+
+These four documents pin the project's contributor-facing policies.
+They are short, opinionated, and review feedback will reference
+them directly:
+
+- [Error-handling style](docs/development/error_handling.rst)
+  ([ENG-11](https://github.com/kgdunn/process-improve/issues/293)) -- when to
+  raise, when to assert, when to warn, when to use a dedicated
+  exception class.
+- [Reproducibility contract](docs/development/reproducibility.rst)
+  ([ENG-08](https://github.com/kgdunn/process-improve/issues/290)) --
+  ``random_state`` handling for every public function that
+  touches an RNG.
+- [Deprecation policy](docs/development/deprecation_policy.rst)
+  ([ENG-22](https://github.com/kgdunn/process-improve/issues/304)) --
+  the schedule for retiring public API, including the
+  ``DeprecationWarning`` message format.
+- This guide, the "Versioning policy" and "Performance-regression
+  policy" sections above
+  ([ENG-28](https://github.com/kgdunn/process-improve/issues/310)).

--- a/docs/development/deprecation_policy.rst
+++ b/docs/development/deprecation_policy.rst
@@ -1,0 +1,144 @@
+Deprecation Policy
+==================
+
+.. note::
+
+   This document is the canonical policy for retiring public API in
+   ``process-improve``. Tracks
+   `ENG-22 <https://github.com/kgdunn/process-improve/issues/304>`_.
+
+Scope
+-----
+
+This policy covers anything documented as public:
+
+- Top-level imports (``process_improve.PCA``, ``process_improve.lm``).
+- Public methods and attributes on documented classes
+  (``PCA.scores_``, ``PLS.predict``, ``MCUVScaler.fit``).
+- The public signatures of those methods (kwarg names, defaults,
+  keyword-only-ness).
+- The MCP tool surface declared via ``@tool_spec``: tool names,
+  schema keys, and the meaning of each field.
+
+Private API (anything prefixed with ``_``, anything under
+``process_improve._internal`` or ``process_improve._linalg``,
+and anything not re-exported from a package ``__init__.py``) may
+change without notice.
+
+The contract
+------------
+
+For any breaking change to a public surface, follow this schedule:
+
+============ ===================== =====================================
+Phase        At least one MINOR    What contributors do
+             release each
+============ ===================== =====================================
+Announce     `X.Y.0`               Add the new API. Emit a
+                                   ``DeprecationWarning`` from the
+                                   old API. Document the rename in
+                                   the docstring. Add a CHANGELOG
+                                   entry.
+Warn         `X.(Y+1).*` and on    Old API still works; the warning
+                                   still fires. CHANGELOG carries
+                                   "Deprecated since X.Y; will be
+                                   removed in (X+1).0".
+Remove       `(X+1).0`             Old API is deleted. CHANGELOG
+                                   entry under "Removed".
+============ ===================== =====================================
+
+In words: one MINOR cycle of "you can keep using this, but here is the
+new name" plus a second cycle of "we mean it" before removal at the
+next MAJOR.
+
+Mechanism
+---------
+
+A renamed attribute or function uses the helper
+``warnings.warn`` from the standard library with the
+``DeprecationWarning`` category and ``stacklevel=2`` (consistent
+with :doc:`error_handling`):
+
+::
+
+    import warnings
+
+    def old_name(*args, **kwargs):
+        warnings.warn(
+            "process_improve.X.old_name is deprecated since 1.23.0 "
+            "and will be removed in 2.0; use X.new_name instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return new_name(*args, **kwargs)
+
+Required fields in the message:
+
+- The fully qualified deprecated name.
+- The version that announced the deprecation
+  (``deprecated since X.Y.0``).
+- The version that will remove it (``will be removed in
+  (X+1).0``).
+- The intended replacement (or "no replacement; the
+  functionality is no longer supported").
+
+For renamed *attributes* on PCA / PLS / TPLS, the existing
+``__getattr__`` migration helper is the right mechanism; it
+should be updated to emit a ``DeprecationWarning`` rather than
+raising immediately. The helper is a single place to enforce
+the message format.
+
+When a deprecation is unavoidable mid-cycle
+-------------------------------------------
+
+If a bug or security finding forces a behaviour change inside a
+PATCH release:
+
+1. The CHANGELOG entry under "Changed" explicitly names the
+   behaviour change.
+2. If the public signature changes, the next MINOR release
+   includes a deprecation shim under this policy. PATCH
+   releases never break a signature.
+
+If the change is forced by a downstream library (a sklearn or
+statsmodels deprecation cascading through the package), the
+CHANGELOG cross-references the upstream change.
+
+What is *not* a breaking change
+-------------------------------
+
+- Adding a new optional kwarg with a default that preserves the
+  previous behaviour.
+- Adding a new public function.
+- Fixing a documented bug (the fix is the breaking change of
+  the bug, not of the API).
+- A purely internal refactor that does not affect any public
+  surface.
+
+Edge case: ``Bunch`` return types. The fitted-model ``predict``
+methods return ``sklearn.utils.Bunch`` with named fields. Adding
+a field is **not** a breaking change. Renaming or removing one
+**is**.
+
+Tracking and rollout
+--------------------
+
+- The ``__getattr__`` migration helpers on PCA / PLS already
+  exist; they currently raise rather than warn. Migrating them
+  to emit ``DeprecationWarning`` is in scope for the next
+  Wave-7 PR (`ENG-22 <https://github.com/kgdunn/process-improve/issues/304>`_).
+- A ``tools/check_deprecations.py`` script will be added to
+  list everything currently deprecated and its scheduled
+  removal version. The script is run in CI; a deprecation
+  past its removal version fails the build, so we cannot
+  forget to delete the shim.
+
+Cross-references
+----------------
+
+- :doc:`error_handling` -- warnings categories, ``stacklevel``,
+  the ``warnings.warn`` pattern.
+- :doc:`reproducibility` -- ``random_state`` migrations follow
+  this policy.
+- `Keep a Changelog <https://keepachangelog.com/en/1.1.0/>`_ -
+  the format the project's CHANGELOG follows.

--- a/docs/development/error_handling.rst
+++ b/docs/development/error_handling.rst
@@ -51,7 +51,7 @@ follow the linked section.
 .. _eng11_caller_error:
 
 1. User-input violations -> ``ValueError`` / ``TypeError``
----------------------------------------------------------
+----------------------------------------------------------
 
 This is the most common case. The caller passed something the
 function cannot work with: a wrong type, an out-of-range scalar, an

--- a/docs/development/error_handling.rst
+++ b/docs/development/error_handling.rst
@@ -1,0 +1,276 @@
+Error-Handling Style Guide
+==========================
+
+.. note::
+
+   This document is the canonical policy for how errors and warnings
+   are surfaced in ``process-improve``. New code is expected to follow
+   it; review feedback will reference it directly. Tracks
+   `ENG-11 <https://github.com/kgdunn/process-improve/issues/293>`_.
+
+Why one style?
+--------------
+
+A reader landing in a new module should be able to predict, without
+running the code, what a failure will look like. Today, the codebase
+mixes ``raise ValueError``, ``assert``, ``return None``,
+``return {"error": ...}``, ``except Exception: pass``, silent
+``NaN``, and bare ``warnings.warn`` calls. Each of those is fine in
+isolation; the cost is the *spread*: a contributor patching one site
+cannot tell whether the surrounding modules will react the same way,
+and the audit work to verify a fix is multiplied.
+
+This guide pins one pattern per situation. The patterns are not
+novel - they follow the conventions used by NumPy, SciPy, and
+scikit-learn - so a contributor familiar with the scientific Python
+stack should not need to memorise anything new.
+
+Decision tree
+-------------
+
+Pick the case that best matches the failure you are handling and
+follow the linked section.
+
+1. The failure is a violation of a contract the *caller* signed
+   (wrong argument type, out-of-range value, mismatched shape).
+   :ref:`raise <eng11_caller_error>`.
+2. The failure is a violation of an invariant the *library*
+   guarantees internally (a "this can't happen" branch).
+   :ref:`assert or RuntimeError <eng11_internal_error>`.
+3. The failure is a known degeneracy of the algorithm
+   (singular design, non-convergence, missing data when not
+   allowed). :ref:`dedicated exception class <eng11_algorithm_error>`.
+4. The failure happens at the MCP boundary (the host's untrusted
+   transport surfaced bad input or a tool died).
+   :ref:`ToolSafetyError subclass <eng11_mcp_error>`.
+5. The condition is recoverable but the caller probably wants to
+   know about it. :ref:`warnings.warn <eng11_warning>`.
+6. **None of the above.** Default to (1) and add a unit test
+   asserting the exception text.
+
+.. _eng11_caller_error:
+
+1. User-input violations -> ``ValueError`` / ``TypeError``
+---------------------------------------------------------
+
+This is the most common case. The caller passed something the
+function cannot work with: a wrong type, an out-of-range scalar, an
+empty dataframe, a column name that does not exist.
+
+Pattern::
+
+    if X.shape[1] != self.n_features_in_:
+        raise ValueError(
+            f"Prediction data must have {self.n_features_in_} columns, "
+            f"got {X.shape[1]}."
+        )
+
+Use ``ValueError`` for wrong *value*; use ``TypeError`` for wrong
+*type*. The message always names:
+
+- the offending parameter,
+- the observed value or type,
+- the expected value or constraint.
+
+**Do not use** ``assert`` for these checks. Asserts are stripped
+by ``python -O``; the check silently disappears in optimised
+deployments, and the bug surfaces miles downstream as a confusing
+NaN or shape mismatch.
+
+**Do not return** ``None``, ``False``, an empty DataFrame, or a
+"sentinel" value. The next caller cannot tell a successful empty
+result from a swallowed error.
+
+**Do not catch** ``Exception`` and re-raise; let the exception
+propagate.
+
+.. _eng11_internal_error:
+
+2. Internal invariants -> ``assert`` (rare) or ``RuntimeError``
+---------------------------------------------------------------
+
+A genuinely impossible branch ("at this point ``A`` must be > 0
+because the constructor checked it") may be guarded with
+``assert``, but **must** carry a comment naming the invariant
+that justifies the assertion.
+
+Pattern::
+
+    # Invariant: _fit_one_component sets self._loadings_np for a >= 0.
+    assert self._loadings_np is not None, "internal: loadings missing after fit"  # noqa: S101
+
+If the branch is *not* genuinely impossible (the input could
+trigger it), use ``RuntimeError`` and let it propagate:
+
+::
+
+    raise RuntimeError(
+        "internal: NIPALS reached max_iter without converging "
+        "after fitting passed shape validation; this is a bug."
+    )
+
+Asserts on user input are forbidden (see SEC-08 / SEC-17 in
+``SECURITY_AUDIT.md``).
+
+.. _eng11_algorithm_error:
+
+3. Algorithm-level degeneracies -> dedicated exception class
+------------------------------------------------------------
+
+When a known algorithmic edge case fires (rank-deficient design,
+non-convergence, singular matrix), raise a *dedicated* exception
+class. This lets callers handle the specific case without catching
+``Exception``.
+
+Existing classes (do not invent more for the same condition):
+
+- ``numpy.linalg.LinAlgError`` for singular / ill-conditioned
+  matrices. ``process_improve._linalg.safe_inverse`` already
+  raises it; mirror its message style.
+- ``process_improve.tool_safety.ToolSafetyError`` and its
+  subclasses for MCP-layer failures (see
+  :ref:`eng11_mcp_error`).
+
+When a new algorithmic case appears (e.g. "PLS NIPALS did not
+converge"), add a class in the relevant module:
+
+::
+
+    class NotConvergedError(RuntimeError):
+        """Iterative algorithm hit max_iter without satisfying tol."""
+
+Then raise it from the algorithm. The caller decides whether to
+catch or propagate.
+
+**Never** silently substitute ``np.nan`` or ``1.0`` for an
+undefined statistic without recording the substitution in the
+fitted model's ``fitting_info_`` dict and warning the caller
+(see :ref:`eng11_warning`).
+
+.. _eng11_mcp_error:
+
+4. MCP-boundary failures -> ``ToolSafetyError`` subclass
+--------------------------------------------------------
+
+The MCP server is the only place in the package where an exception
+becomes an attacker-visible string. ``mcp_server._serialise_tool_error``
+redacts unhandled exceptions, but per-tool ``except`` clauses can
+short-circuit that redaction. Follow the existing pattern in
+``process_improve/tool_safety.py``:
+
+- ``ToolInputTooLargeError`` - request exceeded a size limit.
+- ``ToolInputInvalidError`` - schema / structural violation.
+- ``ToolTimeoutError`` - wall-clock budget exceeded.
+- ``ToolMemoryExceededError`` - worker process died.
+
+Inside a tool wrapper:
+
+- Narrow the ``except`` to the specific exception types the
+  algorithm can raise: ``(ValueError, TypeError, KeyError,
+  numpy.linalg.LinAlgError)`` is the canonical set for the
+  multivariate tools.
+- For anything *outside* that set, let the exception propagate
+  to ``_serialise_tool_error``, which logs the traceback
+  server-side and returns a generic message to the caller.
+
+Forbidden pattern (information disclosure):
+
+::
+
+    # DO NOT do this. str(e) carries pandas / numpy paths and
+    # statsmodels internals.
+    try:
+        ...
+    except Exception as e:
+        return {"error": str(e)}
+
+Replace with:
+
+::
+
+    try:
+        ...
+    except (ValueError, KeyError, LinAlgError) as e:
+        return {"error": str(e)}
+    # Anything else propagates to _serialise_tool_error.
+
+The existing PCA/PLS tools already follow this; new wrappers
+should mirror them.
+
+.. _eng11_warning:
+
+5. Soft warnings -> ``warnings.warn``
+-------------------------------------
+
+For conditions that are recoverable but worth surfacing (a
+non-converged solution returned anyway, a constant column
+dropped, a degenerate fold during cross-validation), use
+``warnings.warn`` with the right category and ``stacklevel=2``:
+
+::
+
+    import warnings
+
+    warnings.warn(
+        "PLS NIPALS hit max_iter without converging; results may "
+        "be unstable. Pass max_iter=... to extend.",
+        category=RuntimeWarning,
+        stacklevel=2,
+    )
+
+Category guide:
+
+- ``RuntimeWarning`` - the result was returned but the user
+  should know it is approximate.
+- ``UserWarning`` - the caller's input was unusual but the
+  function adapted.
+- ``DeprecationWarning`` - the caller used a deprecated path
+  (see :doc:`deprecation_policy`).
+
+**Never** use ``print`` for diagnostics. ``print`` writes to
+``stdout``, which is the MCP server's protocol channel; a stray
+``print`` would corrupt the MCP framing.
+
+**Never** use bare ``warnings.warn("text")`` without a category;
+the default category is ``UserWarning`` and callers cannot
+filter the warning by class.
+
+Logging vs. warning
+-------------------
+
+Use ``logger.debug`` / ``logger.info`` to describe what an
+algorithm is doing (convergence iteration count, intermediate
+shapes). Use ``warnings.warn`` to tell the user something they
+should act on. Logging is for the developer; warnings are for
+the user.
+
+Every module that does real work should declare a module-level
+logger (`ENG-12 <https://github.com/kgdunn/process-improve/issues/294>`_
+covers the rollout)::
+
+    import logging
+    logger = logging.getLogger(__name__)
+
+How to verify
+-------------
+
+Mechanical checks contributors should run locally before
+submitting a PR:
+
+- Tests pass under ``python -O -m pytest`` (catches stripped
+  ``assert``-as-validation).
+- ``ruff check .`` is clean (the codebase's existing rules
+  cover the bare-``except`` and ``print`` cases).
+- New code references one of the patterns above in its
+  docstring or commit message.
+
+Cross-references
+----------------
+
+- :doc:`reproducibility` -- contract for RNG seeding.
+- :doc:`deprecation_policy` -- how to phase out a function safely.
+- `SEC-08 <https://github.com/kgdunn/process-improve/pull/243>`_,
+  `SEC-09 <https://github.com/kgdunn/process-improve/pull/244>`_,
+  `SEC-17 <https://github.com/kgdunn/process-improve/issues/266>`_,
+  `SEC-18 <https://github.com/kgdunn/process-improve/issues/267>`_ --
+  the issues this guide retrospectively documents.

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -1,0 +1,13 @@
+Development
+===========
+
+Process and policy documentation for contributors. The CONTRIBUTING
+guide in the repository root is the starting point; the documents
+below are the deeper policy references it links to.
+
+.. toctree::
+   :maxdepth: 1
+
+   error_handling
+   reproducibility
+   deprecation_policy

--- a/docs/development/reproducibility.rst
+++ b/docs/development/reproducibility.rst
@@ -1,0 +1,186 @@
+Reproducibility Contract (RNG Handling)
+=======================================
+
+.. note::
+
+   This document is the canonical policy for randomness in
+   ``process-improve``. Tracks
+   `ENG-08 <https://github.com/kgdunn/process-improve/issues/290>`_.
+
+Why one contract?
+-----------------
+
+Reproducibility of a fitted model, a bootstrap interval, or an
+optimisation result is part of the package's value proposition. A
+chemometrics or DoE user comparing two runs across a software
+upgrade has to be able to distinguish "the algorithm changed" from
+"the random seed changed". Today the codebase mixes:
+
+- unseeded ``np.random.default_rng()`` calls inside production
+  algorithms,
+- hard-coded literal seeds (``np.random.default_rng(42)``,
+  ``seed=0``) inside production algorithms,
+- well-seeded paths that thread ``random_state`` through correctly,
+- ``@tool_spec(rng={...})`` metadata that *describes* the contract
+  but enforces nothing.
+
+The result is that "this run is reproducible" is currently a vibe,
+not a guarantee. This document pins the guarantee.
+
+The contract
+------------
+
+1. **Every public function that touches an RNG MUST accept a
+   ``random_state`` parameter.** The accepted types are
+   ``int | numpy.random.Generator | None`` (matching the
+   convention used by scikit-learn since 1.4).
+
+   ::
+
+       def bootstrap(
+           self,
+           X: pd.DataFrame,
+           *,
+           n_boot: int = 1000,
+           random_state: int | np.random.Generator | None = None,
+       ) -> ...:
+
+2. **Resolve ``random_state`` once at function entry** using the
+   helper ``process_improve.tool_spec.check_random_state`` (to be
+   added; sklearn's ``check_random_state`` is the reference
+   semantics):
+
+   - ``None`` -> a fresh, unseeded ``np.random.default_rng()``.
+   - ``int`` -> ``np.random.default_rng(int)``.
+   - ``Generator`` -> returned as-is.
+
+   Use the resolved ``Generator`` for all draws inside the
+   function; never call ``np.random.*`` directly.
+
+3. **Hard-coded literal seeds in production code are forbidden.**
+   If a function currently does
+
+   ::
+
+       rng = np.random.default_rng(42)  # don't
+
+   the ``42`` must move to the public signature as the default,
+   and the function must use ``check_random_state`` to resolve it:
+
+   ::
+
+       def find_optimum(
+           ...,
+           *,
+           random_state: int | np.random.Generator | None = None,
+       ):
+           rng = check_random_state(random_state)
+
+4. **Unseeded ``default_rng()`` is forbidden except where
+   "fresh noise on every call" is the documented contract.**
+   The only such case currently is
+   ``simulation.model.simulate``'s noise term, which is part of
+   the simulator's documented behaviour and is gated behind an
+   explicit ``# Fresh noise: documented behaviour, not an
+   accident`` comment.
+
+5. **Every ``@tool_spec`` that touches an RNG MUST declare its
+   contract via the ``rng=`` metadata**:
+
+   ::
+
+       @tool_spec(
+           name="bootstrap_pca",
+           ...,
+           rng={
+               "uses_rng": True,
+               "seed_param": "random_state",
+               "default_seed": 0,
+           },
+       )
+
+   The ``seed_param`` field is the name of the kwarg the
+   reproducibility-check harness will exercise. Deterministic
+   tools declare ``{"uses_rng": False}``.
+
+6. **A self-test harness enforces (5).** A test in
+   ``tests/test_rng_contract.py`` will import every registered
+   tool, run it twice with the declared ``default_seed``, and
+   assert byte-equal outputs. The same test verifies that a
+   tool declaring ``{"uses_rng": False}`` produces byte-equal
+   outputs without any seeding.
+
+How to migrate an existing function
+-----------------------------------
+
+Most production paths are one mechanical edit:
+
+Before:
+
+::
+
+    def my_thing(...):
+        rng = np.random.default_rng()        # or np.random.default_rng(42)
+        ...
+
+After:
+
+::
+
+    def my_thing(
+        ...,
+        *,
+        random_state: int | np.random.Generator | None = None,
+    ):
+        rng = check_random_state(random_state)
+        ...
+
+The behaviour for callers that did not pass ``random_state`` is
+preserved (``None`` falls through to an unseeded ``default_rng``).
+
+For an algorithm whose documented public behaviour was "always
+seeded with 42", set ``default_seed=42`` in the
+``@tool_spec(rng=...)`` metadata and accept ``random_state=None``
+as a synonym; this preserves byte-equivalence for existing
+callers.
+
+What is *not* covered
+---------------------
+
+- The unseeded noise in ``simulation.model.simulate`` is
+  deliberately *not* reproducible; that is the simulator's
+  contract.
+- The hard-coded plot seeds in ``surfaces.py`` /
+  ``design_quality.py`` (seed for plot-only jitter) are
+  in-scope for the migration but are low priority -- a plot
+  with shifted-by-one jitter is not a correctness failure.
+- Numerical reproducibility across NumPy major versions is
+  out of scope (NumPy ships RNG algorithm changes on a
+  documented schedule).
+
+Open work
+---------
+
+Aspects of the contract that are not yet implemented:
+
+- The ``check_random_state`` helper does not yet exist; it
+  will land in the first PR that migrates a production
+  callsite.
+- The ``tests/test_rng_contract.py`` harness will land
+  alongside that helper.
+- Migration of the existing offenders is tracked in
+  `SEC-21 sub-item 9 <https://github.com/kgdunn/process-improve/issues/270>`_
+  (Resampler), the relevant SEC-33 sub-item
+  `(#282) <https://github.com/kgdunn/process-improve/issues/282>`_
+  (``optimization.py:564``), and
+  `ENG-08 (#290) <https://github.com/kgdunn/process-improve/issues/290>`_
+  itself for the remaining call sites.
+
+Cross-references
+----------------
+
+- :doc:`error_handling` -- warnings vs. errors policy.
+- :doc:`deprecation_policy` -- migrating existing callers.
+- scikit-learn's
+  `random-state convention <https://scikit-learn.org/stable/glossary.html#term-random_state>`_
+  is the reference semantics for ``check_random_state``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,3 +24,9 @@ monitoring. Companion to the online textbook
    :caption: Case studies
 
    user_guide/case_studies/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Development
+
+   development/index


### PR DESCRIPTION
## Summary

Wave 1 from the engineering audit (PR #262 originally proposed this
plan). Four policy documents that gate downstream refactors. Each
commit on this branch addresses one issue. All four are docs-only;
no code or behaviour changes.

## Commits

- [x] **ENG-11** (#293) -- `docs/development/error_handling.rst`:
      decision tree for `ValueError` vs `assert` vs `RuntimeError` vs
      `ToolSafetyError` vs `warnings.warn`, with do/don't examples.
- [x] **ENG-08** (#290) -- `docs/development/reproducibility.rst`:
      every public function that touches an RNG must accept
      `random_state: int | Generator | None`; hard-coded literal
      seeds move to public signatures; a self-test harness will
      enforce the existing `@tool_spec(rng={})` metadata.
- [x] **ENG-22** (#304) -- `docs/development/deprecation_policy.rst`:
      one MINOR cycle of `DeprecationWarning`, removal at the next
      MAJOR; required message format; planned
      `tools/check_deprecations.py` CI script.
- [x] **ENG-28** (#310) -- `CONTRIBUTING.md` sections for versioning
      policy, what counts as a breaking change, and the
      performance-regression policy. Plus `docs/development/index.rst`
      toctree and a link from CONTRIBUTING.md to each policy doc.

## Layout

- `docs/development/error_handling.rst` -- ENG-11.
- `docs/development/reproducibility.rst` -- ENG-08.
- `docs/development/deprecation_policy.rst` -- ENG-22.
- `docs/development/index.rst` -- new toctree.
- `docs/index.rst` -- adds `development/index` to the top-level toctree.
- `CONTRIBUTING.md` -- new sections + links.

## Why one PR with four micro-commits

Each policy doc cross-references the others (the error-handling guide
defines the `DeprecationWarning` category that the deprecation policy
uses, etc.). Landing them together avoids broken-link windows on the
docs site. Each commit is independently revertable if any individual
policy needs more discussion.

## Why no version bump or CHANGELOG entry

These are internal contributor-facing policies. They do not change
the installed library's behaviour or public API. Per `CLAUDE.md`'s
rule ("auto-bump the version with every PR that changes code or
configuration"), docs-only PRs are out of scope.

If you'd rather record this PR in the CHANGELOG anyway, the natural
entry is under `## [Unreleased]` -> `Documentation`: "Add Wave 1
contributor policies for error handling, reproducibility,
deprecation, and versioning".

## Test plan

- [x] Doc-only; existing tests run unchanged.
- [ ] Sphinx build succeeds with the new `development/` toctree
      entry (will verify locally; CI does not currently build docs
      on PR).
- [ ] Each policy doc renders correctly (links, code blocks, RST
      directives).

## CI status

Lint and the in-progress test matrix are green. The recurring
`test (3.13t, ubuntu-latest, true)` failure is the experimental
free-threaded Python 3.13t build, marked `continue-on-error: true`
in `.github/workflows/run-tests.yml` because `llvmlite` has no
free-threaded wheels yet -- not actionable.

## Closes
#293, #290, #304, #310

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho9oSSxJUXTkqwVzPUzzFW)_