### PR TITLE
feat(ENG-08): add process_improve._random.check_random_state helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.14] - 2026-06-01
+
+### Added
+
+- New helper `process_improve._random.check_random_state` resolves
+  `int | numpy.random.Generator | None` into a `numpy.random.Generator`,
+  matching the reproducibility contract documented in
+  `docs/development/reproducibility.rst` (ENG-08). Pre-requisite for the
+  Wave 3 RNG sweeps (SEC-21 sub-item 9, SEC-33 sub-item).
+
 ## [1.22.13] - 2026-06-01
 
 ### Fixed
@@ -292,7 +302,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.13...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.14...HEAD
+[1.22.14]: https://github.com/kgdunn/process-improve/compare/v1.22.13...v1.22.14
 [1.22.13]: https://github.com/kgdunn/process-improve/compare/v1.22.12...v1.22.13
 [1.22.12]: https://github.com/kgdunn/process-improve/compare/v1.22.11...v1.22.12
 [1.22.11]: https://github.com/kgdunn/process-improve/compare/v1.22.10...v1.22.11

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.13
+version: 1.22.14
 date-released: "2026-06-01"
 keywords:
   - chemometrics

--- a/docs/development/reproducibility.rst
+++ b/docs/development/reproducibility.rst
@@ -46,9 +46,9 @@ The contract
        ) -> ...:
 
 2. **Resolve ``random_state`` once at function entry** using the
-   helper ``process_improve.tool_spec.check_random_state`` (to be
-   added; sklearn's ``check_random_state`` is the reference
-   semantics):
+   helper :func:`process_improve._random.check_random_state`. Its
+   resolution rules match sklearn's ``check_random_state`` but it
+   returns a modern :class:`numpy.random.Generator`:
 
    - ``None`` -> a fresh, unseeded ``np.random.default_rng()``.
    - ``int`` -> ``np.random.default_rng(int)``.
@@ -163,11 +163,10 @@ Open work
 
 Aspects of the contract that are not yet implemented:
 
-- The ``check_random_state`` helper does not yet exist; it
-  will land in the first PR that migrates a production
-  callsite.
-- The ``tests/test_rng_contract.py`` harness will land
-  alongside that helper.
+- The ``tests/test_rng_contract.py`` harness that exercises every
+  ``@tool_spec(rng={"uses_rng": True})`` against its declared
+  ``default_seed`` will land alongside the first sweep that
+  migrates production callsites.
 - Migration of the existing offenders is tracked in
   `SEC-21 sub-item 9 <https://github.com/kgdunn/process-improve/issues/270>`_
   (Resampler), the relevant SEC-33 sub-item

--- a/process_improve/_random.py
+++ b/process_improve/_random.py
@@ -1,0 +1,95 @@
+"""(c) Kevin Dunn, 2010-2026. MIT License.
+
+Shared ``random_state`` resolver used by every public function in the
+package that touches an RNG.
+
+The :doc:`reproducibility contract </development/reproducibility>` pins
+one rule: every public function accepts ``random_state: int |
+np.random.Generator | None`` and resolves it once at the top of the
+function via this helper. Callers that pass the same ``int`` twice get
+bit-identical draws; callers that pass a ``Generator`` get the
+generator they passed (so they own the state).
+
+Reference semantics: scikit-learn's
+:func:`sklearn.utils.check_random_state` since 1.4, but returning a
+modern ``numpy.random.Generator`` rather than the legacy
+``RandomState``.
+"""
+
+from __future__ import annotations
+
+import numbers
+
+import numpy as np
+
+
+def check_random_state(
+    random_state: int | np.random.Generator | None,
+) -> np.random.Generator:
+    """Resolve ``random_state`` into a :class:`numpy.random.Generator`.
+
+    Parameters
+    ----------
+    random_state : int, np.random.Generator, or None
+        - ``None`` -- a fresh, unseeded ``np.random.default_rng()``.
+        - ``int`` (including ``numpy`` integer scalars) --
+          ``np.random.default_rng(int(random_state))``. Callers passing
+          the same int twice get bit-identical draws.
+        - ``np.random.Generator`` -- returned as-is so the caller owns
+          and advances its own state.
+
+    Returns
+    -------
+    np.random.Generator
+        A generator suitable for any of NumPy's RNG methods.
+
+    Raises
+    ------
+    TypeError
+        If *random_state* is none of the three accepted forms. In
+        particular the legacy :class:`numpy.random.RandomState` is
+        rejected; pass ``int(rs.randint(0, 2**31))`` to migrate.
+
+    Examples
+    --------
+    Same int twice produces the same draws:
+
+    >>> rng1 = check_random_state(0)
+    >>> rng2 = check_random_state(0)
+    >>> float(rng1.random()) == float(rng2.random())
+    True
+
+    A passed generator is returned unchanged:
+
+    >>> g = np.random.default_rng(42)
+    >>> check_random_state(g) is g
+    True
+
+    ``None`` is the documented opt-out for callers that explicitly want
+    fresh entropy:
+
+    >>> rng = check_random_state(None)
+    >>> isinstance(rng, np.random.Generator)
+    True
+
+    Notes
+    -----
+    Booleans are rejected. Python treats ``True`` / ``False`` as
+    integer subclasses, but ``check_random_state(True)`` is almost
+    always a caller mistake (forgetting to pass an actual seed) and
+    silently seeding with ``1`` would hide the bug.
+
+    See Also
+    --------
+    Reproducibility contract: :doc:`/development/reproducibility`.
+    """
+    if random_state is None:
+        return np.random.default_rng()
+    if isinstance(random_state, np.random.Generator):
+        return random_state
+    if isinstance(random_state, numbers.Integral) and not isinstance(random_state, bool):
+        return np.random.default_rng(int(random_state))
+    raise TypeError(
+        f"random_state must be int | np.random.Generator | None, "
+        f"got {type(random_state).__name__}."
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.13"
+version = "1.22.14"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,0 +1,117 @@
+"""Tests for :func:`process_improve._random.check_random_state`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from process_improve._random import check_random_state
+
+
+class TestResolution:
+    """The three accepted forms each resolve as documented."""
+
+    def test_none_returns_a_generator(self):
+        rng = check_random_state(None)
+        assert isinstance(rng, np.random.Generator)
+
+    def test_int_returns_a_generator(self):
+        rng = check_random_state(0)
+        assert isinstance(rng, np.random.Generator)
+
+    def test_generator_is_returned_unchanged(self):
+        rng_in = np.random.default_rng(42)
+        rng_out = check_random_state(rng_in)
+        assert rng_out is rng_in
+
+
+class TestReproducibility:
+    """Same int twice must produce bit-identical draws."""
+
+    def test_same_int_reproducible(self):
+        rng1 = check_random_state(0)
+        rng2 = check_random_state(0)
+        assert float(rng1.random()) == float(rng2.random())
+
+    def test_different_ints_differ(self):
+        # With 53 bits of float precision, two independent draws colliding has
+        # probability ~2^-53. Safe to assert ``!=``.
+        rng1 = check_random_state(0)
+        rng2 = check_random_state(1)
+        assert float(rng1.random()) != float(rng2.random())
+
+    def test_int_run_advances_independently_from_caller_generator(self):
+        # Resolving an int should not perturb any external Generator.
+        external = np.random.default_rng(99)
+        before = float(external.random())
+        # A call that resolves an int and consumes from it.
+        _ = check_random_state(0).random()
+        after = float(external.random())
+        # The external generator must have advanced by exactly one step.
+        external2 = np.random.default_rng(99)
+        _ = external2.random()
+        assert float(external2.random()) == after
+        assert before != after
+
+    def test_numpy_int_accepted(self):
+        # NumPy integer scalars satisfy ``isinstance(_, numbers.Integral)``.
+        rng_np = check_random_state(np.int64(0))
+        rng_py = check_random_state(0)
+        assert float(rng_np.random()) == float(rng_py.random())
+
+
+class TestRejection:
+    """Misuse must raise a clear TypeError, not silently succeed."""
+
+    def test_bool_true_rejected(self):
+        with pytest.raises(TypeError, match="random_state must be"):
+            check_random_state(True)
+
+    def test_bool_false_rejected(self):
+        with pytest.raises(TypeError, match="random_state must be"):
+            check_random_state(False)
+
+    def test_legacy_randomstate_rejected(self):
+        # ``np.random.RandomState`` is the legacy API; migration message in
+        # the helper docstring points callers at ``int(rs.randint(0, 2**31))``.
+        legacy = np.random.RandomState(0)
+        with pytest.raises(TypeError, match="random_state must be"):
+            check_random_state(legacy)
+
+    def test_string_rejected(self):
+        with pytest.raises(TypeError, match="random_state must be"):
+            check_random_state("0")
+
+    def test_float_rejected(self):
+        with pytest.raises(TypeError, match="random_state must be"):
+            check_random_state(0.0)
+
+    def test_list_rejected(self):
+        with pytest.raises(TypeError, match="random_state must be"):
+            check_random_state([0, 1])
+
+
+class TestUnderDashO:
+    """Smoke check that the helper does not rely on ``assert``.
+
+    SEC-08 / SEC-17 / ENG-11 forbid ``assert`` for input validation
+    because ``python -O`` strips it. This test re-imports the module
+    after ensuring ``__debug__`` is consistent with the test runner and
+    confirms that misuse still raises.
+    """
+
+    def test_misuse_raises_even_when_asserts_would_be_stripped(self):
+        # We cannot toggle -O at runtime, but we can verify that the helper
+        # uses an explicit raise rather than an assert by inspecting the
+        # source. This is a regression guard for the ENG-11 rule.
+        import inspect
+
+        from process_improve import _random
+
+        source = inspect.getsource(_random.check_random_state)
+        assert "raise TypeError" in source
+        # The helper must not use an assert for input validation.
+        # (The only ``assert`` allowed in production code is one that
+        # documents an internal invariant -- there are none here.)
+        validation_block = source.split("raise TypeError")[0]
+        assert "assert " not in validation_block


### PR DESCRIPTION
## Summary

Small standalone PR landing the `check_random_state` helper required
by the ENG-08 reproducibility contract (PR #317, Wave 1). The Wave 1
docs *describe* the helper but didn't ship it; without it, the
Wave 3 RNG sweeps (SEC-21 #270 sub-item 9, SEC-33 #282 sub-item)
would each have to ship their own ad-hoc resolver.

## What lands

- `process_improve/_random.py` -- one function, ~20 lines:
  ```python
  def check_random_state(
      random_state: int | np.random.Generator | None,
  ) -> np.random.Generator:
      ...
  ```
  Mirrors `process_improve/_linalg.py` (small focused utility module
  for shared helpers).
- `tests/test_random.py` -- unit tests for the resolution rules and
  the rejection of legacy / wrong-type inputs.
- `docs/development/reproducibility.rst` -- update the path
  reference from `process_improve.tool_spec.check_random_state`
  (placeholder used in Wave 1) to `process_improve._random.check_random_state`.

## Versioning

PATCH bump from 1.22.13 to 1.22.14 per CLAUDE.md (new code +
configuration). `CITATION.cff` and `CHANGELOG.md` updated in the
same commit.

## Test plan

- [x] `pytest tests/test_random.py -v` passes locally.
- [ ] Full CI matrix green.
- [ ] Sphinx docs build clean (the doc edit is a single string
      replacement; no new directives).

## Closes

This PR does not close any issue by itself; it is a prerequisite
for ENG-08 (#290), SEC-21 sub-item 9 (#270), and SEC-33 (#282).
Those issues will close as their dedicated PRs land.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho9oSSxJUXTkqwVzPUzzFW)_