### PR TITLE
test(ENG-15): thin scaffolding for property / perf / fuzz / -O test tracks

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -97,3 +97,25 @@ jobs:
         files: ./coverage.xml
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
+
+  # ENG-15 sub-track: catch validation `assert`s stripped by `python -O`.
+  # SEC-08 already swept ~105 sites; SEC-17 (#266) tracks the remaining
+  # multivariate / bivariate / batch / experiments / monitoring asserts
+  # that are still subject to silent-skip under -O. Until SEC-17 lands,
+  # this job is allowed to fail without blocking the workflow; once SEC-17
+  # is in main, remove `continue-on-error` so a regression turns CI red.
+  test-under-dash-O:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v6
+    - name: Install uv and set the python version
+      uses: astral-sh/setup-uv@v7
+      with:
+        python-version: "3.13"
+    - name: Install the project (editable)
+      run: uv sync --dev --all-extras
+    - name: Test with pytest under python -O
+      # Strip the default --cov / --pdb / -n auto / --exitfirst options;
+      # for -O detection we want the full failure surface, not the first one.
+      run: uv run python -O -m pytest -o "addopts=" -v --tb=short

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.16] - 2026-06-01
+
+### Added
+
+- Thin scaffolding for the ENG-15 testing rigour push: new
+  `tests/properties/` (hypothesis property tests),
+  `tests/perf/` (pytest-benchmark baselines), and `tests/fuzz/`
+  (MCP boundary fuzz). Each directory ships one example test
+  against `process_improve._random.check_random_state` /
+  `robust_scale_sn` so the pattern is documented in code for
+  contributors who add coverage later.
+- New `test-under-dash-O` CI job runs the full suite with
+  `python -O`. Initially `continue-on-error: true` because
+  SEC-17 (#266) has not yet swept the remaining
+  assert-as-validation sites; the job flips to blocking once
+  SEC-17 lands.
+- `pytest-benchmark>=4.0.0` added to dev deps.
+
 ## [1.22.15] - 2026-06-01
 
 ### Added
@@ -315,7 +333,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.15...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.16...HEAD
+[1.22.16]: https://github.com/kgdunn/process-improve/compare/v1.22.15...v1.22.16
 [1.22.15]: https://github.com/kgdunn/process-improve/compare/v1.22.14...v1.22.15
 [1.22.14]: https://github.com/kgdunn/process-improve/compare/v1.22.13...v1.22.14
 [1.22.13]: https://github.com/kgdunn/process-improve/compare/v1.22.12...v1.22.13

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.15
+version: 1.22.16
 date-released: "2026-06-01"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.15"
+version = "1.22.16"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"
@@ -52,6 +52,7 @@ dev = [
     "plotly-stubs>=0.0.6",
     "pre-commit>=4.5.1",
     "pytest>=9.0.2",
+    "pytest-benchmark>=4.0.0",
     "pytest-cov>=7.0.0",
     "pytest-xdist>=3.8.0",
     "pydata-sphinx-theme>=0.16.1",
@@ -86,6 +87,7 @@ dev = [
     "plotly-stubs>=0.0.6",
     "pre-commit>=4.5.1",
     "pytest>=9.0.2",
+    "pytest-benchmark>=4.0.0",
     "pytest-cov>=7.0.0",
     "pytest-xdist>=3.8.0",
     "pydata-sphinx-theme>=0.16.1",

--- a/tests/fuzz/__init__.py
+++ b/tests/fuzz/__init__.py
@@ -1,0 +1,25 @@
+"""Fuzz tests for the MCP boundary.
+
+Hypothesis-driven smoke tests that throw schema-conforming random
+inputs at each registered tool and assert that no *uncaught*
+exception escapes -- only the structured ``ToolSafetyError`` family
+plus the tool's own documented exceptions.
+
+Why this matters: ``mcp_server._serialise_tool_error`` redacts
+unhandled exceptions, but a single ``except Exception: return
+{"error": str(e)}`` inside a per-tool wrapper (SEC-18 / #267)
+short-circuits that redaction. A fuzz pass that produces a stack
+trace inside a tool wrapper is an information-disclosure
+regression even if the tool's "happy path" still works.
+
+Scaffolding landed in ENG-15. The first example uses
+``robust_scale_sn`` -- the simplest registered tool (one
+parameter, list of numbers). A follow-up generalises this to walk
+the whole ``_TOOL_REGISTRY`` using a JSON-Schema -> hypothesis
+strategy converter (the hardest part is supporting ``oneOf`` and
+nested ``items``).
+
+Run locally with::
+
+    pytest tests/fuzz -o "addopts="
+"""

--- a/tests/fuzz/test_robust_scale_sn_fuzz.py
+++ b/tests/fuzz/test_robust_scale_sn_fuzz.py
@@ -1,0 +1,69 @@
+"""Fuzz the simplest MCP tool, as a template for the rest.
+
+``robust_scale_sn`` accepts a single parameter (``values: list of
+numbers``). We throw arbitrary float lists at it via the
+``execute_tool_call`` dispatch path (matching what the MCP server
+would do) and assert:
+
+1. The call returns a dict that JSON-serialises cleanly.
+2. Or it raises one of the documented exception types -- never an
+   uncaught ``Exception`` (which would carry library-internal
+   strings into the MCP response; see SEC-18 / #267).
+
+When generalising to every registered tool, walk
+``_TOOL_REGISTRY``, derive a hypothesis strategy from each tool's
+``input_schema``, and apply the same assertion.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from process_improve.tool_spec import execute_tool_call
+
+# The documented "expected" exception classes for a tool wrapper.
+# Anything outside this set means a wrapper either (a) leaks an
+# implementation exception or (b) raises something undocumented
+# -- both are bugs.
+_EXPECTED = (ValueError, TypeError, KeyError)
+
+
+_finite_floats = st.floats(allow_nan=False, allow_infinity=False, width=64)
+
+
+@given(values=st.lists(_finite_floats, min_size=0, max_size=200))
+@settings(
+    max_examples=50,
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+def test_robust_scale_sn_does_not_leak_unexpected_exceptions(values: list[float]) -> None:
+    """No matter what finite-float list we send, the dispatch path
+    returns either a JSON-serialisable result or a documented error.
+    """
+    try:
+        result = execute_tool_call("robust_scale_sn", {"values": values})
+    except _EXPECTED:
+        # Documented validation failure. Acceptable.
+        return
+    except pytest.fail.Exception:  # type: ignore[attr-defined]
+        # Defensive: hypothesis-internal failure should propagate.
+        raise
+    except Exception as exc:  # noqa: BLE001
+        pytest.fail(
+            f"robust_scale_sn raised an undocumented exception "
+            f"{type(exc).__name__}: {exc!r} on input length "
+            f"{len(values)}. This would leak through "
+            f"_serialise_tool_error and into an MCP response. "
+            f"Narrow the tool wrapper's except clause."
+        )
+
+    # Result must JSON-serialise (the MCP transport requires it).
+    assert isinstance(result, dict)
+    # `clean()` should already have stripped numpy types, so this
+    # round-trip is the strongest assertion we can cheaply make.
+    json.dumps(result)

--- a/tests/fuzz/test_robust_scale_sn_fuzz.py
+++ b/tests/fuzz/test_robust_scale_sn_fuzz.py
@@ -61,9 +61,11 @@ def test_robust_scale_sn_does_not_leak_unexpected_exceptions(values: list[float]
             f"_serialise_tool_error and into an MCP response. "
             f"Narrow the tool wrapper's except clause."
         )
-
-    # Result must JSON-serialise (the MCP transport requires it).
-    assert isinstance(result, dict)
-    # `clean()` should already have stripped numpy types, so this
-    # round-trip is the strongest assertion we can cheaply make.
-    json.dumps(result)
+    else:
+        # Reachable only when execute_tool_call returned cleanly; ``result``
+        # is guaranteed bound here. The ``else`` clause also keeps CodeQL
+        # from flagging it as potentially uninitialized.
+        assert isinstance(result, dict)
+        # ``clean()`` should already have stripped numpy types, so this
+        # round-trip is the strongest assertion we can cheaply make.
+        json.dumps(result)

--- a/tests/perf/__init__.py
+++ b/tests/perf/__init__.py
@@ -1,0 +1,20 @@
+"""Performance baselines using ``pytest-benchmark``.
+
+This directory hosts perf tests for hot paths so we notice silent
+regressions. The CI job that enforces a regression budget lands
+once we have at least two baselines and a stored reference run --
+trying to enforce a budget against a single just-introduced
+baseline would be meaningless.
+
+Scaffolding landed in ENG-15. Follow-up PRs add baselines for PCA
+fit, PLS fit/predict, ``analyze_experiment``, ``evaluate_design``,
+and batch alignment (the public-API "hot paths" called out in the
+performance-regression section of CONTRIBUTING.md).
+
+Run locally with::
+
+    pytest tests/perf -o "addopts=" --benchmark-only
+
+The default ``addopts`` in ``pytest.ini`` include ``-n auto`` which
+``pytest-benchmark`` does not support; the local run above strips it.
+"""

--- a/tests/perf/test_random_helper_perf.py
+++ b/tests/perf/test_random_helper_perf.py
@@ -1,0 +1,34 @@
+"""Perf baseline for :func:`process_improve._random.check_random_state`.
+
+First example of the ENG-15 pattern. Use as a template when adding
+baselines for PCA fit, PLS fit/predict, ``analyze_experiment``, and
+``evaluate_design`` in follow-up PRs:
+
+- One test per hot path.
+- Use the smallest representative input that exercises the
+  function; the baseline is about *change detection*, not real-world
+  workloads.
+- Name the test ``test_<function>_baseline`` so the regression-budget
+  CI job (planned follow-up) can identify them.
+- Mark anything that exceeds ~1 second per call as ``slow`` (see
+  CONTRIBUTING.md / ENG-29) so contributors can skip it locally.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from process_improve._random import check_random_state
+
+
+def test_check_random_state_int_baseline(benchmark) -> None:  # type: ignore[no-untyped-def]
+    """Resolving an ``int`` seed is the hot path inside any future
+    iterative algorithm; track regressions here.
+    """
+    benchmark(check_random_state, 42)
+
+
+def test_check_random_state_generator_passthrough_baseline(benchmark) -> None:  # type: ignore[no-untyped-def]
+    """Passing a pre-built ``Generator`` should be near-zero overhead."""
+    g = np.random.default_rng(42)
+    benchmark(check_random_state, g)

--- a/tests/properties/__init__.py
+++ b/tests/properties/__init__.py
@@ -1,0 +1,10 @@
+"""Property-based tests using `hypothesis`.
+
+This directory hosts property tests (round-trip invariants,
+permutation invariants, sign-flip equivalences) rather than the
+example-based tests in the top-level `tests/` directory.
+
+Scaffolding landed in ENG-15. Follow-up PRs broaden coverage to
+PCA / PLS / TPLS, the multivariate scalers, and the experiments
+formula API.
+"""

--- a/tests/properties/test_random_helper_properties.py
+++ b/tests/properties/test_random_helper_properties.py
@@ -1,0 +1,96 @@
+"""Property tests for :func:`process_improve._random.check_random_state`.
+
+First example of the ENG-15 property-test pattern. Use as a template
+when adding properties for PCA / PLS / scalers in follow-up PRs:
+
+- Pick a property that must hold for *all* legal inputs, not a
+  specific case.
+- Use ``hypothesis.strategies`` to generate the legal inputs.
+- Use ``np.testing.assert_array_equal`` / ``assert_allclose`` for
+  numerical equality, never raw ``==`` on floats.
+- Keep the test small (one property per function); hypothesis
+  shrinks failing inputs better when each function tests one thing.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from process_improve._random import check_random_state
+
+
+@given(seed=st.integers(min_value=0, max_value=2**31 - 1))
+@settings(max_examples=50)
+def test_int_seed_is_deterministic(seed: int) -> None:
+    """For any int seed, two calls draw bit-identical sequences.
+
+    This is the load-bearing property of the helper: the entire
+    reproducibility contract (`docs/development/reproducibility.rst`)
+    rests on it.
+    """
+    draws_1 = check_random_state(seed).random(10)
+    draws_2 = check_random_state(seed).random(10)
+    np.testing.assert_array_equal(draws_1, draws_2)
+
+
+@given(seed=st.integers(min_value=0, max_value=2**31 - 1))
+@settings(max_examples=50)
+def test_int_input_returns_a_generator(seed: int) -> None:
+    """Whatever ``int`` we feed in, we get a ``Generator`` back."""
+    rng = check_random_state(seed)
+    assert isinstance(rng, np.random.Generator)
+
+
+@given(seed=st.integers(min_value=0, max_value=2**31 - 1))
+@settings(max_examples=50)
+def test_generator_input_is_returned_unchanged(seed: int) -> None:
+    """A passed ``Generator`` is the *same* object on the way out.
+
+    This is how the contract preserves caller-owned state: the
+    caller's generator advances in place, so a subsequent call by
+    the caller sees the advance.
+    """
+    g_in = np.random.default_rng(seed)
+    g_out = check_random_state(g_in)
+    assert g_out is g_in
+
+
+@given(
+    seed=st.integers(min_value=0, max_value=2**31 - 1),
+    n_draws=st.integers(min_value=1, max_value=100),
+)
+@settings(max_examples=30)
+def test_int_seed_advances_a_freshly_built_generator(seed: int, n_draws: int) -> None:
+    """The ``Generator`` returned for an ``int`` seed behaves like a
+    fresh ``default_rng(seed)``: same byte stream, same advance.
+
+    This pins the "int -> default_rng(int)" rule against any future
+    refactor that might add a transformation in between.
+    """
+    helper = check_random_state(seed).random(n_draws)
+    reference = np.random.default_rng(seed).random(n_draws)
+    np.testing.assert_array_equal(helper, reference)
+
+
+@given(
+    bad=st.one_of(
+        st.text(),
+        st.floats(),
+        st.lists(st.integers()),
+        st.dictionaries(keys=st.text(), values=st.integers()),
+        st.booleans(),  # bool is excluded per docstring
+    )
+)
+@settings(max_examples=50)
+def test_unsupported_types_are_rejected(bad: object) -> None:
+    """Anything outside ``int | Generator | None`` must raise ``TypeError``.
+
+    No silent fall-through to "use it anyway" or "convert it
+    somehow"; the rejection is the contract.
+    """
+    import pytest
+
+    with pytest.raises(TypeError, match="random_state must be"):
+        check_random_state(bad)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Wave 2 sub-track 1 (testing), thin scaffolding for ENG-15 (#297).
The audit lists four sub-deliverables (property tests, ``python -O``
CI, perf baselines, MCP fuzz); per the agreed plan this PR lands a
minimal example of each so the patterns are demonstrated and the CI
plumbing exists, then follow-up PRs expand each track as we touch
relevant modules.

## What lands

1. **`tests/properties/`** -- one hypothesis-driven property test
   for `process_improve._random.check_random_state`, demonstrating
   the pattern for round-trip / invariant tests. The helper is the
   right first target: small, pure, and freshly written.
2. **`tests/perf/`** -- one `pytest-benchmark` baseline for the same
   helper. Adds `pytest-benchmark` to dev deps. The perf-regression
   CI job (>25% fail) lands as a follow-up once we have at least
   two baselines and a stored reference run.
3. **`tests/fuzz/`** -- one hypothesis-driven smoke fuzz for a
   single MCP tool, demonstrating the "JSON-Schema -> hypothesis
   strategy" pattern. Generalising to walk the whole
   `_TOOL_REGISTRY` is a follow-up.
4. **CI workflow** -- new `test-under-dash-O` job that runs
   `python -O -m pytest`. Initially `continue-on-error: true`
   because SEC-17 (#266) has not yet swept the remaining
   assert-as-validation sites. The job is visible on PRs so the
   `to-do` list is in front of reviewers; once SEC-17 lands the
   job flips to blocking.

## Out of scope (deliberate)

- No general "fuzz every registered tool" harness; that grows as a
  follow-up.
- No regression-budget enforcement on perf yet (need a stored
  baseline; trying to set one in the same PR that introduces
  `pytest-benchmark` is too eager).
- No MCP-fuzz CI job; the fuzz tests run as part of the regular
  pytest invocation for now.

## Versioning

PATCH bump 1.22.15 -> 1.22.16. New tests are dev-only; CHANGELOG
entry under "Added" because contributors will notice the new dirs
and CI job.

## Test plan

- [x] `pytest tests/properties tests/perf tests/fuzz -o "addopts="` passes locally.
- [x] `python -O -m pytest tests/test_multivariate.py -x` reproduces
      the expected SEC-17 failure (assert-validation in PCA).
- [ ] Full CI matrix green.
- [ ] The new `test-under-dash-O` CI job runs and is visible on
      the PR page (allowed to fail until SEC-17 lands).

## Closes
Partial closure of #297. The follow-ups are: generalise the MCP
fuzz harness, add the perf-regression-budget CI job, broaden
property coverage to PCA / PLS / TPLS round-trips.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho9oSSxJUXTkqwVzPUzzFW)_