### PR TITLE
ci(ENG-20): run mypy in CI (non-blocking; exposes existing type debt)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,6 +36,27 @@ jobs:
     - name: Lint with ruff
       run: uv run ruff check .
 
+  # ENG-20 sub-track: surface type errors on every PR.
+  # The codebase currently has ~333 mypy errors (with the existing
+  # permissive config: `disallow_untyped_defs = false`, plus
+  # `ignore_missing_imports` and `import-untyped` disabled). The job is
+  # `continue-on-error: true` so it does not block merges while a staged
+  # cleanup catches up; once the count reaches zero (per subpackage --
+  # follow-up to ENG-03 #285), flip this flag to `false`.
+  typecheck:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v6
+    - name: Install uv and set the python version
+      uses: astral-sh/setup-uv@v7
+      with:
+        python-version: "3.13"
+    - name: Install the project (editable)
+      run: uv sync --dev --all-extras
+    - name: Type-check with mypy
+      run: uv run mypy process_improve
+
   test:
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.17] - 2026-06-01
+
+### Added
+
+- New `typecheck` CI job runs `mypy process_improve` on every PR
+  (ENG-20). Initially `continue-on-error: true` because the codebase
+  currently surfaces ~333 mypy errors with the existing permissive
+  config (`disallow_untyped_defs = false`); the job will flip to
+  blocking once a staged ENG-03 (#285) follow-up has paid the debt
+  down. `notebooks_examples/` is excluded from the type-check (the
+  scripts are not production code).
+
 ## [1.22.16] - 2026-06-01
 
 ### Added
@@ -333,7 +345,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.16...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.17...HEAD
+[1.22.17]: https://github.com/kgdunn/process-improve/compare/v1.22.16...v1.22.17
 [1.22.16]: https://github.com/kgdunn/process-improve/compare/v1.22.15...v1.22.16
 [1.22.15]: https://github.com/kgdunn/process-improve/compare/v1.22.14...v1.22.15
 [1.22.14]: https://github.com/kgdunn/process-improve/compare/v1.22.13...v1.22.14

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.16
+version: 1.22.17
 date-released: "2026-06-01"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.16"
+version = "1.22.17"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"
@@ -117,6 +117,13 @@ disallow_untyped_defs = false
 warn_unused_ignores = false
 # Specifically disable import-untyped errors
 disable_error_code = ["import-untyped"]
+# Example scripts under notebooks_examples/ are not production code and
+# are already exempted from many strict ruff rules; they pull in
+# notebook-flavoured patterns (untyped locals, dynamic axis manipulation)
+# that are noise under type checking.
+exclude = [
+    "process_improve/notebooks_examples/",
+]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
## Summary

Wave 2 sub-track 2, part 1: add mypy to CI in non-blocking mode so the
existing type debt becomes visible on every PR. The existing config in
`[tool.mypy]` is preserved exactly (no `disallow_untyped_defs` flip;
that is **ENG-03**, deferred per the audit reality check in the PR
discussion).

## What lands

- `.github/workflows/run-tests.yml` -- new `typecheck` job, runs
  `uv run mypy process_improve`. Marked `continue-on-error: true`
  because the codebase currently has 347 mypy errors that were
  silent until this job was added; the job will report them on
  every PR so contributors see them, but it will not block the
  workflow until a staged cleanup catches up.
- `pyproject.toml [tool.mypy]` -- one change: exclude
  `process_improve/notebooks_examples/` from mypy. The folder
  contains example scripts (not production code) and is already
  exempted from many of the strict ruff rules. Excluding it removes
  14 errors that are not worth chasing.

## Out of scope (deliberate)

- **No `disallow_untyped_defs = true` flip.** That is ENG-03 (#285);
  it lands as its own PR after a staged subpackage rollout chips the
  existing 347-error pile down to zero. A follow-up issue captures
  the rollout plan.
- **No production fixes.** This PR only exposes the debt; it does
  not pay it down.
- **No mypy-strict-mode flags.** The existing
  `ignore_missing_imports = true` and `disable_error_code =
  ["import-untyped"]` are preserved as-is.

## Versioning

PATCH bump 1.22.16 -> 1.22.17. CI config + mypy exclude are
contributor-facing surface; CHANGELOG entry under "Added".

## Test plan

- [x] `uv run mypy process_improve` reports the same 347 errors
      locally as it did before the exclude change took effect
      (the 14 `notebooks_examples` errors disappear, leaving 333).
- [ ] The new `typecheck` CI job is visible on the PR page and is
      marked as a non-blocking failure.

## Follow-up

A separate "type-debt reduction" issue will track the staged
ENG-03 rollout (clean subpackages first: regression, simulation,
visualization, bivariate; defer the big three: multivariate,
experiments, batch).

## Closes
Partial closure of #302; follow-up issue + ENG-03 (#285).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho9oSSxJUXTkqwVzPUzzFW)_