### PR TITLE
fix(SEC-17): convert validation asserts to explicit raises

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -120,14 +120,11 @@ jobs:
         fail_ci_if_error: false
 
   # ENG-15 sub-track: catch validation `assert`s stripped by `python -O`.
-  # SEC-08 already swept ~105 sites; SEC-17 (#266) tracks the remaining
-  # multivariate / bivariate / batch / experiments / monitoring asserts
-  # that are still subject to silent-skip under -O. Until SEC-17 lands,
-  # this job is allowed to fail without blocking the workflow; once SEC-17
-  # is in main, remove `continue-on-error` so a regression turns CI red.
+  # SEC-08 swept ~105 sites; SEC-17 (#266) swept the multivariate / bivariate /
+  # batch / experiments / monitoring sites that survived. This job now runs as
+  # a blocking check so a regression turns CI red.
   test-under-dash-O:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
     - uses: actions/checkout@v6
     - name: Install uv and set the python version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,44 @@ those changes.
 
 ## [Unreleased]
 
+## [1.22.18] - 2026-06-01
+
+### Security
+
+- Complete the SEC-17 sweep: every remaining validation `assert` in
+  `multivariate/methods.py`, `multivariate/plots.py`,
+  `bivariate/methods.py`, `univariate/tools.py`,
+  `experiments/structures.py`, `batch/features.py`,
+  `batch/plotting.py`, `batch/preprocessing.py`, and
+  `monitoring/metrics.py` is now an explicit
+  `if not X: raise ValueError(...)` (or `TypeError` / `KeyError` /
+  `NotImplementedError` per the [error-handling style guide](docs/development/error_handling.rst)).
+  Under `python -O` these checks no longer disappear (SEC-17 #266).
+- The `test-under-dash-O` CI job is now a blocking check (was
+  `continue-on-error: true` in v1.22.16; flipped in this release).
+  A future regression that re-introduces a validation `assert`
+  turns CI red.
+
+### Changed
+
+- `PCA.t2_plot` and `PCA.spe_plot` now raise `ValueError` (rather
+  than `AssertionError`) for `with_a == 0` or `with_a >
+  n_components`. Tests updated.
+- `PCA.fit` raises `ValueError` (rather than `AssertionError`) on
+  invalid `missing_data_settings["md_tol"]`. Tests updated.
+- `process_improve.batch.features._make_phase_features` raises
+  `NotImplementedError` when multiple columns are passed, replacing
+  a silent `assert len(columns) == 1`.
+
+### Internal
+
+- Post-preprocessing invariants in `TPLS._learn_center_and_scaling_parameters`
+  (cross-checks on the centered/scaled `z_mats`, `f_mats`, `d_mats`,
+  `y_mats`) remain as `assert`s with explanatory inline comments,
+  per the error-handling guide's "internal invariant" carve-out.
+- Endpoint invariants in `batch.preprocessing` (`new_time_axis.min()
+  == sequence.min()`) likewise remain.
+
 ## [1.22.17] - 2026-06-01
 
 ### Added
@@ -345,7 +383,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.17...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.22.18...HEAD
+[1.22.18]: https://github.com/kgdunn/process-improve/compare/v1.22.17...v1.22.18
 [1.22.17]: https://github.com/kgdunn/process-improve/compare/v1.22.16...v1.22.17
 [1.22.16]: https://github.com/kgdunn/process-improve/compare/v1.22.15...v1.22.16
 [1.22.15]: https://github.com/kgdunn/process-improve/compare/v1.22.14...v1.22.15

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.22.17
+version: 1.22.18
 date-released: "2026-06-01"
 keywords:
   - chemometrics

--- a/process_improve/batch/features.py
+++ b/process_improve/batch/features.py
@@ -64,7 +64,11 @@ def _prepare_data(  # noqa: C901, PLR0912
         tags = [tags]
 
     # Check that all these columns actually exist in the df
-    assert all(column_name in list(df) for column_name in tags)
+    missing_tags = [column_name for column_name in tags if column_name not in df.columns]
+    if missing_tags:
+        raise KeyError(
+            f"Tag(s) not found in the dataframe columns: {missing_tags}."
+        )
 
     # First make a copy! else, it will repeatedly add these. Ensure it is
     # a unique list too.
@@ -322,7 +326,10 @@ def f_rupture(
     within each unique phase, per batch, of the ``phase_col`` column.
     """
     # Handle phase detection based on 1 column for now.
-    assert len(columns) == 1
+    if len(columns) != 1:
+        raise NotImplementedError(
+            f"Phase detection currently supports a single column only; got {len(columns)}."
+        )
 
     # TODO: see https://github.com/deepcharles/ruptures
 
@@ -596,8 +603,10 @@ def f_crossing(  # noqa: PLR0913
     """
     base_name = f"cross-{int(threshold)}" if suffix is None else str(suffix)
 
-    assert isinstance(tag, str)
-    assert tag in data, f"Desired tag ['{tag}'] not found in the dataframe."
+    if not isinstance(tag, str):
+        raise TypeError(f"tag must be a string; got {type(tag).__name__}.")
+    if tag not in data:
+        raise KeyError(f"Desired tag ['{tag}'] not found in the dataframe.")
 
     prepared, _tags, output, _ = _prepare_data(
         data,

--- a/process_improve/batch/plotting.py
+++ b/process_improve/batch/plotting.py
@@ -26,7 +26,10 @@ def get_rgba_from_triplet(incolour: list, alpha: float = 1, as_string: bool = Fa
 
     E.g.    [0.9677975592919913, 0.44127456009157356, 0.5358103155058701] -> 'rgba(246,112,136,1)'
     """
-    assert 3 <= len(incolour) <= 4, "`incolour` must be a list of 3 or 4 values; ignores 4th entry"
+    if not 3 <= len(incolour) <= 4:
+        raise ValueError(
+            f"`incolour` must be a list of 3 or 4 values; got {len(incolour)} entries."
+        )
     colours = [max(0, math.floor(c * 255)) for c in list(incolour)[0:3]]
     if as_string:
         return f"rgba({colours[0]},{colours[1]},{colours[2]},{float(alpha)})"
@@ -138,9 +141,10 @@ def plot_all_batches_per_tag(  # noqa: PLR0912, PLR0913
     fig = go.Figure()
 
     for batch_id, batch_df in df_dict.items():
-        assert tag in batch_df.columns, f"Tag '{tag}' not found in the batch with id {batch_id}."
-        if tag_y2:
-            assert tag_y2 in batch_df.columns, f"Tag '{tag}' not found in the batch with id {batch_id}."
+        if tag not in batch_df.columns:
+            raise KeyError(f"Tag '{tag}' not found in the batch with id {batch_id}.")
+        if tag_y2 and tag_y2 not in batch_df.columns:
+            raise KeyError(f"Tag '{tag_y2}' not found in the batch with id {batch_id}.")
         time_data = batch_df[time_column] if time_column in batch_df.columns else list(range(batch_df.shape[0]))
 
         if batch_id in highlight_list:
@@ -405,7 +409,11 @@ def plot_multitags(  # noqa: PLR0912, PLR0913, PLR0915
         tag_list.remove(time_column)
 
     # Check that the tag_list is present in all batches.
-    assert check_valid_batch_dict({k: v[tag_list] for k, v in df_dict.items() if k in batch_list}, no_nan=False)
+    if not check_valid_batch_dict(
+        {k: v[tag_list] for k, v in df_dict.items() if k in batch_list},
+        no_nan=False,
+    ):
+        raise ValueError("One or more batches in df_dict failed validation.")
 
     if settings["ncols"] == 0:
         settings["ncols"] = int(np.ceil(len(tag_list) / int(settings["nrows"])))

--- a/process_improve/batch/preprocessing.py
+++ b/process_improve/batch/preprocessing.py
@@ -184,7 +184,11 @@ def dtw_core(test: pd.DataFrame, ref: pd.DataFrame, weight_matrix: np.ndarray) -
     show_plot = False
     nt = test.shape[0]  # 'test' data; will be align to the 'reference' data
     nr = ref.shape[0]
-    assert test.shape[1] == ref.shape[1]
+    if test.shape[1] != ref.shape[1]:
+        raise ValueError(
+            f"test and ref must have the same number of columns; "
+            f"got test.shape[1]={test.shape[1]}, ref.shape[1]={ref.shape[1]}."
+        )
 
     D = distance_matrix(test.values, ref.values, weight_matrix)
     md_path, distance = backtrack_optimal_path(D)
@@ -264,7 +268,7 @@ def one_iteration_dtw(
     return aligned_batches, average_batch
 
 
-def batch_dtw(  # noqa: PLR0915
+def batch_dtw(  # noqa: C901, PLR0915
     batches: dict[str, pd.DataFrame],
     columns_to_align: list,
     reference_batch: str,
@@ -328,10 +332,20 @@ def batch_dtw(  # noqa: PLR0915
     if settings:
         default_settings.update(settings)
     settings = default_settings
-    assert settings["maximum_iterations"] >= 3, "At least 3 iterations are required"
-    assert reference_batch in batches, "`reference_batch` was not found in the dict of batches."
+    if settings["maximum_iterations"] < 3:
+        raise ValueError(
+            f"At least 3 iterations are required; got maximum_iterations={settings['maximum_iterations']}."
+        )
+    if reference_batch not in batches:
+        raise KeyError(
+            f"`reference_batch` was not found in the dict of batches; got {reference_batch!r}."
+        )
 
-    assert check_valid_batch_dict({k: v[columns_to_align] for k, v in batches.items()}, no_nan=True)
+    if not check_valid_batch_dict(
+        {k: v[columns_to_align] for k, v in batches.items()},
+        no_nan=True,
+    ):
+        raise ValueError("One or more batches in the input dict failed validation.")
 
     scale_df = determine_scaling(batches=batches, columns_to_align=columns_to_align, settings=settings)
     batches_scaled = apply_scaling(batches, scale_df, columns_to_align)
@@ -407,8 +421,9 @@ def batch_dtw(  # noqa: PLR0915
             settings["interpolate_time_axis_maximum"] - settings["interpolate_time_axis_delta"],
             synced.shape[0],
         )
-        assert new_time_axis.min() == sequence.min()
-        assert new_time_axis.max() == sequence.max()
+        # Internal invariants on the just-built axes; not user input.
+        assert new_time_axis.min() == sequence.min()  # post-construction invariant
+        assert new_time_axis.max() == sequence.max()  # post-construction invariant
 
         synced_interpolated = pd.DataFrame()
         for column in synced:
@@ -590,9 +605,14 @@ def find_reference_batch(
         default_settings.update(settings)
     settings = default_settings
 
-    assert isinstance(columns_to_align, list), "`columns_to_align` must be a list of column names."
+    if not isinstance(columns_to_align, list):
+        raise TypeError(
+            f"`columns_to_align` must be a list of column names; "
+            f"got {type(columns_to_align).__name__}."
+        )
 
-    assert check_valid_batch_dict({k: v[columns_to_align] for k, v in batches.items()})
+    if not check_valid_batch_dict({k: v[columns_to_align] for k, v in batches.items()}):
+        raise ValueError("One or more batches in the input dict failed validation.")
 
     # Starts with the average duration batch.
     initial_reference_id = find_average_length(batches, settings)

--- a/process_improve/bivariate/methods.py
+++ b/process_improve/bivariate/methods.py
@@ -11,7 +11,7 @@ import numpy as np
 from ..regression.methods import fit_robust_lm
 
 
-def find_elbow_point(x: np.ndarray, y: np.ndarray, max_iter: int = 41) -> int | float:  # noqa: PLR0915
+def find_elbow_point(x: np.ndarray, y: np.ndarray, max_iter: int = 41) -> int | float:  # noqa: C901, PLR0915
     """
     Find the elbow point when plotting numeric entries in `x` vs numeric values in list `y`.
 
@@ -46,7 +46,10 @@ def find_elbow_point(x: np.ndarray, y: np.ndarray, max_iter: int = 41) -> int | 
     # Ensure it is a Numpy array: pandas objects and lists are correctly handled.
     x = np.array(x.copy())
     y = np.array(y.copy())
-    assert len(x) == len(y)
+    if len(x) != len(y):
+        raise ValueError(
+            f"x and y must have the same length; got len(x)={len(x)}, len(y)={len(y)}."
+        )
 
     # Stop if everything is missing:
     if np.isnan(np.nanmedian(x)) or np.isnan(np.nanmedian(y)):
@@ -54,7 +57,10 @@ def find_elbow_point(x: np.ndarray, y: np.ndarray, max_iter: int = 41) -> int | 
 
     # Eliminate missing values in x and y simultaneously.
     x, y = x[~(np.isnan(x) | np.isnan(y))], y[~(np.isnan(x) | np.isnan(y))]
-    assert len(x) > 10, "Requires more than 10 values in the vectors (not including missing data)."
+    if len(x) <= 10:
+        raise ValueError(
+            "Requires more than 10 values in the vectors (not including missing data)."
+        )
     idx_sort = x.argsort()
     x = x[idx_sort]
     y = y[idx_sort]

--- a/process_improve/experiments/structures.py
+++ b/process_improve/experiments/structures.py
@@ -79,7 +79,10 @@ class Column(pd.Series):
 
     def extend(self, values: list) -> Column:
         """Extend the column with the list of new values."""
-        assert isinstance(values, list), "The 'values' must be in a list [...]"
+        if not isinstance(values, list):
+            raise TypeError(
+                f"'values' must be a list; got {type(values).__name__}."
+            )
         prior_n = self.index[-1]
         index = list(range(prior_n + 1, prior_n + len(values) + 1))
         new = pd.Series(data=values, index=index)
@@ -276,7 +279,11 @@ def c(*args, **kwargs) -> Column:  # noqa: C901, PLR0912, PLR0915
             _ = (e for e in out.pi_range)
         except TypeError as err:
             raise TypeError("The `range` input must be an iterable, with 2 values.") from err
-        assert len(out.pi_range) == 2, "The `range` variable must be a tuple, with 2 values."
+        if len(out.pi_range) != 2:
+            raise ValueError(
+                f"The `range` variable must be a tuple with 2 values; "
+                f"got {len(out.pi_range)} value(s)."
+            )
         out.pi_range = tuple(out.pi_range)
 
         try:
@@ -296,9 +303,9 @@ def c(*args, **kwargs) -> Column:  # noqa: C901, PLR0912, PLR0915
             out.pi_is_coded = override_coded
 
     elif "levels" in kwargs:
-        msg = "Levels must be list or tuple of the unique level names."
         levels = kwargs.get("levels")
-        assert isinstance(levels, Iterable), msg
+        if not isinstance(levels, Iterable):
+            raise TypeError("Levels must be list or tuple of the unique level names.")
         levels_list = list(levels)
         raw_values: list = []
         for arg in args:

--- a/process_improve/monitoring/metrics.py
+++ b/process_improve/monitoring/metrics.py
@@ -49,8 +49,14 @@ def calculate_cpk(
     float
         The Cpk value.
     """
-    assert trim_percentile >= 0
-    assert trim_percentile < 40  # typically a max of 10 to 20 is advised.
+    if trim_percentile < 0:
+        raise ValueError(
+            f"trim_percentile must be non-negative; got {trim_percentile}."
+        )
+    if trim_percentile >= 40:
+        raise ValueError(
+            f"trim_percentile must be < 40 (typically <= 10-20); got {trim_percentile}."
+        )
     lower_spec, upper_spec = specifications
 
     if lower_spec is None:

--- a/process_improve/multivariate/methods.py
+++ b/process_improve/multivariate/methods.py
@@ -687,8 +687,10 @@ class PCA(TransformerMixin, BaseEstimator):
         settings["md_max_iter"] = int(settings["md_max_iter"])
 
         if algo in ("nipals", "tsr"):
-            assert settings["md_tol"] < 10, "Tolerance should not be too large"
-            assert settings["md_tol"] > epsqrt**1.95, "Tolerance must exceed machine precision"
+            if not settings["md_tol"] < 10:
+                raise ValueError("Tolerance should not be too large.")
+            if not settings["md_tol"] > epsqrt**1.95:
+                raise ValueError("Tolerance must exceed machine precision.")
 
         # Storage for numpy results (set by _fit_* methods)
         X_values = np.asarray(X.copy())
@@ -965,7 +967,10 @@ class PCA(TransformerMixin, BaseEstimator):
         check_is_fitted(self, "loadings_")
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X)
-        assert X.shape[1] == self.n_features_in_, f"New data must have {self.n_features_in_} columns, got {X.shape[1]}."
+        if X.shape[1] != self.n_features_in_:
+            raise ValueError(
+                f"New data must have {self.n_features_in_} columns, got {X.shape[1]}."
+            )
         scores = X.values @ self.loadings_.values
         return pd.DataFrame(scores, index=X.index, columns=self.loadings_.columns)
 
@@ -989,9 +994,10 @@ class PCA(TransformerMixin, BaseEstimator):
         check_is_fitted(self, "loadings_")
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X)
-        assert X.shape[1] == self.n_features_in_, (
-            f"Prediction data must have {self.n_features_in_} columns, got {X.shape[1]}."
-        )
+        if X.shape[1] != self.n_features_in_:
+            raise ValueError(
+                f"Prediction data must have {self.n_features_in_} columns, got {X.shape[1]}."
+            )
 
         scores = self.transform(X)
 
@@ -1596,9 +1602,10 @@ class PLS(RegressorMixin, TransformerMixin, BaseEstimator):
         self.n_features_in_: int = X.shape[1]
         Ny: int = Y.shape[0]
         self.n_targets_: int = Y.shape[1]
-        assert Ny == self.n_samples_, (
-            f"The X and Y arrays must have the same number of rows: X has {self.n_samples_} and Y has {Ny}."
-        )
+        if Ny != self.n_samples_:
+            raise ValueError(
+                f"The X and Y arrays must have the same number of rows: X has {self.n_samples_} and Y has {Ny}."
+            )
 
         N = self.n_samples_
         K = self.n_features_in_
@@ -1820,9 +1827,10 @@ class PLS(RegressorMixin, TransformerMixin, BaseEstimator):
         check_is_fitted(self, "scores_")
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X)
-        assert X.shape[1] == self.n_features_in_, (
-            f"Prediction data must have {self.n_features_in_} columns, got {X.shape[1]}."
-        )
+        if X.shape[1] != self.n_features_in_:
+            raise ValueError(
+                f"Prediction data must have {self.n_features_in_} columns, got {X.shape[1]}."
+            )
 
         scores = X @ self.direct_weights_
 
@@ -2622,8 +2630,10 @@ def hotellings_t2_limit(conf_level: float = 0.95, n_components: int = 0, n_rows:
         The Hotelling's T2 limit at the given level of confidence. Returns
         ``inf`` when ``n_components == n_rows``.
     """
-    assert 0.0 < conf_level < 1.0
-    assert n_rows > 0
+    if not 0.0 < conf_level < 1.0:
+        raise ValueError(f"conf_level must lie in (0, 1); got {conf_level}.")
+    if n_rows <= 0:
+        raise ValueError(f"n_rows must be positive; got {n_rows}.")
     if n_components == n_rows:
         return float("inf")
     return (
@@ -2675,8 +2685,8 @@ def spe_calculation(spe_values: np.ndarray, conf_level: float = 0.95) -> float:
         The limit, above which we judge observations in the model to have a different correlation
         structure than those values which were used to build the model.
     """
-    assert conf_level > 0.0, "conf_level must be a value between (0.0, 1.0)"
-    assert conf_level < 1.0, "conf_level must be a value between (0.0, 1.0)"
+    if not 0.0 < conf_level < 1.0:
+        raise ValueError(f"conf_level must lie in (0, 1); got {conf_level}.")
 
     # The limit is for the squares (i.e. the sum of the squared errors)
     # I.e. `spe_values` are square-rooted outside this function, so undo that.
@@ -2749,10 +2759,18 @@ def ellipse_coordinates(  # noqa: PLR0913
 
         where t ranges between 0 and 2*pi.
     """
-    assert 1 <= score_horiz <= n_components
-    assert 1 <= score_vert <= n_components
-    assert 0 < conf_level < 1
-    assert n_rows > 0
+    if not 1 <= score_horiz <= n_components:
+        raise ValueError(
+            f"score_horiz must lie in [1, {n_components}]; got {score_horiz}."
+        )
+    if not 1 <= score_vert <= n_components:
+        raise ValueError(
+            f"score_vert must lie in [1, {n_components}]; got {score_vert}."
+        )
+    if not 0 < conf_level < 1:
+        raise ValueError(f"conf_level must lie in (0, 1); got {conf_level}.")
+    if n_rows <= 0:
+        raise ValueError(f"n_rows must be positive; got {n_rows}.")
     s_h = scaling_factor_for_scores.iloc[score_horiz - 1]
     s_v = scaling_factor_for_scores.iloc[score_vert - 1]
     t2_limit_specific = np.sqrt(hotellings_t2_limit(conf_level, n_components=n_components, n_rows=n_rows))
@@ -3061,16 +3079,21 @@ class TPLS(RegressorMixin, BaseEstimator):
         skip_f_matrix_preprocessing: bool = False,
     ):
         super().__init__()
-        assert n_components > 0, "Number of components must be positive."
+        if n_components <= 0:
+            raise ValueError(f"n_components must be positive; got {n_components}.")
         self.n_components = n_components
 
         self.d_matrix = d_matrix  # This is required input dict containing the properties for each group.
-        assert isinstance(self.d_matrix, dict), "d_matrix must be a dictionary of dataframes."
-
-        assert all(isinstance(df, pd.DataFrame) for df in self.d_matrix.values()), "d_matrix must contain dataframes."
+        if not isinstance(self.d_matrix, dict):
+            raise TypeError(
+                f"d_matrix must be a dict of DataFrames; got {type(self.d_matrix).__name__}."
+            )
+        if not all(isinstance(df, pd.DataFrame) for df in self.d_matrix.values()):
+            raise TypeError("d_matrix must contain pandas DataFrames as values.")
 
         self.max_iter = max_iter
-        assert self.max_iter > 0, "Maximum number of iterations must be positive."
+        if self.max_iter <= 0:
+            raise ValueError(f"max_iter must be positive; got {self.max_iter}.")
 
         self.skip_f_matrix_preprocessing = skip_f_matrix_preprocessing
 
@@ -3097,7 +3120,8 @@ class TPLS(RegressorMixin, BaseEstimator):
         self : object
             Returns self.
         """
-        assert isinstance(X, DataFrameDict)
+        if not isinstance(X, DataFrameDict):
+            raise TypeError(f"X must be a DataFrameDict; got {type(X).__name__}.")
         self._input_data_checks(X)
         group_keys = [str(key) for key in self.d_matrix]
 
@@ -3277,7 +3301,8 @@ class TPLS(RegressorMixin, BaseEstimator):
             Returns an array of prediction objects. More details to come here later. Please ask.
         """
         check_is_fitted(self)  # Check if fit had been called
-        assert isinstance(X, DataFrameDict), "The input 'X' must be a DataFrameDict object."
+        if not isinstance(X, DataFrameDict):
+            raise TypeError(f"X must be a DataFrameDict; got {type(X).__name__}.")
 
         # TODO: Check consistency on the data: the columns names in the new data must match the columns names in the
         # training data.
@@ -3313,16 +3338,26 @@ class TPLS(RegressorMixin, BaseEstimator):
         }
 
         for key, df_f in x_f.items():
-            assert df_f.shape[0] == num_obs, "All formula blocks must have the same number of rows."
-            assert set(df_f.columns) == set(self.material_names[key]), (
-                f"Columns in block F, group [{key}] must match training data column names for each material"
-            )
+            if df_f.shape[0] != num_obs:
+                raise ValueError(
+                    f"All formula blocks must have the same number of rows; "
+                    f"group [{key}] has {df_f.shape[0]} rows, expected {num_obs}."
+                )
+            if set(df_f.columns) != set(self.material_names[key]):
+                raise ValueError(
+                    f"Columns in block F, group [{key}] must match training data column names for each material."
+                )
 
         for key, df_z in x_z.items():
-            assert df_z.shape[0] == num_obs, "All condition blocks must have the same number of rows."
-            assert set(df_z.columns) == set(self.condition_names[key]), (
-                f"Columns names in block Z, group [{key}] must match training data column names."
-            )
+            if df_z.shape[0] != num_obs:
+                raise ValueError(
+                    f"All condition blocks must have the same number of rows; "
+                    f"group [{key}] has {df_z.shape[0]} rows, expected {num_obs}."
+                )
+            if set(df_z.columns) != set(self.condition_names[key]):
+                raise ValueError(
+                    f"Column names in block Z, group [{key}] must match training data column names."
+                )
 
         for pc_a in range(self.n_components):
             # Regress the row of each new formula block on the r_loadings_f, to get the t-score for that pc_a component.
@@ -3543,10 +3578,17 @@ class TPLS(RegressorMixin, BaseEstimator):
 
     def _input_data_checks(self, X: DataFrameDict) -> None:
         """Check the incoming data."""
-        assert isinstance(X, DataFrameDict), "The input data must be a DataFrameDict."
-        assert set(X.keys()) == self.required_inputs_, f"Expected keys: {self.required_inputs_}, got: {set(X.keys())}"
+        if not isinstance(X, DataFrameDict):
+            raise TypeError(
+                f"The input data must be a DataFrameDict; got {type(X).__name__}."
+            )
+        if set(X.keys()) != self.required_inputs_:
+            raise ValueError(
+                f"Expected keys: {self.required_inputs_}, got: {set(X.keys())}."
+            )
         group_keys = [str(key) for key in self.d_matrix]
-        assert set(X["F"]) == set(group_keys), "The keys in F must match the keys in D."
+        if set(X["F"]) != set(group_keys):
+            raise ValueError("The keys in F must match the keys in D.")
 
         for key in X["Y"]:
             self._validate_df(X["Y"][key])
@@ -3554,7 +3596,10 @@ class TPLS(RegressorMixin, BaseEstimator):
             self._validate_df(X["Z"][key])
         for key in self.d_matrix:
             self._validate_df(self.d_matrix[key])
-            assert key in X["F"], f"Block/group name '{key}' in D must also be present in F."
+            if key not in X["F"]:
+                raise ValueError(
+                    f"Block/group name '{key}' in D must also be present in F."
+                )
             self._validate_df(X["F"][key])  # this also ensures the keys in F are the same as in D
 
     def _learn_center_and_scaling_parameters(self, y: pd.DataFrame) -> tuple[pd.Series, pd.Series]:
@@ -3957,11 +4002,12 @@ class TPLS(RegressorMixin, BaseEstimator):
 
         # Test that all blocks and groups within a block have a mean of 0 and a standard deviation of 1.
         # Note the extra complexity for checking columns that have perfectly zero variance.
+        # Internal invariants on the just-preprocessed matrices, not user input.
         for key in self.z_mats:
-            assert np.allclose(np.nanmean(self.z_mats[key], axis=0), 0, atol=1e-6)
+            assert np.allclose(np.nanmean(self.z_mats[key], axis=0), 0, atol=1e-6)  # noqa: S101 - post-centering invariant
             for item in np.nanstd(self.z_mats[key], axis=0, ddof=1):
                 if item != 0:
-                    assert np.isclose(item, 1)
+                    assert np.isclose(item, 1)  # noqa: S101 - post-scaling invariant
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
@@ -3970,22 +4016,24 @@ class TPLS(RegressorMixin, BaseEstimator):
                 if not self.skip_f_matrix_preprocessing:
                     vector = np.nanmean(self.f_mats[key], axis=0)
                     vector[np.isnan(vector)] = 0
-                    assert np.allclose(vector, 0, atol=1e-6)
+                    assert np.allclose(vector, 0, atol=1e-6)  # noqa: S101 - post-centering invariant
 
                     vector = np.nanstd(self.f_mats[key], axis=0, ddof=1)
                     vector[np.isnan(vector)] = 1
-                    assert np.allclose(vector, 1)
+                    assert np.allclose(vector, 1)  # noqa: S101 - post-scaling invariant
 
                 vector = np.nanmean(self.d_mats[key], axis=0)
                 vector[np.isnan(vector)] = 0
-                assert np.allclose(vector, 0, atol=1e-6)
+                assert np.allclose(vector, 0, atol=1e-6)  # noqa: S101 - post-centering invariant
                 vector = np.nanstd(self.d_mats[key], axis=0, ddof=1) * self.preproc_["D"][key]["block"].values[0]
                 vector[np.isnan(vector)] = 1
-                assert np.allclose(vector, 1)
+                assert np.allclose(vector, 1)  # noqa: S101 - post-scaling invariant
 
-        # Checks on the Y-block
-        assert all(np.allclose(np.nanmean(self.y_mats[key], axis=0), 0, atol=1e-6) for key in self.y_mats)
-        assert all(
+        # Checks on the Y-block: post-centering / post-scaling invariants.
+        assert all(  # noqa: S101 - post-centering invariant on every Y block
+            np.allclose(np.nanmean(self.y_mats[key], axis=0), 0, atol=1e-6) for key in self.y_mats
+        )
+        assert all(  # noqa: S101 - post-scaling invariant on every Y block
             np.allclose(np.where((in_array := np.nanstd(self.y_mats[key], axis=0, ddof=1)) == 0, 1, in_array), 1)
             for key in self.y_mats
         )
@@ -4276,8 +4324,10 @@ class MBPLS(RegressorMixin, BaseEstimator):
         missing_data_settings: dict | None = None,
     ):
         super().__init__()
-        assert n_components > 0, "Number of components must be positive."
-        assert max_iter > 0, "max_iter must be positive."
+        if n_components <= 0:
+            raise ValueError(f"n_components must be positive; got {n_components}.")
+        if max_iter <= 0:
+            raise ValueError(f"max_iter must be positive; got {max_iter}.")
         self.n_components = n_components
         self.max_iter = max_iter
         self.tol = tol
@@ -4348,8 +4398,10 @@ class MBPLS(RegressorMixin, BaseEstimator):
             settings.update(self.missing_data_settings)
         settings["md_max_iter"] = int(settings["md_max_iter"])
         if algo == "nipals":
-            assert settings["md_tol"] < 10, "Tolerance should not be too large"
-            assert settings["md_tol"] > epsqrt**1.95, "Tolerance must exceed machine precision"
+            if not settings["md_tol"] < 10:
+                raise ValueError("Tolerance should not be too large.")
+            if not settings["md_tol"] > epsqrt**1.95:
+                raise ValueError("Tolerance must exceed machine precision.")
             # Degeneracy guards: any column or any (block, row) entirely NaN
             # leaves the masked NIPALS denominator at zero, which would
             # silently produce a spurious score or loading. Refuse the fit
@@ -5175,8 +5227,10 @@ class MBPCA(TransformerMixin, BaseEstimator):
         missing_data_settings: dict | None = None,
     ):
         super().__init__()
-        assert n_components > 0, "Number of components must be positive."
-        assert max_iter > 0, "max_iter must be positive."
+        if n_components <= 0:
+            raise ValueError(f"n_components must be positive; got {n_components}.")
+        if max_iter <= 0:
+            raise ValueError(f"max_iter must be positive; got {max_iter}.")
         self.n_components = n_components
         self.max_iter = max_iter
         self.tol = tol
@@ -5233,8 +5287,10 @@ class MBPCA(TransformerMixin, BaseEstimator):
             settings.update(self.missing_data_settings)
         settings["md_max_iter"] = int(settings["md_max_iter"])
         if algo == "nipals":
-            assert settings["md_tol"] < 10, "Tolerance should not be too large"
-            assert settings["md_tol"] > epsqrt**1.95, "Tolerance must exceed machine precision"
+            if not settings["md_tol"] < 10:
+                raise ValueError("Tolerance should not be too large.")
+            if not settings["md_tol"] > epsqrt**1.95:
+                raise ValueError("Tolerance must exceed machine precision.")
             # Degeneracy guards: any column or any (block, row) entirely NaN
             # leaves the masked NIPALS denominator at zero, which would
             # silently produce a spurious score or loading. Refuse the fit

--- a/process_improve/multivariate/methods.py
+++ b/process_improve/multivariate/methods.py
@@ -629,7 +629,7 @@ class PCA(TransformerMixin, BaseEstimator):
         self.missing_data_settings = missing_data_settings
 
     @_fit_context(prefer_skip_nested_validation=True)
-    def fit(self, X: DataMatrix, y: DataMatrix | None = None) -> PCA:  # noqa: ARG002, PLR0915, C901
+    def fit(self, X: DataMatrix, y: DataMatrix | None = None) -> PCA:  # noqa: ARG002, PLR0912, PLR0915, C901
         """Fit a principal component analysis (PCA) model to the data.
 
         Parameters
@@ -3274,7 +3274,7 @@ class TPLS(RegressorMixin, BaseEstimator):
         self.is_fitted_ = True
         return self
 
-    def predict(self, X: DataFrameDict) -> Bunch:  # noqa: C901, PLR0912
+    def predict(self, X: DataFrameDict) -> Bunch:  # noqa: C901, PLR0912, PLR0915
         """
         Model inference on new data.
 
@@ -4004,10 +4004,10 @@ class TPLS(RegressorMixin, BaseEstimator):
         # Note the extra complexity for checking columns that have perfectly zero variance.
         # Internal invariants on the just-preprocessed matrices, not user input.
         for key in self.z_mats:
-            assert np.allclose(np.nanmean(self.z_mats[key], axis=0), 0, atol=1e-6)  # noqa: S101 - post-centering invariant
+            assert np.allclose(np.nanmean(self.z_mats[key], axis=0), 0, atol=1e-6)  # post-centering invariant
             for item in np.nanstd(self.z_mats[key], axis=0, ddof=1):
                 if item != 0:
-                    assert np.isclose(item, 1)  # noqa: S101 - post-scaling invariant
+                    assert np.isclose(item, 1)  # post-scaling invariant
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
@@ -4016,24 +4016,24 @@ class TPLS(RegressorMixin, BaseEstimator):
                 if not self.skip_f_matrix_preprocessing:
                     vector = np.nanmean(self.f_mats[key], axis=0)
                     vector[np.isnan(vector)] = 0
-                    assert np.allclose(vector, 0, atol=1e-6)  # noqa: S101 - post-centering invariant
+                    assert np.allclose(vector, 0, atol=1e-6)  # post-centering invariant
 
                     vector = np.nanstd(self.f_mats[key], axis=0, ddof=1)
                     vector[np.isnan(vector)] = 1
-                    assert np.allclose(vector, 1)  # noqa: S101 - post-scaling invariant
+                    assert np.allclose(vector, 1)  # post-scaling invariant
 
                 vector = np.nanmean(self.d_mats[key], axis=0)
                 vector[np.isnan(vector)] = 0
-                assert np.allclose(vector, 0, atol=1e-6)  # noqa: S101 - post-centering invariant
+                assert np.allclose(vector, 0, atol=1e-6)  # post-centering invariant
                 vector = np.nanstd(self.d_mats[key], axis=0, ddof=1) * self.preproc_["D"][key]["block"].values[0]
                 vector[np.isnan(vector)] = 1
-                assert np.allclose(vector, 1)  # noqa: S101 - post-scaling invariant
+                assert np.allclose(vector, 1)  # post-scaling invariant
 
         # Checks on the Y-block: post-centering / post-scaling invariants.
-        assert all(  # noqa: S101 - post-centering invariant on every Y block
+        assert all(  # post-centering invariant on every Y block
             np.allclose(np.nanmean(self.y_mats[key], axis=0), 0, atol=1e-6) for key in self.y_mats
         )
-        assert all(  # noqa: S101 - post-scaling invariant on every Y block
+        assert all(  # post-scaling invariant on every Y block
             np.allclose(np.where((in_array := np.nanstd(self.y_mats[key], axis=0, ddof=1)) == 0, 1, in_array), 1)
             for key in self.y_mats
         )

--- a/process_improve/multivariate/plots.py
+++ b/process_improve/multivariate/plots.py
@@ -380,7 +380,7 @@ def loading_plot(  # noqa: PLR0913
     return fig
 
 
-def spe_plot(
+def spe_plot(  # noqa: C901
     model: BaseEstimator,
     with_a: int = -1,
     items_to_highlight: dict[str, list] | None = None,
@@ -532,7 +532,7 @@ def spe_plot(
     return fig
 
 
-def t2_plot(
+def t2_plot(  # noqa: C901
     model: BaseEstimator,
     with_a: int = -1,
     items_to_highlight: dict[str, list] | None = None,

--- a/process_improve/multivariate/plots.py
+++ b/process_improve/multivariate/plots.py
@@ -22,17 +22,21 @@ from process_improve.visualization.themes import (
 def plot_pre_checks(model: BaseEstimator, pc_horiz: int, pc_vert: int, pc_depth: int) -> bool:
     """Check the inputs for the plot functions are valid."""
     n_components = model.n_components if hasattr(model, "n_components") else model._parent.n_components
-    assert 0 < pc_horiz <= n_components, (
-        f"The model has {n_components} components. Ensure that 1 <= pc_horiz<={n_components}."
-    )
-    assert 0 < pc_vert <= n_components, (
-        f"The model has {n_components} components. Ensure that 1 <= pc_vert<={n_components}."
-    )
-    assert -1 <= pc_depth <= n_components, (
-        f"The model has {n_components} components. Ensure that pc_depth is -1 (no depth axis) "
-        f"or 1 <= pc_depth <= {n_components}."
-    )
-    assert len({pc_horiz, pc_vert, pc_depth}) == 3, "Specify distinct components for each axis"
+    if not 0 < pc_horiz <= n_components:
+        raise ValueError(
+            f"The model has {n_components} components. Ensure that 1 <= pc_horiz <= {n_components}."
+        )
+    if not 0 < pc_vert <= n_components:
+        raise ValueError(
+            f"The model has {n_components} components. Ensure that 1 <= pc_vert <= {n_components}."
+        )
+    if not -1 <= pc_depth <= n_components:
+        raise ValueError(
+            f"The model has {n_components} components. Ensure that pc_depth is -1 (no depth axis) "
+            f"or 1 <= pc_depth <= {n_components}."
+        )
+    if len({pc_horiz, pc_vert, pc_depth}) != 3:
+        raise ValueError("Specify distinct components for each axis.")
 
     return True
 
@@ -427,9 +431,13 @@ def spe_plot(
         # Get the actual name of the last column in the model if negative indexing is used
         with_a = model.spe_.columns[with_a]
     elif with_a == 0:
-        raise AssertionError("`with_a` must be >= 1, or specified with negative indexing")
+        raise ValueError("`with_a` must be >= 1, or specified with negative indexing.")
 
-    assert with_a <= model.n_components, "`with_a` must be <= the number of components fitted"
+    if not with_a <= model.n_components:
+        raise ValueError(
+            f"`with_a` must be <= the number of components fitted "
+            f"({model.n_components}); got {with_a}."
+        )
 
     class Settings(BaseModel):
         """Validated display settings for the SPE plot."""
@@ -574,9 +582,13 @@ def t2_plot(
     if with_a < 0:
         with_a = model.hotellings_t2_.columns[with_a]
     elif with_a == 0:
-        raise AssertionError("`with_a` must be >= 1, or specified with negative indexing")
+        raise ValueError("`with_a` must be >= 1, or specified with negative indexing.")
 
-    assert with_a <= model.n_components, "`with_a` must be <= the number of components fitted"
+    if not with_a <= model.n_components:
+        raise ValueError(
+            f"`with_a` must be <= the number of components fitted "
+            f"({model.n_components}); got {with_a}."
+        )
 
     class Settings(BaseModel):
         """Validated display settings for the Hotelling's T2 plot."""

--- a/process_improve/univariate/tools.py
+++ b/process_improve/univariate/tools.py
@@ -571,7 +571,11 @@ def ttest_paired_samples(
     """Paired t-test; see tool spec for details."""
     a = pd.Series(np.asarray(group_a, dtype=float))
     b = pd.Series(np.asarray(group_b, dtype=float))
-    assert len(a) == len(b), "group_a and group_b must have the same length for a paired test."
+    if len(a) != len(b):
+        raise ValueError(
+            f"group_a and group_b must have the same length for a paired test; "
+            f"got len(group_a)={len(a)}, len(group_b)={len(b)}."
+        )
     differences = a - b.values
     differences = differences.dropna()
     raw = ttest_paired(differences, conflevel=confidence_level)
@@ -657,7 +661,11 @@ def within_between_variance(
     groups: list[Any],
 ) -> dict:
     """Within- and between-group variance decomposition; see tool spec for details."""
-    assert len(values) == len(groups), "'values' and 'groups' must have the same length."
+    if len(values) != len(groups):
+        raise ValueError(
+            f"'values' and 'groups' must have the same length; "
+            f"got len(values)={len(values)}, len(groups)={len(groups)}."
+        )
     df = pd.DataFrame({"measured": values, "repeat": groups})
     result = variance_decomposition(df, measured="measured", repeat="repeat")
     return clean(result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.22.17"
+version = "1.22.18"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -390,7 +390,7 @@ def test_pca_invalid_calls() -> None:
     ):
         model.fit(data)
     data.iloc[0, 0] = np.nan
-    with pytest.raises(AssertionError, match="Tolerance must exceed machine precision"):
+    with pytest.raises(ValueError, match="Tolerance must exceed machine precision"):
         _ = PCA(n_components=A, algorithm="nipals", missing_data_settings=dict(md_tol=0)).fit(data)
 
     with pytest.raises(ValueError, match=r"Algorithm .* is not recognized(.*)"):
@@ -2791,14 +2791,14 @@ def test_t2_plot_with_highlights(fixture_pca_for_plots: PCA) -> None:
 
 def test_t2_plot_rejects_zero_with_a(fixture_pca_for_plots: PCA) -> None:
     """t2_plot should reject `with_a == 0`."""
-    with pytest.raises(AssertionError, match="with_a"):
+    with pytest.raises(ValueError, match="with_a"):
         fixture_pca_for_plots.t2_plot(with_a=0)
 
 
 def test_t2_plot_rejects_with_a_above_components(fixture_pca_for_plots: PCA) -> None:
     """t2_plot should reject `with_a` larger than the number of fitted components."""
     model = fixture_pca_for_plots
-    with pytest.raises(AssertionError, match="with_a"):
+    with pytest.raises(ValueError, match="with_a"):
         model.t2_plot(with_a=model.n_components + 1)
 
 


### PR DESCRIPTION
## Summary

Sweep the remaining validation `assert`s identified in **SEC-17 (#266)**
and convert them to explicit `if not ...: raise ValueError(...)` per
the [error-handling style guide](https://github.com/kgdunn/process-improve/blob/main/docs/development/error_handling.rst)
(ENG-11, PR #317). SEC-08 (#243) swept ~105 sites; this PR covers
the multivariate / bivariate / batch / experiments / monitoring
sites that survived.

The companion goal: flip the `test-under-dash-O` CI job (added in
PR #320 / ENG-15) from non-blocking to blocking. As of PR #320,
the job failed on two concrete sites that this sweep fixes:

- `tests/test_multivariate.py::test_pca_invalid_calls`
- `tests/test_multivariate.py::test_t2_plot_rejects_with_a_above_components`

## Scope of conversion

For each site listed in SEC-17:

- **Validation `assert`** (checks user input or external state) ->
  `if not X: raise ValueError(...)`.
- **Internal invariant `assert`** (provably-impossible branch) ->
  keep as `assert`, add `# noqa: S101` comment naming the invariant
  that justifies the assertion.

When the call is borderline I leave a comment and skip rather than
guess. Any skipped site is noted in this PR description as a
follow-up.

## Sites swept

Per the [SEC-17 issue body](https://github.com/kgdunn/process-improve/issues/266):

- `process_improve/multivariate/methods.py`
- `process_improve/bivariate/methods.py`
- `process_improve/univariate/tools.py`
- `process_improve/experiments/structures.py`
- `process_improve/batch/features.py`
- `process_improve/batch/plotting.py`
- `process_improve/batch/preprocessing.py`
- `process_improve/monitoring/metrics.py`

## Test updates

- `test_pca_invalid_calls` -> assert on `ValueError` with the new
  message text.
- `test_t2_plot_rejects_with_a_above_components` -> assert on
  `ValueError` instead of the pandas `KeyError` it fell through to.
- Any other test that previously asserted on `AssertionError`
  updated similarly.

## CI plumbing

- `.github/workflows/run-tests.yml` -- remove `continue-on-error:
  true` from the `test-under-dash-O` job so a future regression
  turns CI red.

## Versioning

PATCH bump 1.22.17 -> 1.22.18. CHANGELOG entry under "Security"
(this closes a SEC-NN item) plus a "Changed" note for the test
expectation updates.

## Test plan

- [x] `pytest -o "addopts="` passes locally.
- [x] `python -O -m pytest -o "addopts="` passes locally
      (the two previously-failing tests now go green).
- [x] `ruff check .` clean.
- [ ] Full CI matrix green.
- [ ] `test-under-dash-O` job now blocking; remaining `-O` runs
      stay green.

## Closes
#266

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho9oSSxJUXTkqwVzPUzzFW)_