### PR TITLE
feat(ENG-04, ENG-10): migrate monitoring + regression + bivariate to pydantic (PR2/N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.1] - 2026-06-02
+
+### Changed
+
+- Migrated the **monitoring**, **regression**, and **bivariate**
+  packages to the pydantic `@tool_spec` contract introduced in
+  1.24.0 (ENG-04 / ENG-10; PR2/N of the per-package roll-out).
+  Five tools updated: `control_chart`, `process_capability`,
+  `robust_regression`, `repeated_median`, `find_elbow`. Each pairs
+  its decorator with a `BaseModel` carrying
+  `ConfigDict(extra="forbid")`; functions now take the parsed
+  model as their single positional argument. Unknown keys raise
+  `ToolInputInvalidError` at the dispatch boundary. No
+  behavioural change for valid inputs.
+
+### Tests
+
+- The tool-call tests in `tests/test_bivariate.py`,
+  `tests/test_monitoring.py`, and `tests/test_regression.py` now
+  exercise the dispatch boundary via `execute_tool_call(...)`
+  rather than importing the tool functions directly, mirroring
+  PR1's univariate pattern.
+
 ## [1.24.0] - 2026-06-02
 
 ### Changed (breaking)
@@ -690,7 +713,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.1...HEAD
+[1.24.1]: https://github.com/kgdunn/process-improve/compare/v1.24.0...v1.24.1
 [1.24.0]: https://github.com/kgdunn/process-improve/compare/v1.23.2...v1.24.0
 [1.23.2]: https://github.com/kgdunn/process-improve/compare/v1.23.1...v1.23.2
 [1.23.1]: https://github.com/kgdunn/process-improve/compare/v1.23.0...v1.23.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.0
+version: 1.24.1
 date-released: "2026-06-02"
 keywords:
   - chemometrics

--- a/process_improve/bivariate/tools.py
+++ b/process_improve/bivariate/tools.py
@@ -1,6 +1,11 @@
 """(c) Kevin Dunn, 2010-2026. MIT License.
 
 Agent-callable tool wrappers for bivariate analysis.
+
+Pydantic input contract (ENG-04 / ENG-10): each tool pairs its
+``@tool_spec`` decorator with a ``BaseModel`` carrying
+``ConfigDict(extra="forbid")``; the function receives the parsed
+model as its single positional argument.
 """
 
 from __future__ import annotations
@@ -8,6 +13,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+from pydantic import BaseModel, ConfigDict, Field
 
 from process_improve.tool_spec import clean, get_tool_specs, tool_spec
 
@@ -19,8 +25,25 @@ def _register(name: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Tools
+# find_elbow
 # ---------------------------------------------------------------------------
+
+
+class FindElbowInput(BaseModel):
+    """Input contract for ``find_elbow``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    x: list[float] = Field(
+        ...,
+        min_length=6,
+        description="X-axis values (e.g. component numbers, cluster counts).",
+    )
+    y: list[float] = Field(
+        ...,
+        min_length=6,
+        description="Y-axis values (e.g. explained variance, SSE). Must be same length as x.",
+    )
 
 
 @tool_spec(
@@ -33,50 +56,27 @@ def _register(name: str) -> None:
         "Uses a robust line-fitting approach to identify where two linear regimes meet. "
         "Returns the index and coordinates of the elbow point."
     ),
-    input_schema={
-        "json": {
-            "type": "object",
-            "properties": {
-                "x": {
-                    "type": "array",
-                    "items": {"type": "number"},
-                    "description": "X-axis values (e.g. component numbers, cluster counts).",
-                    "minItems": 6,
-                },
-                "y": {
-                    "type": "array",
-                    "items": {"type": "number"},
-                    "description": "Y-axis values (e.g. explained variance, SSE). Must be same length as x.",
-                    "minItems": 6,
-                },
-            },
-            "required": ["x", "y"],
-        }
-    },
+    input_model=FindElbowInput,
     examples="""
     # "Where is the elbow in my scree plot? Components [1,2,3,4,5,6,7,8], variance [40,25,15,8,5,3,2,2]"
         -> ``find_elbow(x=[1,2,3,4,5,6,7,8], y=[40,25,15,8,5,3,2,2])``
     """,
     category="bivariate",
 )
-def find_elbow(
-    *,
-    x: list[float],
-    y: list[float],
-) -> dict[str, Any]:
+def find_elbow(spec: FindElbowInput) -> dict[str, Any]:
     """Find the elbow point in an x-y curve."""
     from process_improve.bivariate.methods import find_elbow_point  # noqa: PLC0415
 
     try:
-        x_arr = np.asarray(x, dtype=float)
-        y_arr = np.asarray(y, dtype=float)
+        x_arr = np.asarray(spec.x, dtype=float)
+        y_arr = np.asarray(spec.y, dtype=float)
         elbow_idx = find_elbow_point(x_arr, y_arr)
         elbow_idx = int(elbow_idx)
         return clean({
             "elbow_index": elbow_idx,
-            "elbow_x": x[elbow_idx],
-            "elbow_y": y[elbow_idx],
-            "n": len(x),
+            "elbow_x": spec.x[elbow_idx],
+            "elbow_y": spec.y[elbow_idx],
+            "n": len(spec.x),
         })
     except (ValueError, TypeError, IndexError) as exc:
         return {"error": str(exc)}

--- a/process_improve/monitoring/tools.py
+++ b/process_improve/monitoring/tools.py
@@ -1,14 +1,20 @@
 """(c) Kevin Dunn, 2010-2026. MIT License.
 
 Agent-callable tool wrappers for process monitoring.
+
+Pydantic input contract (ENG-04 / ENG-10): each tool pairs its
+``@tool_spec`` decorator with a ``BaseModel`` carrying
+``ConfigDict(extra="forbid")``; the function receives the parsed
+model as its single positional argument.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
+from pydantic import BaseModel, ConfigDict, Field
 
 from process_improve.tool_spec import clean, get_tool_specs, tool_spec
 
@@ -20,8 +26,32 @@ def _register(name: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Tools
+# control_chart
 # ---------------------------------------------------------------------------
+
+
+class ControlChartInput(BaseModel):
+    """Input contract for ``control_chart``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    values: list[float] = Field(
+        ...,
+        min_length=5,
+        description="Time-ordered sequence of numeric observations.",
+    )
+    chart_type: Literal["shewhart", "cusum", "holt_winters"] = Field(
+        "holt_winters",
+        description=(
+            "Type of control chart. 'shewhart': individual observations chart. "
+            "'cusum': cumulative sum chart. 'holt_winters' (default): a blend of "
+            "Shewhart and CUSUM properties."
+        ),
+    )
+    style: Literal["robust", "regular"] = Field(
+        "robust",
+        description="'robust' (default): uses median/MAD. 'regular': uses mean/std.",
+    )
 
 
 @tool_spec(
@@ -34,34 +64,7 @@ def _register(name: str) -> None:
         "Returns the calculated target (center line), upper and lower control limits, and indices of "
         "any out-of-control observations."
     ),
-    input_schema={
-        "json": {
-            "type": "object",
-            "properties": {
-                "values": {
-                    "type": "array",
-                    "items": {"type": "number"},
-                    "description": "Time-ordered sequence of numeric observations.",
-                    "minItems": 5,
-                },
-                "chart_type": {
-                    "type": "string",
-                    "enum": ["shewhart", "cusum", "holt_winters"],
-                    "description": (
-                        "Type of control chart. 'shewhart': individual observations chart. "
-                        "'cusum': cumulative sum chart. 'holt_winters' (default): a blend of "
-                        "Shewhart and CUSUM properties."
-                    ),
-                },
-                "style": {
-                    "type": "string",
-                    "enum": ["robust", "regular"],
-                    "description": "'robust' (default): uses median/MAD. 'regular': uses mean/std.",
-                },
-            },
-            "required": ["values"],
-        }
-    },
+    input_model=ControlChartInput,
     examples="""
     # "Are any of these measurements out of control? [10.1, 10.3, 10.2, 10.0, 15.5, 10.1]"
         -> ``control_chart(values=[10.1, 10.3, 10.2, 10.0, 15.5, 10.1])``
@@ -71,12 +74,7 @@ def _register(name: str) -> None:
     """,
     category="monitoring",
 )
-def control_chart(
-    *,
-    values: list[float],
-    chart_type: str = "holt_winters",
-    style: str = "robust",
-) -> dict[str, Any]:
+def control_chart(spec: ControlChartInput) -> dict[str, Any]:
     """Build a control chart and return limits + out-of-control points."""
     from process_improve.monitoring.control_charts import ControlChart  # noqa: PLC0415
 
@@ -85,11 +83,11 @@ def control_chart(
         "cusum": "cusum",
         "holt_winters": "hw",
     }
-    variant = variant_map.get(chart_type, "hw")
+    variant = variant_map.get(spec.chart_type, "hw")
 
     try:
-        cc = ControlChart(style=style, variant=variant)
-        y = pd.Series(np.asarray(values, dtype=float))
+        cc = ControlChart(style=spec.style, variant=variant)
+        y = pd.Series(np.asarray(spec.values, dtype=float))
         cc.calculate_limits(y)
 
         target = cc.target
@@ -97,7 +95,7 @@ def control_chart(
         ucl = target + 3 * s if s is not None and target is not None else None
         lcl = target - 3 * s if s is not None and target is not None else None
         ooc_indices = list(cc.idx_outside_3S) if cc.idx_outside_3S else []
-        ooc_values = [float(values[i]) for i in ooc_indices if i < len(values)]
+        ooc_values = [float(spec.values[i]) for i in ooc_indices if i < len(spec.values)]
 
         return clean({
             "target": target,
@@ -107,15 +105,47 @@ def control_chart(
             "out_of_control_indices": ooc_indices,
             "out_of_control_values": ooc_values,
             "n_out_of_control": len(ooc_indices),
-            "n_observations": len(values),
-            "chart_type": chart_type,
-            "style": style,
+            "n_observations": len(spec.values),
+            "chart_type": spec.chart_type,
+            "style": spec.style,
         })
     except (ValueError, TypeError, KeyError) as exc:
         return {"error": str(exc)}
 
 
 _register("control_chart")
+
+
+# ---------------------------------------------------------------------------
+# process_capability
+# ---------------------------------------------------------------------------
+
+
+class ProcessCapabilityInput(BaseModel):
+    """Input contract for ``process_capability``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    values: list[float] = Field(
+        ...,
+        min_length=5,
+        description="Process measurement values.",
+    )
+    lower_spec: float | None = Field(
+        None,
+        description="Lower specification limit. Omit if there is no lower limit.",
+    )
+    upper_spec: float | None = Field(
+        None,
+        description="Upper specification limit. Omit if there is no upper limit.",
+    )
+    robust: bool = Field(
+        True,
+        description=(
+            "If true (default), use robust statistics (median/Sn) for the calculation. "
+            "Set to false for classical mean/std calculation."
+        ),
+    )
 
 
 @tool_spec(
@@ -128,56 +158,24 @@ _register("control_chart")
         "Cpk < 1.0 means the process is producing out-of-spec output. "
         "Provide at least one of lower_spec or upper_spec."
     ),
-    input_schema={
-        "json": {
-            "type": "object",
-            "properties": {
-                "values": {
-                    "type": "array",
-                    "items": {"type": "number"},
-                    "description": "Process measurement values.",
-                    "minItems": 5,
-                },
-                "lower_spec": {
-                    "type": "number",
-                    "description": "Lower specification limit. Omit if there is no lower limit.",
-                },
-                "upper_spec": {
-                    "type": "number",
-                    "description": "Upper specification limit. Omit if there is no upper limit.",
-                },
-                "robust": {
-                    "type": "boolean",
-                    "description": (
-                        "If true (default), use robust statistics (median/Sn) for the calculation. "
-                        "Set to false for classical mean/std calculation."
-                    ),
-                },
-            },
-            "required": ["values"],
-        }
-    },
+    input_model=ProcessCapabilityInput,
     examples="""
     # "What is the Cpk for my data [10.1, 10.2, 9.9, 10.0] with spec limits 9.5 to 10.5?"
         -> ``process_capability(values=[10.1, 10.2, 9.9, 10.0], lower_spec=9.5, upper_spec=10.5)``
     """,
     category="monitoring",
 )
-def process_capability(
-    *,
-    values: list[float],
-    lower_spec: float | None = None,
-    upper_spec: float | None = None,
-    robust: bool = True,
-) -> dict[str, Any]:
+def process_capability(spec: ProcessCapabilityInput) -> dict[str, Any]:
     """Calculate Cpk process capability index."""
     from process_improve.monitoring.metrics import calculate_cpk  # noqa: PLC0415
 
     try:
-        df = pd.DataFrame({"value": np.asarray(values, dtype=float)})
-        trim = 2.5 if robust else 0.0
-        specs = (lower_spec if lower_spec is not None else np.nan,
-                 upper_spec if upper_spec is not None else np.nan)
+        df = pd.DataFrame({"value": np.asarray(spec.values, dtype=float)})
+        trim = 2.5 if spec.robust else 0.0
+        specs = (
+            spec.lower_spec if spec.lower_spec is not None else np.nan,
+            spec.upper_spec if spec.upper_spec is not None else np.nan,
+        )
 
         cpk_result = calculate_cpk(df, which_column="value", specifications=specs, trim_percentile=trim)
         cpk_float = float(cpk_result.cpk)
@@ -195,10 +193,10 @@ def process_capability(
             "cpk": cpk_float,
             "rsd": float(cpk_result.rsd),
             "interpretation": interpretation,
-            "lower_spec": lower_spec,
-            "upper_spec": upper_spec,
-            "n": len(values),
-            "robust": robust,
+            "lower_spec": spec.lower_spec,
+            "upper_spec": spec.upper_spec,
+            "n": len(spec.values),
+            "robust": spec.robust,
         })
     except (ValueError, TypeError, KeyError) as exc:
         return {"error": str(exc)}

--- a/process_improve/regression/tools.py
+++ b/process_improve/regression/tools.py
@@ -1,6 +1,11 @@
 """(c) Kevin Dunn, 2010-2026. MIT License.
 
 Agent-callable tool wrappers for robust regression.
+
+Pydantic input contract (ENG-04 / ENG-10): each tool pairs its
+``@tool_spec`` decorator with a ``BaseModel`` carrying
+``ConfigDict(extra="forbid")``; the function receives the parsed
+model as its single positional argument.
 """
 
 from __future__ import annotations
@@ -8,6 +13,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+from pydantic import BaseModel, ConfigDict, Field
 
 from process_improve.tool_spec import clean, get_tool_specs, tool_spec
 
@@ -19,8 +25,35 @@ def _register(name: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Tools
+# robust_regression
 # ---------------------------------------------------------------------------
+
+
+class RobustRegressionInput(BaseModel):
+    """Input contract for ``robust_regression``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    x: list[float] = Field(
+        ...,
+        min_length=3,
+        description="Independent variable (predictor) values.",
+    )
+    y: list[float] = Field(
+        ...,
+        min_length=3,
+        description="Dependent variable (response) values. Must be same length as x.",
+    )
+    confidence_level: float = Field(
+        0.95,
+        gt=0,
+        lt=1,
+        description="Confidence level for intervals (default 0.95).",
+    )
+    fit_intercept: bool = Field(
+        True,
+        description="If true (default), fit an intercept term. If false, force through origin.",
+    )
 
 
 @tool_spec(
@@ -34,36 +67,7 @@ def _register(name: str) -> None:
         "fitted values. "
         "Use this when you suspect outliers in the data or want a more reliable fit."
     ),
-    input_schema={
-        "json": {
-            "type": "object",
-            "properties": {
-                "x": {
-                    "type": "array",
-                    "items": {"type": "number"},
-                    "description": "Independent variable (predictor) values.",
-                    "minItems": 3,
-                },
-                "y": {
-                    "type": "array",
-                    "items": {"type": "number"},
-                    "description": "Dependent variable (response) values. Must be same length as x.",
-                    "minItems": 3,
-                },
-                "confidence_level": {
-                    "type": "number",
-                    "description": "Confidence level for intervals (default 0.95).",
-                    "exclusiveMinimum": 0,
-                    "exclusiveMaximum": 1,
-                },
-                "fit_intercept": {
-                    "type": "boolean",
-                    "description": "If true (default), fit an intercept term. If false, force through origin.",
-                },
-            },
-            "required": ["x", "y"],
-        }
-    },
+    input_model=RobustRegressionInput,
     examples="""
     # "Fit a robust line to x=[1,2,3,4,5] and y=[2.1,4.0,5.9,8.1,10.0]"
         -> ``robust_regression(x=[1,2,3,4,5], y=[2.1,4.0,5.9,8.1,10.0])``
@@ -73,24 +77,18 @@ def _register(name: str) -> None:
     """,
     category="regression",
 )
-def robust_regression(
-    *,
-    x: list[float],
-    y: list[float],
-    confidence_level: float = 0.95,
-    fit_intercept: bool = True,
-) -> dict[str, Any]:
+def robust_regression(spec: RobustRegressionInput) -> dict[str, Any]:
     """Fit a robust simple linear regression."""
     from process_improve.regression.methods import robust_regression as _robust_regression  # noqa: PLC0415
 
     try:
-        x_arr = np.asarray(x, dtype=float)
-        y_arr = np.asarray(y, dtype=float)
+        x_arr = np.asarray(spec.x, dtype=float)
+        y_arr = np.asarray(spec.y, dtype=float)
 
         result = _robust_regression(
             x_arr, y_arr,
-            fit_intercept=fit_intercept,
-            conflevel=confidence_level,
+            fit_intercept=spec.fit_intercept,
+            conflevel=spec.confidence_level,
         )
 
         out: dict[str, Any] = {
@@ -102,7 +100,7 @@ def robust_regression(
             "n": result["N"],
             "fitted_values": list(result["fitted_values"]),
             "residuals": list(result["residuals"]),
-            "confidence_level": confidence_level,
+            "confidence_level": spec.confidence_level,
         }
 
         if result.get("conf_intervals") is not None:
@@ -125,6 +123,28 @@ def robust_regression(
 _register("robust_regression")
 
 
+# ---------------------------------------------------------------------------
+# repeated_median
+# ---------------------------------------------------------------------------
+
+
+class RepeatedMedianInput(BaseModel):
+    """Input contract for ``repeated_median``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    x: list[float] = Field(
+        ...,
+        min_length=3,
+        description="Independent variable values.",
+    )
+    y: list[float] = Field(
+        ...,
+        min_length=3,
+        description="Dependent variable values. Must be same length as x.",
+    )
+
+
 @tool_spec(
     name="repeated_median",
     description=(
@@ -133,45 +153,22 @@ _register("robust_regression")
         "It gives just the slope (no intercept, no full regression output). "
         "Use robust_regression if you need a complete regression analysis."
     ),
-    input_schema={
-        "json": {
-            "type": "object",
-            "properties": {
-                "x": {
-                    "type": "array",
-                    "items": {"type": "number"},
-                    "description": "Independent variable values.",
-                    "minItems": 3,
-                },
-                "y": {
-                    "type": "array",
-                    "items": {"type": "number"},
-                    "description": "Dependent variable values. Must be same length as x.",
-                    "minItems": 3,
-                },
-            },
-            "required": ["x", "y"],
-        }
-    },
+    input_model=RepeatedMedianInput,
     examples="""
     # "What is the robust slope between x=[1,2,3,4,5] and y=[2.1,4.0,5.9,8.1,10.0]?"
         -> ``repeated_median(x=[1,2,3,4,5], y=[2.1,4.0,5.9,8.1,10.0])``
     """,
     category="regression",
 )
-def repeated_median(
-    *,
-    x: list[float],
-    y: list[float],
-) -> dict[str, Any]:
+def repeated_median(spec: RepeatedMedianInput) -> dict[str, Any]:
     """Compute the repeated median slope."""
     from process_improve.regression.methods import repeated_median_slope  # noqa: PLC0415
 
     try:
-        x_arr = np.asarray(x, dtype=float)
-        y_arr = np.asarray(y, dtype=float)
+        x_arr = np.asarray(spec.x, dtype=float)
+        y_arr = np.asarray(spec.y, dtype=float)
         slope = float(repeated_median_slope(x_arr, y_arr))
-        return clean({"slope": slope, "n": len(x)})
+        return clean({"slope": slope, "n": len(spec.x)})
     except (ValueError, TypeError, np.linalg.LinAlgError) as exc:
         return {"error": str(exc)}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.0"
+version = "1.24.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_bivariate.py
+++ b/tests/test_bivariate.py
@@ -2,7 +2,9 @@ import numpy as np
 import pytest
 
 from process_improve.bivariate.methods import find_elbow_point
-from process_improve.bivariate.tools import find_elbow, get_bivariate_tool_specs
+from process_improve.bivariate.tools import get_bivariate_tool_specs
+from process_improve.tool_safety import ToolInputInvalidError
+from process_improve.tool_spec import execute_tool_call
 
 
 @pytest.fixture
@@ -117,7 +119,7 @@ def test__corner_case() -> None:
 def test_find_elbow_tool_returns_index_on_clean_data(elbow_with_synthetic_data: tuple) -> None:
     """The tool wrapper returns an integer index plus the (x, y) at the elbow."""
     x, y, break_pt = elbow_with_synthetic_data
-    result = find_elbow(x=list(x), y=list(y))
+    result = execute_tool_call("find_elbow", {"x": list(x), "y": list(y)})
 
     assert "error" not in result
     assert result["n"] == len(x)
@@ -128,10 +130,9 @@ def test_find_elbow_tool_returns_index_on_clean_data(elbow_with_synthetic_data: 
 
 
 def test_find_elbow_tool_reports_error_on_too_few_points() -> None:
-    """The wrapper's `except` branch returns {"error": ...} on bad input."""
-    # The underlying assertion in find_elbow_point requires more than 10 non-NaN values.
-    result = find_elbow(x=[1.0, 2.0, 3.0], y=[1.0, 2.0, 3.0])
-    assert "error" in result
+    """Inputs shorter than the pydantic min_length raise ToolInputInvalidError (ENG-04)."""
+    with pytest.raises(ToolInputInvalidError):
+        execute_tool_call("find_elbow", {"x": [1.0, 2.0, 3.0], "y": [1.0, 2.0, 3.0]})
 
 
 def test_get_bivariate_tool_specs_lists_find_elbow() -> None:

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -8,12 +8,10 @@ import pytest
 from process_improve.monitoring.control_charts import ControlChart
 from process_improve.monitoring.metrics import calculate_cpk
 from process_improve.monitoring.tools import (
-    control_chart as control_chart_tool,
-)
-from process_improve.monitoring.tools import (
     get_monitoring_tool_specs,
-    process_capability,
 )
+from process_improve.tool_safety import ToolInputInvalidError
+from process_improve.tool_spec import execute_tool_call
 
 
 class TestValidateAgainstRQccXbarOne:
@@ -294,7 +292,7 @@ def in_control_series_with_one_outlier() -> list[float]:
 
 def test_control_chart_tool_default_holt_winters(in_control_series_with_one_outlier: list[float]) -> None:
     """Default chart_type='holt_winters' returns target, limits, and flags the outlier."""
-    result = control_chart_tool(values=in_control_series_with_one_outlier)
+    result = execute_tool_call("control_chart", {"values": in_control_series_with_one_outlier})
 
     assert "error" not in result
     assert result["chart_type"] == "holt_winters"
@@ -318,7 +316,7 @@ def test_control_chart_tool_supports_each_chart_type(chart_type: str) -> None:
     """
     rng = np.random.default_rng(0)
     values = [float(v) for v in rng.normal(loc=0.0, scale=1.0, size=40)]
-    result = control_chart_tool(values=values, chart_type=chart_type)
+    result = execute_tool_call("control_chart", {"values": values, "chart_type": chart_type})
 
     assert "error" not in result
     assert result["chart_type"] == chart_type
@@ -328,7 +326,7 @@ def test_control_chart_tool_regular_style() -> None:
     """style='regular' uses mean/std and still returns a coherent result."""
     rng = np.random.default_rng(1)
     values = [float(v) for v in rng.normal(loc=5.0, scale=0.5, size=30)]
-    result = control_chart_tool(values=values, style="regular")
+    result = execute_tool_call("control_chart", {"values": values, "style": "regular"})
 
     assert "error" not in result
     assert result["style"] == "regular"
@@ -336,16 +334,19 @@ def test_control_chart_tool_regular_style() -> None:
 
 
 def test_control_chart_tool_returns_error_on_bad_input() -> None:
-    """Non-numeric values surface as an error dict, not an exception."""
-    result = control_chart_tool(values=["not", "numbers"])  # type: ignore[arg-type]
-    assert "error" in result
+    """Non-numeric values are rejected by the pydantic contract."""
+    with pytest.raises(ToolInputInvalidError):
+        execute_tool_call("control_chart", {"values": ["not", "numbers"]})
 
 
 def test_process_capability_tool_excellent() -> None:
     """Tight, centered process should report excellent capability (cpk >= 1.67)."""
     rng = np.random.default_rng(2)
     values = [float(v) for v in rng.normal(loc=10.0, scale=0.1, size=200)]
-    result = process_capability(values=values, lower_spec=9.0, upper_spec=11.0, robust=False)
+    result = execute_tool_call(
+        "process_capability",
+        {"values": values, "lower_spec": 9.0, "upper_spec": 11.0, "robust": False},
+    )
 
     assert "error" not in result
     assert result["cpk"] >= 1.67
@@ -368,7 +369,10 @@ def test_process_capability_tool_interpretation_bands(scale: float, expected: st
     """The interpretation string matches the documented capability bands."""
     rng = np.random.default_rng(3)
     values = [float(v) for v in rng.normal(loc=10.0, scale=scale, size=300)]
-    result = process_capability(values=values, lower_spec=9.0, upper_spec=11.0, robust=False)
+    result = execute_tool_call(
+        "process_capability",
+        {"values": values, "lower_spec": 9.0, "upper_spec": 11.0, "robust": False},
+    )
 
     assert "error" not in result
     assert expected in result["interpretation"]
@@ -378,7 +382,10 @@ def test_process_capability_tool_one_sided_spec() -> None:
     """Omitting one spec limit is allowed."""
     rng = np.random.default_rng(4)
     values = [float(v) for v in rng.normal(loc=10.0, scale=0.5, size=100)]
-    result = process_capability(values=values, lower_spec=8.0, robust=False)
+    result = execute_tool_call(
+        "process_capability",
+        {"values": values, "lower_spec": 8.0, "robust": False},
+    )
 
     assert "error" not in result
     assert result["lower_spec"] == 8.0
@@ -386,9 +393,9 @@ def test_process_capability_tool_one_sided_spec() -> None:
 
 
 def test_process_capability_tool_returns_error_on_bad_input() -> None:
-    """The wrapper's `except` branch returns {"error": ...} on bad input."""
-    result = process_capability(values=["bad", "input"])  # type: ignore[arg-type]
-    assert "error" in result
+    """Non-numeric values are rejected by the pydantic contract."""
+    with pytest.raises(ToolInputInvalidError):
+        execute_tool_call("process_capability", {"values": ["bad", "input"]})
 
 
 def test_get_monitoring_tool_specs_lists_both_tools() -> None:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -11,12 +11,8 @@ from process_improve.regression.methods import (
 from process_improve.regression.tools import (
     get_regression_tool_specs,
 )
-from process_improve.regression.tools import (
-    repeated_median as repeated_median_tool,
-)
-from process_improve.regression.tools import (
-    robust_regression as robust_regression_tool,
-)
+from process_improve.tool_safety import ToolInputInvalidError
+from process_improve.tool_spec import execute_tool_call
 
 
 @pytest.fixture
@@ -768,7 +764,7 @@ def test_robust_regression_tool_recovers_known_line() -> None:
     rng = np.random.default_rng(11)
     x = list(np.arange(0.0, 10.0, 0.1))
     y = [2.0 * xi + 1.0 + 0.01 * float(rng.standard_normal()) for xi in x]
-    result = robust_regression_tool(x=x, y=y)
+    result = execute_tool_call("robust_regression", {"x": x, "y": y})
 
     assert "error" not in result
     assert result["slope"] == pytest.approx(2.0, abs=0.05)
@@ -794,7 +790,10 @@ def test_robust_regression_tool_no_intercept() -> None:
     """fit_intercept=False forces the line through the origin."""
     x = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
     y = [3.0, 6.0, 9.0, 12.0, 15.0, 18.0]
-    result = robust_regression_tool(x=x, y=y, fit_intercept=False, confidence_level=0.99)
+    result = execute_tool_call(
+        "robust_regression",
+        {"x": x, "y": y, "fit_intercept": False, "confidence_level": 0.99},
+    )
 
     assert "error" not in result
     assert result["slope"] == pytest.approx(3.0, abs=1e-6)
@@ -803,8 +802,11 @@ def test_robust_regression_tool_no_intercept() -> None:
 
 
 def test_robust_regression_tool_returns_error_on_mismatched_lengths() -> None:
-    """Length-mismatched inputs surface as an error dict, not an exception."""
-    result = robust_regression_tool(x=[1.0, 2.0, 3.0], y=[1.0, 2.0])
+    """Length-mismatched inputs (both above the pydantic min_length) surface as an error dict."""
+    result = execute_tool_call(
+        "robust_regression",
+        {"x": [1.0, 2.0, 3.0, 4.0], "y": [1.0, 2.0, 3.0]},
+    )
     assert "error" in result
 
 
@@ -813,7 +815,7 @@ def test_repeated_median_tool_matches_underlying_method() -> None:
     rng = np.random.default_rng(13)
     x = np.linspace(0.0, 10.0, 50)
     y = 1.5 * x - 4.0 + rng.standard_normal(50) * 0.05
-    result = repeated_median_tool(x=list(x), y=list(y))
+    result = execute_tool_call("repeated_median", {"x": list(x), "y": list(y)})
 
     assert "error" not in result
     assert result["n"] == len(x)
@@ -821,9 +823,9 @@ def test_repeated_median_tool_matches_underlying_method() -> None:
 
 
 def test_repeated_median_tool_returns_error_on_bad_input() -> None:
-    """Non-numeric input should surface as an error dict."""
-    result = repeated_median_tool(x=["a", "b"], y=[1.0, 2.0])  # type: ignore[arg-type]
-    assert "error" in result
+    """Non-numeric input is rejected by the pydantic contract."""
+    with pytest.raises(ToolInputInvalidError):
+        execute_tool_call("repeated_median", {"x": ["a", "b"], "y": [1.0, 2.0]})
 
 
 def test_get_regression_tool_specs_lists_both_tools() -> None:


### PR DESCRIPTION
## Summary

Wave 5 sub-track, PR2/N. Migrates the next batch of `@tool_spec`
wrappers to the pydantic-input contract introduced by PR #328:

- **monitoring**: `control_chart`, `process_capability` (2 tools)
- **regression**: `robust_regression`, `repeated_median` (2 tools)
- **bivariate**: `find_elbow` (1 tool)

5 tools total. Same recipe as PR1: a pydantic `BaseModel` with
`ConfigDict(extra="forbid")` co-located with each `@tool_spec`,
the function receives the parsed model as its single positional
argument, the hand-written JSON Schema dict is gone.

## Versioning

PATCH bump 1.24.0 -> 1.24.1. The decorator's public surface
already changed in PR1 (the MINOR); this is a per-package
roll-out of the same contract.

## Test plan

- [ ] Full pytest suite passes locally (incl. `python -O`).
- [ ] `ruff check .` clean.
- [ ] Full CI matrix green.

## Closes (partial)
#286, #292 -- one more PR brings the remaining packages
(experiments, multivariate, batch, visualization, simulation).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho9oSSxJUXTkqwVzPUzzFW)_