### PR TITLE
chore(ENG-04, ENG-10): delete legacy input_schema= path now that pydantic migration is complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,47 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.4] - 2026-06-02
+
+### Changed (breaking, internal API)
+
+- `@tool_spec` no longer accepts the legacy `input_schema=` dict
+  parameter -- `input_model=` (a pydantic `BaseModel` subclass with
+  `ConfigDict(extra="forbid")`) is now the only supported form.
+  This is the cleanup follow-up to PR1-PR4 (#328, #329, #330, #331)
+  of the ENG-04 / ENG-10 migration. Every in-tree `@tool_spec`
+  already uses `input_model=`; external callers that still passed
+  `input_schema={...}` must migrate.
+- `process_improve.tool_safety` drops the bespoke JSON-schema walker:
+  `validate_against_schema()`, `_validate_value()`, `_JSON_TYPE_CHECKS`,
+  and `_lookup_input_schema()` are gone. `safe_execute_tool_call` now
+  validates via `input_model.model_validate(...)` and translates the
+  resulting `pydantic.ValidationError` to `ToolInputInvalidError`.
+  The new internal helpers are `_lookup_input_model()` and
+  `_validate_against_model()`.
+- `process_improve.tool_spec._filter_to_declared_keys` was removed;
+  its job (rejecting undeclared kwargs) is now done structurally by
+  `ConfigDict(extra="forbid")` at the pydantic boundary.
+
+### Security
+
+- SEC-20 (#266) and SEC-25 (#274) are closed by this PR: the
+  "implicit MCP boundary trust" and "silent unknown-key drop hides
+  bugs" findings both relied on the bespoke schema walker as a
+  defence-in-depth backstop. With every `@tool_spec` now built on a
+  pydantic `BaseModel` carrying `extra="forbid"`, those guarantees
+  are part of the single canonical validation path
+  (`execute_tool_call` and `safe_execute_tool_call`).
+
+### Tests
+
+- `tests/test_tool_spec.py` and `tests/test_tool_safety.py`: the
+  synthetic test-only tools and the validation tests are rebuilt
+  on top of pydantic. The previous `TestFilterToDeclaredKeys` and
+  `TestValidateAgainstSchema` classes are replaced by a single
+  `TestValidateAgainstModel` class that pins the new
+  `_validate_against_model` / `_lookup_input_model` surface.
+
 ## [1.24.3] - 2026-06-02
 
 ### Changed
@@ -792,7 +833,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.3...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.4...HEAD
+[1.24.4]: https://github.com/kgdunn/process-improve/compare/v1.24.3...v1.24.4
 [1.24.3]: https://github.com/kgdunn/process-improve/compare/v1.24.2...v1.24.3
 [1.24.2]: https://github.com/kgdunn/process-improve/compare/v1.24.1...v1.24.2
 [1.24.1]: https://github.com/kgdunn/process-improve/compare/v1.24.0...v1.24.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.3
+version: 1.24.4
 date-released: "2026-06-02"
 keywords:
   - chemometrics

--- a/process_improve/tool_safety.py
+++ b/process_improve/tool_safety.py
@@ -31,11 +31,12 @@ from __future__ import annotations
 import contextlib
 import multiprocessing
 import sys
-from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from concurrent.futures.process import BrokenProcessPool
 from typing import Any
+
+from pydantic import BaseModel, ValidationError
 
 from process_improve.config import settings
 
@@ -249,135 +250,37 @@ def validate_input(
 
 
 # ---------------------------------------------------------------------------
-# JSON-schema enforcement
+# Pydantic-derived input validation
 # ---------------------------------------------------------------------------
 #
-# Each tool ships an ``input_schema`` (JSON Schema), but the dispatch path
-# passes the input straight through as ``**kwargs`` without checking it. For an
-# untrusted transport that means types, bounds, enums and ``required`` are
-# unenforced and unknown keys reach the function. ``validate_against_schema``
-# enforces the subset of JSON Schema actually used by the tool specs. It is
-# deliberately dependency-free (no ``jsonschema``) so it adds no install/lockfile
-# churn.
-
-# A JSON "number" accepts ints; "integer" rejects floats. ``bool`` is excluded
-# from the numeric types because ``True``/``False`` are ints in Python.
-_JSON_TYPE_CHECKS: dict[str, Callable[[Any], bool]] = {
-    "number": lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
-    "integer": lambda v: isinstance(v, int) and not isinstance(v, bool),
-    "string": lambda v: isinstance(v, str),
-    "boolean": lambda v: isinstance(v, bool),
-    "array": lambda v: isinstance(v, list),
-    "object": lambda v: isinstance(v, dict),
-}
+# Every tool's input is described by a ``BaseModel`` with
+# ``ConfigDict(extra="forbid")`` (ENG-04 / ENG-10). Validation lives on the
+# model: types, bounds, enums, required fields and "no unknown keys" all come
+# from ``model_validate``. ``safe_execute_tool_call`` runs the model
+# pre-submission so an oversize or malformed payload is rejected before the
+# subprocess pool is even touched.
 
 
-def _validate_value(key: str, value: Any, subschema: dict[str, Any]) -> None:  # noqa: ANN401
-    """Validate a single parameter *value* against its property *subschema*."""
-    # Optional parameters may be supplied as an explicit ``null``; the tool
-    # function then falls back to its own default, so do not type-check None.
-    if value is None:
-        return
+def _lookup_input_model(tool_name: str) -> type[BaseModel] | None:
+    """Return the pydantic input model for *tool_name*, or None if not registered."""
+    from process_improve.tool_spec import _TOOL_REGISTRY, discover_tools  # noqa: PLC0415
 
-    expected = subschema.get("type")
-    check = _JSON_TYPE_CHECKS.get(expected) if isinstance(expected, str) else None
-    if check is not None and not check(value):
+    discover_tools()
+    func = _TOOL_REGISTRY.get(tool_name)
+    if func is None:
+        return None
+    return getattr(func, "_input_model", None)
+
+
+def _validate_against_model(tool_name: str, tool_input: dict[str, Any], model_cls: type[BaseModel]) -> None:
+    """Run ``model_cls.model_validate`` and translate ``ValidationError`` -> ``ToolInputInvalidError``."""
+    try:
+        model_cls.model_validate(tool_input)
+    except ValidationError as exc:
         raise ToolInputInvalidError(
-            f"Parameter {key!r} must be of type {expected!r}, got {type(value).__name__}.",
-            details={"key": key, "expected_type": expected, "observed_type": type(value).__name__},
-        )
-
-    enum = subschema.get("enum")
-    if enum is not None and value not in enum:
-        raise ToolInputInvalidError(
-            f"Parameter {key!r}={value!r} is not one of {enum}.",
-            details={"key": key, "enum": list(enum)},
-        )
-
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        minimum = subschema.get("minimum")
-        if minimum is not None and value < minimum:
-            raise ToolInputInvalidError(
-                f"Parameter {key!r}={value} is below the minimum of {minimum}.",
-                details={"key": key, "minimum": minimum, "observed": value},
-            )
-        maximum = subschema.get("maximum")
-        if maximum is not None and value > maximum:
-            raise ToolInputInvalidError(
-                f"Parameter {key!r}={value} exceeds the maximum of {maximum}.",
-                details={"key": key, "maximum": maximum, "observed": value},
-            )
-
-    if isinstance(value, list):
-        min_items = subschema.get("minItems")
-        if min_items is not None and len(value) < min_items:
-            raise ToolInputInvalidError(
-                f"Parameter {key!r} has {len(value)} items; minimum is {min_items}.",
-                details={"key": key, "min_items": min_items, "observed": len(value)},
-            )
-        max_items = subschema.get("maxItems")
-        if max_items is not None and len(value) > max_items:
-            raise ToolInputInvalidError(
-                f"Parameter {key!r} has {len(value)} items; maximum is {max_items}.",
-                details={"key": key, "max_items": max_items, "observed": len(value)},
-            )
-
-
-def validate_against_schema(tool_input: dict[str, Any], schema: dict[str, Any]) -> None:
-    """Validate *tool_input* against a tool's JSON ``input_schema``.
-
-    Enforces the subset of JSON Schema used by process-improve tool specs:
-    the object's ``required`` keys must be present, parameters not declared in
-    ``properties`` are rejected (no additional keys), and each supplied value is
-    checked against its property ``type``, ``enum``, ``minimum``/``maximum``
-    (numbers) and ``minItems``/``maxItems`` (arrays).
-
-    Parameters
-    ----------
-    tool_input:
-        The ``input`` dict that would be passed as keyword arguments to the tool.
-    schema:
-        The tool's ``input_schema`` (a JSON Schema object).
-
-    Raises
-    ------
-    ToolInputInvalidError
-        On any missing-required, unknown-key, type, enum, bound, or item-count
-        violation.
-    """
-    if schema.get("type") != "object":
-        return
-
-    properties: dict[str, Any] = schema.get("properties", {})
-    required = schema.get("required", [])
-
-    for req_key in required:
-        if req_key not in tool_input:
-            raise ToolInputInvalidError(
-                f"Missing required parameter {req_key!r}.",
-                details={"key": req_key, "required": list(required)},
-            )
-
-    if properties:
-        unknown = sorted(set(tool_input) - set(properties))
-        if unknown:
-            raise ToolInputInvalidError(
-                f"Unknown parameter(s): {unknown}. Allowed: {sorted(properties)}.",
-                details={"unknown": unknown, "allowed": sorted(properties)},
-            )
-
-    for key, value in tool_input.items():
-        subschema = properties.get(key)
-        if isinstance(subschema, dict):
-            _validate_value(key, value, subschema)
-
-
-def _lookup_input_schema(tool_name: str) -> dict[str, Any] | None:
-    """Return the ``input_schema`` for *tool_name*, or None if not registered."""
-    from process_improve.tool_spec import get_tool_specs  # noqa: PLC0415
-
-    specs = get_tool_specs(names=[tool_name])
-    return specs[0]["input_schema"] if specs else None
+            f"Input to tool {tool_name!r} failed validation: {exc}",
+            details={"tool_name": tool_name, "errors": exc.errors()},
+        ) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -561,13 +464,14 @@ def safe_execute_tool_call(  # noqa: PLR0913
         max_depth=max_depth,
     )
 
-    # Enforce the tool's declared JSON schema (types, bounds, enums, required,
-    # no unknown keys). Done after the size check so an oversize payload is still
-    # reported as ToolInputTooLargeError. Unknown tools fall through to the
-    # worker, which raises the canonical "Unknown tool" ValueError.
-    schema = _lookup_input_schema(tool_name)
-    if schema is not None:
-        validate_against_schema(tool_input, schema)
+    # Enforce the tool's pydantic input contract (types, bounds, enums,
+    # required, no unknown keys). Done after the size check so an oversize
+    # payload is still reported as ToolInputTooLargeError. Unknown tools
+    # fall through to the worker, which raises the canonical "Unknown tool"
+    # ValueError.
+    model_cls = _lookup_input_model(tool_name)
+    if model_cls is not None:
+        _validate_against_model(tool_name, tool_input, model_cls)
 
     pool = executor if executor is not None else get_pool(memory_mb=memory_mb)
     future = pool.submit(_worker_run, tool_name, tool_input)

--- a/process_improve/tool_spec.py
+++ b/process_improve/tool_spec.py
@@ -108,12 +108,11 @@ def _validate_rng_metadata(name: str, rng: dict[str, Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def tool_spec(  # noqa: C901, PLR0913
+def tool_spec(  # noqa: PLR0913
     name: str,
     description: str,
     *,
-    input_model: type[BaseModel] | None = None,
-    input_schema: dict[str, Any] | None = None,
+    input_model: type[BaseModel],
     examples: str = "",
     category: str = "",
     rng: dict[str, Any] | None = None,
@@ -128,10 +127,9 @@ def tool_spec(  # noqa: C901, PLR0913
         Natural-language description of what the tool does and when to use it.
     input_model:
         A :class:`pydantic.BaseModel` subclass describing the tool's
-        input. **This is the preferred form** (ENG-04 / ENG-10): the
-        model is the single source of truth for both the function's
-        Python signature and the MCP JSON Schema (derived via
-        :meth:`BaseModel.model_json_schema`). Every input model
+        input. The model is the single source of truth for both the
+        function's Python signature and the MCP JSON Schema (derived
+        via :meth:`BaseModel.model_json_schema`). Every input model
         **must** set ``model_config = ConfigDict(extra="forbid")`` so
         unknown keys are rejected (closes the SEC-15
         kwarg-injection vector at the schema layer).
@@ -146,12 +144,6 @@ def tool_spec(  # noqa: C901, PLR0913
             @tool_spec(name="foo", description="...", input_model=FooInput)
             def foo(spec: FooInput) -> dict:
                 return {"n": len(spec.values)}
-    input_schema:
-        **Legacy.** A dict with a single ``"json"`` key whose value is
-        a hand-written JSON Schema. Kept while the
-        per-package migration to ``input_model=`` lands; new code
-        must not use this form. Exactly one of ``input_model`` /
-        ``input_schema`` must be provided.
     examples:
         Optional natural-language -> tool-call mappings appended to
         ``description`` so the LLM sees worked examples.
@@ -159,46 +151,30 @@ def tool_spec(  # noqa: C901, PLR0913
         Optional category string (e.g. ``"univariate"``). Used for
         filtering with :func:`get_tool_specs`.
     rng:
-        Optional reproducibility metadata; see the prior docstring
+        Optional reproducibility metadata; see :func:`_validate_rng_metadata`
         for the contract.
 
     Returns
     -------
     Callable
         The original function, with an attached ``_tool_spec`` dict
-        and ``_input_model`` attribute (None for legacy tools).
+        and ``_input_model`` attribute.
     """
     if rng is not None:
         _validate_rng_metadata(name, rng)
 
-    # Exactly one input contract -- mutually exclusive, neither defaults.
-    if input_model is None and input_schema is None:
+    if not (isinstance(input_model, type) and issubclass(input_model, BaseModel)):
         raise TypeError(
-            f"@tool_spec(name={name!r}): must provide either input_model= "
-            "(preferred) or input_schema= (legacy)."
+            f"@tool_spec(name={name!r}): input_model must be a pydantic "
+            f"BaseModel subclass; got {input_model!r}."
         )
-    if input_model is not None and input_schema is not None:
-        raise TypeError(
-            f"@tool_spec(name={name!r}): pass either input_model= or "
-            "input_schema=, not both."
+    extra_policy = input_model.model_config.get("extra")
+    if extra_policy != "forbid":
+        raise ValueError(
+            f"@tool_spec(name={name!r}): input_model {input_model.__name__} "
+            "must set model_config = ConfigDict(extra='forbid') so unknown "
+            "kwargs are rejected (ENG-04 / SEC-15 contract)."
         )
-
-    if input_model is not None:
-        # Pydantic-derived path. Enforce the ``extra="forbid"`` contract so
-        # SEC-15's kwarg-injection vector closes at the schema layer rather
-        # than relying on a downstream filter.
-        if not (isinstance(input_model, type) and issubclass(input_model, BaseModel)):
-            raise TypeError(
-                f"@tool_spec(name={name!r}): input_model must be a pydantic "
-                f"BaseModel subclass; got {input_model!r}."
-            )
-        extra_policy = input_model.model_config.get("extra")
-        if extra_policy != "forbid":
-            raise ValueError(
-                f"@tool_spec(name={name!r}): input_model {input_model.__name__} "
-                "must set model_config = ConfigDict(extra='forbid') so unknown "
-                "kwargs are rejected (ENG-04 / SEC-15 contract)."
-            )
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         """Attach the assembled tool spec to ``func`` and return it unchanged."""
@@ -206,16 +182,10 @@ def tool_spec(  # noqa: C901, PLR0913
         if examples:
             full_description = f"{description}\n\nExamples\n--------\n{examples}"
 
-        json_schema = (
-            input_model.model_json_schema()
-            if input_model is not None
-            else input_schema["json"]  # type: ignore[index]
-        )
-
         spec: dict[str, Any] = {
             "name": name,
             "description": full_description,
-            "input_schema": json_schema,
+            "input_schema": input_model.model_json_schema(),
         }
         if category:
             spec["category"] = category
@@ -344,39 +314,14 @@ def get_tool_specs(
     return specs
 
 
-def _filter_to_declared_keys(func: Callable[..., Any], tool_input: dict[str, Any]) -> dict[str, Any]:
-    """Drop ``tool_input`` keys not declared in the tool's ``input_schema``.
-
-    The dispatch path forwards ``tool_input`` straight through as ``**kwargs``.
-    Some tools deliberately keep host-injected parameters (e.g. the simulator's
-    ``simulator_state`` / ``confirmed``) out of the public JSON schema; without
-    this filter a prompt-injected agent could re-introduce them as ordinary
-    kwargs and reach the function (SEC-15). We keep only keys the schema's
-    ``properties`` declare. Tools whose schema is not an ``object`` or declares
-    no ``properties`` are passed through unchanged.
-    """
-    spec = getattr(func, "_tool_spec", None)
-    if not isinstance(spec, dict):
-        return tool_input
-    schema = spec.get("input_schema")
-    if not isinstance(schema, dict) or schema.get("type") != "object":
-        return tool_input
-    properties = schema.get("properties")
-    if not isinstance(properties, dict) or not properties:
-        return tool_input
-    extra = set(tool_input) - set(properties)
-    if not extra:
-        return tool_input
-    logger.warning(
-        "Dropping undeclared key(s) %s from input to tool %r before dispatch.",
-        sorted(extra),
-        spec.get("name", "<unknown>"),
-    )
-    return {k: v for k, v in tool_input.items() if k in properties}
-
-
 def execute_tool_call(tool_name: str, tool_input: dict[str, Any]) -> Any:  # noqa: ANN401
     """Dispatch a single tool call from an Anthropic ``tool_use`` content block.
+
+    The input dict is validated via
+    ``input_model.model_validate(tool_input)``. Unknown keys raise
+    ``ToolInputInvalidError`` (closes the SEC-15 ``confirmed=True``
+    kwarg-injection at the schema layer). The parsed pydantic model is
+    passed to the tool function as a single positional argument.
 
     Parameters
     ----------
@@ -384,15 +329,6 @@ def execute_tool_call(tool_name: str, tool_input: dict[str, Any]) -> Any:  # noq
         The ``name`` field from the ``tool_use`` block.
     tool_input:
         The ``input`` dict from the ``tool_use`` block.
-
-        - **Pydantic tools** (``input_model=``): the dict is validated
-          via ``input_model.model_validate(tool_input)``. Unknown keys
-          raise ``ToolInputInvalidError`` (closes the SEC-15
-          ``confirmed=True`` kwarg-injection at the schema layer).
-        - **Legacy tools** (``input_schema=``): the dict is filtered
-          to the keys declared in ``properties`` before being
-          forwarded as ``**kwargs`` -- the same defence-in-depth
-          filter that has shipped since SEC-15 was first patched.
 
     Returns
     -------
@@ -405,24 +341,22 @@ def execute_tool_call(tool_name: str, tool_input: dict[str, Any]) -> Any:  # noq
     ValueError
         If *tool_name* is not in the registry.
     ToolInputInvalidError
-        If a pydantic-tool's input fails validation.
+        If the input fails pydantic validation.
     """
     discover_tools()
     if tool_name not in _TOOL_REGISTRY:
         available = sorted(_TOOL_REGISTRY)
         raise ValueError(f"Unknown tool {tool_name!r}. Available tools: {available}")
     func = _TOOL_REGISTRY[tool_name]
-    model_cls: type[BaseModel] | None = getattr(func, "_input_model", None)
-    if model_cls is not None:
-        try:
-            parsed = model_cls.model_validate(tool_input)
-        except ValidationError as exc:
-            raise ToolInputInvalidError(
-                f"Input to tool {tool_name!r} failed validation: {exc}",
-                details={"tool_name": tool_name, "errors": exc.errors()},
-            ) from exc
-        return func(parsed)
-    return func(**_filter_to_declared_keys(func, tool_input))
+    model_cls: type[BaseModel] = func._input_model  # type: ignore[attr-defined]
+    try:
+        parsed = model_cls.model_validate(tool_input)
+    except ValidationError as exc:
+        raise ToolInputInvalidError(
+            f"Input to tool {tool_name!r} failed validation: {exc}",
+            details={"tool_name": tool_name, "errors": exc.errors()},
+        ) from exc
+    return func(parsed)
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.3"
+version = "1.24.4"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_tool_safety.py
+++ b/tests/test_tool_safety.py
@@ -23,6 +23,7 @@ import time
 
 import numpy as np
 import pytest
+from pydantic import BaseModel, ConfigDict, Field
 
 from process_improve.tool_safety import (
     ToolInputInvalidError,
@@ -32,14 +33,14 @@ from process_improve.tool_safety import (
     ToolTimeoutError,
     _apply_memory_limit,
     _count_numeric_leaves,
-    _lookup_input_schema,
+    _lookup_input_model,
     _pool_initializer,
     _terminate_workers,
+    _validate_against_model,
     _worker_run,
     get_pool,
     safe_execute_tool_call,
     shutdown_pool,
-    validate_against_schema,
     validate_input,
 )
 from process_improve.tool_spec import _TOOL_REGISTRY, tool_spec
@@ -59,45 +60,62 @@ _skip_if_not_linux = pytest.mark.skipif(
 # ---------------------------------------------------------------------------
 
 
+class _EchoInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    value: float
+
+
 @tool_spec(
     name="_safety_test_echo",
     description="Return the input unchanged. Test-only.",
-    input_schema={"json": {"type": "object", "properties": {"value": {"type": "number"}}, "required": ["value"]}},
+    input_model=_EchoInput,
 )
-def _safety_test_echo(*, value: float) -> dict:
-    return {"value": value}
+def _safety_test_echo(spec: _EchoInput) -> dict:
+    return {"value": spec.value}
+
+
+class _SleepInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    seconds: float
 
 
 @tool_spec(
     name="_safety_test_sleep",
     description="Sleep for the given number of seconds. Test-only.",
-    input_schema={"json": {"type": "object", "properties": {"seconds": {"type": "number"}}, "required": ["seconds"]}},
+    input_model=_SleepInput,
 )
-def _safety_test_sleep(*, seconds: float) -> dict:
-    time.sleep(seconds)
-    return {"slept": seconds}
+def _safety_test_sleep(spec: _SleepInput) -> dict:
+    time.sleep(spec.seconds)
+    return {"slept": spec.seconds}
+
+
+class _MemoryBombInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    megabytes: int
 
 
 @tool_spec(
     name="_safety_test_memory_bomb",
     description="Allocate the given number of megabytes. Test-only.",
-    input_schema={
-        "json": {"type": "object", "properties": {"megabytes": {"type": "integer"}}, "required": ["megabytes"]},
-    },
+    input_model=_MemoryBombInput,
 )
-def _safety_test_memory_bomb(*, megabytes: int) -> dict:
+def _safety_test_memory_bomb(spec: _MemoryBombInput) -> dict:
     # Allocate a NumPy array to force a real RSS increase.
-    size = int(megabytes) * 1024 * 1024 // 8
+    size = int(spec.megabytes) * 1024 * 1024 // 8
     _ = np.zeros(size, dtype=np.float64)
-    return {"allocated_mb": megabytes}
+    return {"allocated_mb": spec.megabytes}
+
+
+class _BusyLoopInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
 
 
 @tool_spec(
     name="_safety_test_busy_loop",
     description="Spin on the CPU forever. Test-only.",
-    input_schema={"json": {"type": "object", "properties": {}}},
+    input_model=_BusyLoopInput,
 )
-def _safety_test_busy_loop() -> dict:
+def _safety_test_busy_loop(spec: _BusyLoopInput) -> dict:
     while True:
         pass
 
@@ -174,107 +192,97 @@ class TestValidateInput:
 
 
 # ---------------------------------------------------------------------------
-# validate_against_schema: SEC-04, synchronous, in-process
+# _validate_against_model + _lookup_input_model: SEC-04, synchronous, in-process
+#
+# The legacy bespoke ``validate_against_schema`` JSON-schema walker was
+# removed alongside the legacy ``input_schema=`` parameter (ENG-04 / ENG-10
+# cleanup). Validation now lives on the pydantic ``BaseModel`` attached to
+# each tool: types, bounds, enums, ``required`` fields, and "no unknown keys"
+# (via ``ConfigDict(extra="forbid")``) all come from ``model_validate``. The
+# tests below pin that surface through the helpers ``safe_execute_tool_call``
+# actually uses.
 # ---------------------------------------------------------------------------
 
 
-_DEMO_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "data": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 5},
-        "n_components": {"type": "integer", "minimum": 1},
-        "conf_level": {"type": "number", "minimum": 0.8, "maximum": 0.999},
-        "method": {"type": "string", "enum": ["a", "b"]},
-        "name": {"type": "string"},
-    },
-    "required": ["data", "n_components"],
-}
+class _DemoInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    data: list[float] = Field(..., min_length=3, max_length=5)
+    n_components: int = Field(..., ge=1)
+    conf_level: float = Field(0.95, ge=0.8, le=0.999)
+    method: str | None = Field(None, pattern="^[ab]$")
+    name: str | None = None
 
 
-class TestValidateAgainstSchema:
+class TestValidateAgainstModel:
     def test_valid_input_passes(self) -> None:
-        validate_against_schema(
+        _validate_against_model(
+            "demo",
             {"data": [1, 2, 3], "n_components": 2, "conf_level": 0.95, "method": "a"},
-            _DEMO_SCHEMA,
-        )
-
-    def test_int_accepted_for_number_type(self) -> None:
-        # JSON "number" accepts integers.
-        validate_against_schema(
-            {"x": 5},
-            {"type": "object", "properties": {"x": {"type": "number"}}},
+            _DemoInput,
         )
 
     def test_missing_required_rejected(self) -> None:
-        with pytest.raises(ToolInputInvalidError, match="required"):
-            validate_against_schema({"data": [1, 2, 3]}, _DEMO_SCHEMA)
+        with pytest.raises(ToolInputInvalidError, match="n_components"):
+            _validate_against_model("demo", {"data": [1, 2, 3]}, _DemoInput)
 
     def test_unknown_key_rejected(self) -> None:
-        with pytest.raises(ToolInputInvalidError, match="Unknown parameter"):
-            validate_against_schema(
-                {"data": [1, 2, 3], "n_components": 2, "bogus": 1}, _DEMO_SCHEMA
+        with pytest.raises(ToolInputInvalidError, match="bogus"):
+            _validate_against_model(
+                "demo", {"data": [1, 2, 3], "n_components": 2, "bogus": 1}, _DemoInput
             )
 
     def test_wrong_type_rejected(self) -> None:
-        with pytest.raises(ToolInputInvalidError, match="type 'integer'"):
-            validate_against_schema({"data": [1, 2, 3], "n_components": "two"}, _DEMO_SCHEMA)
-
-    def test_float_rejected_for_integer(self) -> None:
-        with pytest.raises(ToolInputInvalidError):
-            validate_against_schema({"data": [1, 2, 3], "n_components": 2.5}, _DEMO_SCHEMA)
-
-    def test_bool_rejected_for_number(self) -> None:
-        with pytest.raises(ToolInputInvalidError):
-            validate_against_schema({"data": [1, 2, 3], "n_components": True}, _DEMO_SCHEMA)
+        with pytest.raises(ToolInputInvalidError, match="n_components"):
+            _validate_against_model(
+                "demo", {"data": [1, 2, 3], "n_components": "two"}, _DemoInput
+            )
 
     def test_below_minimum_rejected(self) -> None:
-        with pytest.raises(ToolInputInvalidError, match="minimum"):
-            validate_against_schema({"data": [1, 2, 3], "n_components": 0}, _DEMO_SCHEMA)
+        with pytest.raises(ToolInputInvalidError, match="greater than or equal to 1"):
+            _validate_against_model(
+                "demo", {"data": [1, 2, 3], "n_components": 0}, _DemoInput
+            )
 
     def test_above_maximum_rejected(self) -> None:
-        with pytest.raises(ToolInputInvalidError, match="maximum"):
-            validate_against_schema(
-                {"data": [1, 2, 3], "n_components": 2, "conf_level": 2.0}, _DEMO_SCHEMA
+        with pytest.raises(ToolInputInvalidError, match=r"less than or equal to 0\.999"):
+            _validate_against_model(
+                "demo",
+                {"data": [1, 2, 3], "n_components": 2, "conf_level": 2.0},
+                _DemoInput,
             )
 
     def test_too_few_items_rejected(self) -> None:
-        with pytest.raises(ToolInputInvalidError, match="minimum is 3"):
-            validate_against_schema({"data": [1, 2], "n_components": 2}, _DEMO_SCHEMA)
+        with pytest.raises(ToolInputInvalidError, match="at least 3 items"):
+            _validate_against_model("demo", {"data": [1, 2], "n_components": 2}, _DemoInput)
 
     def test_too_many_items_rejected(self) -> None:
-        with pytest.raises(ToolInputInvalidError, match="maximum is 5"):
-            validate_against_schema({"data": [1, 2, 3, 4, 5, 6], "n_components": 2}, _DEMO_SCHEMA)
+        with pytest.raises(ToolInputInvalidError, match="at most 5 items"):
+            _validate_against_model(
+                "demo", {"data": [1, 2, 3, 4, 5, 6], "n_components": 2}, _DemoInput
+            )
 
     def test_bad_enum_rejected(self) -> None:
-        with pytest.raises(ToolInputInvalidError, match="not one of"):
-            validate_against_schema(
-                {"data": [1, 2, 3], "n_components": 2, "method": "z"}, _DEMO_SCHEMA
+        with pytest.raises(ToolInputInvalidError, match="method"):
+            _validate_against_model(
+                "demo", {"data": [1, 2, 3], "n_components": 2, "method": "z"}, _DemoInput
             )
 
     def test_explicit_null_for_optional_allowed(self) -> None:
-        # An optional parameter passed as null falls back to the tool's default.
-        validate_against_schema(
-            {"data": [1, 2, 3], "n_components": 2, "name": None}, _DEMO_SCHEMA
+        _validate_against_model(
+            "demo",
+            {"data": [1, 2, 3], "n_components": 2, "name": None},
+            _DemoInput,
         )
 
-    def test_non_object_schema_is_noop(self) -> None:
-        # Schemas that are not object-typed are not enforced (no raise).
-        validate_against_schema({"anything": 1}, {"type": "array"})
+    def test_lookup_input_model_unknown_returns_none(self) -> None:
+        assert _lookup_input_model("definitely_not_a_registered_tool") is None
 
-    def test_property_without_recognised_type_is_skipped(self) -> None:
-        # A property whose subschema declares no (or an unknown) type is accepted
-        # as-is; only enum/bounds, if present, still apply.
-        schema = {"type": "object", "properties": {"x": {"description": "free-form"}}}
-        validate_against_schema({"x": ["whatever", 1, {"k": "v"}]}, schema)
-
-    def test_lookup_input_schema_unknown_returns_none(self) -> None:
-        assert _lookup_input_schema("definitely_not_a_registered_tool") is None
-
-    def test_lookup_input_schema_known_returns_schema(self) -> None:
-        schema = _lookup_input_schema("_safety_test_echo")
-        assert schema is not None
-        assert schema["type"] == "object"
-        assert "value" in schema["properties"]
+    def test_lookup_input_model_known_returns_model(self) -> None:
+        model = _lookup_input_model("_safety_test_echo")
+        assert model is not None
+        assert issubclass(model, BaseModel)
+        assert "value" in model.model_fields
 
 
 # ---------------------------------------------------------------------------
@@ -399,7 +407,9 @@ class TestSafeExecuteToolCall:
             safe_execute_tool_call("_safety_test_echo", {"value": "not-a-number"}, timeout=10)
 
     def test_schema_unknown_key_rejected_before_subprocess(self) -> None:
-        with pytest.raises(ToolInputInvalidError, match="Unknown parameter"):
+        # Pydantic ``extra="forbid"`` rejects undeclared keys; the error message
+        # references the extra-forbidden discriminator and the offending key.
+        with pytest.raises(ToolInputInvalidError, match="extra_forbidden"):
             safe_execute_tool_call("_safety_test_echo", {"value": 1, "rogue": 2}, timeout=10)
 
     def test_timeout_raises_structured_error(self) -> None:

--- a/tests/test_tool_spec.py
+++ b/tests/test_tool_spec.py
@@ -97,6 +97,29 @@ class TestToolSpecDecorator:
         assert "test_dummy_add" in _TOOL_REGISTRY
         assert "test_dummy_mul" in _TOOL_REGISTRY
 
+    def test_rejects_non_basemodel_input_model(self) -> None:
+        """input_model must be a pydantic BaseModel subclass."""
+        with pytest.raises(TypeError, match="must be a pydantic"):
+            tool_spec(
+                name="_bad_model",
+                description="x",
+                input_model=dict,  # type: ignore[arg-type]
+            )
+
+    def test_rejects_input_model_missing_extra_forbid(self) -> None:
+        """Input models must declare ``ConfigDict(extra='forbid')`` (ENG-04 / SEC-15)."""
+
+        class _NotForbidden(BaseModel):
+            # Default policy is "ignore", not "forbid" -- should be rejected.
+            value: float
+
+        with pytest.raises(ValueError, match="extra='forbid'"):
+            tool_spec(
+                name="_bad_extra",
+                description="x",
+                input_model=_NotForbidden,
+            )
+
 
 class TestGetToolSpecs:
     def test_returns_list_of_dicts(self) -> None:
@@ -122,6 +145,12 @@ class TestGetToolSpecs:
         """Verify an empty names filter returns an empty list."""
         specs = get_tool_specs(names=[])
         assert specs == []
+
+    def test_category_filter(self) -> None:
+        """Verify filtering specs by category returns only matching entries."""
+        specs = get_tool_specs(category="univariate")
+        assert len(specs) > 0
+        assert all(s.get("category") == "univariate" for s in specs)
 
 
 class TestExecuteToolCall:

--- a/tests/test_tool_spec.py
+++ b/tests/test_tool_spec.py
@@ -7,19 +7,29 @@ from collections.abc import Callable
 
 import numpy as np
 import pytest
+from pydantic import BaseModel, ConfigDict
 
 # Importing the univariate tools module triggers @tool_spec registration.
 import process_improve.multivariate.tools
 import process_improve.univariate.tools  # noqa: F401
 from process_improve.tool_spec import (
     _TOOL_REGISTRY,
-    _filter_to_declared_keys,
     clean,
     execute_tool_call,
     get_tool_specs,
     tool_spec,
 )
 from process_improve.univariate.tools import get_univariate_tool_specs
+
+
+class _AddInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    a: float
+    b: float
+
+
+class _EmptyInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
 
 # ---------------------------------------------------------------------------
 # tool_spec decorator and registry
@@ -33,16 +43,10 @@ class TestToolSpecDecorator:
         @tool_spec(
             name="test_dummy_add",
             description="Add two numbers.",
-            input_schema={
-                "json": {
-                    "type": "object",
-                    "properties": {"a": {"type": "number"}, "b": {"type": "number"}},
-                    "required": ["a", "b"],
-                }
-            },
+            input_model=_AddInput,
         )
-        def _dummy(*, a: float, b: float) -> dict:
-            return {"result": a + b}
+        def _dummy(spec: _AddInput) -> dict:
+            return {"result": spec.a + spec.b}
 
         assert hasattr(_dummy, "_tool_spec")
         assert _dummy._tool_spec["name"] == "test_dummy_add"
@@ -53,18 +57,12 @@ class TestToolSpecDecorator:
         @tool_spec(
             name="test_dummy_mul",
             description="Multiply.",
-            input_schema={
-                "json": {
-                    "type": "object",
-                    "properties": {"a": {"type": "number"}, "b": {"type": "number"}},
-                    "required": ["a", "b"],
-                }
-            },
+            input_model=_AddInput,
         )
-        def _mul(*, a: float, b: float) -> dict:
-            return {"result": a * b}
+        def _mul(spec: _AddInput) -> dict:
+            return {"result": spec.a * spec.b}
 
-        assert _mul(a=3, b=4)["result"] == 12
+        assert _mul(_AddInput(a=3, b=4))["result"] == 12
 
     def test_examples_appended_to_description(self) -> None:
         """Verify examples text is appended to the description."""
@@ -72,10 +70,10 @@ class TestToolSpecDecorator:
         @tool_spec(
             name="test_dummy_examples",
             description="A tool.",
-            input_schema={"json": {"type": "object", "properties": {}, "required": []}},
+            input_model=_EmptyInput,
             examples="# example -> call()",
         )
-        def _ex() -> dict:
+        def _ex(spec: _EmptyInput) -> dict:
             return {}
 
         assert "Examples" in _ex._tool_spec["description"]
@@ -87,9 +85,9 @@ class TestToolSpecDecorator:
         @tool_spec(
             name="test_dummy_no_examples",
             description="Plain description.",
-            input_schema={"json": {"type": "object", "properties": {}, "required": []}},
+            input_model=_EmptyInput,
         )
-        def _plain() -> dict:
+        def _plain(spec: _EmptyInput) -> dict:
             return {}
 
         assert _plain._tool_spec["description"] == "Plain description."
@@ -155,42 +153,10 @@ class TestExecuteToolCall:
             )
 
 
-class TestFilterToDeclaredKeys:
-    """Unit tests for the schema-key filter used by execute_tool_call (SEC-15)."""
-
-    def test_keeps_declared_keys_and_drops_others(self) -> None:
-        func = _TOOL_REGISTRY["robust_summary_stats"]
-        filtered = _filter_to_declared_keys(func, {"values": [1], "rogue": 9})
-        assert filtered == {"values": [1]}
-
-    def test_passthrough_when_no_extra_keys(self) -> None:
-        func = _TOOL_REGISTRY["robust_summary_stats"]
-        payload = {"values": [1, 2]}
-        # Returned unchanged (and is the same object: nothing to filter).
-        assert _filter_to_declared_keys(func, payload) is payload
-
-    def test_passthrough_when_no_tool_spec(self) -> None:
-        def bare() -> None:  # no _tool_spec attribute
-            return None
-
-        payload = {"anything": 1}
-        assert _filter_to_declared_keys(bare, payload) is payload
-
-    def test_passthrough_when_schema_not_object(self) -> None:
-        def fn() -> None:
-            return None
-
-        fn._tool_spec = {"name": "fn", "input_schema": {"type": "string"}}
-        payload = {"a": 1}
-        assert _filter_to_declared_keys(fn, payload) is payload
-
-    def test_passthrough_when_no_properties(self) -> None:
-        def fn() -> None:
-            return None
-
-        fn._tool_spec = {"name": "fn", "input_schema": {"type": "object"}}
-        payload = {"a": 1}
-        assert _filter_to_declared_keys(fn, payload) is payload
+# The pre-pydantic ``_filter_to_declared_keys`` helper was deleted in the
+# ENG-04 / ENG-10 cleanup; its job (dropping undeclared kwargs) is now done by
+# pydantic's ``ConfigDict(extra="forbid")``, exercised end-to-end by
+# ``test_rejects_keys_not_declared_in_pydantic_model`` above.
 
 
 # ---------------------------------------------------------------------------
@@ -642,7 +608,7 @@ class TestValidateRngMetadata:
         return tool_spec(
             name=f"_rng_test_tool_{id(rng_value)}",
             description="x",
-            input_schema={"json": {"type": "object", "properties": {}, "required": []}},
+            input_model=_EmptyInput,
             rng=rng_value,  # type: ignore[arg-type]
         )(dict)
 
@@ -697,7 +663,7 @@ class TestValidateRngMetadata:
         @tool_spec(
             name="_rng_test_valid",
             description="x",
-            input_schema={"json": {"type": "object", "properties": {}, "required": []}},
+            input_model=_EmptyInput,
             rng={"uses_rng": True, "seed_param": "seed", "default_seed": 42},
         )
         def _f() -> dict:
@@ -715,7 +681,7 @@ class TestValidateRngMetadata:
         @tool_spec(
             name="_rng_test_deterministic",
             description="x",
-            input_schema={"json": {"type": "object", "properties": {}, "required": []}},
+            input_model=_EmptyInput,
             rng={"uses_rng": False},
         )
         def _f() -> dict:


### PR DESCRIPTION
## Summary

Follow-up to the four-PR pydantic migration (PR1 #328 → PR4 #331). Now that every `@tool_spec` in the codebase uses `input_model=`, the legacy `input_schema=` parameter, `validate_against_schema()`, and `_filter_to_declared_keys()` can be removed without behavioural change.

Planned changes:

1. **`process_improve/tool_spec.py`** — drop `input_schema=` from the decorator signature; remove the legacy dispatch branch in `execute_tool_call`; delete `_filter_to_declared_keys()`.

2. **`process_improve/tool_safety.py`** — switch `safe_execute_tool_call` to validate via `input_model.model_validate(...)` instead of the bespoke `validate_against_schema()`. Replace `_lookup_input_schema` with a model lookup. Delete `validate_against_schema()`.

3. **Tests** — migrate the remaining test fixtures in `tests/test_tool_spec.py` and `tests/test_tool_safety.py` from `input_schema=` to `input_model=`. Delete or convert the `validate_against_schema` tests (now redundant with pydantic).

4. **Close SEC-20 (#266) and SEC-25 (#274)** with cross-references — the pydantic `extra="forbid"` boundary is now the structural closure for both.

## Test plan

- [ ] `uv run ruff check .` clean
- [ ] Full `pytest` suite passes locally
- [ ] `python -O -m pytest` passes
- [ ] PATCH bump 1.24.3 -> 1.24.4; CITATION.cff and CHANGELOG in sync

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho9oSSxJUXTkqwVzPUzzFW)_