### PR TITLE
test: pin regression tests for 7 audit findings; close 8 issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.5] - 2026-06-02
+
+### Tests
+
+- Add regression tests pinning the existing fixes for seven open audit
+  findings that already shipped code-level mitigations but lacked dedicated
+  tests:
+  - **SEC-27 (#276)**: `_parse_term` accepts both `I(A ** 2)` and the
+    `np.power(A, 2)` / `power(A, 2)` forms emitted by newer statsmodels.
+  - **SEC-28 (#277)**: `draw_initial_seed` returns at least 63 bits of
+    entropy (sampled via `secrets.randbits(63)`).
+  - **SEC-29 (#278)**: the `_SIGNIFICANT_FACTOR_PATTERN` regex parses a
+    50KB whitespace-heavy payload in well under a second.
+  - **SEC-30 (#279)**: `engine._load_yaml` rejects a file larger than
+    `_MAX_YAML_BYTES` before `yaml.safe_load` resolves anchors.
+  - **SEC-32 (#281)**: a non-JSON `batches_to_highlight` key raises
+    `ValueError` at the plotting API surface, not `JSONDecodeError`.
+  - **SEC-31 (#280)**: `test_cpython_pool_still_exposes_processes_attribute`
+    (already in `tests/test_tool_safety.py`) pins the assumption.
+  - **ENG-27 (#309)**: `tests/test_config.py` already covers lazy env-var
+    reads via the central `settings` module (PR #326).
+- **SEC-20 (#269)** items 2-4 (oneOf, nested items / properties, non-object
+  root, missing array enum) are structurally closed by PR #332 -- the
+  bespoke JSON-schema walker was replaced by `BaseModel.model_validate`,
+  which supports all four directly. Item 1 (the `_SCALAR_CAPS` string-vs-
+  number gap in `validate_input`) is mitigated in practice: a string
+  `"50000"` passes the numeric cap but the very next stage,
+  `_validate_against_model`, rejects it with `ToolInputInvalidError` via
+  the tool's typed pydantic field.
+
 ## [1.24.4] - 2026-06-02
 
 ### Changed (breaking, internal API)
@@ -833,7 +863,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.4...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.5...HEAD
+[1.24.5]: https://github.com/kgdunn/process-improve/compare/v1.24.4...v1.24.5
 [1.24.4]: https://github.com/kgdunn/process-improve/compare/v1.24.3...v1.24.4
 [1.24.3]: https://github.com/kgdunn/process-improve/compare/v1.24.2...v1.24.3
 [1.24.2]: https://github.com/kgdunn/process-improve/compare/v1.24.1...v1.24.2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.4
+version: 1.24.5
 date-released: "2026-06-02"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.4"
+version = "1.24.5"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/batch/test_plotting.py
+++ b/tests/batch/test_plotting.py
@@ -52,6 +52,21 @@ def test_plotting_nylon(nylon_data: dict) -> None:
     assert len(fig["data"]) == len(dict_df) * 2  # plotting two tags; double the number.
 
 
+def test_plotting_nylon_bad_highlight_key_raises_clear_value_error(nylon_data: dict) -> None:
+    """SEC-32 (#281): a non-JSON ``batches_to_highlight`` key raises ValueError at
+    the API surface, not a confusing ``JSONDecodeError`` from inside a
+    comprehension.
+    """
+    with pytest.raises(ValueError, match="JSON-encoded"):
+        plot_all_batches_per_tag(
+            df_dict=nylon_data,
+            tag="Tag09",
+            x_axis_label="Samples since start of batch",
+            # Plain string instead of a JSON-encoded line-style spec.
+            batches_to_highlight={"not-a-json-key": [2, 3]},
+        )
+
+
 def test_plotting_tags(nylon_data: dict) -> None:
     """Test plotting multiple tags."""
     scale_df = determine_scaling(nylon_data, settings={"robust": False})

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -99,6 +99,18 @@ class TestParseTerm:
         """Quadratic I(A ** 2) returns (A, A)."""
         assert _parse_term("I(A ** 2)") == ("A", "A")
 
+    def test_quadratic_np_power_form(self) -> None:
+        """``np.power(A, 2)`` / ``power(A, 2)`` (SEC-27 #276) parse identically to ``I(A ** 2)``.
+
+        Newer statsmodels emits the ``np.power`` form. If the regex misses it,
+        a quadratic term silently falls through to the linear branch and the
+        downstream surface / optimisation produces wrong predictions.
+        """
+        assert _parse_term("np.power(A, 2)") == ("A", "A")
+        assert _parse_term("power(A, 2)") == ("A", "A")
+        # Whitespace tolerance.
+        assert _parse_term("np.power(A,2)") == ("A", "A")
+
     def test_three_way_interaction(self) -> None:
         """Three-way interaction A:B:C returns three-element tuple."""
         assert _parse_term("A:B:C") == ("A", "B", "C")

--- a/tests/test_recommend_strategy.py
+++ b/tests/test_recommend_strategy.py
@@ -166,6 +166,30 @@ class TestPriorKnowledgeParsing:
         pk = _parse_prior_knowledge("Some random text without keywords", [])
         assert 0.1 <= pk.confidence <= 0.5
 
+    def test_significant_factor_regex_runs_in_linear_time(self):
+        r"""SEC-29 (#278) regression guard.
+
+        The previous ``_SIGNIFICANT_FACTOR_PATTERN`` used ``[\\w\\s]*?`` which is
+        O(n^2) on whitespace-heavy input. Combined with the ``max_string``
+        ceiling, a ~50KB whitespace payload burned significant CPU. The fix
+        bounded the capture to ``\\w+(?:\\s\\w+){0,4}`` (linear time). This
+        test sends a 50KB whitespace-heavy payload and asserts the parse
+        completes well under a second.
+        """
+        import time
+
+        # 50KB of mostly whitespace with one trigger phrase at the end.
+        payload = (" " * 49_900) + "Temperature is significant"
+        start = time.perf_counter()
+        pk = _parse_prior_knowledge(payload, ["Temperature"])
+        elapsed = time.perf_counter() - start
+        assert elapsed < 1.0, (
+            f"_SIGNIFICANT_FACTOR_PATTERN took {elapsed:.3f}s on a 50KB "
+            "whitespace payload; the bounded regex should be linear in size."
+        )
+        # Sanity: still extracts the legitimate trigger.
+        assert "Temperature" in pk.known_significant_factors
+
 
 # ---------------------------------------------------------------------------
 # Budget allocation

--- a/tests/test_sec10_path_and_fetch.py
+++ b/tests/test_sec10_path_and_fetch.py
@@ -32,6 +32,23 @@ class TestLoadYamlTraversal:
         assert engine._load_yaml("does_not_exist.yaml") == []
 
 
+class TestLoadYamlSizeCap:
+    """SEC-30 (#279): an oversize YAML file is rejected before yaml.safe_load
+    resolves anchors, defending against a billion-laughs anchor bomb on a
+    tampered file in the data directory.
+    """
+
+    def test_oversize_yaml_rejected(self, tmp_path, monkeypatch) -> None:
+        # Point the loader at a tmp data dir holding a single very large file.
+        bomb = tmp_path / "bomb.yaml"
+        bomb.write_text("x: " + ("y" * (2 * 1024 * 1024)))  # ~2 MB
+        monkeypatch.setattr(engine, "_DATA_DIR", tmp_path)
+        monkeypatch.setattr(engine, "_MAX_YAML_BYTES", 1024 * 1024)  # 1 MB cap
+
+        with pytest.raises(ValueError, match="exceeds the cap"):
+            engine._load_yaml("bomb.yaml")
+
+
 class TestRemoteCsvErrorHandling:
     def test_network_failure_raises_clear_error(self, monkeypatch) -> None:
         def _boom(_url):

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -99,6 +99,32 @@ def _make_sim(seed: int = 42, **overrides) -> dict:
 # ---------------------------------------------------------------------------
 
 
+class TestDrawInitialSeed:
+    """SEC-28 (#277): seeds must carry at least 63 bits of entropy.
+
+    The previous implementation truncated to 31 bits, which combined with
+    observable simulator outputs allowed brute-forcing the hidden model. The
+    fix uses ``secrets.randbits(63)`` for a JSON-int-safe 63-bit seed.
+    """
+
+    def test_seed_uses_at_least_63_bits(self):
+        from process_improve.simulation.model import draw_initial_seed
+
+        # Sample many seeds and assert the spread occupies the full 63-bit range.
+        # 200 samples is plenty: P(all-bits-below-2**62) when sampling from a
+        # uniform 63-bit space is (1/2)**200, i.e. statistically impossible.
+        samples = [draw_initial_seed() for _ in range(200)]
+        assert all(s >= 0 for s in samples)
+        # At least one sample must exceed 2**31 to prove width > 31 bits.
+        assert max(samples) > 2**31, (
+            f"draw_initial_seed appears truncated to <=31 bits; max={max(samples)}"
+        )
+        # At least one sample must exceed 2**62 to prove width >= 63 bits.
+        assert max(samples) > 2**62, (
+            f"draw_initial_seed appears truncated to <=62 bits; max={max(samples)}"
+        )
+
+
 class TestCreateSimulator:
     def test_returns_sim_id_public_and_private(self):
         sim = _make_sim()


### PR DESCRIPTION
## Summary

A sweep of the open audit-finding backlog turned up **seven issues that already shipped code-level fixes** during the security / engineering program but stayed open because they lacked dedicated regression tests. This PR adds the missing tests and closes those issues, plus closes SEC-20 with a cross-reference to PR #332.

### Tests added (5)

| Finding | Test | What it pins |
|---|---|---|
| **SEC-27** #276 | `test_quadratic_np_power_form` | `_parse_term` matches both `I(A ** 2)` and the newer `np.power(A, 2)` / `power(A, 2)` statsmodels spellings. |
| **SEC-28** #277 | `test_seed_uses_at_least_63_bits` | Simulator seed entropy is >= 63 bits (was 31 bits). |
| **SEC-29** #278 | `test_significant_factor_regex_runs_in_linear_time` | A 50KB whitespace payload parses in < 1s. |
| **SEC-30** #279 | `test_oversize_yaml_rejected` | YAML > `_MAX_YAML_BYTES` is rejected before `safe_load` resolves anchors. |
| **SEC-32** #281 | `test_plotting_nylon_bad_highlight_key_raises_clear_value_error` | Non-JSON `batches_to_highlight` key raises `ValueError`, not `JSONDecodeError`. |

### Already-covered findings closed by cross-reference

- **SEC-31** #280: `test_cpython_pool_still_exposes_processes_attribute` in `tests/test_tool_safety.py` already pins the `_processes` assumption.
- **ENG-27** #309: `tests/test_config.py` already exercises the lazy env-var reads via the central `settings` module (shipped in PR #326).

### SEC-20 #269 cross-reference closure

Items 2-4 (oneOf, nested items / properties / additionalProperties, non-object root, missing array enum) are structurally closed by PR #332 — the bespoke JSON-schema walker was replaced by `BaseModel.model_validate` which supports all four directly. Item 1 (the `_SCALAR_CAPS` string-vs-number gap) is mitigated in practice: a string `"50000"` passes the numeric cap but the very next stage, `_validate_against_model`, rejects it with `ToolInputInvalidError`.

## Test plan

- [x] Full `pytest` suite (1490 + 10 skipped) passes locally
- [x] `ruff check .` clean
- [x] PATCH bump 1.24.4 → 1.24.5; CITATION.cff and CHANGELOG in sync
- [ ] CI green

Closes #269 #276 #277 #278 #279 #280 #281 #309 — eight audit issues in one PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho9oSSxJUXTkqwVzPUzzFW)_