### PR TITLE
fix(SEC-13): bound find_reference_batch cutoff loop; raise clear ValueError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.6] - 2026-06-02
+
+### Fixed
+
+- **SEC-13 (#261)**: `find_reference_batch` no longer enters an unbounded
+  cutoff-relaxation loop when the caller requests more reference batches
+  than candidates exist. The loop is now bounded at `conf_level <= 0.95`
+  and the function validates `number_of_reference_batches` against the
+  candidate count up front. The previous behaviour eventually tripped a
+  `python -O`-strippable `assert conf_level < 1.0` inside
+  `spe_calculation`; the fix raises a clear `ValueError` instead.
+
+### Tests
+
+- `tests/batch/test_preprocessing.py` adds regression guards for the two
+  newly-validated error paths (`number_of_reference_batches > len(batches)`
+  and `number_of_reference_batches < 1`).
+
 ## [1.24.5] - 2026-06-02
 
 ### Tests
@@ -863,7 +881,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.5...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.6...HEAD
+[1.24.6]: https://github.com/kgdunn/process-improve/compare/v1.24.5...v1.24.6
 [1.24.5]: https://github.com/kgdunn/process-improve/compare/v1.24.4...v1.24.5
 [1.24.4]: https://github.com/kgdunn/process-improve/compare/v1.24.3...v1.24.4
 [1.24.3]: https://github.com/kgdunn/process-improve/compare/v1.24.2...v1.24.3

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.5
+version: 1.24.6
 date-released: "2026-06-02"
 keywords:
   - chemometrics

--- a/process_improve/batch/preprocessing.py
+++ b/process_improve/batch/preprocessing.py
@@ -653,15 +653,40 @@ def find_reference_batch(
         }
     )
     metrics = metrics.sort_values(by=["HT2", "SPE"])
-    start_cutoff = 0.5
-    # Boolean-mask indexing instead of a DataFrame.query() expression string built
-    # by f-string (no expression is assembled or evaluated).
+    requested = int(settings["number_of_reference_batches"])
+    if requested < 1:
+        raise ValueError(
+            f"number_of_reference_batches must be >= 1, got {requested}."
+        )
+    if requested > len(metrics):
+        # SEC-13 (#261): without this guard the cutoff-relaxation loop below
+        # walks past ``conf_level=1.0``, which trips an ``assert`` inside
+        # ``spe_calculation`` and was -O-strippable. Fail fast with a clear
+        # message instead.
+        raise ValueError(
+            f"number_of_reference_batches={requested} exceeds the number of "
+            f"candidate batches ({len(metrics)}); cannot select that many."
+        )
+
+    # Boolean-mask indexing instead of a DataFrame.query() expression string
+    # built by f-string (no expression is assembled or evaluated).
     spe_metrics = metrics[metrics["SPE"] < pca_second.spe_limit(conf_level=0.5)]
-    while spe_metrics.shape[0] < int(settings["number_of_reference_batches"]):
+    # SEC-13 (#261): bound the cutoff strictly below 1.0. If the loop runs out
+    # of headroom before enough batches pass, give up with a clear error
+    # rather than tripping the inner ``assert conf_level < 1.0`` (which is
+    # ``python -O``-strippable).
+    start_cutoff = 0.5
+    max_cutoff = 0.95
+    while spe_metrics.shape[0] < requested and start_cutoff <= max_cutoff:
         spe_metrics = metrics[metrics["SPE"] < pca_second.spe_limit(conf_level=start_cutoff)]
         start_cutoff += 0.05
+    if spe_metrics.shape[0] < requested:
+        raise ValueError(
+            f"Could not find {requested} reference batches even at "
+            f"conf_level={max_cutoff:.2f}; only {spe_metrics.shape[0]} "
+            "batches passed the SPE cutoff."
+        )
 
-    if settings["number_of_reference_batches"] == 1:
+    if requested == 1:
         return spe_metrics.index[0]  # returns a single entry from the index
-    else:
-        return spe_metrics.index[0 : int(settings["number_of_reference_batches"])].to_list()
+    return spe_metrics.index[0:requested].to_list()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.5"
+version = "1.24.6"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/batch/test_preprocessing.py
+++ b/tests/batch/test_preprocessing.py
@@ -261,6 +261,53 @@ def test_reference_batch_selection_nylon(nylon_data: dict) -> None:
     assert good_reference_candidate == 45
 
 
+def test_find_reference_batch_rejects_request_exceeding_candidates(dryer_data: dict) -> None:
+    """SEC-13 (#261) regression guard.
+
+    Requesting more reference batches than exist used to enter an unbounded
+    cutoff-relaxation loop that eventually tripped ``assert conf_level < 1.0``
+    inside ``spe_calculation`` -- an opaque, ``python -O``-strippable
+    AssertionError. The fix validates up front and raises a clear
+    ValueError.
+    """
+    columns_to_align = [
+        "AgitatorPower",
+        "AgitatorTorque",
+        "JacketTemperatureSP",
+        "JacketTemperature",
+        "DryerTemp",
+    ]
+    with pytest.raises(ValueError, match="exceeds the number of candidate batches"):
+        find_reference_batch(
+            dryer_data,
+            columns_to_align=columns_to_align,
+            settings={
+                "robust": False,
+                "number_of_reference_batches": len(dryer_data) + 100,
+            },
+        )
+
+
+def test_find_reference_batch_rejects_zero_request(dryer_data: dict) -> None:
+    """SEC-13 (#261): a non-positive request raises a clear ValueError."""
+    columns_to_align = [
+        "AgitatorPower",
+        "AgitatorTorque",
+        "JacketTemperatureSP",
+        "JacketTemperature",
+        "DryerTemp",
+    ]
+    with pytest.raises(ValueError, match=r"must be >= 1"):
+        find_reference_batch(
+            dryer_data,
+            columns_to_align=columns_to_align,
+            settings={
+                "robust": False,
+                "number_of_reference_batches": 0,
+            },
+        )
+
+
 # ---- Alignment helper tests (batch/alignment_helpers.py) ----
 
 

--- a/tests/batch/test_preprocessing.py
+++ b/tests/batch/test_preprocessing.py
@@ -288,6 +288,29 @@ def test_find_reference_batch_rejects_request_exceeding_candidates(dryer_data: d
         )
 
 
+def test_find_reference_batch_returns_multiple(dryer_data: dict) -> None:
+    """SEC-13 (#261): requesting >1 batches returns a list, exercising the
+    cutoff-relaxation loop body and the multi-batch return path.
+    """
+    columns_to_align = [
+        "AgitatorPower",
+        "AgitatorTorque",
+        "JacketTemperatureSP",
+        "JacketTemperature",
+        "DryerTemp",
+    ]
+    result = find_reference_batch(
+        dryer_data,
+        columns_to_align=columns_to_align,
+        settings={
+            "robust": False,
+            "number_of_reference_batches": 3,
+        },
+    )
+    assert isinstance(result, list)
+    assert len(result) == 3
+
+
 def test_find_reference_batch_rejects_zero_request(dryer_data: dict) -> None:
     """SEC-13 (#261): a non-positive request raises a clear ValueError."""
     columns_to_align = [


### PR DESCRIPTION
## Summary

Closes **SEC-13 (#261)** — the unbounded cutoff-relaxation loop in `find_reference_batch` that crashed via a `python -O`-strippable `AssertionError` when the caller asked for more reference batches than candidates exist.

## Change

`process_improve/batch/preprocessing.py::find_reference_batch`:

1. Validate `number_of_reference_batches` up front. `> len(metrics)` and `< 1` both raise a clear `ValueError`.
2. Bound the cutoff-relaxation loop at `conf_level <= 0.95`. If the target cannot be met at that ceiling, raise a `ValueError` instead of stepping past `1.0` and tripping `assert conf_level < 1.0` in `spe_calculation`.

Two regression tests in `tests/batch/test_preprocessing.py`.

## Stacked PR

This stacks on **PR #333** (test coverage for already-fixed audit findings). After #333 merges, rebasing this PR onto main produces a clean diff. The base branch is set to #333's branch for review.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `pytest tests/batch/test_preprocessing.py` green (10 passing)
- [x] PATCH bump 1.24.5 -> 1.24.6; CITATION.cff and CHANGELOG in sync

Closes #261.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho9oSSxJUXTkqwVzPUzzFW)_