### PR TITLE
docs(ENG-24): document the pi_ prefix and Expt class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.7] - 2026-06-02
+
+### Documentation
+
+- **ENG-24 (#306)**: documented the `pi_` prefix used on `Expt` /
+  `Column` metadata attributes. The prefix stands for "process-improve"
+  and namespaces library-managed metadata so it cannot collide with
+  caller-supplied DataFrame column names. CONTRIBUTING.md gains a
+  "Naming conventions" subsection covering the prefix and the `Expt`
+  abbreviation; the `Expt` class docstring now lists the pinned
+  ``_metadata`` fields and points at CONTRIBUTING.md.
+
 ## [1.24.6] - 2026-06-02
 
 ### Fixed
@@ -881,7 +893,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.6...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.7...HEAD
+[1.24.7]: https://github.com/kgdunn/process-improve/compare/v1.24.6...v1.24.7
 [1.24.6]: https://github.com/kgdunn/process-improve/compare/v1.24.5...v1.24.6
 [1.24.5]: https://github.com/kgdunn/process-improve/compare/v1.24.4...v1.24.5
 [1.24.4]: https://github.com/kgdunn/process-improve/compare/v1.24.3...v1.24.4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.6
+version: 1.24.7
 date-released: "2026-06-02"
 keywords:
   - chemometrics

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,21 @@ The line length is 120 characters.
 - **Prose:** do not use em-dashes in code, comments, docstrings, or commit
   messages; use a hyphen, a semicolon, or split the sentence.
 
+### Naming conventions
+
+- **`pi_` prefix on attributes** stands for **"process-improve"** and marks
+  library-managed metadata on `Expt` (and related) objects: `pi_title`,
+  `pi_source`, `pi_units`, `pi_range`, `pi_lo`, `pi_hi`, `pi_center`,
+  `pi_name`. The prefix exists to keep these reserved names from colliding
+  with column names from a user-supplied DataFrame. Treat `pi_*` attributes
+  as part of the public API surface; new metadata fields should use the
+  same prefix.
+- **`Expt`** is the canonical (and only) name for the experiment container
+  class, an abbreviation of "Experiment". It is a `pd.DataFrame` subclass
+  carrying the `pi_*` metadata above. The abbreviation predates the rest of
+  the package's spell-out-everything convention; it is retained for backwards
+  compatibility.
+
 ## Adding new methods to PCA / PLS
 
 1. Add the method to the class in `process_improve/multivariate/methods.py`.

--- a/process_improve/experiments/structures.py
+++ b/process_improve/experiments/structures.py
@@ -98,9 +98,26 @@ class Column(pd.Series):
 
 
 class Expt(pd.DataFrame):
-    """
-    Dataframe object with experimental data. Builds on the Pandas dataframe,
-    but with some extra attributes.
+    """Dataframe carrying experimental data plus process-improve metadata.
+
+    ``Expt`` (short for "Experiment") is a :class:`pandas.DataFrame` subclass
+    that adds library-managed metadata fields prefixed with ``pi_`` -- short
+    for "process-improve". The prefix is what keeps these reserved attribute
+    names from colliding with column names from a caller-supplied DataFrame.
+
+    Pinned metadata (preserved across subsetting via ``_metadata``):
+
+    - ``pi_title``  -- short human-readable name for the dataset
+    - ``pi_source`` -- provenance string (file path, URL, ...)
+    - ``pi_units``  -- units string for the numeric columns
+
+    Other ``pi_*`` attributes (``pi_range``, ``pi_lo``, ``pi_hi``,
+    ``pi_center``, ``pi_name``) are set by the experiments factory helpers
+    in this module; see :func:`expt` / :func:`create_names`.
+
+    The ``pi_`` prefix is documented in ``CONTRIBUTING.md`` and is part of
+    the package's public API surface; new metadata fields should follow the
+    same prefix.
     """
 
     # Temporary properties

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.6"
+version = "1.24.7"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Closes **ENG-24 (#306)**. The `pi_*` attributes on `Expt` / `Column` carry library-managed metadata, but the prefix was undocumented; new readers had to grep the codebase to discover that it stands for **"process-improve"** (and is namespaced to avoid colliding with caller-supplied DataFrame column names).

## Changes

- **`CONTRIBUTING.md`**: new "Naming conventions" subsection under Code style covering:
  - The `pi_` prefix on metadata attributes (`pi_title`, `pi_source`, `pi_units`, `pi_range`, `pi_lo`, `pi_hi`, `pi_center`, `pi_name`) and the collision-avoidance rationale.
  - The `Expt` class abbreviation, retained for backwards compatibility.
- **`process_improve/experiments/structures.py::Expt`**: docstring rewritten to list the pinned `_metadata` fields and point readers at the CONTRIBUTING section.

## Stacked PR

Stacked on **PR #334 → PR #333**. After both upstream PRs merge, this rebases cleanly. The base branch is set to #334's branch for review.

## Test plan

- [x] `uv run ruff check .` clean
- [x] No code changes; the docstring rewrite is information-only
- [x] PATCH bump 1.24.6 → 1.24.7; CITATION.cff and CHANGELOG in sync

Closes #306.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho9oSSxJUXTkqwVzPUzzFW)_