### PR TITLE
fix(SEC-25): cap model_params arrays in pca_predict / pls_predict before np.array allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.8] - 2026-06-02
+
+### Security
+
+- **SEC-25 (#274)**: `pca_predict` and `pls_predict` now validate every
+  array-like sub-field of the incoming `model_params` dict against
+  `settings.max_matrix_rows` / `settings.max_matrix_cols` **before** any
+  `np.array(...)` allocation. Previously, the `model_params` schema was
+  `{type: object}` with no inner shape; an attacker-controlled
+  `loadings=[[0]*10**6]*10**6` would allocation-bomb numpy before any
+  later check could fire.
+
+  The new internal helper `_validate_model_params` caps the 2-D keys
+  (loadings, weights, beta-coefficients) via the existing
+  `_validate_matrix_shape`, length-caps the 1-D keys (means, stds,
+  spe_values, scaling factors), and bounds the scalar `n_components` /
+  `n_samples` against `settings.max_matrix_cols` /
+  `settings.max_matrix_rows`. A non-integer or negative scalar is
+  rejected outright.
+
+### Tests
+
+- `tests/test_sec19_dos_caps.py` adds a `TestModelParamsCaps` class
+  with six regression tests covering each of: oversize loadings rows,
+  oversize loadings columns, oversize 1-D arrays, oversize
+  `n_components`, negative `n_samples`, and PLS-specific
+  `x_loadings` caps.
+
 ## [1.24.7] - 2026-06-02
 
 ### Documentation
@@ -893,7 +921,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.7...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.8...HEAD
+[1.24.8]: https://github.com/kgdunn/process-improve/compare/v1.24.7...v1.24.8
 [1.24.7]: https://github.com/kgdunn/process-improve/compare/v1.24.6...v1.24.7
 [1.24.6]: https://github.com/kgdunn/process-improve/compare/v1.24.5...v1.24.6
 [1.24.5]: https://github.com/kgdunn/process-improve/compare/v1.24.4...v1.24.5

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.7
+version: 1.24.8
 date-released: "2026-06-02"
 keywords:
   - chemometrics

--- a/process_improve/multivariate/tools.py
+++ b/process_improve/multivariate/tools.py
@@ -44,6 +44,72 @@ def _validate_matrix_shape(data: list, name: str) -> None:
         )
 
 
+def _validate_model_params(  # noqa: C901
+    model_params: dict,
+    *,
+    keys_2d: tuple[str, ...],
+    keys_1d: tuple[str, ...],
+    scalar_keys: tuple[str, ...] = ("n_components", "n_samples"),
+) -> None:
+    """Cap every array-like sub-field of a ``model_params`` payload (SEC-25 #274).
+
+    ``pca_predict`` / ``pls_predict`` previously read attacker-controlled
+    sizes straight into ``np.array(...)`` and could be allocation-bombed
+    with a multi-million-element nested list (the input ``model_params``
+    field had no inner schema, no ``properties``, no ``maxItems``).
+
+    This guard runs **before** any ``np.array(...)`` allocation:
+
+    - 2-D keys (loadings, weights, beta-coefficients) are checked via
+      :func:`_validate_matrix_shape`, which caps rows against
+      ``settings.max_matrix_rows`` and cols against
+      ``settings.max_matrix_cols``.
+    - 1-D keys (means, stds, spe_values, scaling factors) are length-
+      capped against ``settings.max_matrix_rows``.
+    - Scalar keys (``n_components``, ``n_samples``) are capped against
+      ``settings.max_matrix_cols`` and ``settings.max_matrix_rows``
+      respectively; non-integer values are rejected outright.
+
+    Missing keys propagate as the natural ``KeyError`` from the caller's
+    own dict access; the goal of this function is solely to bound the
+    sizes, not to enforce the full schema (that lives on the underlying
+    fit_pca / fit_pls output).
+    """
+    for key in keys_2d:
+        value = model_params.get(key)
+        if value is not None:
+            _validate_matrix_shape(value, f"model_params[{key!r}]")
+
+    for key in keys_1d:
+        value = model_params.get(key)
+        if value is None:
+            continue
+        n = len(value)
+        if n > settings.max_matrix_rows:
+            raise ValueError(
+                f"model_params[{key!r}] has {n} entries; the cap is "
+                f"settings.max_matrix_rows={settings.max_matrix_rows}."
+            )
+
+    for key in scalar_keys:
+        if key not in model_params:
+            continue
+        value = model_params[key]
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise TypeError(
+                f"model_params[{key!r}] must be an int, got {type(value).__name__}."
+            )
+        cap = settings.max_matrix_cols if key == "n_components" else settings.max_matrix_rows
+        if value > cap:
+            raise ValueError(
+                f"model_params[{key!r}]={value} exceeds the cap of {cap}."
+            )
+        if value < 0:
+            raise ValueError(
+                f"model_params[{key!r}]={value} must be non-negative."
+            )
+
+
 _MULTIVARIATE_TOOL_NAMES: list[str] = []
 
 
@@ -435,6 +501,13 @@ def pca_predict(spec: PcaPredictInput) -> dict[str, Any]:
     """Project new data into a PCA model."""
     try:
         _validate_matrix_shape(spec.new_data, "new_data")
+        # SEC-25 (#274): cap every array-like sub-field of model_params
+        # before any np.array(...) allocation.
+        _validate_model_params(
+            spec.model_params,
+            keys_2d=("loadings",),
+            keys_1d=("means", "stds", "scaling_factor_for_scores", "spe_values"),
+        )
         from process_improve.multivariate.methods import hotellings_t2_limit, spe_calculation  # noqa: PLC0415
 
         means = np.array(spec.model_params["means"])
@@ -525,6 +598,16 @@ def pls_predict(spec: PlsPredictInput) -> dict[str, Any]:
     """Predict Y from new X data using PLS model params."""
     try:
         _validate_matrix_shape(spec.new_data, "new_data")
+        # SEC-25 (#274): cap every array-like sub-field of model_params
+        # before any np.array(...) allocation.
+        _validate_model_params(
+            spec.model_params,
+            keys_2d=("x_loadings", "y_loadings", "direct_weights", "beta_coefficients"),
+            keys_1d=(
+                "x_means", "x_stds", "y_means", "y_stds",
+                "scaling_factor_for_scores", "spe_values",
+            ),
+        )
         from process_improve.multivariate.methods import hotellings_t2_limit, spe_calculation  # noqa: PLC0415
 
         x_means = np.array(spec.model_params["x_means"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.7"
+version = "1.24.8"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_sec19_dos_caps.py
+++ b/tests/test_sec19_dos_caps.py
@@ -316,6 +316,41 @@ class TestModelParamsCaps:
         )
         assert "error" in result
 
+    def test_pca_predict_rejects_non_integer_n_components(self) -> None:
+        from process_improve.tool_spec import execute_tool_call
+
+        params = self._good_pca_params()
+        # A string slips past pydantic's ``dict[str, Any]`` typing but is
+        # rejected by the SEC-25 type check before allocation.
+        params["n_components"] = "not-an-int"
+
+        result = execute_tool_call(
+            "pca_predict",
+            {"new_data": [[0.0]], "model_params": params},
+        )
+        assert "error" in result
+        assert "n_components" in result["error"]
+
+    def test_pca_predict_accepts_well_formed_params(self) -> None:
+        """Sanity check: a well-formed params dict goes through the validator
+        without firing any of the cap branches (covers the loop happy paths).
+        """
+        from process_improve.tool_spec import execute_tool_call
+
+        params = self._good_pca_params()
+        # Strip an optional sub-key to exercise the ``value is None`` short-
+        # circuits in both the 1-D and scalar loops.
+        params.pop("spe_values", None)
+
+        result = execute_tool_call(
+            "pca_predict",
+            {"new_data": [[0.0]], "model_params": params},
+        )
+        # The validator does not fire; the subsequent algorithm may still
+        # error (we stripped spe_values), but the failure surface is *not*
+        # the size-cap path -- which is the SEC-25 invariant.
+        assert result is not None
+
     def test_pls_predict_rejects_oversize_x_loadings(self) -> None:
         from process_improve.tool_spec import execute_tool_call
 

--- a/tests/test_sec19_dos_caps.py
+++ b/tests/test_sec19_dos_caps.py
@@ -218,3 +218,126 @@ class TestFitLinearModelCaps:
         )
         assert "error" not in result
         assert result["r2"] >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# SEC-25 (#274): pca_predict / pls_predict model_params caps
+# ---------------------------------------------------------------------------
+
+
+class TestModelParamsCaps:
+    """``pca_predict`` and ``pls_predict`` previously took unbounded model_params.
+
+    A multi-million-element nested ``loadings`` list slipped past the original
+    ``{type: object}`` schema and was passed straight to ``np.array(...)``,
+    causing an allocation bomb. The fix bounds every array-like sub-field
+    against ``settings.max_matrix_rows`` / ``settings.max_matrix_cols`` before
+    any allocation.
+    """
+
+    def _good_pca_params(self) -> dict:
+        # Minimal well-formed model_params, sized 1x1 to exercise the
+        # validator without doing real PCA work.
+        return {
+            "loadings": [[1.0]],
+            "means": [0.0],
+            "stds": [1.0],
+            "scaling_factor_for_scores": [1.0],
+            "spe_values": [0.0],
+            "n_components": 1,
+            "n_samples": 1,
+        }
+
+    def test_pca_predict_rejects_oversize_loadings_rows(self) -> None:
+        from process_improve.tool_spec import execute_tool_call
+
+        settings.max_matrix_rows = 5
+        params = self._good_pca_params()
+        params["loadings"] = [[0.0]] * 10  # 10 rows > cap of 5
+
+        result = execute_tool_call(
+            "pca_predict",
+            {"new_data": [[0.0]], "model_params": params},
+        )
+        assert "error" in result
+        assert "max_matrix_rows" in result["error"]
+
+    def test_pca_predict_rejects_oversize_loadings_cols(self) -> None:
+        from process_improve.tool_spec import execute_tool_call
+
+        settings.max_matrix_cols = 4
+        params = self._good_pca_params()
+        params["loadings"] = [[0.0] * 10]  # 10 cols > cap of 4
+
+        result = execute_tool_call(
+            "pca_predict",
+            {"new_data": [[0.0]], "model_params": params},
+        )
+        assert "error" in result
+        assert "max_matrix_cols" in result["error"]
+
+    def test_pca_predict_rejects_oversize_means(self) -> None:
+        from process_improve.tool_spec import execute_tool_call
+
+        settings.max_matrix_rows = 5
+        params = self._good_pca_params()
+        params["means"] = [0.0] * 100
+
+        result = execute_tool_call(
+            "pca_predict",
+            {"new_data": [[0.0]], "model_params": params},
+        )
+        assert "error" in result
+        assert "max_matrix_rows" in result["error"]
+
+    def test_pca_predict_rejects_oversize_n_components(self) -> None:
+        from process_improve.tool_spec import execute_tool_call
+
+        settings.max_matrix_cols = 4
+        params = self._good_pca_params()
+        params["n_components"] = 10_000
+
+        result = execute_tool_call(
+            "pca_predict",
+            {"new_data": [[0.0]], "model_params": params},
+        )
+        assert "error" in result
+        assert "n_components" in result["error"]
+
+    def test_pca_predict_rejects_negative_n_samples(self) -> None:
+        from process_improve.tool_spec import execute_tool_call
+
+        params = self._good_pca_params()
+        params["n_samples"] = -1
+
+        result = execute_tool_call(
+            "pca_predict",
+            {"new_data": [[0.0]], "model_params": params},
+        )
+        assert "error" in result
+
+    def test_pls_predict_rejects_oversize_x_loadings(self) -> None:
+        from process_improve.tool_spec import execute_tool_call
+
+        settings.max_matrix_rows = 5
+        params = {
+            "x_loadings": [[0.0]] * 10,  # > cap
+            "y_loadings": [[0.0]],
+            "direct_weights": [[1.0]],
+            "beta_coefficients": [[1.0]],
+            "x_means": [0.0],
+            "x_stds": [1.0],
+            "y_means": [0.0],
+            "y_stds": [1.0],
+            "scaling_factor_for_scores": [1.0],
+            "spe_values": [0.0],
+            "n_components": 1,
+            "n_samples": 1,
+        }
+
+        result = execute_tool_call(
+            "pls_predict",
+            {"new_data": [[0.0]], "model_params": params},
+        )
+        assert "error" in result
+        assert "max_matrix_rows" in result["error"]


### PR DESCRIPTION
## Summary

Closes **SEC-25 (#274)**. `pca_predict` and `pls_predict` previously took an unbounded `model_params` dict and read sizes straight into `np.array(...)`. The input schema was `{type: object}` with no inner shape, so an attacker-controlled `model_params={"loadings": [[0]*10**6]*10**6, ...}` would allocation-bomb numpy before any later check could fire. The per-key cap on `n_components` in `_SCALAR_CAPS` only applied to the **top-level** kwarg, not to the nested `model_params['n_components']`.

## Fix

New internal helper `_validate_model_params` runs **before** any `np.array(...)` allocation:

- **2-D keys** (loadings, weights, beta-coefficients) → validated via the existing `_validate_matrix_shape`, which caps rows against `settings.max_matrix_rows` and cols against `settings.max_matrix_cols`.
- **1-D keys** (means, stds, spe_values, scaling factors) → length-capped against `settings.max_matrix_rows`.
- **Scalar keys** (`n_components`, `n_samples`) → capped against `settings.max_matrix_cols` / `settings.max_matrix_rows`; non-integer or negative values rejected outright.

Both `pca_predict` and `pls_predict` now call the helper at the top of their try-block, listing the keys their algorithm reads.

## Test plan

- [x] `uv run ruff check .` clean
- [x] Full pytest suite (1499 tests + 10 skipped) passes locally
- [x] PATCH bump 1.24.7 → 1.24.8; CITATION.cff and CHANGELOG in sync

Six new regression tests in `tests/test_sec19_dos_caps.py::TestModelParamsCaps` cover oversize loadings rows / cols, oversize 1-D arrays, oversize `n_components`, negative `n_samples`, and PLS-specific `x_loadings` caps.

This addresses fix-direction (b) of the issue (bound dimensions). Fix-direction (a) — HMAC-signing of `model_params` so a tampered blob is rejected — would require server-side state and is a much larger change; left for a separate follow-up if needed.

Closes #274.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho9oSSxJUXTkqwVzPUzzFW)_