### PR TITLE
refactor(ENG-25): chip away 2 noqa: PLR0913 via dataclass arg bundling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.13] - 2026-06-02
+
+### Changed (internal)
+
+- **ENG-25 (#307) chip-away**: two internal helpers now take a bundled
+  options dataclass instead of nine / six loose arguments, which
+  removes their ``noqa: PLR0913`` suppressions. Net: 2 noqa
+  suppressions deleted, one new internal dataclass per helper. No
+  public API change.
+  - ``process_improve/experiments/evaluate.py::_build_context`` now
+    takes a single ``_EvalRequest`` (9 args -> 1).
+  - ``process_improve/experiments/designs_optimal.py::_run_pyoptex``
+    now takes an optional ``_PyoptexOptions`` (6 args -> 4).
+
+  Combined with PR #340's ``find_elbow_point`` slim-down (-1 noqa),
+  the running ENG-25 count is now **65** suppressions, down from
+  68 at the start of this release window. Per the issue policy
+  ("each release lowers the count"), this is on track.
+
 ## [1.24.12] - 2026-06-02
 
 ### Changed (internal)
@@ -1040,7 +1059,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.12...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.13...HEAD
+[1.24.13]: https://github.com/kgdunn/process-improve/compare/v1.24.12...v1.24.13
 [1.24.12]: https://github.com/kgdunn/process-improve/compare/v1.24.11...v1.24.12
 [1.24.11]: https://github.com/kgdunn/process-improve/compare/v1.24.10...v1.24.11
 [1.24.10]: https://github.com/kgdunn/process-improve/compare/v1.24.9...v1.24.10

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.12
+version: 1.24.13
 date-released: "2026-06-02"
 keywords:
   - chemometrics

--- a/process_improve/experiments/designs_optimal.py
+++ b/process_improve/experiments/designs_optimal.py
@@ -11,6 +11,7 @@ built-in ``point_exchange()`` in ``optimal.py`` for D-optimal when
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -131,13 +132,24 @@ def _convert_factors_to_pyoptex(
     return pyoptex_factors
 
 
-def _run_pyoptex(  # noqa: PLR0913
+@dataclass
+class _PyoptexOptions:
+    """Optional knobs for :func:`_run_pyoptex`.
+
+    Pulled into a dataclass so the function signature stays at four
+    parameters (ENG-25 / #307: removes one ``noqa: PLR0913``).
+    """
+
+    model_type: str = "interactions"
+    hard_to_change: list[str] | None = None
+    n_tries: int = 10
+
+
+def _run_pyoptex(
     factors: list[Factor],
     criterion: str,
     budget: int,
-    model_type: str = "interactions",
-    hard_to_change: list[str] | None = None,
-    n_tries: int = 10,
+    options: _PyoptexOptions | None = None,
 ) -> tuple[np.ndarray, dict]:
     """Run pyoptex's coordinate-exchange optimizer.
 
@@ -149,12 +161,9 @@ def _run_pyoptex(  # noqa: PLR0913
         One of ``"d_optimal"``, ``"i_optimal"``, ``"a_optimal"``.
     budget : int
         Number of runs in the design.
-    model_type : str
-        One of ``"main_effects"``, ``"interactions"``, ``"quadratic"``.
-    hard_to_change : list[str] or None
-        Names of hard-to-change factors (triggers split-plot structure).
-    n_tries : int
-        Number of random restarts for the coordinate exchange algorithm.
+    options : _PyoptexOptions or None
+        Optional knobs (model_type, hard_to_change, n_tries). Defaults
+        are interactions / no hard-to-change / 10 restarts.
 
     Returns
     -------
@@ -162,6 +171,11 @@ def _run_pyoptex(  # noqa: PLR0913
         Coded design matrix (-1 / +1 for continuous, labels for categorical)
         and metadata dict.
     """
+    opts = options if options is not None else _PyoptexOptions()
+    model_type = opts.model_type
+    hard_to_change = opts.hard_to_change
+    n_tries = opts.n_tries
+
     pyoptex_factors = _convert_factors_to_pyoptex(
         factors,
         hard_to_change=hard_to_change,
@@ -293,8 +307,7 @@ def dispatch_d_optimal(
             factors,
             criterion="d_optimal",
             budget=budget,
-            model_type=model_type,
-            hard_to_change=hard_to_change,
+            options=_PyoptexOptions(model_type=model_type, hard_to_change=hard_to_change),
         )
 
     if hard_to_change:
@@ -352,8 +365,7 @@ def dispatch_i_optimal(
         factors,
         criterion="i_optimal",
         budget=budget,
-        model_type=model_type,
-        hard_to_change=hard_to_change,
+        options=_PyoptexOptions(model_type=model_type, hard_to_change=hard_to_change),
     )
 
 
@@ -404,6 +416,5 @@ def dispatch_a_optimal(
         factors,
         criterion="a_optimal",
         budget=budget,
-        model_type=model_type,
-        hard_to_change=hard_to_change,
+        options=_PyoptexOptions(model_type=model_type, hard_to_change=hard_to_change),
     )

--- a/process_improve/experiments/evaluate.py
+++ b/process_improve/experiments/evaluate.py
@@ -39,6 +39,27 @@ from process_improve.experiments.models import validate_formula_is_safe, validat
 
 
 @dataclass
+class _EvalRequest:
+    """Caller-supplied evaluation request.
+
+    Bundles every piece of metric-independent input so
+    :func:`_build_context` can accept a single dataclass instead of
+    nine positional / keyword arguments (ENG-25 / #307: removes one
+    ``noqa: PLR0913``).
+    """
+
+    design_df: pd.DataFrame
+    factor_names: list[str]
+    model: str | None
+    generators: list[str] | None
+    defining_relation: list[str] | None
+    resolution: int | None
+    effect_size: float | None
+    alpha: float
+    sigma: float | None
+
+
+@dataclass
 class _EvalContext:
     """Shared evaluation context, computed once and reused by all metrics."""
 
@@ -122,19 +143,9 @@ def _build_model_matrix(
     return X, column_names
 
 
-def _build_context(  # noqa: PLR0913
-    design_df: pd.DataFrame,
-    factor_names: list[str],
-    model: str | None,
-    generators: list[str] | None,
-    defining_relation: list[str] | None,
-    resolution: int | None,
-    effect_size: float | None,
-    alpha: float,
-    sigma: float | None,
-) -> _EvalContext:
+def _build_context(req: _EvalRequest) -> _EvalContext:
     """Build the shared evaluation context."""
-    X, column_names = _build_model_matrix(design_df, model, factor_names)
+    X, column_names = _build_model_matrix(req.design_df, req.model, req.factor_names)
     N, p = X.shape
     XtX = X.T @ X
 
@@ -147,19 +158,19 @@ def _build_context(  # noqa: PLR0913
     return _EvalContext(
         X=X,
         column_names=column_names,
-        factor_names=factor_names,
-        design_df=design_df,
+        factor_names=req.factor_names,
+        design_df=req.design_df,
         N=N,
         p=p,
         XtX=XtX,
         XtX_inv=XtX_inv,
         is_singular=is_singular,
-        generators=generators,
-        defining_relation=defining_relation,
-        resolution=resolution,
-        effect_size=effect_size,
-        alpha=alpha,
-        sigma=sigma,
+        generators=req.generators,
+        defining_relation=req.defining_relation,
+        resolution=req.resolution,
+        effect_size=req.effect_size,
+        alpha=req.alpha,
+        sigma=req.sigma,
     )
 
 
@@ -789,15 +800,17 @@ def evaluate_design(  # noqa: PLR0913
 
     # --- Build context ---
     ctx = _build_context(
-        design_df=design_df,
-        factor_names=factor_names,
-        model=model,
-        generators=generators,
-        defining_relation=defining_relation,
-        resolution=resolution,
-        effect_size=effect_size,
-        alpha=alpha,
-        sigma=sigma,
+        _EvalRequest(
+            design_df=design_df,
+            factor_names=factor_names,
+            model=model,
+            generators=generators,
+            defining_relation=defining_relation,
+            resolution=resolution,
+            effect_size=effect_size,
+            alpha=alpha,
+            sigma=sigma,
+        )
     )
 
     # --- Compute requested metrics ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.12"
+version = "1.24.13"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

ENG-25 (#307) chip-away. Two internal helpers now take a single bundled options dataclass instead of loose positional arguments. The arg count drops below the PLR0913 threshold (5) and the suppression goes with it.

## Changes

**`evaluate.py::_build_context`** — 9 args → 1: bundles `design_df`, `factor_names`, `model`, `generators`, `defining_relation`, `resolution`, `effect_size`, `alpha`, `sigma` into a new `_EvalRequest` dataclass. The single internal caller in `evaluate_design` is updated.

**`designs_optimal.py::_run_pyoptex`** — 6 args → 4: bundles the three optional kwargs (`model_type`, `hard_to_change`, `n_tries`) into a new `_PyoptexOptions` dataclass. The three internal call sites (`dispatch_d_optimal`, `dispatch_i_optimal`, `dispatch_a_optimal`) are updated.

## ENG-25 running count

Net: **−2 noqa suppressions** in this PR.

Combined with PR #340's `find_elbow_point` slim-down (**−1 noqa**), the running ENG-25 count is now **65**, down from 68 at the start of this release window. Per the issue's "each release lowers the count" policy, on track.

## Test plan

- [x] `uv run ruff check .` clean
- [x] Full pytest suite (1514 tests + 10 skipped) passes locally
- [x] PATCH bump 1.24.12 → 1.24.13; CITATION.cff and CHANGELOG in sync
- [x] No public API change — both refactored functions are private (`_` prefix)

Refs #307.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho9oSSxJUXTkqwVzPUzzFW)_