### PR TITLE
ENG-05: replace functools.partial bindings with introspectable methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.16] - 2026-06-03
+
+### Changed
+
+- **ENG-05 (#287)**: the multivariate estimators (PCA, PLS, TPLS, MBPLS, MBPCA)
+  now expose their convenience callables (``score_plot``, ``spe_limit``,
+  ``vip``, ``hotellings_t2_limit``, ``ellipse_coordinates``, ...) as real
+  methods instead of ``functools.partial`` instances bound in ``fit``. As a
+  result ``help(model.score_plot)`` shows the underlying docstring,
+  ``inspect.signature`` reports the true parameters (minus ``model``), IDEs can
+  autocomplete, the methods are overridable by subclasses, and fitted models
+  pickle robustly. Call sites are unchanged. The standalone functions remain
+  available for advanced callers, and TPLS's ``spe_limit`` dict-of-callables
+  API is unchanged.
+
 ## [1.24.15] - 2026-06-03
 
 ### Changed (internal)
@@ -1092,7 +1107,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.15...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.16...HEAD
+[1.24.16]: https://github.com/kgdunn/process-improve/compare/v1.24.15...v1.24.16
 [1.24.15]: https://github.com/kgdunn/process-improve/compare/v1.24.14...v1.24.15
 [1.24.14]: https://github.com/kgdunn/process-improve/compare/v1.24.13...v1.24.14
 [1.24.13]: https://github.com/kgdunn/process-improve/compare/v1.24.12...v1.24.13

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.15
+version: 1.24.16
 date-released: "2026-06-03"
 keywords:
   - chemometrics

--- a/process_improve/multivariate/_common.py
+++ b/process_improve/multivariate/_common.py
@@ -10,7 +10,9 @@ sibling submodules, so it sits at the base of the dependency graph.
 
 from __future__ import annotations
 
-from typing import TypeAlias
+import functools
+from collections.abc import Callable
+from typing import Any, TypeAlias
 
 import numpy as np
 import pandas as pd
@@ -45,3 +47,22 @@ def _nz(denominator: float) -> float:
 
 class SpecificationWarning(UserWarning):
     """Parent warning class."""
+
+
+def _model_method(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap a module-level ``fn(model, ...)`` as an introspectable instance method.
+
+    ENG-05: estimators (PCA / PLS / ...) expose convenience methods such as
+    ``score_plot``, ``spe_limit`` and ``vip`` that forward to the standalone
+    functions with ``self`` supplied as the ``model`` argument. Defining them
+    via this factory at class-body time - rather than binding
+    ``functools.partial`` instances in ``fit`` - means ``help`` and
+    ``inspect.signature`` report the underlying function (minus ``self``), the
+    fitted model stays picklable, and subclasses can override cleanly.
+    """
+
+    @functools.wraps(fn)
+    def method(self: object, *args, **kwargs) -> object:
+        return fn(self, *args, **kwargs)
+
+    return method

--- a/process_improve/multivariate/_mbpca.py
+++ b/process_improve/multivariate/_mbpca.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import time
 import typing
 import warnings
-from functools import partial
 
 import numpy as np
 import pandas as pd
@@ -18,7 +17,8 @@ from sklearn.utils import Bunch
 from sklearn.utils.validation import check_is_fitted
 
 from ._common import SpecificationWarning, _nz, epsqrt
-from ._limits import hotellings_t2_limit, spe_calculation
+from ._limits import hotellings_t2_limit as _hotellings_t2_limit
+from ._limits import spe_calculation
 from ._nipals import quick_regress, ssq
 from ._preprocessing import MCUVScaler
 
@@ -156,6 +156,17 @@ class MBPCA(TransformerMixin, BaseEstimator):
         self.tol = tol
         self.algorithm = algorithm
         self.missing_data_settings = missing_data_settings
+
+    # ENG-05: convenience method forwarding to the standalone function (was a
+    # functools.partial bound in fit; a real method keeps help/inspect.signature
+    # accurate and the fitted model picklable).
+    def hotellings_t2_limit(self, conf_level: float = 0.95) -> float:
+        """Hotelling's T2 limit at the given confidence level (see :func:`hotellings_t2_limit`)."""
+        return _hotellings_t2_limit(
+            conf_level=conf_level,
+            n_components=self.n_components,
+            n_rows=self.n_samples_,
+        )
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X: dict[str, pd.DataFrame], y: None = None) -> MBPCA:  # noqa: ARG002, C901, PLR0912, PLR0915
@@ -420,7 +431,6 @@ class MBPCA(TransformerMixin, BaseEstimator):
         super_t2 = np.cumsum((super_scores_np**2) / super_score_var, axis=1)
         self.super_hotellings_t2_ = pd.DataFrame(super_t2, index=self._sample_index, columns=component_names)
 
-        self.hotellings_t2_limit = partial(hotellings_t2_limit, n_components=n_components, n_rows=n_samples)
         return self
 
     def transform(self, X: dict[str, pd.DataFrame]) -> pd.DataFrame:

--- a/process_improve/multivariate/_mbpls.py
+++ b/process_improve/multivariate/_mbpls.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import time
 import typing
 import warnings
-from functools import partial
 
 import numpy as np
 import pandas as pd
@@ -21,7 +20,8 @@ from sklearn.utils.validation import check_is_fitted
 
 from ..visualization.themes import REFERENCE_LINE_COLOR
 from ._common import SpecificationWarning, _nz, epsqrt
-from ._limits import hotellings_t2_limit, spe_calculation
+from ._limits import hotellings_t2_limit as _hotellings_t2_limit
+from ._limits import spe_calculation
 from ._nipals import quick_regress, ssq
 from ._preprocessing import MCUVScaler
 
@@ -180,6 +180,17 @@ class MBPLS(RegressorMixin, BaseEstimator):
         self.tol = tol
         self.algorithm = algorithm
         self.missing_data_settings = missing_data_settings
+
+    # ENG-05: convenience method forwarding to the standalone function (was a
+    # functools.partial bound in fit; a real method keeps help/inspect.signature
+    # accurate and the fitted model picklable).
+    def hotellings_t2_limit(self, conf_level: float = 0.95) -> float:
+        """Hotelling's T2 limit at the given confidence level (see :func:`hotellings_t2_limit`)."""
+        return _hotellings_t2_limit(
+            conf_level=conf_level,
+            n_components=self.n_components,
+            n_rows=self.n_samples_,
+        )
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X: dict[str, pd.DataFrame], y: pd.DataFrame) -> MBPLS:  # noqa: C901, PLR0912, PLR0915
@@ -548,9 +559,6 @@ class MBPLS(RegressorMixin, BaseEstimator):
         super_score_var = np.where(self.explained_variance_ > 0, self.explained_variance_, 1.0)
         super_t2 = np.cumsum((super_scores_np**2) / super_score_var, axis=1)
         self.super_hotellings_t2_ = pd.DataFrame(super_t2, index=self._sample_index, columns=component_names)
-
-        # --- Convenience method bindings ---
-        self.hotellings_t2_limit = partial(hotellings_t2_limit, n_components=n_components, n_rows=n_samples)
 
         return self
 

--- a/process_improve/multivariate/_pca.py
+++ b/process_improve/multivariate/_pca.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import time
 import typing
 import warnings
-from functools import partial
 
 import numpy as np
 import pandas as pd
@@ -22,23 +21,52 @@ from sklearn.utils import Bunch
 from sklearn.utils.validation import check_is_fitted
 
 from ..univariate.metrics import detect_outliers_esd
-from ._common import DataMatrix, SpecificationWarning, epsqrt
+from ._common import DataMatrix, SpecificationWarning, _model_method, epsqrt
 from ._diagnostics import (
-    eigenvalue_summary,
-    observation_contributions,
-    project_variables,
-    squared_cosine,
-    vip,
+    eigenvalue_summary as _eigenvalue_summary,
 )
-from ._limits import ellipse_coordinates, hotellings_t2_limit, score_limit, spe_limit
+from ._diagnostics import (
+    observation_contributions as _observation_contributions,
+)
+from ._diagnostics import (
+    project_variables as _project_variables,
+)
+from ._diagnostics import (
+    squared_cosine as _squared_cosine,
+)
+from ._diagnostics import (
+    vip as _vip,
+)
+from ._limits import (
+    ellipse_coordinates as _ellipse_coordinates,
+)
+from ._limits import (
+    hotellings_t2_limit as _hotellings_t2_limit,
+)
+from ._limits import (
+    score_limit as _score_limit,
+)
+from ._limits import (
+    spe_limit as _spe_limit,
+)
 from ._nipals import quick_regress, ssq, terminate_check
 from .plots import (
-    correlation_loadings_plot,
-    explained_variance_plot,
-    loading_plot,
-    score_plot,
-    spe_plot,
-    t2_plot,
+    correlation_loadings_plot as _correlation_loadings_plot,
+)
+from .plots import (
+    explained_variance_plot as _explained_variance_plot,
+)
+from .plots import (
+    loading_plot as _loading_plot,
+)
+from .plots import (
+    score_plot as _score_plot,
+)
+from .plots import (
+    spe_plot as _spe_plot,
+)
+from .plots import (
+    t2_plot as _t2_plot,
 )
 
 
@@ -106,8 +134,53 @@ class PCA(TransformerMixin, BaseEstimator):
         self.algorithm = algorithm
         self.missing_data_settings = missing_data_settings
 
+    # ENG-05: convenience methods forwarding to the standalone functions. These
+    # used to be ``functools.partial`` instances bound in ``fit``; defining them
+    # as real methods keeps ``help`` / ``inspect.signature`` accurate, the fitted
+    # model picklable, and the methods overridable by subclasses. The standalone
+    # functions remain available for advanced callers.
+    score_plot = _model_method(_score_plot)
+    spe_plot = _model_method(_spe_plot)
+    t2_plot = _model_method(_t2_plot)
+    loading_plot = _model_method(_loading_plot)
+    explained_variance_plot = _model_method(_explained_variance_plot)
+    correlation_loadings_plot = _model_method(_correlation_loadings_plot)
+    spe_limit = _model_method(_spe_limit)
+    score_limit = _model_method(_score_limit)
+    vip = _model_method(_vip)
+    squared_cosine = _model_method(_squared_cosine)
+    observation_contributions = _model_method(_observation_contributions)
+    eigenvalue_summary = _model_method(_eigenvalue_summary)
+    project_variables = _model_method(_project_variables)
+
+    def hotellings_t2_limit(self, conf_level: float = 0.95) -> float:
+        """Hotelling's T2 limit at the given confidence level (see :func:`hotellings_t2_limit`)."""
+        return _hotellings_t2_limit(
+            conf_level=conf_level,
+            n_components=self.n_components,
+            n_rows=self.n_samples_,
+        )
+
+    def ellipse_coordinates(
+        self,
+        score_horiz: int,
+        score_vert: int,
+        conf_level: float = 0.95,
+        n_points: int = 100,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Coordinates of the T2 confidence ellipse (see :func:`ellipse_coordinates`)."""
+        return _ellipse_coordinates(
+            score_horiz=score_horiz,
+            score_vert=score_vert,
+            conf_level=conf_level,
+            n_points=n_points,
+            n_components=self.n_components,
+            scaling_factor_for_scores=self.scaling_factor_for_scores_,
+            n_rows=self.n_samples_,
+        )
+
     @_fit_context(prefer_skip_nested_validation=True)
-    def fit(self, X: DataMatrix, y: DataMatrix | None = None) -> PCA:  # noqa: ARG002, PLR0912, PLR0915, C901
+    def fit(self, X: DataMatrix, y: DataMatrix | None = None) -> PCA:  # noqa: ARG002, PLR0912, C901
         """Fit a principal component analysis (PCA) model to the data.
 
         Parameters
@@ -232,28 +305,6 @@ class PCA(TransformerMixin, BaseEstimator):
                 self.hotellings_t2_.iloc[:, max(0, a - 1)]
                 + (self.scores_.iloc[:, a] / self.scaling_factor_for_scores_.iloc[a]) ** 2
             )
-
-        # Bind convenience methods
-        self.ellipse_coordinates = partial(
-            ellipse_coordinates,
-            n_components=self.n_components,
-            scaling_factor_for_scores=self.scaling_factor_for_scores_,
-            n_rows=N,
-        )
-        self.hotellings_t2_limit = partial(hotellings_t2_limit, n_components=self.n_components, n_rows=N)
-        self.spe_plot = partial(spe_plot, model=self)
-        self.t2_plot = partial(t2_plot, model=self)
-        self.loading_plot = partial(loading_plot, model=self, loadings_type="p")
-        self.score_plot = partial(score_plot, model=self)
-        self.explained_variance_plot = partial(explained_variance_plot, model=self)
-        self.correlation_loadings_plot = partial(correlation_loadings_plot, model=self)
-        self.spe_limit = partial(spe_limit, model=self)
-        self.score_limit = partial(score_limit, model=self)
-        self.vip = partial(vip, model=self)
-        self.squared_cosine = partial(squared_cosine, model=self)
-        self.observation_contributions = partial(observation_contributions, model=self)
-        self.eigenvalue_summary = partial(eigenvalue_summary, model=self)
-        self.project_variables = partial(project_variables, self)
 
         # Clean up temporary numpy arrays
         del self._loadings_np, self._scores_np, self._r2_np, self._r2cum_np, self._r2_per_var_np, self._spe_np

--- a/process_improve/multivariate/_pls.py
+++ b/process_improve/multivariate/_pls.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import time
 import warnings
-from functools import partial
 
 import numpy as np
 import pandas as pd
@@ -24,25 +23,58 @@ from tqdm import tqdm
 
 from .._linalg import safe_inverse
 from ..univariate.metrics import detect_outliers_esd
-from ._common import DataMatrix, SpecificationWarning, epsqrt
+from ._common import DataMatrix, SpecificationWarning, _model_method, epsqrt
 from ._diagnostics import (
-    eigenvalue_summary,
-    observation_contributions,
-    project_variables,
-    squared_cosine,
-    vip,
+    eigenvalue_summary as _eigenvalue_summary,
 )
-from ._limits import ellipse_coordinates, hotellings_t2_limit, score_limit, spe_limit
+from ._diagnostics import (
+    observation_contributions as _observation_contributions,
+)
+from ._diagnostics import (
+    project_variables as _project_variables,
+)
+from ._diagnostics import (
+    squared_cosine as _squared_cosine,
+)
+from ._diagnostics import (
+    vip as _vip,
+)
+from ._limits import (
+    ellipse_coordinates as _ellipse_coordinates,
+)
+from ._limits import (
+    hotellings_t2_limit as _hotellings_t2_limit,
+)
+from ._limits import (
+    score_limit as _score_limit,
+)
+from ._limits import (
+    spe_limit as _spe_limit,
+)
 from ._nipals import quick_regress, ssq, terminate_check
 from .plots import (
-    coefficient_plot,
-    correlation_loadings_plot,
-    explained_variance_plot,
-    loading_plot,
-    predictions_vs_observed_plot,
-    score_plot,
-    spe_plot,
-    t2_plot,
+    coefficient_plot as _coefficient_plot,
+)
+from .plots import (
+    correlation_loadings_plot as _correlation_loadings_plot,
+)
+from .plots import (
+    explained_variance_plot as _explained_variance_plot,
+)
+from .plots import (
+    loading_plot as _loading_plot,
+)
+from .plots import (
+    predictions_vs_observed_plot as _predictions_vs_observed_plot,
+)
+from .plots import (
+    score_plot as _score_plot,
+)
+from .plots import (
+    spe_plot as _spe_plot,
+)
+from .plots import (
+    t2_plot as _t2_plot,
 )
 
 
@@ -158,6 +190,53 @@ class PLS(RegressorMixin, TransformerMixin, BaseEstimator):
         self.copy = copy
         self.missing_data_settings = missing_data_settings
         self.has_missing_data_ = False
+
+    # ENG-05: convenience methods forwarding to the standalone functions. These
+    # used to be ``functools.partial`` instances bound in ``fit``; defining them
+    # as real methods keeps ``help`` / ``inspect.signature`` accurate, the fitted
+    # model picklable, and the methods overridable by subclasses. The standalone
+    # functions remain available for advanced callers.
+    score_plot = _model_method(_score_plot)
+    spe_plot = _model_method(_spe_plot)
+    t2_plot = _model_method(_t2_plot)
+    loading_plot = _model_method(_loading_plot)
+    explained_variance_plot = _model_method(_explained_variance_plot)
+    correlation_loadings_plot = _model_method(_correlation_loadings_plot)
+    predictions_vs_observed_plot = _model_method(_predictions_vs_observed_plot)
+    coefficient_plot = _model_method(_coefficient_plot)
+    spe_limit = _model_method(_spe_limit)
+    score_limit = _model_method(_score_limit)
+    vip = _model_method(_vip)
+    squared_cosine = _model_method(_squared_cosine)
+    observation_contributions = _model_method(_observation_contributions)
+    eigenvalue_summary = _model_method(_eigenvalue_summary)
+    project_variables = _model_method(_project_variables)
+
+    def hotellings_t2_limit(self, conf_level: float = 0.95) -> float:
+        """Hotelling's T2 limit at the given confidence level (see :func:`hotellings_t2_limit`)."""
+        return _hotellings_t2_limit(
+            conf_level=conf_level,
+            n_components=self.n_components,
+            n_rows=self.n_samples_,
+        )
+
+    def ellipse_coordinates(
+        self,
+        score_horiz: int,
+        score_vert: int,
+        conf_level: float = 0.95,
+        n_points: int = 100,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Coordinates of the T2 confidence ellipse (see :func:`ellipse_coordinates`)."""
+        return _ellipse_coordinates(
+            score_horiz=score_horiz,
+            score_vert=score_vert,
+            conf_level=conf_level,
+            n_points=n_points,
+            n_components=self.n_components,
+            scaling_factor_for_scores=self.scaling_factor_for_scores_,
+            n_rows=self.n_samples_,
+        )
 
     def _fit_nipals(self, X: DataMatrix, Y: DataMatrix, A: int, settings: dict) -> None:  # noqa: PLR0915
         """Fit PLS via the NIPALS algorithm, handling missing data transparently.
@@ -433,30 +512,6 @@ class PLS(RegressorMixin, TransformerMixin, BaseEstimator):
                 prior_SSY_col > 0, col_SSY / np.where(prior_SSY_col > 0, prior_SSY_col, 1.0), np.nan
             )
             self.rmse_.iloc[:, a] = (Yd.values - y_hat).pow(2).mean().pow(0.5)
-
-        # Bind convenience methods
-        self.ellipse_coordinates = partial(
-            ellipse_coordinates,
-            n_components=self.n_components,
-            scaling_factor_for_scores=self.scaling_factor_for_scores_,
-            n_rows=N,
-        )
-        self.hotellings_t2_limit = partial(hotellings_t2_limit, n_components=self.n_components, n_rows=N)
-        self.spe_limit = partial(spe_limit, model=self)
-        self.score_limit = partial(score_limit, model=self)
-        self.spe_plot = partial(spe_plot, model=self)
-        self.t2_plot = partial(t2_plot, model=self)
-        self.loading_plot = partial(loading_plot, model=self)
-        self.score_plot = partial(score_plot, model=self)
-        self.explained_variance_plot = partial(explained_variance_plot, model=self)
-        self.correlation_loadings_plot = partial(correlation_loadings_plot, model=self)
-        self.predictions_vs_observed_plot = partial(predictions_vs_observed_plot, model=self)
-        self.coefficient_plot = partial(coefficient_plot, model=self)
-        self.vip = partial(vip, model=self)
-        self.squared_cosine = partial(squared_cosine, model=self)
-        self.observation_contributions = partial(observation_contributions, model=self)
-        self.eigenvalue_summary = partial(eigenvalue_summary, model=self)
-        self.project_variables = partial(project_variables, self)
 
         return self
 

--- a/process_improve/multivariate/_tpls.py
+++ b/process_improve/multivariate/_tpls.py
@@ -24,7 +24,9 @@ from sklearn.utils.validation import check_array, check_is_fitted
 
 from .._linalg import safe_inverse
 from ._common import _nz
-from ._limits import ellipse_coordinates, hotellings_t2_limit, spe_calculation
+from ._limits import ellipse_coordinates as _ellipse_coordinates
+from ._limits import hotellings_t2_limit as _hotellings_t2_limit
+from ._limits import spe_calculation
 from ._nipals import internal_pls_nipals_fit_one_pc, nan_to_zeros, regress_a_space_on_b_row
 from .plots import Plot
 
@@ -253,6 +255,36 @@ class TPLS(RegressorMixin, BaseEstimator):
         self.required_inputs_ = {"F", "Y", "Z"}
         self.plot = Plot(self)
 
+    # ENG-05: convenience methods forwarding to the standalone functions. These
+    # used to be ``functools.partial`` instances bound in ``fit``; defining them
+    # as real methods keeps ``help`` / ``inspect.signature`` accurate and the
+    # fitted model picklable.
+    def hotellings_t2_limit(self, conf_level: float = 0.95) -> float:
+        """Hotelling's T2 limit at the given confidence level (see :func:`hotellings_t2_limit`)."""
+        return _hotellings_t2_limit(
+            conf_level=conf_level,
+            n_components=self.n_components,
+            n_rows=self.hotellings_t2.shape[0],
+        )
+
+    def ellipse_coordinates(
+        self,
+        score_horiz: int,
+        score_vert: int,
+        conf_level: float = 0.95,
+        n_points: int = 100,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Coordinates of the T2 confidence ellipse (see :func:`ellipse_coordinates`)."""
+        return _ellipse_coordinates(
+            score_horiz=score_horiz,
+            score_vert=score_vert,
+            conf_level=conf_level,
+            n_points=n_points,
+            n_components=self.n_components,
+            scaling_factor_for_scores=self.scaling_factor_for_scores,
+            n_rows=self.t_scores_super.shape[0],
+        )
+
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X: DataFrameDict, y: None = None) -> TPLS:  # noqa: ARG002, PLR0915
         """Fit the preprocessing parameters and also the latent variable model from the training data.
@@ -413,9 +445,7 @@ class TPLS(RegressorMixin, BaseEstimator):
 
         # 4. Hotelling's T2 values for each observation, per component
         self.hotellings_t2: pd.DataFrame = pd.DataFrame()
-        self.hotellings_t2_limit: Callable = hotellings_t2_limit
         self.scaling_factor_for_scores = pd.Series()
-        self.ellipse_coordinates: Callable = ellipse_coordinates
 
         self._fit_iterative_regressions()
         self.is_fitted_ = True
@@ -1070,19 +1100,10 @@ class TPLS(RegressorMixin, BaseEstimator):
             index=self.observation_names,
             columns=["Hotelling's T^2"],
         )
-        self.hotellings_t2_limit = partial(
-            hotellings_t2_limit, n_components=self.n_components, n_rows=self.hotellings_t2.shape[0]
-        )
         self.scaling_factor_for_scores = pd.Series(
             np.sqrt(np.diag(variance_matrix)),
             index=[a + 1 for a in range(self.n_components)],
             name="Standard deviation per score",
-        )
-        self.ellipse_coordinates = partial(
-            ellipse_coordinates,
-            n_components=self.n_components,
-            scaling_factor_for_scores=self.scaling_factor_for_scores,
-            n_rows=self.t_scores_super.shape[0],
         )
 
         # Squared prediction error limits. This is a measure of the prediction error = difference between the actual

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.15"
+version = "1.24.16"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2332,6 +2332,19 @@ def fixture_tpls_example() -> dict[str, dict[str, pd.DataFrame]]:
     }
 
 
+def test_tpls_pickle_round_trips(fixture_tpls_example: dict) -> None:
+    """ENG-05 (#287): a fitted TPLS model pickles and its hotellings_t2_limit method survives."""
+    import pickle
+
+    d_matrix = fixture_tpls_example.pop("D")
+    tpls_test = TPLS(n_components=3, d_matrix=d_matrix).fit(DataFrameDict(fixture_tpls_example))
+    reloaded = pickle.loads(pickle.dumps(tpls_test))  # noqa: S301 - trusted round-trip of our own object
+    assert float(reloaded.hotellings_t2_limit()) == float(tpls_test.hotellings_t2_limit())
+    # The spe_limit dict-of-partials API also survives the round-trip.
+    block, group = "Y", next(iter(reloaded.spe_limit["Y"]))
+    assert float(reloaded.spe_limit[block][group](0.95)) == float(tpls_test.spe_limit[block][group](0.95))
+
+
 def test_tpls_model_fitting(fixture_tpls_example: dict) -> None:
     """
     Test the fitting process of the TPLS model to ensure it functions as expected.

--- a/tests/test_multivariate_introspection.py
+++ b/tests/test_multivariate_introspection.py
@@ -1,0 +1,101 @@
+"""ENG-05 (#287): the convenience plot / limit / diagnostic bindings on the
+multivariate estimators must be real, introspectable methods rather than
+``functools.partial`` instances.
+
+Acceptance: ``help`` / ``inspect.signature`` report the underlying function
+(minus the model parameter), fitted models pickle round-trip, and subclasses can
+override the methods.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import pickle
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from process_improve.multivariate import plots as _plots
+from process_improve.multivariate.methods import MBPCA, MBPLS, PCA, PLS, MCUVScaler
+
+
+def _fitted_pca() -> PCA:
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame(rng.standard_normal((20, 5)), columns=list("abcde"))
+    return PCA(n_components=2).fit(MCUVScaler().fit_transform(X))
+
+
+def _fitted_pls() -> PLS:
+    rng = np.random.default_rng(1)
+    X = pd.DataFrame(rng.standard_normal((20, 5)), columns=list("abcde"))
+    Y = pd.DataFrame(rng.standard_normal((20, 2)), columns=["y1", "y2"])
+    return PLS(n_components=2).fit(MCUVScaler().fit_transform(X), MCUVScaler().fit_transform(Y))
+
+
+def _two_block() -> dict[str, pd.DataFrame]:
+    rng = np.random.default_rng(2)
+    latent = rng.standard_normal((30, 2))
+    a = latent @ rng.standard_normal((2, 6)) + 0.05 * rng.standard_normal((30, 6))
+    b = latent @ rng.standard_normal((2, 4)) + 0.05 * rng.standard_normal((30, 4))
+    return {
+        "A": pd.DataFrame(a, columns=[f"a{i}" for i in range(6)]),
+        "B": pd.DataFrame(b, columns=[f"b{i}" for i in range(4)]),
+    }
+
+
+def _fitted_mbpca() -> MBPCA:
+    return MBPCA(n_components=2).fit(_two_block())
+
+
+def _fitted_mbpls() -> MBPLS:
+    rng = np.random.default_rng(3)
+    y = pd.DataFrame(rng.standard_normal((30, 1)), columns=["y"])
+    return MBPLS(n_components=2).fit(_two_block(), y)
+
+
+@pytest.mark.parametrize("factory", [_fitted_pca, _fitted_pls, _fitted_mbpca, _fitted_mbpls])
+def test_fitted_model_pickle_round_trips(factory) -> None:
+    """A fitted model pickles and the reloaded model's limit method agrees."""
+    model = factory()
+    reloaded = pickle.loads(pickle.dumps(model))  # noqa: S301 - trusted round-trip of our own object
+    assert float(reloaded.hotellings_t2_limit()) == pytest.approx(float(model.hotellings_t2_limit()))
+
+
+def test_convenience_bindings_are_not_partial() -> None:
+    """None of the bound convenience callables is a functools.partial."""
+    model = _fitted_pca()
+    for name in ("score_plot", "spe_plot", "vip", "spe_limit", "hotellings_t2_limit", "ellipse_coordinates"):
+        assert not isinstance(getattr(model, name), functools.partial), name
+
+
+def test_score_plot_signature_and_doc() -> None:
+    """``score_plot`` exposes the underlying signature (minus model) and docstring."""
+    model = _fitted_pca()
+    sig = inspect.signature(model.score_plot)
+    assert "model" not in sig.parameters
+    assert "self" not in sig.parameters
+    assert next(iter(sig.parameters)) == "pc_horiz"
+    assert model.score_plot.__name__ == "score_plot"
+    assert model.score_plot.__doc__ == _plots.score_plot.__doc__
+    assert "partial(" not in (model.score_plot.__doc__ or "")
+
+
+def test_hotellings_t2_limit_signature() -> None:
+    """The explicit ``hotellings_t2_limit`` method exposes only ``conf_level``."""
+    model = _fitted_pca()
+    assert list(inspect.signature(model.hotellings_t2_limit).parameters) == ["conf_level"]
+
+
+def test_subclass_can_override_method() -> None:
+    """A subclass can override a convenience method via normal MRO."""
+
+    class SubPCA(PCA):
+        def score_plot(self, *args, **kwargs):  # noqa: ARG002
+            return "overridden"
+
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame(rng.standard_normal((20, 5)), columns=list("abcde"))
+    model = SubPCA(n_components=2).fit(MCUVScaler().fit_transform(X))
+    assert model.score_plot() == "overridden"


### PR DESCRIPTION
## ENG-05 (#287): replace `functools.partial` plot/limit bindings with introspectable methods

After `fit()`, the multivariate estimators currently bind convenience callables via
`functools.partial` (e.g. `self.score_plot = partial(score_plot, model=self)`). That works in a
notebook but `help(model.score_plot)` shows the *partial* doc, `inspect.signature` reports the
partial (with `model` still present), IDE autocomplete fails, and the "methods" can't be cleanly
overridden by subclasses.

This PR replaces those bindings with real, introspectable methods:
- A shared `_model_method` factory (in `_common.py`) wraps the uniform `partial(fn, model=self)`
  cases with `functools.wraps`, so `help` / `inspect.signature` / `__name__` report the underlying
  function (minus `model`).
- `hotellings_t2_limit` and `ellipse_coordinates` (which pre-bind instance-derived stats, not
  `model`) become explicit methods reading the fitted attributes.
- The per-instance `partial` assignments are removed from each `fit()`.

### Scope
PCA, PLS, TPLS, MBPLS, MBPCA. TPLS's `spe_limit` is a nested **dict** of `partial(spe_calculation, …)`
(a public `spe_limit["Y"][key](conf)` API, no `self` reference) and is intentionally left as-is.

### Acceptance
- `help(model.score_plot)` / `model.score_plot.__doc__` show the function docstring.
- `inspect.signature(model.score_plot)` matches the underlying function minus `model`.
- `pickle.dumps(fitted_model)` round-trips.
- Subclasses can override the methods.
- No change to how callers invoke them.

https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW)_