### PR TITLE
ENG-17: shared _LatentVariableModel base class for the latent-variable estimators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.18] - 2026-06-03
+
+### Changed (internal)
+
+- **ENG-17 (#299)**: factor the duplicated latent-variable scaffolding into a
+  shared base. New ``multivariate/_base.py`` provides ``_LatentVariableModel``
+  (the ENG-05 convenience methods + ``ellipse_coordinates``), a
+  ``_HotellingsT2LimitMixin`` (the ``hotellings_t2_limit`` shared by
+  PCA/PLS/MBPLS/MBPCA), and a ``_RenameGetattrMixin`` (the migration
+  ``__getattr__`` driven by a per-class ``_ATTRIBUTE_RENAMES`` map). PCA and PLS
+  inherit ``_LatentVariableModel``; MBPLS/MBPCA inherit only the T2-limit mixin;
+  TPLS is unchanged (it reads differently-named fitted attributes). No public
+  API change: each class's public method set is byte-identical, and the fit /
+  predict / transform algorithms are untouched.
+
 ## [1.24.17] - 2026-06-03
 
 ### Changed
@@ -1121,7 +1136,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.17...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.18...HEAD
+[1.24.18]: https://github.com/kgdunn/process-improve/compare/v1.24.17...v1.24.18
 [1.24.17]: https://github.com/kgdunn/process-improve/compare/v1.24.16...v1.24.17
 [1.24.16]: https://github.com/kgdunn/process-improve/compare/v1.24.15...v1.24.16
 [1.24.15]: https://github.com/kgdunn/process-improve/compare/v1.24.14...v1.24.15

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.17
+version: 1.24.18
 date-released: "2026-06-03"
 keywords:
   - chemometrics

--- a/process_improve/multivariate/_base.py
+++ b/process_improve/multivariate/_base.py
@@ -25,6 +25,9 @@ import typing
 
 import numpy as np
 
+if typing.TYPE_CHECKING:
+    import pandas as pd
+
 from ._common import _model_method
 from ._diagnostics import (
     eigenvalue_summary as _eigenvalue_summary,
@@ -101,6 +104,10 @@ class _HotellingsT2LimitMixin:
     four estimators. (TPLS reads a differently-named row count and keeps its own.)
     """
 
+    if typing.TYPE_CHECKING:  # fitted attributes provided by concrete subclasses
+        n_components: int
+        n_samples_: int
+
     def hotellings_t2_limit(self, conf_level: float = 0.95) -> float:
         """Hotelling's T2 limit at the given confidence level (see :func:`hotellings_t2_limit`)."""
         return _hotellings_t2_limit(
@@ -119,6 +126,9 @@ class _LatentVariableModel(_RenameGetattrMixin, _HotellingsT2LimitMixin):
     mixins (``TransformerMixin`` / ``RegressorMixin``) and ``BaseEstimator``, and
     provide the algorithm-specific ``fit`` / ``predict`` / ``transform``.
     """
+
+    if typing.TYPE_CHECKING:  # fitted attribute provided by concrete subclasses
+        scaling_factor_for_scores_: pd.Series
 
     score_plot = _model_method(_score_plot)
     spe_plot = _model_method(_spe_plot)

--- a/process_improve/multivariate/_base.py
+++ b/process_improve/multivariate/_base.py
@@ -1,0 +1,153 @@
+# (c) Kevin Dunn, 2010-2026. MIT License. Based on own private work over the years.
+"""Shared base class and mixins for the latent-variable estimators (ENG-17).
+
+PCA and PLS duplicated a large block of identical scaffolding: the ENG-05
+convenience methods (``score_plot``, ``vip``, ``spe_limit``, ...), the
+``hotellings_t2_limit`` / ``ellipse_coordinates`` wrappers, and the attribute
+rename ``__getattr__``. This module factors that out:
+
+* :class:`_RenameGetattrMixin` - the migration ``__getattr__`` driven by a
+  per-class ``_ATTRIBUTE_RENAMES`` dict and ``_RENAME_CONTEXT`` label.
+* :class:`_HotellingsT2LimitMixin` - the ``hotellings_t2_limit`` method shared,
+  byte-identically, by PCA / PLS / MBPLS / MBPCA (it reads ``self.n_components``
+  and ``self.n_samples_``).
+* :class:`_LatentVariableModel` - the PCA/PLS convenience-method surface plus
+  ``ellipse_coordinates``.
+
+A fix to any of this shared scaffolding now propagates to all derived classes at
+once. TPLS keeps its own copies (its ``hotellings_t2_limit`` / ``ellipse_coordinates``
+read differently-named fitted attributes), so it does not inherit these.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import numpy as np
+
+from ._common import _model_method
+from ._diagnostics import (
+    eigenvalue_summary as _eigenvalue_summary,
+)
+from ._diagnostics import (
+    observation_contributions as _observation_contributions,
+)
+from ._diagnostics import (
+    project_variables as _project_variables,
+)
+from ._diagnostics import (
+    squared_cosine as _squared_cosine,
+)
+from ._diagnostics import (
+    vip as _vip,
+)
+from ._limits import (
+    ellipse_coordinates as _ellipse_coordinates,
+)
+from ._limits import (
+    hotellings_t2_limit as _hotellings_t2_limit,
+)
+from ._limits import (
+    score_limit as _score_limit,
+)
+from ._limits import (
+    spe_limit as _spe_limit,
+)
+from .plots import (
+    correlation_loadings_plot as _correlation_loadings_plot,
+)
+from .plots import (
+    explained_variance_plot as _explained_variance_plot,
+)
+from .plots import (
+    loading_plot as _loading_plot,
+)
+from .plots import (
+    score_plot as _score_plot,
+)
+from .plots import (
+    spe_plot as _spe_plot,
+)
+from .plots import (
+    t2_plot as _t2_plot,
+)
+
+
+class _RenameGetattrMixin:
+    """``__getattr__`` that raises a helpful message for renamed attributes.
+
+    Subclasses set ``_ATTRIBUTE_RENAMES`` (old name -> new name) and
+    ``_RENAME_CONTEXT`` (the label used in the message, e.g. ``"PCA"``).
+    """
+
+    _ATTRIBUTE_RENAMES: typing.ClassVar[dict[str, str]] = {}
+    _RENAME_CONTEXT: typing.ClassVar[str] = ""
+
+    def __getattr__(self, name: str):
+        """Provide helpful error messages for old attribute names."""
+        renames = type(self)._ATTRIBUTE_RENAMES
+        if name in renames:
+            raise AttributeError(
+                f"'{name}' was renamed to '{renames[name]}' in the {type(self)._RENAME_CONTEXT} refactoring. "
+                f"Please update your code to use '{renames[name]}'."
+            )
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
+
+class _HotellingsT2LimitMixin:
+    """The ``hotellings_t2_limit`` method shared by PCA / PLS / MBPLS / MBPCA.
+
+    Reads ``self.n_components`` and ``self.n_samples_``; identical across those
+    four estimators. (TPLS reads a differently-named row count and keeps its own.)
+    """
+
+    def hotellings_t2_limit(self, conf_level: float = 0.95) -> float:
+        """Hotelling's T2 limit at the given confidence level (see :func:`hotellings_t2_limit`)."""
+        return _hotellings_t2_limit(
+            conf_level=conf_level,
+            n_components=self.n_components,
+            n_rows=self.n_samples_,
+        )
+
+
+class _LatentVariableModel(_RenameGetattrMixin, _HotellingsT2LimitMixin):
+    """Convenience-method scaffolding shared by :class:`PCA` and :class:`PLS`.
+
+    Hosts the ENG-05 convenience methods that forward to the standalone functions
+    (so ``help`` / ``inspect.signature`` stay accurate and the methods are
+    overridable), plus ``ellipse_coordinates``. Subclasses add their own sklearn
+    mixins (``TransformerMixin`` / ``RegressorMixin``) and ``BaseEstimator``, and
+    provide the algorithm-specific ``fit`` / ``predict`` / ``transform``.
+    """
+
+    score_plot = _model_method(_score_plot)
+    spe_plot = _model_method(_spe_plot)
+    t2_plot = _model_method(_t2_plot)
+    loading_plot = _model_method(_loading_plot)
+    explained_variance_plot = _model_method(_explained_variance_plot)
+    correlation_loadings_plot = _model_method(_correlation_loadings_plot)
+    spe_limit = _model_method(_spe_limit)
+    score_limit = _model_method(_score_limit)
+    vip = _model_method(_vip)
+    squared_cosine = _model_method(_squared_cosine)
+    observation_contributions = _model_method(_observation_contributions)
+    eigenvalue_summary = _model_method(_eigenvalue_summary)
+    project_variables = _model_method(_project_variables)
+
+    def ellipse_coordinates(
+        self,
+        score_horiz: int,
+        score_vert: int,
+        conf_level: float = 0.95,
+        n_points: int = 100,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Coordinates of the T2 confidence ellipse (see :func:`ellipse_coordinates`)."""
+        return _ellipse_coordinates(
+            score_horiz=score_horiz,
+            score_vert=score_vert,
+            conf_level=conf_level,
+            n_points=n_points,
+            n_components=self.n_components,
+            scaling_factor_for_scores=self.scaling_factor_for_scores_,
+            n_rows=self.n_samples_,
+        )

--- a/process_improve/multivariate/_mbpca.py
+++ b/process_improve/multivariate/_mbpca.py
@@ -16,8 +16,8 @@ from sklearn.base import BaseEstimator, TransformerMixin, _fit_context
 from sklearn.utils import Bunch
 from sklearn.utils.validation import check_is_fitted
 
+from ._base import _HotellingsT2LimitMixin
 from ._common import SpecificationWarning, _nz, epsqrt
-from ._limits import hotellings_t2_limit as _hotellings_t2_limit
 from ._limits import spe_calculation
 from ._nipals import quick_regress, ssq
 from ._preprocessing import MCUVScaler
@@ -30,7 +30,7 @@ except ImportError:  # pragma: no cover - exercised via env-without-plotly
     go = _MissingExtra("plotly", "plotting")  # type: ignore[assignment]
 
 
-class MBPCA(TransformerMixin, BaseEstimator):
+class MBPCA(_HotellingsT2LimitMixin, TransformerMixin, BaseEstimator):
     r"""Multi-block PCA (hierarchical / consensus PCA).
 
     Generic multi-block PCA following the consensus-PCA / hierarchical PCA
@@ -156,17 +156,6 @@ class MBPCA(TransformerMixin, BaseEstimator):
         self.tol = tol
         self.algorithm = algorithm
         self.missing_data_settings = missing_data_settings
-
-    # ENG-05: convenience method forwarding to the standalone function (was a
-    # functools.partial bound in fit; a real method keeps help/inspect.signature
-    # accurate and the fitted model picklable).
-    def hotellings_t2_limit(self, conf_level: float = 0.95) -> float:
-        """Hotelling's T2 limit at the given confidence level (see :func:`hotellings_t2_limit`)."""
-        return _hotellings_t2_limit(
-            conf_level=conf_level,
-            n_components=self.n_components,
-            n_rows=self.n_samples_,
-        )
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X: dict[str, pd.DataFrame], y: None = None) -> MBPCA:  # noqa: ARG002, C901, PLR0912, PLR0915

--- a/process_improve/multivariate/_mbpls.py
+++ b/process_improve/multivariate/_mbpls.py
@@ -19,8 +19,8 @@ from sklearn.utils import Bunch
 from sklearn.utils.validation import check_is_fitted
 
 from ..visualization.themes import REFERENCE_LINE_COLOR
+from ._base import _HotellingsT2LimitMixin
 from ._common import SpecificationWarning, _nz, epsqrt
-from ._limits import hotellings_t2_limit as _hotellings_t2_limit
 from ._limits import spe_calculation
 from ._nipals import quick_regress, ssq
 from ._preprocessing import MCUVScaler
@@ -33,7 +33,7 @@ except ImportError:  # pragma: no cover - exercised via env-without-plotly
     go = _MissingExtra("plotly", "plotting")  # type: ignore[assignment]
 
 
-class MBPLS(RegressorMixin, BaseEstimator):
+class MBPLS(_HotellingsT2LimitMixin, RegressorMixin, BaseEstimator):
     r"""Multi-block PLS (hierarchical / superblock formulation).
 
     Generic multi-block PLS as described by Westerhuis, Kourti & MacGregor
@@ -180,17 +180,6 @@ class MBPLS(RegressorMixin, BaseEstimator):
         self.tol = tol
         self.algorithm = algorithm
         self.missing_data_settings = missing_data_settings
-
-    # ENG-05: convenience method forwarding to the standalone function (was a
-    # functools.partial bound in fit; a real method keeps help/inspect.signature
-    # accurate and the fitted model picklable).
-    def hotellings_t2_limit(self, conf_level: float = 0.95) -> float:
-        """Hotelling's T2 limit at the given confidence level (see :func:`hotellings_t2_limit`)."""
-        return _hotellings_t2_limit(
-            conf_level=conf_level,
-            n_components=self.n_components,
-            n_rows=self.n_samples_,
-        )
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X: dict[str, pd.DataFrame], y: pd.DataFrame) -> MBPLS:  # noqa: C901, PLR0912, PLR0915

--- a/process_improve/multivariate/_pca.py
+++ b/process_improve/multivariate/_pca.py
@@ -21,56 +21,12 @@ from sklearn.utils import Bunch
 from sklearn.utils.validation import check_is_fitted
 
 from ..univariate.metrics import detect_outliers_esd
-from ._common import DataMatrix, SpecificationWarning, _model_method, epsqrt
-from ._diagnostics import (
-    eigenvalue_summary as _eigenvalue_summary,
-)
-from ._diagnostics import (
-    observation_contributions as _observation_contributions,
-)
-from ._diagnostics import (
-    project_variables as _project_variables,
-)
-from ._diagnostics import (
-    squared_cosine as _squared_cosine,
-)
-from ._diagnostics import (
-    vip as _vip,
-)
-from ._limits import (
-    ellipse_coordinates as _ellipse_coordinates,
-)
-from ._limits import (
-    hotellings_t2_limit as _hotellings_t2_limit,
-)
-from ._limits import (
-    score_limit as _score_limit,
-)
-from ._limits import (
-    spe_limit as _spe_limit,
-)
+from ._base import _LatentVariableModel
+from ._common import DataMatrix, SpecificationWarning, epsqrt
 from ._nipals import quick_regress, ssq, terminate_check
-from .plots import (
-    correlation_loadings_plot as _correlation_loadings_plot,
-)
-from .plots import (
-    explained_variance_plot as _explained_variance_plot,
-)
-from .plots import (
-    loading_plot as _loading_plot,
-)
-from .plots import (
-    score_plot as _score_plot,
-)
-from .plots import (
-    spe_plot as _spe_plot,
-)
-from .plots import (
-    t2_plot as _t2_plot,
-)
 
 
-class PCA(TransformerMixin, BaseEstimator):
+class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
     """Principal Component Analysis with support for missing data.
 
     Parameters
@@ -134,50 +90,25 @@ class PCA(TransformerMixin, BaseEstimator):
         self.algorithm = algorithm
         self.missing_data_settings = missing_data_settings
 
-    # ENG-05: convenience methods forwarding to the standalone functions. These
-    # used to be ``functools.partial`` instances bound in ``fit``; defining them
-    # as real methods keeps ``help`` / ``inspect.signature`` accurate, the fitted
-    # model picklable, and the methods overridable by subclasses. The standalone
-    # functions remain available for advanced callers.
-    score_plot = _model_method(_score_plot)
-    spe_plot = _model_method(_spe_plot)
-    t2_plot = _model_method(_t2_plot)
-    loading_plot = _model_method(_loading_plot)
-    explained_variance_plot = _model_method(_explained_variance_plot)
-    correlation_loadings_plot = _model_method(_correlation_loadings_plot)
-    spe_limit = _model_method(_spe_limit)
-    score_limit = _model_method(_score_limit)
-    vip = _model_method(_vip)
-    squared_cosine = _model_method(_squared_cosine)
-    observation_contributions = _model_method(_observation_contributions)
-    eigenvalue_summary = _model_method(_eigenvalue_summary)
-    project_variables = _model_method(_project_variables)
-
-    def hotellings_t2_limit(self, conf_level: float = 0.95) -> float:
-        """Hotelling's T2 limit at the given confidence level (see :func:`hotellings_t2_limit`)."""
-        return _hotellings_t2_limit(
-            conf_level=conf_level,
-            n_components=self.n_components,
-            n_rows=self.n_samples_,
-        )
-
-    def ellipse_coordinates(
-        self,
-        score_horiz: int,
-        score_vert: int,
-        conf_level: float = 0.95,
-        n_points: int = 100,
-    ) -> tuple[np.ndarray, np.ndarray]:
-        """Coordinates of the T2 confidence ellipse (see :func:`ellipse_coordinates`)."""
-        return _ellipse_coordinates(
-            score_horiz=score_horiz,
-            score_vert=score_vert,
-            conf_level=conf_level,
-            n_points=n_points,
-            n_components=self.n_components,
-            scaling_factor_for_scores=self.scaling_factor_for_scores_,
-            n_rows=self.n_samples_,
-        )
+    # ENG-17: the convenience methods (score_plot, vip, spe_limit, ...),
+    # hotellings_t2_limit, ellipse_coordinates and the rename __getattr__ are
+    # inherited from _LatentVariableModel. PCA supplies only its rename map.
+    _ATTRIBUTE_RENAMES: typing.ClassVar[dict[str, str]] = {
+        "x_scores": "scores_",
+        "loadings": "loadings_",
+        "x_loadings": "loadings_",
+        "squared_prediction_error": "spe_",
+        "R2": "r2_per_component_",
+        "R2cum": "r2_cumulative_",
+        "R2X_cum": "r2_per_variable_",
+        "hotellings_t2": "hotellings_t2_",
+        "scaling_factor_for_scores": "scaling_factor_for_scores_",
+        "N": "n_samples_",
+        "K": "n_features_in_",
+        "A": "n_components",
+        "extra_info": "fitting_info_",
+    }
+    _RENAME_CONTEXT: typing.ClassVar[str] = "PCA"
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X: DataMatrix, y: DataMatrix | None = None) -> PCA:  # noqa: ARG002, PLR0912, C901
@@ -878,27 +809,3 @@ class PCA(TransformerMixin, BaseEstimator):
 
         results.sort(key=lambda d: d["severity"], reverse=True)
         return results
-
-    def __getattr__(self, name: str):
-        """Provide helpful error messages for old attribute names."""
-        renames = {
-            "x_scores": "scores_",
-            "loadings": "loadings_",
-            "x_loadings": "loadings_",
-            "squared_prediction_error": "spe_",
-            "R2": "r2_per_component_",
-            "R2cum": "r2_cumulative_",
-            "R2X_cum": "r2_per_variable_",
-            "hotellings_t2": "hotellings_t2_",
-            "scaling_factor_for_scores": "scaling_factor_for_scores_",
-            "N": "n_samples_",
-            "K": "n_features_in_",
-            "A": "n_components",
-            "extra_info": "fitting_info_",
-        }
-        if name in renames:
-            raise AttributeError(
-                f"'{name}' was renamed to '{renames[name]}' in the PCA refactoring. "
-                f"Please update your code to use '{renames[name]}'."
-            )
-        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")

--- a/process_improve/multivariate/_pls.py
+++ b/process_improve/multivariate/_pls.py
@@ -9,6 +9,7 @@ plotting bound as convenience methods after ``fit()``.
 from __future__ import annotations
 
 import time
+import typing
 import warnings
 
 import numpy as np
@@ -23,62 +24,18 @@ from tqdm import tqdm
 
 from .._linalg import safe_inverse
 from ..univariate.metrics import detect_outliers_esd
+from ._base import _LatentVariableModel
 from ._common import DataMatrix, SpecificationWarning, _model_method, epsqrt
-from ._diagnostics import (
-    eigenvalue_summary as _eigenvalue_summary,
-)
-from ._diagnostics import (
-    observation_contributions as _observation_contributions,
-)
-from ._diagnostics import (
-    project_variables as _project_variables,
-)
-from ._diagnostics import (
-    squared_cosine as _squared_cosine,
-)
-from ._diagnostics import (
-    vip as _vip,
-)
-from ._limits import (
-    ellipse_coordinates as _ellipse_coordinates,
-)
-from ._limits import (
-    hotellings_t2_limit as _hotellings_t2_limit,
-)
-from ._limits import (
-    score_limit as _score_limit,
-)
-from ._limits import (
-    spe_limit as _spe_limit,
-)
 from ._nipals import quick_regress, ssq, terminate_check
 from .plots import (
     coefficient_plot as _coefficient_plot,
 )
 from .plots import (
-    correlation_loadings_plot as _correlation_loadings_plot,
-)
-from .plots import (
-    explained_variance_plot as _explained_variance_plot,
-)
-from .plots import (
-    loading_plot as _loading_plot,
-)
-from .plots import (
     predictions_vs_observed_plot as _predictions_vs_observed_plot,
 )
-from .plots import (
-    score_plot as _score_plot,
-)
-from .plots import (
-    spe_plot as _spe_plot,
-)
-from .plots import (
-    t2_plot as _t2_plot,
-)
 
 
-class PLS(RegressorMixin, TransformerMixin, BaseEstimator):
+class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator):
     """Projection to Latent Structures (PLS) regression with diagnostics.
 
     Implements PLS via the NIPALS algorithm with production diagnostics: SPE,
@@ -190,52 +147,40 @@ class PLS(RegressorMixin, TransformerMixin, BaseEstimator):
         self.copy = copy
         self.missing_data_settings = missing_data_settings
 
-    # ENG-05: convenience methods forwarding to the standalone functions. These
-    # used to be ``functools.partial`` instances bound in ``fit``; defining them
-    # as real methods keeps ``help`` / ``inspect.signature`` accurate, the fitted
-    # model picklable, and the methods overridable by subclasses. The standalone
-    # functions remain available for advanced callers.
-    score_plot = _model_method(_score_plot)
-    spe_plot = _model_method(_spe_plot)
-    t2_plot = _model_method(_t2_plot)
-    loading_plot = _model_method(_loading_plot)
-    explained_variance_plot = _model_method(_explained_variance_plot)
-    correlation_loadings_plot = _model_method(_correlation_loadings_plot)
+    # ENG-17: the 13 shared convenience methods, hotellings_t2_limit,
+    # ellipse_coordinates and the rename __getattr__ are inherited from
+    # _LatentVariableModel. PLS keeps only its two PLS-specific plot methods and
+    # supplies its own rename map.
     predictions_vs_observed_plot = _model_method(_predictions_vs_observed_plot)
     coefficient_plot = _model_method(_coefficient_plot)
-    spe_limit = _model_method(_spe_limit)
-    score_limit = _model_method(_score_limit)
-    vip = _model_method(_vip)
-    squared_cosine = _model_method(_squared_cosine)
-    observation_contributions = _model_method(_observation_contributions)
-    eigenvalue_summary = _model_method(_eigenvalue_summary)
-    project_variables = _model_method(_project_variables)
 
-    def hotellings_t2_limit(self, conf_level: float = 0.95) -> float:
-        """Hotelling's T2 limit at the given confidence level (see :func:`hotellings_t2_limit`)."""
-        return _hotellings_t2_limit(
-            conf_level=conf_level,
-            n_components=self.n_components,
-            n_rows=self.n_samples_,
-        )
-
-    def ellipse_coordinates(
-        self,
-        score_horiz: int,
-        score_vert: int,
-        conf_level: float = 0.95,
-        n_points: int = 100,
-    ) -> tuple[np.ndarray, np.ndarray]:
-        """Coordinates of the T2 confidence ellipse (see :func:`ellipse_coordinates`)."""
-        return _ellipse_coordinates(
-            score_horiz=score_horiz,
-            score_vert=score_vert,
-            conf_level=conf_level,
-            n_points=n_points,
-            n_components=self.n_components,
-            scaling_factor_for_scores=self.scaling_factor_for_scores_,
-            n_rows=self.n_samples_,
-        )
+    _ATTRIBUTE_RENAMES: typing.ClassVar[dict[str, str]] = {
+        "x_scores": "scores_",
+        "y_scores": "y_scores_",
+        "x_weights": "x_weights_",
+        "y_weights": "y_weights_",
+        "x_loadings": "x_loadings_",
+        "y_loadings": "y_loadings_",
+        "direct_weights": "direct_weights_",
+        "beta_coefficients": "beta_coefficients_",
+        "predictions": "predictions_",
+        "squared_prediction_error": "spe_",
+        "hotellings_t2": "hotellings_t2_",
+        "R2": "r2_per_component_",
+        "R2cum": "r2_cumulative_",
+        "R2X_cum": "r2_per_variable_",
+        "R2Y_cum": "r2y_per_variable_",
+        "RMSE": "rmse_",
+        "explained_variance": "explained_variance_",
+        "scaling_factor_for_scores": "scaling_factor_for_scores_",
+        "extra_info": "fitting_info_",
+        "has_missing_data": "has_missing_data_",
+        "N": "n_samples_",
+        "K": "n_features_in_",
+        "M": "n_targets_",
+        "A": "n_components",
+    }
+    _RENAME_CONTEXT: typing.ClassVar[str] = "PLS"
 
     def _fit_nipals(self, X: DataMatrix, Y: DataMatrix, A: int, settings: dict) -> None:  # noqa: PLR0915
         """Fit PLS via the NIPALS algorithm, handling missing data transparently.
@@ -1230,39 +1175,4 @@ class PLS(RegressorMixin, TransformerMixin, BaseEstimator):
         lower = pd.DataFrame(y_hat.values - half_width, index=y_hat.index, columns=y_hat.columns)
         upper = pd.DataFrame(y_hat.values + half_width, index=y_hat.index, columns=y_hat.columns)
         return Bunch(y_hat=y_hat, lower=lower, upper=upper, conf_level=conf_level)
-
-    def __getattr__(self, name: str):
-        """Provide helpful error messages for old attribute names."""
-        renames = {
-            "x_scores": "scores_",
-            "y_scores": "y_scores_",
-            "x_weights": "x_weights_",
-            "y_weights": "y_weights_",
-            "x_loadings": "x_loadings_",
-            "y_loadings": "y_loadings_",
-            "direct_weights": "direct_weights_",
-            "beta_coefficients": "beta_coefficients_",
-            "predictions": "predictions_",
-            "squared_prediction_error": "spe_",
-            "hotellings_t2": "hotellings_t2_",
-            "R2": "r2_per_component_",
-            "R2cum": "r2_cumulative_",
-            "R2X_cum": "r2_per_variable_",
-            "R2Y_cum": "r2y_per_variable_",
-            "RMSE": "rmse_",
-            "explained_variance": "explained_variance_",
-            "scaling_factor_for_scores": "scaling_factor_for_scores_",
-            "extra_info": "fitting_info_",
-            "has_missing_data": "has_missing_data_",
-            "N": "n_samples_",
-            "K": "n_features_in_",
-            "M": "n_targets_",
-            "A": "n_components",
-        }
-        if name in renames:
-            raise AttributeError(
-                f"'{name}' was renamed to '{renames[name]}' in the PLS refactoring. "
-                f"Please update your code to use '{renames[name]}'."
-            )
-        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.17"
+version = "1.24.18"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## ENG-17 (#299): shared `_LatentVariableModel` base class to dedupe estimator scaffolding

Each latent-variable estimator re-implemented the same convenience-method block, `__getattr__`
rename helper, and `hotellings_t2_limit` / `ellipse_coordinates` wrappers. This PR factors the
duplicated scaffolding into `process_improve/multivariate/_base.py`:

- `_RenameGetattrMixin` — the migration `__getattr__`, driven by a per-class `_ATTRIBUTE_RENAMES`
  dict + `_RENAME_CONTEXT` label (preserves the exact error messages).
- `_HotellingsT2LimitMixin` — the `hotellings_t2_limit` shared byte-identically by PCA/PLS/MBPLS/MBPCA.
- `_LatentVariableModel` — the 13 ENG-05 convenience methods (`score_plot`, `vip`, `spe_limit`, …)
  plus `ellipse_coordinates`, shared by PCA and PLS.

### Scope (conservative, behaviour-preserving)
- **PCA** and **PLS** inherit `_LatentVariableModel` (PLS keeps its 2 extra methods
  `predictions_vs_observed_plot`/`coefficient_plot`).
- **MBPLS**/**MBPCA** inherit only `_HotellingsT2LimitMixin` (their `hotellings_t2_limit` is identical).
- **TPLS** is left untouched (its `hotellings_t2_limit`/`ellipse_coordinates` read differently-named
  fitted attributes; routing it through the base would change behaviour).

Full 5-way unification of `fit`/`predict` is deliberately **not** attempted — those bodies genuinely
differ (X-vs-XY arity, different `Bunch` keys/T² shapes), and the numerical primitives are already
shared via `_nipals.py`/`_common.py`/`_limits.py` (ENG-01).

### Acceptance / safety
- Hard guard: each class's public `dir()` surface must be unchanged (no methods gained/lost).
- `get_params`/`clone` unaffected (base defines no `__init__`; sklearn introspects the leaf signature).
- Existing tests pass unchanged.

https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW)_