### PR TITLE
ENG-26: architecture overview + tool-authoring guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.21] - 2026-06-03
+
+### Added
+
+- **ENG-26 (#308)**: documentation - an architecture overview
+  (``docs/architecture.rst``: package layout, conventions, the multivariate
+  estimator stack, and the MCP tool layer), linked from the top of
+  ``README.md``, and a step-by-step tool-authoring guide
+  (``docs/development/tool_authoring.rst``). Complements the existing
+  error-handling, reproducibility, deprecation-policy, and logging policy pages.
+
 ## [1.24.20] - 2026-06-03
 
 ### Added
@@ -1167,7 +1178,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.20...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.21...HEAD
+[1.24.21]: https://github.com/kgdunn/process-improve/compare/v1.24.20...v1.24.21
 [1.24.20]: https://github.com/kgdunn/process-improve/compare/v1.24.19...v1.24.20
 [1.24.19]: https://github.com/kgdunn/process-improve/compare/v1.24.18...v1.24.19
 [1.24.18]: https://github.com/kgdunn/process-improve/compare/v1.24.17...v1.24.18

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.20
+version: 1.24.21
 date-released: "2026-06-03"
 keywords:
   - chemometrics

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Built for chemometrics, manufacturing, and pharma data - the methods that scikit
 
 ---
 
+> **New here?** The [architecture overview](https://kgdunn.github.io/process-improve/architecture.html)
+> ([source](docs/architecture.rst)) is the map of the codebase - package layout, the estimator
+> stack, and the MCP tool layer.
+
 ## What it does
 
 `process-improve` provides production-grade implementations of the methods

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,0 +1,126 @@
+Architecture overview
+=====================
+
+This page is the map of the codebase: how ``process-improve`` is laid out, the
+conventions every subpackage follows, and the two cross-cutting systems (the
+estimator stack and the MCP tool layer) that most changes touch. Read it before
+your first contribution; the per-topic policy pages under
+:doc:`development/index` go deeper.
+
+Package layout
+--------------
+
+.. code-block:: text
+
+   process_improve/
+       multivariate/    # PCA, PLS, TPLS, and multi-block (MBPCA / MBPLS)
+       experiments/     # designed experiments: designs, analysis, optimisation
+       monitoring/      # control charts (Shewhart / CUSUM / EWMA-style)
+       batch/           # batch data alignment (DTW), features, preprocessing
+       regression/      # robust regression (repeated median, Theil-Sen)
+       bivariate/       # elbow / peak detection, area-under-curve
+       univariate/      # robust summary statistics, outlier detection
+       visualization/   # shared plotting themes and helpers
+       simulation/      # process simulators
+       datasets/        # sample datasets used by examples and tests
+       tool_spec.py     # the MCP @tool_spec decorator + global tool registry
+       config.py        # runtime settings (caps, limits)
+       _linalg.py, _random.py, _extras.py   # small shared utilities
+
+Each domain subpackage exposes its public API through a thin re-export module
+(``methods.py`` for multivariate, package ``__init__`` elsewhere) so the import
+path callers use is stable even when the implementation files move.
+
+Conventions every subpackage follows
+-------------------------------------
+
+- **sklearn-compatible estimators.** Estimators inherit ``BaseEstimator`` plus
+  the relevant mixin (``TransformerMixin`` / ``RegressorMixin``). They do *not*
+  inherit a concrete sklearn estimator - the mixins give ``get_params`` /
+  ``set_params`` / ``clone`` / Pipeline support without coupling to sklearn's
+  private attribute layout (ENG-07). ``fit()`` returns ``self``; fitted
+  attributes use the trailing-underscore convention (``scores_``, ``spe_``,
+  ``hotellings_t2_``) and are set only in ``fit()``, never in ``__init__``.
+- **Optional dependencies live in extras.** Plotting (plotly / ridgeplot),
+  the experiments designed-experiment generators (pyDOE3 / pyoptex), the batch
+  and MCP layers are installed via ``[plotting]`` / ``[expt]`` / ``[batch]`` /
+  ``[mcp]`` extras (ENG-13). Modules import them through a ``_MissingExtra``
+  stand-in so a missing optional dependency only fails when the feature is
+  actually used, not at import time.
+- **Diagnostic logging.** Modules that do real work define
+  ``logger = logging.getLogger(__name__)`` and emit ``debug`` records at major
+  algorithm steps; nothing configures handlers. See :doc:`development/logging`.
+- **Error handling.** Tool wrappers narrow their ``except`` to a canonical set
+  so unexpected errors propagate to the server and get redacted. See
+  :doc:`development/error_handling`.
+- **Reproducibility.** Randomised paths take an explicit ``random_state``. See
+  :doc:`development/reproducibility`.
+
+The multivariate estimator stack
+---------------------------------
+
+The latent-variable estimators are split into single-responsibility modules
+under ``multivariate/`` and aggregated by ``methods.py`` (the stable public
+import path; ``_pca_pls.py`` remains as a backward-compatibility shim):
+
+.. code-block:: text
+
+   _common.py        # DataMatrix alias, epsqrt, _nz, SpecificationWarning, _model_method
+   _preprocessing.py # MCUVScaler, center, scale
+   _nipals.py        # NIPALS / least-squares kernels (missing-data aware)
+   _limits.py        # Hotelling's T2 / SPE / score limits, ellipse geometry
+   _diagnostics.py   # VIP, squared cosine, contributions, RV coefficients
+   _base.py          # _LatentVariableModel base + mixins (see below)
+   _pca.py  _pls.py  _tpls.py  _mbpls.py  _mbpca.py   # the estimators
+   _resampling.py    # jackknife / bootstrap resampling
+   plots.py          # score / loading / SPE / T2 / coefficient plots + Plot accessor
+
+Two base-class ideas tie the estimators together (``_base.py``):
+
+- **``_LatentVariableModel``** owns the scaffolding PCA and PLS share: the
+  convenience methods (``score_plot``, ``vip``, ``spe_limit``, ...) that forward
+  to the standalone functions, ``ellipse_coordinates``, and the attribute-rename
+  ``__getattr__`` (driven by a per-class ``_ATTRIBUTE_RENAMES`` map). The
+  convenience methods are *real methods* built by the ``_model_method`` factory,
+  so ``help`` / ``inspect.signature`` report the underlying function and the
+  fitted model pickles and subclasses cleanly (ENG-05, ENG-17). MBPLS / MBPCA
+  share only ``_HotellingsT2LimitMixin``.
+- **Ndarray-backed fitted attributes.** Hot-path attributes (``scores_``,
+  ``loadings_``, ``spe_``, ...) are stored as private numpy ndarrays; the public
+  ``pd.DataFrame`` is a lazily-built, cached view via the ``_LazyFrame``
+  descriptor. Internal math reads the ndarray (no per-call ``.values``
+  conversion); the cache is excluded from pickling (ENG-18).
+
+A typical fit therefore: validates input, runs the algorithm-specific
+``_fit_*`` (SVD / NIPALS / TSR for PCA; NIPALS for PLS; hierarchical NIPALS for
+the multi-block models), stores the ndarrays + index/column metadata, and
+computes limits and R-squared bookkeeping. The numerical kernels live in
+``_nipals.py`` and are shared, so a fix there benefits every estimator.
+
+The MCP tool layer
+------------------
+
+Agent-callable tools are declared with the ``@tool_spec`` decorator
+(``process_improve/tool_spec.py``). Each tool pairs a pydantic
+``BaseModel`` input contract (``ConfigDict(extra="forbid")``) with a wrapper
+function; the decorator registers the function in a global ``_TOOL_REGISTRY``
+and attaches the JSON-schema spec. ``get_tool_specs()`` returns the specs in
+registry (decorator-execution) order; ``discover_tools()`` imports each
+subpackage's ``tools`` module so the decorators run.
+
+In ``experiments/`` the tools and analyses are split one-per-module
+(``_tools/<tool>.py``, ``_analyses/<analysis>.py``) with ``tools.py`` acting as
+the ordered aggregator (ENG-02). To add a tool, see :doc:`development/tool_authoring`.
+
+Where to make a change
+----------------------
+
+- A numerical fix to a latent-variable algorithm: the shared kernels in
+  ``multivariate/_nipals.py`` / ``_limits.py`` / ``_common.py``, or the
+  estimator's ``_fit_*`` method.
+- A new estimator convenience method shared by PCA and PLS:
+  ``multivariate/_base.py``.
+- A new agent-callable tool: a new module under the subpackage's ``_tools/``
+  (or ``tools.py``) - see :doc:`development/tool_authoring`.
+- A new designed-experiment analysis: a module under
+  ``experiments/_analyses/`` dispatched from ``experiments/analysis.py``.

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -8,6 +8,7 @@ below are the deeper policy references it links to.
 .. toctree::
    :maxdepth: 1
 
+   tool_authoring
    error_handling
    logging
    reproducibility

--- a/docs/development/tool_authoring.rst
+++ b/docs/development/tool_authoring.rst
@@ -1,0 +1,106 @@
+Authoring an MCP tool
+=====================
+
+.. note::
+
+   This is the step-by-step for adding a new agent-callable tool. Tracks
+   `ENG-26 <https://github.com/kgdunn/process-improve/issues/308>`_. See
+   :doc:`../architecture` for how the tool layer fits together.
+
+Anatomy of a tool
+-----------------
+
+Every tool is three things in one module:
+
+#. a pydantic **input contract** - a ``BaseModel`` with
+   ``model_config = ConfigDict(extra="forbid")`` so unknown keys are rejected;
+#. a **wrapper function** decorated with ``@tool_spec(...)`` that takes the
+   parsed model as its single positional argument and returns a JSON-serialisable
+   ``dict``;
+#. a **registration** so discovery can find it.
+
+The ``@tool_spec`` decorator (``process_improve/tool_spec.py``) attaches the
+JSON-schema spec (derived from the ``input_model``) and registers the function
+in the global ``_TOOL_REGISTRY``. ``get_tool_specs()`` returns specs in
+registry order; ``discover_tools()`` imports each subpackage's ``tools`` module
+so the decorators run.
+
+Step by step
+------------
+
+1. **Pick the home.** Domain tools live in ``<subpackage>/tools.py`` (small
+   subpackages) or, where the surface is large, one module per tool under
+   ``<subpackage>/_tools/<tool_name>.py`` with ``tools.py`` as the aggregator -
+   this is the pattern in ``experiments/`` (ENG-02).
+
+2. **Define the input model.** Use ``Field(...)`` with descriptions and
+   validation (``ge``/``le``, ``min_length``, ``Literal[...]``). The descriptions
+   become the tool's JSON schema that the LLM reads, so write them for a caller.
+
+   .. code-block:: python
+
+      from pydantic import BaseModel, ConfigDict, Field
+
+      class SummariseInput(BaseModel):
+          model_config = ConfigDict(extra="forbid")
+          data: list[float] = Field(..., min_length=1, description="The values to summarise.")
+
+3. **Write the wrapper** and decorate it. Narrow the ``except`` to the canonical
+   expected set (see :doc:`error_handling`) and pass the result through
+   ``clean(...)`` so numpy / pandas types serialise:
+
+   .. code-block:: python
+
+      from process_improve.tool_spec import clean, tool_spec
+
+      @tool_spec(
+          name="summarise_values",
+          description="Return the mean and standard deviation of a list of numbers.",
+          input_model=SummariseInput,
+          examples='# "summarise [1, 2, 3]" -> ``summarise_values(data=[1, 2, 3])``',
+          category="univariate",
+      )
+      def summarise_values(spec: SummariseInput) -> dict:
+          try:
+              import numpy as np  # noqa: PLC0415 - keep heavy imports lazy
+
+              arr = np.asarray(spec.data, dtype=float)
+              return clean({"mean": arr.mean(), "std": arr.std(ddof=1)})
+          except (ValueError, TypeError) as exc:
+              logger.exception("Tool summarise_values failed")
+              return {"error": str(exc)}
+
+4. **Register it.** Importing the module must run the decorator. If you use the
+   per-tool layout, the subpackage's ``tools.py`` imports each tool module **in
+   a fixed order** (the order fixes the spec-emission order) and tracks the
+   names; if you add tools inline in ``tools.py`` they register in source order.
+   Do not reorder existing imports - the tool-spec output is asserted stable.
+
+5. **Confirm discovery.** ``tool_spec.discover_tools()`` imports your
+   subpackage's ``tools`` module. If the subpackage is new, add its dotted
+   ``...tools`` path to the discovery list in ``tool_spec.py``.
+
+Conventions
+-----------
+
+- Keep heavy imports (numpy, pandas, statsmodels, the domain algorithm)
+  **inside** the wrapper function (``# noqa: PLC0415``) so importing the tools
+  module stays cheap.
+- Return ``{"error": "..."}`` for *expected* failures; let unexpected exceptions
+  propagate (the server redacts them).
+- Always wrap the payload in ``clean(...)``.
+
+Verifying
+---------
+
+.. code-block:: python
+
+   from process_improve.tool_spec import get_tool_specs
+
+   specs = {s["name"]: s for s in get_tool_specs()}
+   assert "summarise_values" in specs
+   assert specs["summarise_values"]["input_schema"]["additionalProperties"] is False
+
+Add a test under ``tests/`` that drives the tool through the same path the MCP
+server uses, plus an assertion that the spec is present and well-formed (see the
+existing ``tests/test_experiments_tools.py`` and ``tests/test_tool_spec.py``).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ monitoring. Companion to the online textbook
    :caption: Contents
 
    quickstart
+   architecture
    user_guide/index
    api/index
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.20"
+version = "1.24.21"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## ENG-26 (#308): architecture overview + tool-authoring guide

The Sphinx setup was wired up but content-thin (mostly an algorithm catalogue). This PR adds the two
missing high-value pages and links the architecture page from the README.

### New pages
- **`docs/architecture.rst`** — the map of the codebase: package layout, the conventions every
  subpackage follows (sklearn-compat-via-mixins, extras, logging, error handling, reproducibility),
  the multivariate estimator stack (the ENG-01 split, the `_LatentVariableModel` base + mixins from
  ENG-05/17, the `_LazyFrame` ndarray-backed attributes from ENG-18), the MCP tool layer
  (`@tool_spec` / `_TOOL_REGISTRY` / discovery, the ENG-02 `_tools`/`_analyses` split), and a
  "where to make a change" guide.
- **`docs/development/tool_authoring.rst`** — step-by-step for adding an agent-callable tool (the
  pydantic `extra="forbid"` input contract, `@tool_spec`, registration/discovery order, error
  handling, `clean()`), with a verification snippet.

Both are wired into the toctrees; the architecture page is linked from the **top of `README.md`**.
The error-handling / reproducibility / deprecation-policy / logging policy pages already exist under
`docs/development/`, satisfying the rest of the issue's page list.

### Verification
Both `.rst` files parse cleanly and the Sphinx build emits no warnings on them (the build's
`pandoc`/notebook step is a pre-existing, unrelated env gap). Version bumped to 1.24.21.

### Acceptance
- Architecture, tool-authoring (+ the existing error-handling/reproducibility/deprecation/logging) pages exist.
- The architecture page is linked from the top of `README.md`.
- A new contributor can land a first PR from the docs (architecture map + tool-authoring + dev policies).

https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW)_