### PR TITLE
ENG-30: offload MCP tool dispatch to a worker thread (non-blocking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.22] - 2026-06-03
+
+### Changed
+
+- **ENG-30 (#312)**: the MCP server no longer blocks its event loop on tool
+  execution. The FastMCP handler now offloads the synchronous tool call (the
+  ``ProcessPoolExecutor`` future in safe mode, or the in-process call otherwise)
+  to a worker thread via ``loop.run_in_executor``, so a slow tool call no longer
+  serialises other calls when the server is fronted by HTTP / SSE. Single-call
+  behaviour is unchanged; a regression test demonstrates concurrent dispatch.
+
 ## [1.24.21] - 2026-06-03
 
 ### Added
@@ -1178,7 +1189,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.21...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.22...HEAD
+[1.24.22]: https://github.com/kgdunn/process-improve/compare/v1.24.21...v1.24.22
 [1.24.21]: https://github.com/kgdunn/process-improve/compare/v1.24.20...v1.24.21
 [1.24.20]: https://github.com/kgdunn/process-improve/compare/v1.24.19...v1.24.20
 [1.24.19]: https://github.com/kgdunn/process-improve/compare/v1.24.18...v1.24.19

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.21
+version: 1.24.22
 date-released: "2026-06-03"
 keywords:
   - chemometrics

--- a/process_improve/mcp_server.py
+++ b/process_improve/mcp_server.py
@@ -30,8 +30,10 @@ Configuration for Claude Desktop (``claude_desktop_config.json``)::
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -87,22 +89,23 @@ def _register_all_tools() -> None:
         _create_mcp_tool(tool_name, tool_description, tool_schema)
 
 
-def _create_mcp_tool(
-    tool_name: str,
-    tool_description: str,
-    tool_schema: dict[str, Any],
-) -> None:
-    """Create and register a single MCP tool that delegates to execute_tool_call."""
+def _make_tool_handler(tool_name: str) -> Callable[..., Awaitable[str]]:
+    """Build the async MCP handler for ``tool_name``.
 
-    # Define an async handler that calls through to our tool registry
+    ENG-30: the tool execution path is synchronous (in safe mode it blocks on a
+    ``ProcessPoolExecutor`` future; otherwise it runs the tool in-process). To
+    avoid blocking the FastMCP event loop - which would serialise concurrent
+    requests when the server is fronted by HTTP / SSE - the blocking call is
+    offloaded to a worker thread via ``run_in_executor``. Single-call behaviour
+    is unchanged.
+    """
+
     async def handler(**kwargs: Any) -> str:  # noqa: ANN401
         """Run the registered tool and return its result as a JSON string."""
+        loop = asyncio.get_running_loop()
+        sync_call = safe_execute_tool_call if settings.mcp_safe_mode else execute_tool_call
         try:
-            result = (
-                safe_execute_tool_call(tool_name, kwargs)
-                if settings.mcp_safe_mode
-                else execute_tool_call(tool_name, kwargs)
-            )
+            result = await loop.run_in_executor(None, sync_call, tool_name, kwargs)
             if isinstance(result, dict):
                 return json.dumps(result, indent=2, default=str)
             return str(result)
@@ -111,6 +114,17 @@ def _create_mcp_tool(
             return json.dumps(exc.to_dict())
         except Exception as exc:  # noqa: BLE001
             return _serialise_tool_error(exc, tool_name)
+
+    return handler
+
+
+def _create_mcp_tool(
+    tool_name: str,
+    tool_description: str,
+    tool_schema: dict[str, Any],
+) -> None:
+    """Create and register a single MCP tool that delegates to execute_tool_call."""
+    handler = _make_tool_handler(tool_name)
 
     # Set proper function metadata for FastMCP
     handler.__name__ = tool_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.21"
+version = "1.24.22"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,55 @@
+"""ENG-30 (#312): the MCP dispatch path offloads blocking tool execution to a
+worker thread, so a slow tool call does not block other calls on the same
+(async) server.
+
+The MCP optional dependency is only present with the ``[mcp]`` extra, so these
+tests skip when it is not installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+pytest.importorskip("mcp.server.fastmcp")
+
+from process_improve import mcp_server
+
+_SLEEP = 0.5
+
+
+def test_single_call_returns_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A single dispatch returns the tool result serialised as JSON (unchanged behaviour)."""
+    monkeypatch.setattr(mcp_server, "execute_tool_call", lambda name, payload: {"name": name, "echo": payload})
+    handler = mcp_server._make_tool_handler("echo")
+
+    out = asyncio.run(handler(value=5))
+
+    assert '"name": "echo"' in out
+    assert '"value": 5' in out
+
+
+def test_concurrent_dispatch_does_not_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two slow tool calls run concurrently rather than serialising on the event loop."""
+
+    def fake_exec(tool_name: str, _payload: dict) -> dict:
+        time.sleep(_SLEEP)
+        return {"tool": tool_name, "ok": True}
+
+    monkeypatch.setattr(mcp_server, "execute_tool_call", fake_exec)
+    handler = mcp_server._make_tool_handler("slow")
+
+    async def run_two() -> tuple[list[str], float]:
+        start = time.perf_counter()
+        results = await asyncio.gather(handler(), handler())
+        return results, time.perf_counter() - start
+
+    results, elapsed = asyncio.run(run_two())
+
+    assert len(results) == 2
+    assert all('"ok": true' in r for r in results)
+    # Offloaded to threads, the two ``_SLEEP``-second calls overlap; a blocking
+    # (serialised) dispatch would take ~2 * _SLEEP.
+    assert elapsed < 1.7 * _SLEEP, f"dispatch appears serialised: {elapsed:.3f}s for two {_SLEEP}s calls"


### PR DESCRIPTION
## ENG-30 (#312): offload MCP tool dispatch to a worker thread

`mcp_server.py` defined `async def handler(...)` but called the **synchronous** tool path directly:
in safe mode it blocks on a `ProcessPoolExecutor` future (`future.result(timeout=...)`), otherwise it
runs the tool in-process. Either way it blocks the FastMCP event loop, so when the server is fronted
by HTTP / SSE, one slow tool call serialises all others.

### Change
The handler is factored into `_make_tool_handler(tool_name)` and now offloads the blocking call to a
worker thread:

```python
loop = asyncio.get_running_loop()
result = await loop.run_in_executor(None, sync_call, tool_name, kwargs)
```

The event loop is free to serve other requests while the tool runs. Single-call behaviour (result
serialisation, `ToolSafetyError` handling, error redaction) is unchanged.

### Test
`tests/test_mcp_server.py` (skips when the optional `mcp` extra is absent) demonstrates that two slow
tool calls run concurrently (`gather` completes in ~`_SLEEP`, not ~`2 * _SLEEP`), plus a single-call
behaviour check.

### Acceptance
- A slow tool call no longer blocks other tool calls in the same server.
- Existing single-call behaviour is unchanged.
- A regression test demonstrates concurrent dispatch.

Note (from the issue): this matters when the server is fronted by HTTP / SSE (`SAFE_MODE`); the default
stdio path is single-client and is unaffected.

https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW)_