### PR TITLE
ENG-19: document in-memory assumption + RAM limits (out-of-core code deferred)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.24] - 2026-06-03
+
+### Added
+
+- **ENG-19 (#301)**: a "Scaling and memory" docs page (``docs/scaling.rst``)
+  documenting the estimators' in-memory assumption, how to estimate RAM
+  (~``rows x cols x 8`` bytes, with 2-4x headroom during ``fit``), what to do
+  for larger-than-RAM data, and the out-of-core roadmap. The README's
+  "production-grade" claim now carries an honest note about scale. The
+  out-of-core code path itself is deferred (demand-driven) per the issue.
+
 ## [1.24.23] - 2026-06-03
 
 ### Changed (internal)
@@ -1203,7 +1214,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.23...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.24...HEAD
+[1.24.24]: https://github.com/kgdunn/process-improve/compare/v1.24.23...v1.24.24
 [1.24.23]: https://github.com/kgdunn/process-improve/compare/v1.24.22...v1.24.23
 [1.24.22]: https://github.com/kgdunn/process-improve/compare/v1.24.21...v1.24.22
 [1.24.21]: https://github.com/kgdunn/process-improve/compare/v1.24.20...v1.24.21

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.23
+version: 1.24.24
 date-released: "2026-06-03"
 keywords:
   - chemometrics

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ practitioners actually use on real plant and lab data:
 Outputs are `pandas`-native: scores, loadings, and predictions keep your row
 and column labels.
 
+> **Scale:** the estimators are *in-memory* - they assume the (scaled) data
+> matrix fits in RAM, plus a couple of working copies during `fit`. A float64
+> matrix needs about `rows x cols x 8 bytes` (e.g. 10M x 200 is ~16 GB). For
+> the practical limits and guidance on larger-than-RAM data, see
+> [Scaling and memory](https://kgdunn.github.io/process-improve/scaling.html)
+> ([source](docs/scaling.rst)).
+
 It is the companion package to the online textbook
 [Process Improvement using Data](https://learnche.org/pid), and powers the
 statistical engine behind [factori.al](https://factori.al).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ monitoring. Companion to the online textbook
 
    quickstart
    architecture
+   scaling
    user_guide/index
    api/index
 

--- a/docs/scaling.rst
+++ b/docs/scaling.rst
@@ -1,0 +1,70 @@
+Scaling and memory
+==================
+
+.. note::
+
+   This page documents the in-memory assumption of the estimators and the
+   practical data-size limits. Tracks
+   `ENG-19 <https://github.com/kgdunn/process-improve/issues/301>`_.
+
+The in-memory assumption
+------------------------
+
+The estimators in ``process-improve`` (PCA, PLS, TPLS, MBPCA, MBPLS, and the
+batch feature pipeline) are **in-memory**: ``fit`` expects the (scaled) data
+matrix to fit in RAM, and the iterative NIPALS / SVD paths hold a small number
+of working copies on top of it. There is currently **no out-of-core or
+streaming code path** - the whole matrix is materialised as a dense
+``numpy``/``pandas`` array.
+
+This is the right trade-off for the data sizes these methods are normally
+applied to (process and lab data: thousands to low millions of rows, tens to a
+few hundred columns), where keeping the pandas row/column labels and the full
+diagnostic suite (SPE, Hotelling's T2, contributions) is worth far more than
+streaming.
+
+Estimating the memory you need
+------------------------------
+
+A dense ``float64`` matrix needs roughly:
+
+.. code-block:: text
+
+   bytes ~= n_rows x n_cols x 8
+
+So a ``10,000,000 x 200`` matrix is about **16 GB** just for the data - before
+any working copies. As a rule of thumb, budget **2-4x** the raw matrix size for
+a fit:
+
+- ``MCUVScaler`` / ``center`` / ``scale`` return a scaled copy.
+- ``PCA.fit`` copies ``X`` once for the working array; NIPALS deflation works in
+  place on that copy.
+- ``PLS.fit`` similarly holds scaled ``X`` and ``Y`` plus deflation copies.
+
+Example: a ``1,000,000 x 100`` matrix is ~0.8 GB raw, so expect ~2-3 GB
+resident during ``fit`` - comfortable on a workstation, tight on a laptop.
+
+When this is *not* the right tool
+---------------------------------
+
+If your matrix does not fit in RAM (with the 2-4x headroom above), this package
+is not currently the right fit for a single ``fit`` call. Options today:
+
+- **Down-sample or aggregate** to a representative subset for model building,
+  then ``transform`` / ``predict`` the full data in chunks (``transform`` and
+  ``predict`` are far cheaper than ``fit`` and can be applied batch-by-batch).
+- **Reduce dtype** upstream (e.g. ``float32``) if the precision budget allows;
+  this halves the footprint. Note the estimators promote to ``float64``
+  internally, so this mainly helps the input/transform side.
+- **Use an out-of-core PCA** from another library (e.g.
+  ``sklearn.decomposition.IncrementalPCA`` with ``partial_fit`` over chunks, or
+  a ``dask``-backed SVD) for the dimensionality-reduction step, then bring the
+  reduced scores back into this package for the diagnostics.
+
+Roadmap
+-------
+
+A first-class out-of-core path for PCA (an incremental / chunked fitter, likely
+behind a ``[bigdata]`` optional-dependency extra) is tracked in
+`ENG-19 <https://github.com/kgdunn/process-improve/issues/301>`_. It is demand-driven:
+if you have a concrete larger-than-RAM use case, please comment on that issue.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.23"
+version = "1.24.24"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## ENG-19 (#301): document the in-memory assumption and RAM limits (code path deferred)

The issue notes the out-of-core path "could be deferred until a real user requests it." Per that
guidance (and your steer), this PR does the **honest-documentation** part now and leaves the
out-of-core code path as demand-driven future work.

### Changes
- **`docs/scaling.rst`** (new, wired into the Contents toctree): documents that the estimators are
  in-memory, how to estimate RAM (~`rows x cols x 8` bytes, with 2-4x headroom during `fit`), when the
  package is *not* the right tool (down-sample / chunked `transform`/`predict` / external IncrementalPCA),
  and the ENG-19 roadmap.
- **README**: the "production-grade" section gains a concise, honest **Scale** note linking to the page.

### Acceptance
- A docs page explains when in-memory use is appropriate and what to do beyond RAM. ✓
- The README's "production-grade" claim is honest about scale. ✓
- The out-of-core code path (incremental PCA under a `[bigdata]` extra) is explicitly deferred and
  tracked on the issue. (Partial close: code path remains open.)

Docs-only; the new page parses cleanly (no Sphinx warnings on it).

https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW)_