### PR TITLE
Fix #343: value-based equality for DataFrameDict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.29] - 2026-06-03
+
+### Fixed
+
+- **#343**: `DataFrameDict` (multivariate T-PLS container) now compares by value.
+  It subclasses `dict` but stores all data in `self.datadict`, leaving the `dict`
+  base empty, so the inherited `dict.__eq__` / `dict.__ne__` reported every
+  instance as equal regardless of its contents (CodeQL `py/missing-equals`). It
+  now defines value-based `__eq__` / `__ne__` (comparing block structure and each
+  contained `DataFrame` via `DataFrame.equals`) and is explicitly unhashable.
+  Surfaced by CodeQL during the ENG-01 module split (#342).
+
 ## [1.24.28] - 2026-06-03
 
 ### Added
@@ -1255,7 +1267,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.28...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.29...HEAD
+[1.24.29]: https://github.com/kgdunn/process-improve/compare/v1.24.28...v1.24.29
 [1.24.28]: https://github.com/kgdunn/process-improve/compare/v1.24.27...v1.24.28
 [1.24.27]: https://github.com/kgdunn/process-improve/compare/v1.24.26...v1.24.27
 [1.24.26]: https://github.com/kgdunn/process-improve/compare/v1.24.24...v1.24.26

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.28
+version: 1.24.29
 date-released: "2026-06-03"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.28"
+version = "1.24.29"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_tpls.py
+++ b/src/process_improve/multivariate/_tpls.py
@@ -127,6 +127,49 @@ class DataFrameDict(dict):
         """Return the number of samples in the DataFrameDict."""
         return self.n_samples
 
+    @staticmethod
+    def _value_equal(a: object, b: object) -> bool:
+        """Compare two stored block values, which may be DataFrames or nested dicts of them."""
+        if isinstance(a, pd.DataFrame) and isinstance(b, pd.DataFrame):
+            return a.equals(b)
+        if isinstance(a, dict) and isinstance(b, dict):
+            return a.keys() == b.keys() and all(DataFrameDict._value_equal(a[k], b[k]) for k in a)
+        return type(a) is type(b) and bool(a == b)
+
+    def __eq__(self, other: object) -> bool:
+        """Value-based equality over the held data.
+
+        Two :class:`DataFrameDict` instances are equal when they share the same
+        block structure and every contained :class:`pandas.DataFrame` is equal
+        (via :meth:`pandas.DataFrame.equals`). The inherited ``dict.__eq__``
+        would instead compare the (always-empty) ``dict`` base - all data lives
+        in ``self.datadict`` - and so report every instance as equal regardless
+        of its contents (CodeQL ``py/missing-equals``).
+        """
+        if self is other:
+            return True
+        if not isinstance(other, DataFrameDict):
+            return NotImplemented
+        return (
+            self.partitionable_blocks == other.partitionable_blocks
+            and self.datadict.keys() == other.datadict.keys()
+            and all(self._value_equal(self.datadict[b], other.datadict[b]) for b in self.datadict)
+        )
+
+    def __ne__(self, other: object) -> bool:
+        """Negation of :meth:`__eq__`.
+
+        Defined explicitly because the C-level ``dict.__ne__`` would otherwise
+        bypass the Python ``__eq__`` above and compare the empty ``dict`` bases.
+        """
+        result = self.__eq__(other)
+        return result if result is NotImplemented else not result
+
+    # All data lives in ``self.datadict`` and instances are mutable, so a
+    # ``DataFrameDict`` is deliberately unhashable (matching ``dict``); make the
+    # intent explicit now that ``__eq__`` is defined.
+    __hash__ = None  # type: ignore[assignment]  # reason: intentionally unhashable, mirrors dict
+
     def __repr__(self):
         """Return a string representation of the DataFrameDict."""
         groups_in_block_f = list(self.datadict["F"].keys())

--- a/tests/test_multivariate_dataframedict.py
+++ b/tests/test_multivariate_dataframedict.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
-import pytest
 
 from process_improve.multivariate.methods import DataFrameDict
 
@@ -67,6 +66,7 @@ class TestDataFrameDictEquality:
     def test_remains_unhashable(self) -> None:
         # Defining __eq__ must not accidentally make instances hashable; like
         # the dict base they must stay unhashable so they cannot be silently
-        # used as set members or dict keys.
-        with pytest.raises(TypeError):
-            hash(_make(1.0))
+        # used as set members or dict keys. Assert the contract at the class
+        # level (__hash__ is None) rather than calling hash() on a known-
+        # unhashable instance, which CodeQL flags as py/hash-unhashable-value.
+        assert DataFrameDict.__hash__ is None

--- a/tests/test_multivariate_dataframedict.py
+++ b/tests/test_multivariate_dataframedict.py
@@ -1,0 +1,72 @@
+"""Equality semantics for ``DataFrameDict`` (regression test for #343).
+
+``DataFrameDict`` subclasses ``dict`` but stores all of its data in the
+``self.datadict`` instance attribute, leaving the inherited ``dict`` base
+empty. Before #343 it inherited ``dict.__eq__`` / ``dict.__ne__``, which
+compared the (always-empty) base and therefore reported *every* instance as
+equal regardless of the data it held. These tests pin the value-based
+behaviour.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from process_improve.multivariate.methods import DataFrameDict
+
+
+def _make(value: float, n: int = 4) -> DataFrameDict:
+    """Build a small DataFrameDict whose F block carries the given value."""
+    rng = np.random.default_rng(0)
+    return DataFrameDict(
+        {
+            "F": {"main": pd.DataFrame({"f1": [value] * n, "f2": rng.standard_normal(n)})},
+            "Z": {"conds": pd.DataFrame({"z1": [value] * n})},
+            "Y": {"out": pd.DataFrame({"y1": [value] * n})},
+        }
+    )
+
+
+class TestDataFrameDictEquality:
+    def test_equal_data_compares_equal(self) -> None:
+        # Exercise both operators explicitly: __ne__ is a separate method.
+        assert (_make(1.0) == _make(1.0)) is True
+        assert (_make(1.0) != _make(1.0)) is False
+
+    def test_differing_data_compares_unequal(self) -> None:
+        a, b = _make(1.0), _make(999.0)
+        # The bug in #343: these used to compare *equal* (empty dict bases).
+        assert (a != b) is True
+        assert (a == b) is False
+
+    def test_differing_block_structure_compares_unequal(self) -> None:
+        full = _make(1.0)
+        # Same F/Y data but an extra Z group -> different structure.
+        extra = DataFrameDict(
+            {
+                "F": {"main": pd.DataFrame({"f1": [1.0] * 4, "f2": np.random.default_rng(0).standard_normal(4)})},
+                "Z": {"conds": pd.DataFrame({"z1": [1.0] * 4}), "extra": pd.DataFrame({"z2": [2.0] * 4})},
+                "Y": {"out": pd.DataFrame({"y1": [1.0] * 4})},
+            }
+        )
+        assert full != extra
+
+    def test_identity_is_equal(self) -> None:
+        a = _make(1.0)
+        same = a  # alias the same object to hit the `self is other` fast path
+        assert (a == same) is True
+
+    def test_unrelated_type_is_not_equal(self) -> None:
+        a = _make(1.0)
+        assert (a != "not a DataFrameDict") is True
+        assert (a != {"F": {}, "Z": {}, "Y": {}}) is True
+        assert (a == 42) is False
+
+    def test_remains_unhashable(self) -> None:
+        # Defining __eq__ must not accidentally make instances hashable; like
+        # the dict base they must stay unhashable so they cannot be silently
+        # used as set members or dict keys.
+        with pytest.raises(TypeError):
+            hash(_make(1.0))


### PR DESCRIPTION
## #343: `DataFrameDict` compares every instance as equal

`DataFrameDict` (the multivariate T-PLS container, `multivariate/_tpls.py`) subclasses `dict` but stores all of its data in the `self.datadict` instance attribute, leaving the inherited `dict` base **empty**. The inherited `dict.__eq__` / `dict.__ne__` therefore compared the always-empty bases and reported **every instance as equal regardless of its data** (CodeQL `py/missing-equals`). This was surfaced by CodeQL during the ENG-01 module split (#342), where the class was moved verbatim and the fix deliberately deferred (a mechanical split should not change equality semantics).

### Fix
- **Value-based `__eq__`**: compares `partitionable_blocks`, the block keys, and each contained `pandas.DataFrame` via `DataFrame.equals` (a small recursive `_value_equal` helper handles both the normal nested `dict[str, DataFrame]` blocks and the bare-`DataFrame` value the `__setitem__` path can store). Returns `NotImplemented` for unrelated types so Python falls back correctly.
- **Explicit `__ne__`**: required because the C-level `dict.__ne__` would otherwise bypass the Python `__eq__` (confirmed empirically) and keep comparing the empty bases.
- **`__hash__ = None`**: makes the unhashable-ness explicit now that `__eq__` is defined; matches the `dict` base so instances still cannot be silently used as set members / dict keys.

### Tests
New `tests/test_multivariate_dataframedict.py`: equal data -> equal; differing data -> not equal (the exact bug); differing block structure -> not equal; identity fast-path; unrelated-type comparisons; and still-unhashable. Both `==` and `!=` are exercised explicitly (asserting the actual `bool`, since `__ne__` is a separate method).

Behaviour-preserving in practice: no current code path relies on `DataFrameDict` equality (`TPLS` consumes it positionally; `Resampler` indexes/clones it), so the change only corrects the clearly-wrong all-equal result.

Verified: new tests + the TPLS/resampler suites pass; ruff clean; mypy still 0. Version bumped to 1.24.29 (PATCH), `CITATION.cff` + `CHANGELOG.md` synced.

Closes #343.

https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW)_