### PR TITLE
Fix #195: validate fit/predict feature-name consistency in PCA/PLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.31] - 2026-06-03
+
+### Fixed
+
+- **#195**: PCA and PLS now validate feature-name consistency between `fit` and
+  `transform` / `predict`, not just the column count. Previously a
+  correctly-shaped frame with reordered or renamed columns was projected
+  positionally (PCA) or silently label-aligned to all-`NaN` (PLS
+  `X @ direct_weights_`), producing wrong results with no error. Now: columns
+  supplied in a different order are realigned to the training order; renamed or
+  unexpected columns raise a clear `ValueError`; and unnamed (ndarray) input is
+  taken positionally and works (in particular `PLS.transform` on an ndarray no
+  longer returns all-`NaN`). `PLS.transform` also gained the column-count check
+  the other paths already had. Models fitted from unnamed (ndarray) data are
+  unaffected (count-only validation, as before).
+
 ## [1.24.30] - 2026-06-03
 
 ### Changed (internal)
@@ -1280,7 +1296,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.30...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.31...HEAD
+[1.24.31]: https://github.com/kgdunn/process-improve/compare/v1.24.30...v1.24.31
 [1.24.30]: https://github.com/kgdunn/process-improve/compare/v1.24.29...v1.24.30
 [1.24.29]: https://github.com/kgdunn/process-improve/compare/v1.24.28...v1.24.29
 [1.24.28]: https://github.com/kgdunn/process-improve/compare/v1.24.27...v1.24.28

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.30
+version: 1.24.31
 date-released: "2026-06-03"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.30"
+version = "1.24.31"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_common.py
+++ b/src/process_improve/multivariate/_common.py
@@ -49,6 +49,77 @@ class SpecificationWarning(UserWarning):
     """Parent warning class."""
 
 
+def _align_to_fit_features(X: pd.DataFrame, fit_feature_names: pd.Index) -> pd.DataFrame:
+    """Validate and align new-data columns against the features seen during ``fit``.
+
+    PCA / PLS only checked that data passed to ``transform`` / ``predict`` had the
+    right *number* of columns. A correctly-shaped frame whose columns are renamed
+    or reordered would otherwise be projected positionally (PCA, ``X.values @ P``)
+    or silently label-aligned to all-``NaN`` (PLS, ``X @ direct_weights_``),
+    producing wrong scores with no error raised (issue #195). This helper makes
+    that consistency explicit, mirroring scikit-learn's ``feature_names_in_``
+    handling:
+
+    * If both the training data and ``X`` carry string feature names, the *set*
+      of names must match (otherwise :class:`ValueError`); columns supplied in a
+      different order are reordered to the training order.
+    * If the training data had names but ``X`` does not (e.g. a bare ndarray was
+      passed), the columns are taken to correspond positionally and are labelled
+      with the training names, so downstream label-aligned arithmetic stays
+      correct rather than collapsing to ``NaN``.
+    * If the training data itself had no (string) feature names, there is nothing
+      to validate and ``X`` is returned unchanged.
+
+    The caller is expected to have already validated the column *count*.
+
+    Parameters
+    ----------
+    X : pd.DataFrame
+        New data passed to ``transform`` / ``predict`` (already coerced to a
+        DataFrame and count-checked by the caller).
+    fit_feature_names : pd.Index
+        The ``X.columns`` captured during ``fit`` (``self._feature_names``).
+
+    Returns
+    -------
+    pd.DataFrame
+        ``X`` with columns aligned to the training feature order.
+
+    Raises
+    ------
+    ValueError
+        If both sides carry string names but the sets of names differ.
+    """
+    fit_names = list(fit_feature_names)
+    if not (fit_names and all(isinstance(name, str) for name in fit_names)):
+        # Training data had no string feature names (e.g. fitted from an ndarray);
+        # only the column count is meaningful, which the caller already checked.
+        return X
+
+    new_names = list(X.columns)
+    if not all(isinstance(name, str) for name in new_names):
+        # New data carries default positional columns (e.g. came in as an
+        # ndarray). Assume positional correspondence and label it with the
+        # training names so label-aligned operations behave correctly.
+        X = X.copy()
+        X.columns = pd.Index(fit_names)
+        return X
+
+    if set(new_names) != set(fit_names):
+        missing = [name for name in fit_names if name not in set(new_names)]
+        unexpected = [name for name in new_names if name not in set(fit_names)]
+        raise ValueError(
+            "Feature names of the data passed to predict/transform do not match "
+            "those seen during fit. "
+            f"Missing columns: {missing}; unexpected columns: {unexpected}."
+        )
+    if new_names != fit_names:
+        # Same names, different order: reorder to the training order so the
+        # positional projection lines up.
+        X = X[fit_names]
+    return X
+
+
 def _model_method(fn: Callable[..., Any]) -> Callable[..., Any]:
     """Wrap a module-level ``fn(model, ...)`` as an introspectable instance method.
 

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -23,7 +23,7 @@ from sklearn.utils.validation import check_is_fitted
 
 from ..univariate.metrics import detect_outliers_esd
 from ._base import _LatentVariableModel, _LazyFrame
-from ._common import DataMatrix, SpecificationWarning, epsqrt
+from ._common import DataMatrix, SpecificationWarning, _align_to_fit_features, epsqrt
 from ._nipals import quick_regress, ssq, terminate_check
 
 logger = logging.getLogger(__name__)
@@ -468,6 +468,7 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             raise ValueError(
                 f"New data must have {self.n_features_in_} columns, got {X.shape[1]}."
             )
+        X = _align_to_fit_features(X, self._feature_names)
         scores = X.values @ self._loadings
         return pd.DataFrame(scores, index=X.index, columns=self._component_names)
 
@@ -495,6 +496,7 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             raise ValueError(
                 f"Prediction data must have {self.n_features_in_} columns, got {X.shape[1]}."
             )
+        X = _align_to_fit_features(X, self._feature_names)
 
         scores = self.transform(X)
 

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -26,7 +26,7 @@ from tqdm import tqdm
 from .._linalg import safe_inverse
 from ..univariate.metrics import detect_outliers_esd
 from ._base import _LatentVariableModel, _LazyFrame
-from ._common import DataMatrix, SpecificationWarning, _model_method, epsqrt
+from ._common import DataMatrix, SpecificationWarning, _align_to_fit_features, _model_method, epsqrt
 from ._nipals import quick_regress, ssq, terminate_check
 from .plots import (
     coefficient_plot as _coefficient_plot,
@@ -513,6 +513,11 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         check_is_fitted(self, "direct_weights_")
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X)
+        if X.shape[1] != self.n_features_in_:
+            raise ValueError(
+                f"Data to transform must have {self.n_features_in_} columns, got {X.shape[1]}."
+            )
+        X = _align_to_fit_features(X, self._feature_names)
         return X @ self.direct_weights_
 
     def fit_transform(self, X: DataMatrix, Y: DataMatrix | None = None) -> pd.DataFrame:
@@ -575,6 +580,7 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             raise ValueError(
                 f"Prediction data must have {self.n_features_in_} columns, got {X.shape[1]}."
             )
+        X = _align_to_fit_features(X, self._feature_names)
 
         scores = X @ self.direct_weights_
 

--- a/src/process_improve/multivariate/_tpls.py
+++ b/src/process_improve/multivariate/_tpls.py
@@ -543,8 +543,8 @@ class TPLS(RegressorMixin, BaseEstimator):
         if not isinstance(X, DataFrameDict):
             raise TypeError(f"X must be a DataFrameDict; got {type(X).__name__}.")
 
-        # TODO: Check consistency on the data: the columns names in the new data must match the columns names in the
-        # training data.
+        # Column-name consistency between the new data and the training data is
+        # validated per block below (see the ``set(df_f.columns) != ...`` checks).
         x_f: dict[str, pd.DataFrame] = {key: X["F"][key].copy() for key in X["F"]}
         x_z: dict[str, pd.DataFrame] = {key: X["Z"][key].copy() for key in X["Z"]}
 

--- a/tests/test_multivariate_feature_names.py
+++ b/tests/test_multivariate_feature_names.py
@@ -106,3 +106,10 @@ class TestPLSFeatureNames:
         got = pls.predict(X.to_numpy())
         assert not np.isnan(got.y_hat.to_numpy()).any()
         np.testing.assert_allclose(got.y_hat.to_numpy(), base.y_hat.to_numpy(), rtol=1e-10, atol=1e-10)
+
+    def test_transform_wrong_column_count_raises(self, xy: tuple[pd.DataFrame, pd.DataFrame]) -> None:
+        # PLS.transform previously had no count check at all.
+        X, Y = xy
+        pls = PLS(n_components=2).fit(X, Y)
+        with pytest.raises(ValueError, match="columns"):
+            pls.transform(X.iloc[:, :3])

--- a/tests/test_multivariate_feature_names.py
+++ b/tests/test_multivariate_feature_names.py
@@ -1,0 +1,108 @@
+"""Feature-name consistency between fit and transform/predict (issue #195).
+
+Before #195, PCA / PLS only checked the *number* of columns passed to
+``transform`` / ``predict``. A correctly-shaped frame whose columns were
+reordered or renamed was projected positionally (PCA) or silently label-aligned
+to all-``NaN`` (PLS ``X @ direct_weights_``), producing wrong results with no
+error. These tests pin the corrected behaviour:
+
+* reordered columns are realigned to the training order (same result);
+* renamed / wrong columns raise ``ValueError``;
+* unnamed (ndarray) input is taken positionally and still works - in particular
+  PLS no longer returns all-``NaN``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from process_improve.multivariate.methods import PCA, PLS, MCUVScaler
+
+
+@pytest.fixture
+def xy() -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Return a small, well-conditioned scaled (X, Y) pair with named columns."""
+    rng = np.random.default_rng(42)
+    n = 30
+    X = pd.DataFrame(
+        rng.standard_normal((n, 4)),
+        columns=["temp", "pressure", "flow", "ph"],
+    )
+    beta = np.array([[1.5], [-2.0], [0.5], [0.0]])
+    Y = pd.DataFrame(X.values @ beta + 0.1 * rng.standard_normal((n, 1)), columns=["yield"])
+    X_scaled = MCUVScaler().fit_transform(X)
+    Y_scaled = MCUVScaler().fit_transform(Y)
+    return X_scaled, Y_scaled
+
+
+class TestPCAFeatureNames:
+    def test_reordered_columns_are_realigned(self, xy: tuple[pd.DataFrame, pd.DataFrame]) -> None:
+        X, _ = xy
+        pca = PCA(n_components=2).fit(X)
+        reordered = X[X.columns[::-1]]
+        base = pca.transform(X)
+        got = pca.transform(reordered)
+        # Realigned to training order -> identical scores despite the input order.
+        np.testing.assert_allclose(got.to_numpy(), base.to_numpy(), rtol=1e-10, atol=1e-10)
+
+    def test_renamed_column_raises(self, xy: tuple[pd.DataFrame, pd.DataFrame]) -> None:
+        X, _ = xy
+        pca = PCA(n_components=2).fit(X)
+        bad = X.rename(columns={"flow": "FLOW_TYPO"})
+        with pytest.raises(ValueError, match=r"Feature names .* do not match"):
+            pca.transform(bad)
+        with pytest.raises(ValueError, match=r"Feature names .* do not match"):
+            pca.predict(bad)
+
+    def test_ndarray_input_still_works(self, xy: tuple[pd.DataFrame, pd.DataFrame]) -> None:
+        X, _ = xy
+        pca = PCA(n_components=2).fit(X)
+        base = pca.transform(X)
+        got = pca.transform(X.to_numpy())
+        np.testing.assert_allclose(got.to_numpy(), base.to_numpy(), rtol=1e-10, atol=1e-10)
+
+    def test_wrong_column_count_raises(self, xy: tuple[pd.DataFrame, pd.DataFrame]) -> None:
+        X, _ = xy
+        pca = PCA(n_components=2).fit(X)
+        with pytest.raises(ValueError, match="columns"):
+            pca.transform(X.iloc[:, :3])
+
+
+class TestPLSFeatureNames:
+    def test_reordered_columns_are_realigned(self, xy: tuple[pd.DataFrame, pd.DataFrame]) -> None:
+        X, Y = xy
+        pls = PLS(n_components=2).fit(X, Y)
+        reordered = X[X.columns[::-1]]
+        base = pls.predict(X)
+        got = pls.predict(reordered)
+        np.testing.assert_allclose(got.scores.to_numpy(), base.scores.to_numpy(), rtol=1e-10, atol=1e-10)
+        np.testing.assert_allclose(got.y_hat.to_numpy(), base.y_hat.to_numpy(), rtol=1e-10, atol=1e-10)
+
+    def test_renamed_column_raises(self, xy: tuple[pd.DataFrame, pd.DataFrame]) -> None:
+        X, Y = xy
+        pls = PLS(n_components=2).fit(X, Y)
+        bad = X.rename(columns={"temp": "temperature"})
+        with pytest.raises(ValueError, match=r"Feature names .* do not match"):
+            pls.predict(bad)
+        with pytest.raises(ValueError, match=r"Feature names .* do not match"):
+            pls.transform(bad)
+
+    def test_ndarray_transform_is_not_all_nan(self, xy: tuple[pd.DataFrame, pd.DataFrame]) -> None:
+        # Regression: PLS.transform on an ndarray used to label-align integer
+        # columns against the named direct_weights_ index and return all-NaN.
+        X, Y = xy
+        pls = PLS(n_components=2).fit(X, Y)
+        base = pls.transform(X)
+        got = pls.transform(X.to_numpy())
+        assert not np.isnan(got.to_numpy()).any()
+        np.testing.assert_allclose(got.to_numpy(), base.to_numpy(), rtol=1e-10, atol=1e-10)
+
+    def test_ndarray_predict_works(self, xy: tuple[pd.DataFrame, pd.DataFrame]) -> None:
+        X, Y = xy
+        pls = PLS(n_components=2).fit(X, Y)
+        base = pls.predict(X)
+        got = pls.predict(X.to_numpy())
+        assert not np.isnan(got.y_hat.to_numpy()).any()
+        np.testing.assert_allclose(got.y_hat.to_numpy(), base.y_hat.to_numpy(), rtol=1e-10, atol=1e-10)


### PR DESCRIPTION
## #195: fit/predict column-name consistency (multivariate)

Picks off the one **still-real, self-contained** correctness bug from #195. (An investigation of the issue's five sub-items found two already done - the `print(model)` crash and a snap-to-zero helper - and the rest belonging to other tracked issues: TSR/PMP missing-data support is #189, TPLS `feature_importance` is #192. The NIPALS variance-optimal start is the one remaining code item and is left for a separate, isolated numerical change - see the checklist I posted on #195.)

### The bug
PCA and PLS only checked the **number** of columns passed to `transform` / `predict`, never the names. So a correctly-shaped frame with reordered or renamed columns was:
- **PCA**: projected positionally (`X.values @ P`) - wrong scores, silently.
- **PLS**: label-aligned by pandas (`X @ direct_weights_`) - and an **ndarray input produced all-`NaN`** because its integer columns don't match the named weight index. `PLS.transform` had no count check at all.

### The fix
A shared `_align_to_fit_features` helper (`_common.py`) mirrors scikit-learn's `feature_names_in_` handling, applied in `PCA.transform/predict` and `PLS.transform/predict`:

- both sides carry string names -> the name **sets** must match (else `ValueError`); columns in a **different order are realigned** to the training order;
- training named but new data unnamed (ndarray) -> columns are taken positionally and **labelled with the training names**, so label-aligned arithmetic stays correct instead of going `NaN`;
- training data itself unnamed (model fitted from an ndarray) -> **count-only** validation, exactly as before (backward compatible).

`PLS.transform` also gains the column-count check the other paths already had. The now-redundant `TODO` in `TPLS.predict` is removed (TPLS already validates per-block column names just below it).

### Tests
New `tests/test_multivariate_feature_names.py` (8 cases) for PCA and PLS: reordered columns give identical results; renamed/unexpected columns raise `ValueError`; wrong count raises; ndarray input works - including the **PLS-ndarray-no-longer-`NaN`** regression.

### Risk / compatibility
Behaviour-preserving for correct usage: when the input already has matching names in the right order, the helper is a no-op, so it sits *after* the existing count checks and before the unchanged projection arithmetic. Verified: new tests pass; the full multivariate suite (incl. robustness, TPLS, resampler, property tests) is green - **166 passed, 1 skipped**; ruff clean; mypy 0.

Version bumped to 1.24.31 (PATCH), `CITATION.cff` + `CHANGELOG.md` synced.

Refs #195 (resolves the column-name-consistency item; the issue stays open for the NIPALS variance-optimal-start item).

https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW