### PR TITLE
#195: seed NIPALS from the highest-variance column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.32] - 2026-06-03
+
+### Changed (internal)
+
+- **#195**: PCA and PLS NIPALS now seed the iteration from the highest-variance
+  (highest sum-of-squares) column instead of the arbitrary first column. NIPALS
+  converges to the same component for any non-degenerate seed and a
+  deterministic sign convention fixes the sign, so the fitted result is
+  unchanged (the full multivariate suite, including the reference-dataset and
+  property-based invariant tests, is byte-for-byte green). The benefit is purely
+  numerical: the highest-variance column is the best-conditioned seed, needing
+  fewer iterations and avoiding the near-degenerate start when the first column
+  carries little or no variance. This resolves the last open code item in #195.
+
 ## [1.24.31] - 2026-06-03
 
 ### Fixed
@@ -1296,7 +1310,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.31...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.32...HEAD
+[1.24.32]: https://github.com/kgdunn/process-improve/compare/v1.24.31...v1.24.32
 [1.24.31]: https://github.com/kgdunn/process-improve/compare/v1.24.30...v1.24.31
 [1.24.30]: https://github.com/kgdunn/process-improve/compare/v1.24.29...v1.24.30
 [1.24.29]: https://github.com/kgdunn/process-improve/compare/v1.24.28...v1.24.29

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.31
+version: 1.24.32
 date-released: "2026-06-03"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.31"
+version = "1.24.32"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -322,15 +322,22 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
                 )
                 raise RuntimeError(emsg)
 
-            # Pick a column from X as the initial guess.
-            # ``Xd[:, [0]]`` (fancy indexing) already returns a copy in
-            # current numpy, so the in-place ``isnan -> 0`` does not
-            # poison Xd today. The explicit ``.copy()`` here is
-            # defensive: it mirrors the PLS path (~line 1527) and
-            # protects against any future numpy change that flips
-            # fancy indexing to a view-returning variant. SEC-21 (#270)
-            # sub-item 2.
-            t_a_guess = Xd[:, [0]].copy()
+            # Seed the score from the column of X with the greatest
+            # sum-of-squares (variance, for mean-centred data) rather than the
+            # arbitrary first column (#195). NIPALS converges to the same
+            # component for any non-degenerate seed, but the highest-variance
+            # column is closest to the leading component, so it needs fewer
+            # iterations and is far more robust when the first column happens to
+            # be near-orthogonal to it. The deterministic sign convention applied
+            # below makes the fitted sign independent of this seed.
+            #
+            # ``Xd[:, [start_col]]`` (fancy indexing) already returns a copy in
+            # current numpy, so the in-place ``isnan -> 0`` does not poison Xd
+            # today. The explicit ``.copy()`` here is defensive: it mirrors the
+            # PLS path and protects against any future numpy change that flips
+            # fancy indexing to a view-returning variant. SEC-21 (#270) sub-item 2.
+            start_col = int(np.argmax(start_ss_col))
+            t_a_guess = Xd[:, [start_col]].copy()
             t_a_guess[np.isnan(t_a_guess)] = 0
             t_a = t_a_guess + 1.0
             p_a = np.zeros((K, 1))

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -258,8 +258,15 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
                 )
                 raise RuntimeError(emsg)
 
-            # Initialize u_a with the first column of Y (replace NaN with 0)
-            u_a_guess = Yd[:, [0]].copy()
+            # Seed u_a from the column of Y with the greatest sum-of-squares
+            # (variance, for mean-centred data) rather than the arbitrary first
+            # column (#195): NIPALS converges to the same component for any
+            # non-degenerate seed, but the highest-variance column needs fewer
+            # iterations and is more robust. The deterministic sign convention
+            # applied below makes the fitted sign independent of this seed.
+            # (Replace NaN with 0 for the missing-data path.)
+            start_col = int(np.argmax(start_SSY_col))
+            u_a_guess = Yd[:, [start_col]].copy()
             u_a_guess[np.isnan(u_a_guess)] = 0
             u_a = u_a_guess + 1.0
 

--- a/tests/test_multivariate_nipals_seed.py
+++ b/tests/test_multivariate_nipals_seed.py
@@ -1,0 +1,85 @@
+"""NIPALS variance-optimal starting score (issue #195).
+
+PCA / PLS NIPALS now seed the iteration from the column with the greatest
+sum-of-squares (variance, for centred data) instead of the arbitrary *first*
+column. NIPALS converges to the same component for any non-degenerate seed and a
+deterministic sign convention fixes the sign, so the *fitted result is
+unchanged*; the benefit is purely numerical - the highest-variance column is the
+best-conditioned seed, needing fewer iterations and avoiding the near-degenerate
+start you get when the first column carries little or no variance.
+
+These tests therefore lock in two things: the fit stays correct and finite even
+when the first column is constant (a poor seed under the old rule), and the
+fitted model is invariant to input column order.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from process_improve.multivariate.methods import PCA, PLS
+
+
+def _centre(frame: pd.DataFrame) -> pd.DataFrame:
+    return frame - frame.mean(axis=0)
+
+
+def test_pca_converges_when_first_column_is_constant() -> None:
+    rng = np.random.default_rng(0)
+    n = 40
+    latent = rng.standard_normal((n, 1))
+    X = pd.DataFrame(
+        {
+            "c0": np.zeros(n),  # zero-variance: a poor seed for the old first-column rule
+            "c1": (2.0 * latent + 0.01 * rng.standard_normal((n, 1))).ravel(),
+            "c2": (-1.0 * latent + 0.01 * rng.standard_normal((n, 1))).ravel(),
+            "c3": (0.5 * latent + 0.01 * rng.standard_normal((n, 1))).ravel(),
+        }
+    )
+    pca = PCA(n_components=2).fit(_centre(X))
+
+    # The fit is finite (no 0/0 poisoning) and explains the rank-1 structure.
+    assert np.isfinite(pca.loadings_.to_numpy()).all()
+    assert np.isfinite(pca.scores_.to_numpy()).all()
+    assert pca.r2_cumulative_.iloc[0] > 0.99
+    # The first component loads on the informative columns, not the dead c0.
+    leading = pca.loadings_.iloc[:, 0].abs()
+    assert leading["c0"] < leading[["c1", "c2", "c3"]].min()
+
+
+def test_pls_converges_when_first_x_column_is_constant() -> None:
+    rng = np.random.default_rng(1)
+    n = 40
+    latent = rng.standard_normal((n, 1))
+    X = pd.DataFrame(
+        {
+            "c0": np.zeros(n),
+            "c1": (2.0 * latent + 0.01 * rng.standard_normal((n, 1))).ravel(),
+            "c2": (-1.0 * latent + 0.01 * rng.standard_normal((n, 1))).ravel(),
+        }
+    )
+    Y = pd.DataFrame({"y": (3.0 * latent + 0.05 * rng.standard_normal((n, 1))).ravel()})
+    pls = PLS(n_components=2).fit(_centre(X), _centre(Y))
+
+    assert np.isfinite(pls.x_loadings_.to_numpy()).all()
+    assert np.isfinite(pls.beta_coefficients_.to_numpy()).all()
+    # The model predicts the strongly-correlated Y well.
+    y_hat = pls.predict(_centre(X)).y_hat
+    assert np.isfinite(y_hat.to_numpy()).all()
+
+
+def test_pca_fit_is_invariant_to_column_order() -> None:
+    # The variance-optimal seed plus the sign convention make the fitted model
+    # independent of input column order: loadings realigned to the original
+    # order must match those from a permuted fit.
+    rng = np.random.default_rng(7)
+    X = pd.DataFrame(_centre(pd.DataFrame(rng.standard_normal((50, 5)))))
+    X.columns = ["a", "b", "c", "d", "e"]
+    base = PCA(n_components=3).fit(X)
+    permuted_cols = ["d", "a", "e", "c", "b"]
+    permuted = PCA(n_components=3).fit(X[permuted_cols])
+
+    aligned = permuted.loadings_.reindex(base.loadings_.index)
+    np.testing.assert_allclose(aligned.to_numpy(), base.loadings_.to_numpy(), rtol=1e-8, atol=1e-8)
+    np.testing.assert_allclose(permuted.scores_.to_numpy(), base.scores_.to_numpy(), rtol=1e-8, atol=1e-8)


### PR DESCRIPTION
## #195 (final code item): variance-optimal NIPALS starting score

Closes out the last open item on #195. PCA and PLS NIPALS seeded the score iteration from the **arbitrary first column** (`Xd[:, [0]]` for PCA, `Yd[:, [0]]` for PLS). This switches the seed to the column with the **greatest sum-of-squares** (variance, for centred data), reusing the `start_ss_col` / `start_SSY_col` arrays the loops already compute.

### Why it is safe (output-preserving)
NIPALS converges to the same component for any non-degenerate seed, and both estimators already apply a **deterministic sign convention** (largest-magnitude loading element forced positive, flipping the whole component together). So the *fitted result does not change* - only the path to it. This is verified empirically: the **entire multivariate suite stays green**, including the reference-dataset comparisons (`test_multiblock_reference`, TSR) and the property-based invariants (`tests/properties/`) - **259 passed, 1 skipped**.

### Why it is worth doing
The highest-variance column is the best-conditioned seed: it is closest to the leading component, so NIPALS needs fewer iterations, and it avoids the near-degenerate start you get when the first column happens to carry little or no variance (e.g. a constant column after some preprocessing).

### Tests
New `tests/test_multivariate_nipals_seed.py`: PCA/PLS fit correctly and finitely when the first column is constant, and PCA fits are invariant to input column order. (These lock in correct behaviour and the column-order invariant; the change is output-preserving by design, so the suite-wide green run is the primary safety evidence.)

Verified: ruff clean, mypy 0. Version bumped to 1.24.32 (PATCH), `CITATION.cff` + `CHANGELOG.md` synced.

Closes #195.

https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW)_