### PR TITLE
Fix #197: don't contaminate row-0 of DTW batch-alignment averaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.33] - 2026-06-03
+
+### Fixed
+
+- **#197**: the DTW batch-alignment averaging (`batch.preprocessing.align_with_path`)
+  no longer contaminates the first synced row. When several batch samples map to
+  the same reference index (a compression in the warping path), the synced value
+  is the average of those batch samples; the running accumulator was previously
+  seeded from an `initial_row` argument - a reference row in one caller, an
+  out-of-space batch row in the other - which mixed an unrelated row into the
+  row-0 average. The accumulator is now seeded from the first batch sample for
+  the index (matching the value already written to that row), and the misleading
+  `initial_row` parameter is removed. (The thesis page-181 generalisation of the
+  averaging, plus the Sakoe-Chiba and user-`band` constraints, remain tracked on
+  #197.)
+
 ## [1.24.32] - 2026-06-03
 
 ### Changed (internal)
@@ -1310,7 +1326,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.32...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.33...HEAD
+[1.24.33]: https://github.com/kgdunn/process-improve/compare/v1.24.32...v1.24.33
 [1.24.32]: https://github.com/kgdunn/process-improve/compare/v1.24.31...v1.24.32
 [1.24.31]: https://github.com/kgdunn/process-improve/compare/v1.24.30...v1.24.31
 [1.24.30]: https://github.com/kgdunn/process-improve/compare/v1.24.29...v1.24.30

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.32
+version: 1.24.33
 date-released: "2026-06-03"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.32"
+version = "1.24.33"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/batch/preprocessing.py
+++ b/src/process_improve/batch/preprocessing.py
@@ -175,13 +175,23 @@ class DTWresult:
         self.normalized_distance = normalized_distance
 
 
-def align_with_path(md_path: np.ndarray, batch: pd.DataFrame, initial_row: pd.Series) -> pd.DataFrame:
-    """Align a batch to the reference using the DTW path."""
+def align_with_path(md_path: np.ndarray, batch: pd.DataFrame) -> pd.DataFrame:
+    """Align a batch to the reference using the DTW path.
+
+    Where several samples of ``batch`` map to the same reference index (a
+    compression in the warping path), the synced value for that index is the
+    average of those batch samples. The running ``temp`` accumulator is therefore
+    seeded with the first batch sample for the current index - the same value
+    assigned to ``synced`` row 0 just below - not with a reference row. A former
+    ``initial_row`` argument seeded it from the reference row (in one caller) or
+    from an out-of-space batch index (in the other), which mixed an unrelated row
+    into the row-0 average (#197).
+    """
     row = 0
     nr = md_path[:, 0].max() + 1  # to account for the zero-based indexing
     synced = pd.DataFrame(np.zeros((nr, batch.shape[1])), columns=batch.columns)
     synced.iloc[row, :] = batch.iloc[md_path[0, 1], :]
-    temp: pd.Series | np.ndarray = initial_row
+    temp: pd.Series | np.ndarray = batch.iloc[md_path[0, 1], :]
     for idx in np.arange(1, md_path.shape[0]):
         if md_path[idx, 0] != md_path[idx - 1, 0]:
             row += 1
@@ -213,8 +223,7 @@ def dtw_core(test: pd.DataFrame, ref: pd.DataFrame, weight_matrix: np.ndarray) -
         warping_path[idx] = md_path[np.where(md_path[:, 0] == idx)[0][-1], 1]
 
     # Now align the `test` batch:
-    initial_row = ref.iloc[md_path[0, 0], :].copy()
-    synced = align_with_path(md_path=md_path, batch=test, initial_row=initial_row)
+    synced = align_with_path(md_path=md_path, batch=test)
 
     return DTWresult(
         synced,
@@ -414,11 +423,9 @@ def batch_dtw(  # noqa: C901, PLR0915
         desc="Interpolating",
         disable=not (settings["show_progress"]),
     ):
-        initial_row = batches[batch_id].iloc[result.md_path[0, 0], :].copy()
         synced = align_with_path(
             result.md_path,
             batches[batch_id].iloc[:: int(settings["subsample"]), :],
-            initial_row=initial_row,
         )
         # Resample the trajectories of the aligned data now along this sequence.
         sequence = np.linspace(

--- a/tests/batch/test_dtw_align_with_path.py
+++ b/tests/batch/test_dtw_align_with_path.py
@@ -1,0 +1,39 @@
+"""Direct unit tests for ``align_with_path`` DTW averaging (issue #197).
+
+When several samples of a batch map to the same reference index (a compression
+in the warping path), the synced value for that index must be the average of
+*those batch samples only*. The previous implementation seeded the running
+average from an ``initial_row`` argument (a reference row in one caller, an
+out-of-space batch row in the other), so the row-0 average was contaminated by
+an unrelated row. These tests pin the corrected averaging.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from process_improve.batch.preprocessing import align_with_path
+
+
+def test_compression_at_first_index_averages_only_batch_rows() -> None:
+    batch = pd.DataFrame({"a": [10.0, 20.0, 30.0], "b": [1.0, 3.0, 5.0]})
+    # Reference index 0 receives batch samples 0 and 1 (a compression); reference
+    # index 1 receives batch sample 2. Columns are [reference_index, test_index].
+    md_path = np.array([[0, 0], [0, 1], [1, 2]])
+
+    synced = align_with_path(md_path=md_path, batch=batch)
+
+    assert synced.shape == (2, 2)
+    # Row 0 = mean of batch rows 0 and 1; previously this leaked the seed row in.
+    np.testing.assert_allclose(synced.iloc[0].to_numpy(), [15.0, 2.0])
+    np.testing.assert_allclose(synced.iloc[1].to_numpy(), [30.0, 5.0])
+
+
+def test_one_to_one_path_is_a_passthrough() -> None:
+    batch = pd.DataFrame({"a": [10.0, 20.0, 30.0]})
+    md_path = np.array([[0, 0], [1, 1], [2, 2]])
+
+    synced = align_with_path(md_path=md_path, batch=batch)
+
+    np.testing.assert_allclose(synced["a"].to_numpy(), [10.0, 20.0, 30.0])


### PR DESCRIPTION
## #197: DTW alignment averaging seeded from the wrong row

Fixes the one clean, verifiable correctness bug in #197. (Investigation note: the "don't force batch dict keys to `str`" item is already satisfied - keys are used as-is throughout the batch module - and the remaining items, the thesis page-181 averaging generalisation and the Sakoe-Chiba / user-`band` constraints, are feature work left tracked on the issue.)

### The bug
`align_with_path` (`batch/preprocessing.py`) builds the synced trajectory from a DTW warping path. Where several batch samples map to the same reference index (a compression), the synced value for that index is the **average** of those batch samples, accumulated in a running `temp`. But `temp` was seeded from an `initial_row` argument, and the two callers passed **different, wrong things**:

- `dtw_core` passed `ref.iloc[md_path[0,0]]` - a **reference** row;
- the interpolation loop passed `batches[id].iloc[md_path[0,0]]` - a batch row indexed by a **reference-space** index.

So when the warping path compresses at reference index 0, the row-0 average mixed in that unrelated seed row instead of averaging only the batch samples mapped there.

### The fix
Seed `temp` from the first batch sample for the index - `batch.iloc[md_path[0,1]]`, the exact value already written to `synced` row 0 just above - and remove the misleading `initial_row` parameter from the function and both call sites. This makes both call paths consistent and correct.

### Tests
New `tests/batch/test_dtw_align_with_path.py` exercises `align_with_path` directly: a compression at reference index 0 must yield the mean of the two batch rows (no seed-row contamination), and a one-to-one path is a passthrough.

### Risk
Low and bounded: `align_with_path` / `dtw_core` are internal helpers (no external or test callers of the old signature). The full batch suite is unchanged - **66 passed** - and ruff/mypy are clean. The fix only changes output for warping paths that compress at the first reference index, which is exactly the contaminated case.

Version bumped to 1.24.33 (PATCH), `CITATION.cff` + `CHANGELOG.md` synced.

Refs #197 (resolves the averaging-contamination bug; the page-181 generalisation and band / Sakoe-Chiba constraints remain open).

https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW)_