### PR TITLE
#192 (part 1): TPLS feature_importance test coverage + help() cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ those changes.
 
 ## [Unreleased]
 
+## [1.24.34] - 2026-06-03
+
+### Changed (internal)
+
+- **#192 (partial)**: TPLS housekeeping. Removed a stale `TODO:` scratch block
+  that was leaking into `TPLS.help()` output (the attributes it referenced are
+  now methods, per ENG-05) and added a `.vip()` line in its place. Added test
+  coverage for the previously-untested `feature_importance` / `vip()` surface
+  (structure, finite non-negative VIPs, feature-name indexing, the `vip()`
+  accessor and its error cases). This pins the current VIP-based behaviour so the
+  open question in #192 - whether the D/F feature importance should instead use
+  the deflated matrices `S(VᵀS)⁻¹` / `P(PᵀP)⁻¹` - can be settled as a deliberate,
+  reviewed change. The scaling-vector and deflated-matrix items of #192 remain
+  open.
+
 ## [1.24.33] - 2026-06-03
 
 ### Fixed
@@ -1326,7 +1341,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.33...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.34...HEAD
+[1.24.34]: https://github.com/kgdunn/process-improve/compare/v1.24.33...v1.24.34
 [1.24.33]: https://github.com/kgdunn/process-improve/compare/v1.24.32...v1.24.33
 [1.24.32]: https://github.com/kgdunn/process-improve/compare/v1.24.31...v1.24.32
 [1.24.31]: https://github.com/kgdunn/process-improve/compare/v1.24.30...v1.24.31

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.33
+version: 1.24.34
 date-released: "2026-06-03"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.33"
+version = "1.24.34"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_tpls.py
+++ b/src/process_improve/multivariate/_tpls.py
@@ -806,12 +806,7 @@ class TPLS(RegressorMixin, BaseEstimator):
         .hotellings_t2_limit()      Returns the Hotelling's T2 limit for the model              [float]
         .spe_limit[block]()         Return the SPE limit for the block; e.g. .spe_limit["Y"]() [float]
 
-
-        TODO:
-        self.hotellings_t2: pd.DataFrame = pd.DataFrame()
-        self.hotellings_t2_limit: Callable = hotellings_t2_limit
-        self.scaling_factor_for_scores = pd.Series()
-        self.ellipse_coordinates: Callable = ellipse_coordinates
+        .vip()                      Variable importance (VIP) for the D- and F-blocks          [dict]
 
         """
 

--- a/tests/test_multivariate_tpls_feature_importance.py
+++ b/tests/test_multivariate_tpls_feature_importance.py
@@ -1,0 +1,87 @@
+"""Coverage for TPLS ``feature_importance`` / ``vip()`` (issue #192).
+
+The TPLS VIP-based feature importance for the D-block (material properties) and
+F-block (formulation variables) previously had no tests pinning its behaviour.
+These tests lock in the current structure and invariants so that any future
+re-derivation (e.g. the deflated-matrix variant noted in #192) is a deliberate,
+reviewed change rather than a silent one.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from process_improve.multivariate.methods import TPLS, DataFrameDict
+
+
+@pytest.fixture
+def tpls_pyphi_data() -> dict[str, dict[str, pd.DataFrame]]:
+    """Load the pyphi TPLS example dataset (Z, D, F, Y blocks)."""
+    folder = pathlib.Path(__file__).parents[1] / "src" / "process_improve" / "datasets" / "multivariate" / "tpls-pyphi"
+    properties = {
+        f"Group {i}": pd.read_csv(folder / f"properties_Group{i}.csv", sep=",", index_col=0, header=0).astype("float64")
+        for i in range(1, 6)
+    }
+    formulas = {
+        f"Group {i}": pd.read_csv(folder / f"formulas_Group{i}.csv", sep=",", index_col=0, header=0).astype("float64")
+        for i in range(1, 6)
+    }
+    process_conditions = {
+        "Conditions": pd.read_csv(folder / "process_conditions.csv", sep=",", index_col=0, header=0).astype("float64"),
+    }
+    quality_indicators = {
+        "Quality": pd.read_csv(folder / "quality_indicators.csv", sep=",", index_col=0, header=0).astype("float64"),
+    }
+    return {"Z": process_conditions, "D": properties, "F": formulas, "Y": quality_indicators}
+
+
+@pytest.fixture
+def fitted_tpls(tpls_pyphi_data: dict) -> TPLS:
+    d_matrix = tpls_pyphi_data.pop("D")
+    model = TPLS(n_components=2, d_matrix=d_matrix)
+    model.fit(DataFrameDict(tpls_pyphi_data))
+    return model
+
+
+class TestTPLSFeatureImportance:
+    def test_feature_importance_structure(self, fitted_tpls: TPLS) -> None:
+        fi = fitted_tpls.feature_importance
+        assert set(fi.keys()) == {"D", "F", "Z", "Y"}
+        # D and F are populated, one Series per group.
+        assert set(fi["D"].keys()) == {f"Group {i}" for i in range(1, 6)}
+        assert set(fi["F"].keys()) == {f"Group {i}" for i in range(1, 6)}
+
+    def test_vip_values_are_finite_nonnegative(self, fitted_tpls: TPLS) -> None:
+        for block in ("D", "F"):
+            for group, series in fitted_tpls.feature_importance[block].items():
+                assert isinstance(series, pd.Series), f"{block}/{group}"
+                values = series.to_numpy()
+                assert np.isfinite(values).all(), f"{block}/{group} has non-finite VIP"
+                assert (values >= 0).all(), f"{block}/{group} has negative VIP"
+        # There is real signal: not every VIP is zero.
+        all_d = np.concatenate([s.to_numpy() for s in fitted_tpls.feature_importance["D"].values()])
+        assert all_d.max() > 0
+
+    def test_vip_series_indexed_by_feature_names(self, fitted_tpls: TPLS) -> None:
+        for group, series in fitted_tpls.feature_importance["D"].items():
+            assert list(series.index) == list(fitted_tpls.property_names[group])
+        for group, series in fitted_tpls.feature_importance["F"].items():
+            assert list(series.index) == list(fitted_tpls.material_names[group])
+
+    def test_vip_method_matches_attribute(self, fitted_tpls: TPLS) -> None:
+        assert fitted_tpls.vip() is fitted_tpls.feature_importance
+        assert fitted_tpls.vip("D") is fitted_tpls.feature_importance["D"]
+        assert fitted_tpls.vip("F") is fitted_tpls.feature_importance["F"]
+
+    def test_vip_rejects_unknown_block(self, fitted_tpls: TPLS) -> None:
+        with pytest.raises(ValueError, match="block must be"):
+            fitted_tpls.vip("Z")
+
+    def test_vip_before_fit_raises(self, tpls_pyphi_data: dict) -> None:
+        model = TPLS(n_components=2, d_matrix=tpls_pyphi_data["D"])
+        with pytest.raises((RuntimeError, ValueError)):
+            model.vip()


### PR DESCRIPTION
## #192, part 1: the safe, unblocked pieces

Working #192 ("finish TPLS implementation gaps"). I scoped this PR to the parts I can do correctly and safely now, and I'm bringing the rest back for a decision (see below).

### What's here
- **`help()` cleanup** (the "address the open TODO block" item): removed a stale `TODO:` scratch block that was leaking raw attribute-assignment lines into `TPLS.help()` user-facing output. The attributes it referenced (`hotellings_t2_limit`, `ellipse_coordinates`, ...) are real methods now (ENG-05 / #287), so the note was obsolete. Replaced it with a `.vip()` entry.
- **`feature_importance` / `vip()` test coverage**: this surface was **previously untested**. New `tests/test_multivariate_tpls_feature_importance.py` pins the current VIP-based behaviour - block structure (`D`/`F`/`Z`/`Y`, one Series per group), finite non-negative VIPs, feature-name indexing, the `vip()` accessor and its error cases - using the pyphi TPLS reference dataset.

### Why this matters for the rest of #192
The remaining items (re-deriving `feature_importance["D"]`/`["F"]` against the deflated matrices `S(VᵀS)⁻¹` / `P(PᵀP)⁻¹`) would change user-facing numbers. They're defined by the Garcia-Munoz 2014 paper (*Chemometrics & Intelligent Lab Systems* v133), which isn't reachable from the tooling here, and the current code had **no tests** to validate a rewrite against - so a speculative change would be unverifiable. This PR closes that test gap first; a re-derivation can now be a deliberate, diff-visible change.

### Still open on #192 (need your call - I'll comment on the issue)
1. **Deflated-matrix feature importance (D/F)**: the TODOs at the VIP computation are *questions* ("should it not be based on deflated matrices?"). The current VIP is a standard, legitimate importance metric; the `S(VᵀS)⁻¹` form is the regression-coefficient (direct-weights) rotation. I'd keep the documented VIP unless you have the paper's formula / reference values.
2. **"Provide a scaling vector"**: the D-block uses a `√(n_properties)` block *scalar* (stored oddly as a one-element Series). Whether to expose it or allow a user-supplied per-block scaling vector is an API decision.

Verified: ruff clean, mypy 0, 16 TPLS tests pass. Internal-only change (docstring + tests); version bumped to 1.24.34 (PATCH), `CITATION.cff` + `CHANGELOG.md` synced.

Refs #192.

https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW)_