### PR TITLE
#192 (part 2): paper-faithful TPLS D-block scaling + deflated VIP variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ those changes.
 
 ## [Unreleased]
 
+## [1.25.0] - 2026-06-03
+
+### Changed
+
+- **TPLS D-block scaling now matches Garcia-Munoz (2014), section 2.1 (#192).** Each
+  D-block (material properties) is block-scaled by `1/sqrt(P_i * M_i)` (P_i = number of
+  lots/rows, M_i = number of properties/columns) instead of the previous `1/sqrt(M_i)`.
+  After column auto-scaling this makes `trace(X_i^T X_i) ~= 1` for every block, removing
+  bias toward blocks that simply have more lots or properties. The previous factor left
+  `trace = P_i - 1` (e.g. 161 vs 8 across blocks on the pyphi example), over-weighting
+  large blocks. **This changes all fitted TPLS results** (scores, R2, SPE, Hotelling's
+  T2, limits, predictions); affected reference values in the test-suite were re-baselined
+  and an independent `trace ~= 1` invariant test was added.
+
+### Added
+
+- **TPLS `vip(method="deflated")` (#192).** Opt-in deflated direct-weights feature
+  importance: VIP computed on the rotated weights `S(V^T S)^-1` (D-block) and
+  `P(P^T P)^-1` (F-block), which account for the deflation across components (equation 7
+  in the paper). The default `method="vip"` is unchanged and still matches the standard
+  VIP the paper reports. Note that for the D-block the rotation is ~identity
+  (`V^T S ~= I` by construction), so the deflated and default importances coincide there;
+  they differ for the F-block.
+
 ## [1.24.34] - 2026-06-03
 
 ### Changed (internal)
@@ -1341,7 +1365,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.24.34...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.25.0...HEAD
+[1.25.0]: https://github.com/kgdunn/process-improve/compare/v1.24.34...v1.25.0
 [1.24.34]: https://github.com/kgdunn/process-improve/compare/v1.24.33...v1.24.34
 [1.24.33]: https://github.com/kgdunn/process-improve/compare/v1.24.32...v1.24.33
 [1.24.32]: https://github.com/kgdunn/process-improve/compare/v1.24.31...v1.24.32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ those changes.
   VIP the paper reports. Note that for the D-block the rotation is ~identity
   (`V^T S ~= I` by construction), so the deflated and default importances coincide there;
   they differ for the F-block.
+- **TPLS `d_block_scaling_` accessor (#192).** The D-block block-scaling factor is now stored as a
+  plain scalar (previously a one-element `pd.Series` accessed via `[0]`) and exposed through the
+  read-only `d_block_scaling_` property, returning `{group: factor}`.
 
 ## [1.24.34] - 2026-06-03
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.24.34
+version: 1.25.0
 date-released: "2026-06-03"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.24.34"
+version = "1.25.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_tpls.py
+++ b/src/process_improve/multivariate/_tpls.py
@@ -367,7 +367,10 @@ class TPLS(RegressorMixin, BaseEstimator):
 
         # Storage for pre-processing and the raw matrices
         self.fitting_statistics: dict[str, list] = {"iterations": [], "convergance_tolerance": [], "milliseconds": []}
-        self.preproc_: dict[str, dict[str, dict[str, pd.Series]]] = {key: {} for key in self.required_blocks_}
+        # Per block / per group preprocessing parameters. "center" and "scale" are pd.Series (one entry
+        # per column); the D-block additionally stores a scalar "block" factor (float). The heterogeneous
+        # value types make `Any` the honest inner annotation here. See `_preprocess`.
+        self.preproc_: dict[str, dict[str, dict[str, typing.Any]]] = {key: {} for key in self.required_blocks_}
         self.sums_of_squares_: list[dict[str, dict[str, np.ndarray]]] = [{key: {} for key in self.required_blocks_}]
         # These are *fractional* R2 values, i.e. always less than or equal to 1.0.
         # As a list: entry 0 is zeros; entry 1 is after fitting the first component, and so on.
@@ -408,7 +411,7 @@ class TPLS(RegressorMixin, BaseEstimator):
             # trace(X_i^T X_i) ~= 1 for every block, removing bias toward blocks that simply have more lots
             # or more properties. See Garcia-Munoz (2014), section 2.1 (https://doi.org/10.1016/j.chemolab.2014.02.006).
             n_lots, n_properties = df_d.shape
-            self.preproc_["D"][key]["block"] = pd.Series([np.sqrt(n_lots * n_properties)])
+            self.preproc_["D"][key]["block"] = float(np.sqrt(n_lots * n_properties))
             #
             # Also do the same for the formula matrix
             self.preproc_["F"][key] = {}
@@ -1181,6 +1184,28 @@ class TPLS(RegressorMixin, BaseEstimator):
             return importance
         return importance[block]
 
+    @property
+    def d_block_scaling_(self) -> dict[str, float]:
+        """Block-scaling factor applied to each D-block (read-only).
+
+        After column-wise centring and auto-scaling, every D-block ``X_i`` is additionally divided by
+        ``sqrt(P_i * M_i)`` (``P_i`` = number of lots/rows, ``M_i`` = number of properties/columns) so that
+        ``trace(X_i^T X_i) ~= 1``, removing bias toward blocks with more lots or properties
+        (Garcia-Munoz, 2014, section 2.1).
+
+        Returns
+        -------
+        dict[str, float]
+            Mapping of D-block group name to its scalar block-scaling factor.
+
+        Raises
+        ------
+        AttributeError
+            If the model has not been fitted yet.
+        """
+        check_is_fitted(self, "preproc_")
+        return {key: self.preproc_["D"][key]["block"] for key in self.preproc_["D"]}
+
     def _calculate_vip(self, loadings: np.ndarray, r2_vector: np.ndarray) -> np.ndarray:
         """Calculate the VIP values for the current component.
 
@@ -1287,7 +1312,7 @@ class TPLS(RegressorMixin, BaseEstimator):
             self.d_mats[key] = (
                 (self.d_mats[key] - self.preproc_["D"][key]["center"].to_numpy()[None, :])
                 / self.preproc_["D"][key]["scale"].to_numpy()[None, :]
-                / self.preproc_["D"][key]["block"][0]  # scalar!
+                / self.preproc_["D"][key]["block"]  # scalar block-scaling factor
             )
         for key in self.z_mats:
             self.z_mats[key] = (
@@ -1324,7 +1349,7 @@ class TPLS(RegressorMixin, BaseEstimator):
                 vector = np.nanmean(self.d_mats[key], axis=0)
                 vector[np.isnan(vector)] = 0
                 assert np.allclose(vector, 0, atol=1e-6)  # post-centering invariant
-                vector = np.nanstd(self.d_mats[key], axis=0, ddof=1) * self.preproc_["D"][key]["block"].values[0]
+                vector = np.nanstd(self.d_mats[key], axis=0, ddof=1) * self.preproc_["D"][key]["block"]
                 vector[np.isnan(vector)] = 1
                 assert np.allclose(vector, 1)  # post-scaling invariant
 

--- a/src/process_improve/multivariate/_tpls.py
+++ b/src/process_improve/multivariate/_tpls.py
@@ -403,7 +403,12 @@ class TPLS(RegressorMixin, BaseEstimator):
             self.preproc_["D"][key]["center"], self.preproc_["D"][key]["scale"] = (
                 self._learn_center_and_scaling_parameters(df_d)
             )
-            self.preproc_["D"][key]["block"] = pd.Series([np.sqrt(df_d.shape[1])])  # <-- sqrt(number of properties!)
+            # Block-scale each D-block by 1 / sqrt(P_i * M_i), where P_i = number of lots (rows) and
+            # M_i = number of properties (columns). After column-wise auto-scaling this makes
+            # trace(X_i^T X_i) ~= 1 for every block, removing bias toward blocks that simply have more lots
+            # or more properties. See Garcia-Munoz (2014), section 2.1 (https://doi.org/10.1016/j.chemolab.2014.02.006).
+            n_lots, n_properties = df_d.shape
+            self.preproc_["D"][key]["block"] = pd.Series([np.sqrt(n_lots * n_properties)])
             #
             # Also do the same for the formula matrix
             self.preproc_["F"][key] = {}
@@ -1051,20 +1056,37 @@ class TPLS(RegressorMixin, BaseEstimator):
         # For the D-block and F-block: you want to be able to use the VIPs to compare across the entire block, without
         # regards to the banding in groups that might have to be done. So use the total R2 for that block, and do not
         # work per group.
+        # Default ("vip") feature importance: standard VIP computed on the raw block loadings. This matches
+        # the variable importance reported by Garcia-Munoz (2014) (e.g. Table 4). The opt-in "deflated"
+        # variant, exposed through `vip(method="deflated")`, instead uses the direct (rotated) weights
+        # S(V^T S)^-1 and P(P^T P)^-1; see `_feature_importance`.
+        loadings_s = np.concatenate(list(self.s_loadings_d.values()))
+        loadings_f = np.concatenate(list(self.p_loadings_f.values()))
+        vip_split_d, vip_split_f = self._split_block_vip(loadings_s, loadings_f)
+        self.feature_importance["D"] = vip_split_d
+        self.feature_importance["F"] = vip_split_f
+
+    def _split_block_vip(
+        self, loadings_d: np.ndarray, loadings_f: np.ndarray
+    ) -> tuple[dict[str, pd.Series], dict[str, pd.Series]]:
+        """Compute VIP for the D- and F-blocks from (n_features x A) loading/weight matrices.
+
+        The per-component R2 weighting is taken from `self.r2_frac` (the first entry is the pre-fit
+        baseline and is skipped). The flat VIP vector for each block is split back into the original
+        per-group :class:`pandas.Series`, indexed by feature name. Shared by the default VIP (raw block
+        loadings) and the opt-in deflated direct-weights variant.
+        """
         r2_d_a: list[float] = [
             float(np.mean([np.nanmean(r2val) for r2val in r2_frac["D"].values()])) for r2_frac in self.r2_frac
         ]
         r2_f_a: list[float] = [
             float(np.mean([np.nanmean(r2val) for r2val in r2_frac["F"].values()])) for r2_frac in self.r2_frac
         ]
-        loadings_s = np.concatenate(list(self.s_loadings_d.values()))
-        loadings_f = np.concatenate(list(self.p_loadings_f.values()))
-        vip_d = self._calculate_vip(loadings_s, np.array(r2_d_a[1:]))
+        vip_d = self._calculate_vip(loadings_d, np.array(r2_d_a[1:]))
         vip_f = self._calculate_vip(loadings_f, np.array(r2_f_a[1:]))
-        # Split the `vip_d` back into the original groups that it was merged from.
-        # For example: if there are two groups, one with 17 columns, and the second with 3 columns, then there are
-        # a total of 20 values in `vip_d`, and the first 17 values correspond to the first group, and the last 3 values.
-        # Create a dictionary with the group names as keys, and the VIP values as values, split correctly:
+        # Split each flat VIP vector back into the original groups it was concatenated from.
+        # For example: with two groups of 17 and 3 columns, `vip_d` has 20 values; the first 17 belong to
+        # the first group and the last 3 to the second.
         vip_split_d = {}
         start = 0
         for key in self.property_names:
@@ -1078,11 +1100,35 @@ class TPLS(RegressorMixin, BaseEstimator):
             end = start + len(self.material_names[key])
             vip_split_f[key] = pd.Series(vip_f[start:end], index=self.material_names[key])
             start = end
+        return vip_split_d, vip_split_f
 
-        self.feature_importance["D"] = vip_split_d  # TODO: should it not be based on deflated matrices? S(V^TS)^{-1}
-        self.feature_importance["F"] = vip_split_f  # TODO: should it not be based on deflated matrices? P(_^TP)^{-1}
+    def _feature_importance(self, method: str) -> dict[str, dict[str, pd.Series]]:
+        """Return the D-/F-block feature importance for the requested `method`.
 
-    def vip(self, block: str | None = None) -> dict[str, dict[str, pd.Series]] | dict[str, pd.Series]:
+        Parameters
+        ----------
+        method : {"vip", "deflated"}
+            ``"vip"`` returns the standard VIP stored at fit time (computed from the raw block loadings,
+            matching Garcia-Munoz, 2014). ``"deflated"`` computes VIP on the direct (rotated) weights that
+            map the *original* variables onto the scores while accounting for the deflation across
+            components: ``S(V^T S)^-1`` for the D-block and ``P(P^T P)^-1`` for the F-block, where ``S`` and
+            ``V`` are the D-block correlation- and deflation-loadings and ``P`` is the F-block deflation
+            loading (equation 7 in the paper).
+        """
+        if method == "vip":
+            return self.feature_importance
+        s_mat = np.concatenate(list(self.s_loadings_d.values()))  # (K_D x A)
+        v_mat = np.concatenate(list(self.v_loadings_d.values()))  # (K_D x A)
+        p_mat = np.concatenate(list(self.p_loadings_f.values()))  # (K_F x A)
+        # Direct (rotated) weights; `pinv` keeps this well-defined if the A x A core is near-singular.
+        w_d = s_mat @ np.linalg.pinv(v_mat.T @ s_mat)
+        w_f = p_mat @ np.linalg.pinv(p_mat.T @ p_mat)
+        split_d, split_f = self._split_block_vip(w_d, w_f)
+        return {"D": split_d, "F": split_f, "Z": {}, "Y": {}}
+
+    def vip(
+        self, block: str | None = None, method: str = "vip"
+    ) -> dict[str, dict[str, pd.Series]] | dict[str, pd.Series]:
         """Return Variable Importance in Projection (VIP) scores for TPLS blocks.
 
         VIP scores are computed during fitting for the D-block (material properties) and
@@ -1093,6 +1139,15 @@ class TPLS(RegressorMixin, BaseEstimator):
         block : str or None, default=None
             Which block to return. Must be ``"D"`` or ``"F"``, or ``None`` to
             return all blocks.
+        method : {"vip", "deflated"}, default="vip"
+            How importance is measured.
+
+            - ``"vip"`` (default): standard VIP on the raw block loadings, as reported by
+              Garcia-Munoz (2014). These are the values stored in :attr:`feature_importance`.
+            - ``"deflated"``: VIP computed on the direct (rotated) weights that map the *original*
+              variables onto the scores while accounting for the deflation across components,
+              ``S(V^T S)^-1`` for the D-block and ``P(P^T P)^-1`` for the F-block. This is an
+              alternative importance measure; it does not change :attr:`feature_importance`.
 
         Returns
         -------
@@ -1104,21 +1159,27 @@ class TPLS(RegressorMixin, BaseEstimator):
         Raises
         ------
         ValueError
-            If the model is not fitted or *block* is not ``"D"``, ``"F"``, or ``None``.
+            If the model is not fitted, *block* is not ``"D"``, ``"F"``, or ``None``, or *method*
+            is not ``"vip"`` or ``"deflated"``.
 
         Examples
         --------
         >>> tpls = TPLS(...).fit(data)
-        >>> tpls.vip()          # all blocks
-        >>> tpls.vip("D")       # D-block only → {group_name: pd.Series, ...}
+        >>> tpls.vip()                      # all blocks, standard VIP
+        >>> tpls.vip("D")                   # D-block only → {group_name: pd.Series, ...}
+        >>> tpls.vip("D", method="deflated")  # D-block deflated direct-weights importance
         """
         check_is_fitted(self, "feature_importance")
-        if block is None:
-            return self.feature_importance
-        if block not in ("D", "F"):
+        if method not in ("vip", "deflated"):
+            msg = f"method must be 'vip' or 'deflated'; got {method!r}."
+            raise ValueError(msg)
+        if block is not None and block not in ("D", "F"):
             msg = f"block must be 'D', 'F', or None; got {block!r}."
             raise ValueError(msg)
-        return self.feature_importance[block]
+        importance = self._feature_importance(method)
+        if block is None:
+            return importance
+        return importance[block]
 
     def _calculate_vip(self, loadings: np.ndarray, r2_vector: np.ndarray) -> np.ndarray:
         """Calculate the VIP values for the current component.

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2468,25 +2468,25 @@ def test_tpls_model_fitting(fixture_tpls_example: dict) -> None:
     # Test various R2 values for columns in blocks
     # For the last component, for the Z block:
     assert pytest.approx(tpls_test.r2_frac[-1]["Z"]["Conditions"].round(3)) == np.array(
-        [0.411, 0.0, 0.004, 0.262, 0.049, 0.001, 0.028, 0.001, 0.015, 0.015]
+        [0.414, 0.001, 0.004, 0.259, 0.05, 0.0, 0.028, 0.001, 0.014, 0.014]
     ).astype(np.float64)
     # For the D-block
     assert pytest.approx(tpls_test.r2_frac[-1]["D"]["Group 1"].round(3)) == np.array(
-        [0.285, 0.054, 0.437, 0.001, 0.021, 0.143, 0.138]
+        [0.296, 0.051, 0.432, 0.0, 0.015, 0.131, 0.128]
     ).astype(np.float64)
     # For the F-block
     assert pytest.approx(tpls_test.r2_frac[-1]["F"]["Group 2"].round(3)) == np.array(
-        [0.047, 0.0, 0.011, 0.0, 0.047, 0.025, 0.0, 0.003, 0.052]
+        [0.046, 0.0, 0.01, 0.0, 0.048, 0.026, 0.0, 0.003, 0.052]
     ).astype(np.float64)
     # For the Y-block after 1 component, 2 components, and 3 components:
     assert pytest.approx(tpls_test.r2_frac[1]["Y"]["Quality"].round(3)) == np.array(
-        [0.005, 0.079, 0.288, 0.329, 0.332, 0.153]
+        [0.005, 0.078, 0.293, 0.329, 0.337, 0.153]
     ).astype(np.float64)
     assert pytest.approx(tpls_test.r2_frac[2]["Y"]["Quality"].round(3)) == np.array(
-        [0.135, 0.0, 0.039, 0.023, 0.007, 0.051]
+        [0.135, 0.0, 0.039, 0.023, 0.007, 0.052]
     ).astype(np.float64)
     assert pytest.approx(tpls_test.r2_frac[-1]["Y"]["Quality"].round(3)) == np.array(
-        [0.017, 0.073, 0.018, 0.0, 0.005, 0.0]
+        [0.017, 0.074, 0.018, 0.0, 0.005, 0.0]
     ).astype(np.float64)
 
 
@@ -2523,7 +2523,7 @@ def test_tpls_model_predictions(fixture_tpls_example: dict) -> None:  # noqa: PL
 
     # Test the predicted values are what were expected:
     assert pytest.approx(predictions["hat"]["Quality"].iloc[0, :]) == np.array(
-        [33.09434113, 3.15224246, 58.76423934, 3.29991258, 79.90201127, 2.67042528]
+        [33.08751115, 3.15312493, 58.74578748, 3.2956403, 79.89017742, 2.66773621]
     )
     # Compare the predictions to what is stored in the training data
     assert pytest.approx(predictions["hat"]["Quality"].iloc[0, :]) == np.array(
@@ -2532,16 +2532,16 @@ def test_tpls_model_predictions(fixture_tpls_example: dict) -> None:  # noqa: PL
 
     # Test that the SPE_z values:
     assert pytest.approx([predictions["spe"]["Z"][key].values[0, -1] for key in predictions["spe"]["Z"]]) == [
-        1.87201925670
+        1.87556907
     ]
 
     # Test that the SPE_f values are correct:
     assert pytest.approx([predictions["spe"]["F"][key].values[0, -1] for key in predictions["spe"]["F"]]) == [
-        12.9399977,
-        6.92978457,
-        5.56504553,
-        5.59028493,
-        5.54400785,
+        12.94216819,
+        6.93294692,
+        5.56820559,
+        5.59365285,
+        5.54739917,
     ]
     # Check that the Hotelling's T2 matches what would have been calculated by the model.
     assert pytest.approx(tpls_test.hotellings_t2.loc[testing_samples]) == predictions["hotellings_t2"].values[
@@ -2552,17 +2552,17 @@ def test_tpls_model_predictions(fixture_tpls_example: dict) -> None:  # noqa: PL
 
     # scores = cross_val_score(tpls_test, transformed_data, None, cv=5)
     # Ensure model is fitted appropriately, with the expected number of iterations
-    assert tpls_test.fitting_statistics["iterations"] == [11, 8, 26]
+    assert tpls_test.fitting_statistics["iterations"] == [11, 9, 27]
     assert all(tol < epsqrt for tol in tpls_test.fitting_statistics["convergance_tolerance"])
 
     # Model parameters tested
     assert pytest.approx(tpls_test.hotellings_t2.iloc[0:5].values.ravel()) == np.array(
         [
-            2.51977572,
-            2.96430904,
-            2.90972389,
-            4.52220244,
-            5.08398872,
+            2.49885911,
+            2.961537,
+            2.88846366,
+            4.58151729,
+            5.06621405,
         ]
     )
 
@@ -2571,46 +2571,46 @@ def test_tpls_model_predictions(fixture_tpls_example: dict) -> None:  # noqa: PL
     assert tpls_test.hotellings_t2_limit(0.99) == pytest.approx(12.288844, rel=1e-6)
 
     assert np.square(tpls_test.spe["Y"]["Quality"].iloc[0:4].values) == pytest.approx(
-        [5.60884167, 2.79520778, 1.61201577, 3.44436535], rel=1e-8
+        [5.60356584, 2.82414766, 1.69358176, 3.4829089], rel=1e-8
     )
     # Test the last 4 observations
     assert np.square(tpls_test.spe["Z"]["Conditions"].iloc[-4:].values) == pytest.approx(
-        [2.79721437, 2.00803271, 10.77913002, 3.26386299], rel=1e-8
+        [2.79253124, 2.00872637, 10.80292179, 3.26432946], rel=1e-8
     )
     assert np.square(tpls_test.spe["F"]["Group 1"].iloc[0:4].values) == pytest.approx(
-        [167.44354056, 132.23399455, 201.50643669, 198.14628337], rel=1e-8
+        [167.49971736, 132.25813164, 201.56460235, 198.02742727], rel=1e-8
     )
     assert np.square(tpls_test.spe["F"]["Group 2"].iloc[0:4].values) == pytest.approx(
-        [48.02191422, 100.16264439, 47.73820238, 1.7668637], rel=1e-8
+        [48.065753, 100.17604529, 47.80010992, 1.71302689], rel=1e-8
     )
     assert np.square(tpls_test.spe["F"]["Group 3"].iloc[0:4].values) == pytest.approx(
-        [30.96973174, 31.45714235, 30.79004185, 4.45674311], rel=1e-8
+        [31.00491349, 31.47060518, 30.82518225, 4.42512332], rel=1e-8
     )
     assert np.square(tpls_test.spe["F"]["Group 4"].iloc[0:4].values) == pytest.approx(
-        [31.25128561, 31.83840754, 31.03634115, 28.89802456], rel=1e-8
+        [31.28895219, 31.85278369, 31.07114402, 28.82708874], rel=1e-8
     )
     assert np.square(tpls_test.spe["F"]["Group 5"].iloc[0:4].values) == pytest.approx(
-        [30.73602305, 31.60159978, 30.49536591, 97.95906999], rel=1e-8
+        [30.77363754, 31.61877076, 30.53696788, 97.88805239], rel=1e-8
     )
     assert np.square(tpls_test.spe["D"]["Group 3"].iloc[0:4].values) == pytest.approx(
-        [0.340689483, 0.04463833, 1.06575724, 0.0511916], rel=1e-7
+        [0.015504765277819974, 0.002021083231104291, 0.04795499280275304, 0.0024131901105140696], rel=1e-7
     )
     # Is this is all zero because there are only 3 columns of data, and we fit 3 components?
     assert np.square(tpls_test.spe["D"]["Group 5"].iloc[0:4].values) == pytest.approx([0, 0, 0, 0], rel=1e-8)
 
     # Test case uses a different method to calculate the chi2 value, so we use a different tolerance
-    assert tpls_test.spe_limit["Y"]["Quality"](0.95) == pytest.approx(3.7078381486450, rel=1e-8)
-    assert tpls_test.spe_limit["Y"]["Quality"](0.99) == pytest.approx(4.6381115504, rel=1e-8)
-    assert tpls_test.spe_limit["D"]["Group 1"](0.95) == pytest.approx(1.10682253690, rel=1e-8)
-    assert tpls_test.spe_limit["D"]["Group 2"](0.95) == pytest.approx(0.67468300994, rel=1e-8)
-    assert tpls_test.spe_limit["D"]["Group 3"](0.95) == pytest.approx(0.91134417, rel=1e-8)
-    assert tpls_test.spe_limit["D"]["Group 4"](0.95) == pytest.approx(1.0866787434, rel=1e-8)
+    assert tpls_test.spe_limit["Y"]["Quality"](0.95) == pytest.approx(3.70131535, rel=1e-8)
+    assert tpls_test.spe_limit["Y"]["Quality"](0.99) == pytest.approx(4.62900976, rel=1e-8)
+    assert tpls_test.spe_limit["D"]["Group 1"](0.95) == pytest.approx(0.08789854, rel=1e-7)
+    assert tpls_test.spe_limit["D"]["Group 2"](0.95) == pytest.approx(0.22412007, rel=1e-7)
+    assert tpls_test.spe_limit["D"]["Group 3"](0.95) == pytest.approx(0.19404685, rel=1e-7)
+    assert tpls_test.spe_limit["D"]["Group 4"](0.95) == pytest.approx(0.24915518, rel=1e-7)
     assert tpls_test.spe_limit["D"]["Group 5"](0.95) == pytest.approx(0, rel=1e-8)
-    assert tpls_test.spe_limit["F"]["Group 1"](0.99) == pytest.approx(16.180926707, rel=1e-8)
-    assert tpls_test.spe_limit["F"]["Group 2"](0.99) == pytest.approx(8.4753865788, rel=1e-8)
-    assert tpls_test.spe_limit["F"]["Group 3"](0.99) == pytest.approx(9.1176685583, rel=1e-8)
-    assert tpls_test.spe_limit["F"]["Group 4"](0.99) == pytest.approx(8.7773163687, rel=1e-8)
-    assert tpls_test.spe_limit["F"]["Group 5"](0.99) == pytest.approx(7.8446720428, rel=1e-8)
+    assert tpls_test.spe_limit["F"]["Group 1"](0.99) == pytest.approx(16.17958502, rel=1e-8)
+    assert tpls_test.spe_limit["F"]["Group 2"](0.99) == pytest.approx(8.47783716, rel=1e-8)
+    assert tpls_test.spe_limit["F"]["Group 3"](0.99) == pytest.approx(9.11819153, rel=1e-8)
+    assert tpls_test.spe_limit["F"]["Group 4"](0.99) == pytest.approx(8.77664292, rel=1e-8)
+    assert tpls_test.spe_limit["F"]["Group 5"](0.99) == pytest.approx(7.84401832, rel=1e-8)
 
     # Test building the model without the "Z" block.
     fixture_tpls_example.pop("Z")

--- a/tests/test_multivariate_tpls_feature_importance.py
+++ b/tests/test_multivariate_tpls_feature_importance.py
@@ -85,3 +85,74 @@ class TestTPLSFeatureImportance:
         model = TPLS(n_components=2, d_matrix=tpls_pyphi_data["D"])
         with pytest.raises((RuntimeError, ValueError)):
             model.vip()
+
+    def test_vip_deflated_method_structure(self, fitted_tpls: TPLS) -> None:
+        """The opt-in deflated direct-weights variant has the same shape and stays finite/non-negative."""
+        deflated = fitted_tpls.vip(method="deflated")
+        default = fitted_tpls.feature_importance
+        for block in ("D", "F"):
+            assert set(deflated[block].keys()) == set(default[block].keys())
+            for group, series in deflated[block].items():
+                assert isinstance(series, pd.Series)
+                assert list(series.index) == list(default[block][group].index)
+                values = series.to_numpy()
+                assert np.isfinite(values).all()
+                assert (values >= 0).all()
+
+    def test_vip_deflated_d_block_matches_default(self, fitted_tpls: TPLS) -> None:
+        """For the D-block the rotation S(V^T S)^-1 is ~identity (V^T S ~= I by construction), so the
+        deflated importance coincides with the standard VIP. This is a useful sanity result: the TODO's
+        deflated-matrix concern is effectively a no-op for the D-block.
+        """
+        default_d = np.concatenate([s.to_numpy() for s in fitted_tpls.vip("D").values()])
+        deflated_d = np.concatenate([s.to_numpy() for s in fitted_tpls.vip("D", method="deflated").values()])
+        assert np.allclose(default_d, deflated_d, atol=1e-2)
+
+    def test_vip_deflated_f_block_differs(self, fitted_tpls: TPLS) -> None:
+        """For the F-block P^T P is not identity, so P(P^T P)^-1 genuinely rescales the weights and the
+        deflated importance differs from the standard VIP.
+        """
+        default_f = np.concatenate([s.to_numpy() for s in fitted_tpls.vip("F").values()])
+        deflated_f = np.concatenate([s.to_numpy() for s in fitted_tpls.vip("F", method="deflated").values()])
+        assert not np.allclose(default_f, deflated_f)
+
+    def test_vip_deflated_does_not_mutate_stored_importance(self, fitted_tpls: TPLS) -> None:
+        """Requesting the deflated variant must not overwrite the stored (default) feature_importance."""
+        before = fitted_tpls.feature_importance["D"]["Group 1"].copy()
+        _ = fitted_tpls.vip(method="deflated")
+        pd.testing.assert_series_equal(fitted_tpls.feature_importance["D"]["Group 1"], before)
+        # And the default accessor still returns the stored VIP.
+        assert fitted_tpls.vip("D") is fitted_tpls.feature_importance["D"]
+
+    def test_vip_rejects_unknown_method(self, fitted_tpls: TPLS) -> None:
+        with pytest.raises(ValueError, match="method must be"):
+            fitted_tpls.vip(method="bogus")
+
+
+class TestTPLSDBlockScaling:
+    """The D-block is block-scaled by 1/sqrt(P_i * M_i) per Garcia-Munoz (2014), section 2.1."""
+
+    def test_block_factor_is_sqrt_lots_times_properties(self, tpls_pyphi_data: dict) -> None:
+        d_matrix = tpls_pyphi_data.pop("D")
+        model = TPLS(n_components=2, d_matrix=d_matrix)
+        model.fit(DataFrameDict(tpls_pyphi_data))
+        for group, df_d in d_matrix.items():
+            n_lots, n_properties = df_d.shape
+            expected = np.sqrt(n_lots * n_properties)
+            assert model.preproc_["D"][group]["block"][0] == pytest.approx(expected)
+
+    def test_scaling_equalises_block_trace(self, tpls_pyphi_data: dict) -> None:
+        """After centring, auto-scaling and block-scaling, trace(X_i^T X_i) ~= 1 for every D-block.
+
+        This is the paper's stated goal (removing bias toward blocks with more lots or properties) and is
+        an independent anchor for the scaling: the previous 1/sqrt(M_i) factor left trace = P_i - 1, i.e.
+        wildly unequal across blocks (e.g. 161 vs 8 on this dataset).
+        """
+        d_matrix = tpls_pyphi_data["D"]
+        for df_d in d_matrix.values():
+            n_lots, n_properties = df_d.shape
+            autoscaled = (df_d - df_d.mean()) / df_d.std(ddof=1)
+            block_scaled = autoscaled / np.sqrt(n_lots * n_properties)
+            trace = np.nansum(block_scaled.to_numpy() ** 2)
+            # Exactly (P-1)/P for complete data (the ddof=1 vs ddof=0 gap); slightly less with missing data.
+            assert trace == pytest.approx(1.0, abs=0.12)

--- a/tests/test_multivariate_tpls_feature_importance.py
+++ b/tests/test_multivariate_tpls_feature_importance.py
@@ -139,7 +139,16 @@ class TestTPLSDBlockScaling:
         for group, df_d in d_matrix.items():
             n_lots, n_properties = df_d.shape
             expected = np.sqrt(n_lots * n_properties)
-            assert model.preproc_["D"][group]["block"][0] == pytest.approx(expected)
+            # Stored as a plain scalar (not a one-element Series) and exposed read-only.
+            factor = model.preproc_["D"][group]["block"]
+            assert isinstance(factor, float)
+            assert factor == pytest.approx(expected)
+            assert model.d_block_scaling_[group] == pytest.approx(expected)
+
+    def test_d_block_scaling_property_requires_fit(self, tpls_pyphi_data: dict) -> None:
+        model = TPLS(n_components=2, d_matrix=tpls_pyphi_data["D"])
+        with pytest.raises((RuntimeError, ValueError, AttributeError)):
+            _ = model.d_block_scaling_
 
     def test_scaling_equalises_block_trace(self, tpls_pyphi_data: dict) -> None:
         """After centring, auto-scaling and block-scaling, trace(X_i^T X_i) ~= 1 for every D-block.


### PR DESCRIPTION
## #192, part 2: the two paper-grounded changes you chose (+ scalar tidy-up)

Thanks for the Garcia-Munoz (2014) PDF - it let me ground both remaining items directly in the source. Behavioural changes (hence MINOR, 1.25.0):

### 1. D-block scaling fixed to match the paper (§2.1)
Each D-block (material properties) is now block-scaled by `1/√(Pᵢ·Mᵢ)` (Pᵢ = #lots/rows, Mᵢ = #properties/cols) instead of the old `1/√(Mᵢ)`. After column auto-scaling this drives `trace(XᵢᵀXᵢ) ≈ 1` for every block - exactly the paper's stated goal of removing bias toward blocks with more lots or properties.

**The old factor was genuinely buggy**, not just a different convention:

| D group | lots Pᵢ | props Mᵢ | trace, old `/√M` | trace, new `/√(P·M)` |
|---|---|---|---|---|
| Group 1 | 162 | 7 | **161.0** | 0.994 |
| Group 2 | 9 | 6 | **8.0** | 0.889 |
| Group 3 | 22 | 6 | 21.0 | 0.955 |
| Group 4 | 19 | 11 | 17.7 | 0.933 |
| Group 5 | 18 | 3 | 17.0 | 0.944 |

The old scaling let Group 1 dominate the D-block ~20x purely because it had more lots. **This changes all fitted TPLS results** (scores, R², SPE, Hotelling's T², limits, predictions). I re-baselined the affected pinned values in `test_tpls_model_fitting` / `test_tpls_model_predictions`, and - to avoid circular "overwrite expected with actual" re-baselining - added an **independent `trace ≈ 1` invariant test** plus a test asserting the block factor equals `√(Pᵢ·Mᵢ)`. The new numbers are anchored to the paper, not to my code.

(The residual gap from exactly 1.0 is just the `ddof=1` `(P−1)/P` factor and missing data in Group 4; the literal `√(P·M)` formula is the one you approved.)

### 2. Opt-in deflated direct-weights feature importance
`vip(method="deflated")` computes VIP on the rotated weights `S(VᵀS)⁻¹` (D-block) and `P(PᵀP)⁻¹` (F-block) from the deflation loadings (eq. 7). **The default `method="vip"` is unchanged** and still matches the standard VIP the paper reports (Table 4) - `feature_importance` is untouched.

A genuinely useful finding fell out of this: for the **D-block**, `VᵀS ≈ I` by construction in the NIPALS algorithm, so `S(VᵀS)⁻¹ ≈ S` and the deflated importance **coincides** with the default VIP - i.e. the original TODO's concern ("should D importance use deflated matrices?") is effectively a no-op for D. The two **do** differ for the **F-block** (`PᵀP` is not identity). Both behaviours are covered by tests.

### 3. Scaling factor tidied + exposed (`d_block_scaling_`)
The D-block factor is now stored as a plain `float` (was a one-element `pd.Series` accessed via `[0]`) and surfaced through a new read-only `d_block_scaling_` property returning `{group: factor}`. Behaviour unchanged.

### Verification
- TPLS suite green (re-baselined fitting/prediction tests + 16 feature-importance/scaling tests); full multivariate suite `136 passed, 1 skipped` before the tidy-up commit.
- ruff clean, mypy 0 issues.

This, together with #364 (the `help()` cleanup + base VIP test coverage), closes out all four items of #192.

Closes #192.

https://claude.ai/code/session_01JYy57y6F4BYtMgEoCLzbXW