### PR TITLE
docs: fix docstring/implementation mismatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ those changes.
 
 ## [Unreleased]
 
+## [1.25.1] - 2026-06-05
+
+### Fixed
+
+- **Docstring/implementation mismatches across the public API (docs-only).**
+  - `univariate.metrics.median_absolute_deviation`: docstring claimed the
+    default for `scale` was `1.0`, but the signature default is `"normal"`.
+    The docstring now documents the actual default and what the normal
+    consistency factor does.
+  - `experiments.structures.c`: docstring said the helper returns a
+    `DataFrame` and converts every entry to a float. It actually returns a
+    `Column` (a `pandas.Series` subclass) and only coerces numeric entries;
+    categorical entries (via `levels=` or when `float()` raises) are kept
+    as-is.
+  - `multivariate._mbpls.MBPLS.predict`: docstring listed only 3 of the 5
+    fields returned in the result `Bunch`. The full field list now
+    documents `block_spe` and the cumulative `hotellings_t2` series.
+  - `multivariate._tpls.TPLS.predict`: docstring described the return as
+    "dict / Returns an array of prediction objects. More details to come
+    here later." The method actually returns a `sklearn.utils.Bunch` with
+    four well-defined fields (`hat`, `t_scores_super`, `spe`,
+    `hotellings_t2`); they are now described.
+  - `experiments._lm.Model.summary`: docstring said "Side effect: prints to
+    the screen", but the method only returns the statsmodels summary
+    instance and never prints. Replaced with an accurate description that
+    also notes the unused `alpha` / `print_to_screen` arguments are kept
+    for backwards compatibility.
+
 ## [1.25.0] - 2026-06-03
 
 ### Changed
@@ -1368,7 +1396,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.25.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.25.1...HEAD
+[1.25.1]: https://github.com/kgdunn/process-improve/compare/v1.25.0...v1.25.1
 [1.25.0]: https://github.com/kgdunn/process-improve/compare/v1.24.34...v1.25.0
 [1.24.34]: https://github.com/kgdunn/process-improve/compare/v1.24.33...v1.24.34
 [1.24.33]: https://github.com/kgdunn/process-improve/compare/v1.24.32...v1.24.33

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.25.0
-date-released: "2026-06-03"
+version: 1.25.1
+date-released: "2026-06-05"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.25.0"
+version = "1.25.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/experiments/_lm.py
+++ b/src/process_improve/experiments/_lm.py
@@ -313,7 +313,15 @@ class Model(OLS):
         return spec.describe()
 
     def summary(self, alpha: float = 0.05, print_to_screen: bool = True) -> Any:  # noqa: ARG002, ANN401
-        """Side effect: prints to the screen."""
+        """Build the OLS summary table for this model and return it.
+
+        The returned object is the statsmodels summary instance, with the
+        underlying ``self._OLS.summary()`` adjusted to label the residual
+        standard error row. The method does NOT print anything by itself;
+        the top-level :func:`summary` wrapper handles screen output via its
+        own ``show`` flag. The ``alpha`` and ``print_to_screen`` arguments
+        are unused and kept for backwards compatibility.
+        """
         # Taken from statsmodels.regression.linear_model.py
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")

--- a/src/process_improve/experiments/structures.py
+++ b/src/process_improve/experiments/structures.py
@@ -203,7 +203,9 @@ def create_names(n: int, letters: bool = True, prefix: str = "X", start_at: int 
 def c(*args, **kwargs) -> Column:  # noqa: C901, PLR0912, PLR0915
     """
     Perform the equivalent of the R function "c(...)", to combine data elements
-    into a DataFrame. Convert every entry into a floating point object.
+    into a :class:`Column`. Numeric entries are converted to floating point;
+    entries are left as-is for categorical columns (when ``levels=...`` is
+    passed, or when the entries cannot be coerced to float).
 
     Inputs
     ------

--- a/src/process_improve/multivariate/_mbpls.py
+++ b/src/process_improve/multivariate/_mbpls.py
@@ -796,9 +796,12 @@ class MBPLS(_HotellingsT2LimitMixin, RegressorMixin, BaseEstimator):
     def predict(self, X: dict[str, pd.DataFrame]) -> Bunch:
         """Project new data and predict Y on the original scale.
 
-        Returns a :class:`sklearn.utils.Bunch` with fields ``super_scores``,
-        ``block_scores`` (dict[str, DataFrame]) and ``predictions`` (DataFrame
-        on original Y scale).
+        Returns a :class:`sklearn.utils.Bunch` with fields ``super_scores``
+        (DataFrame, n_samples x n_components), ``block_scores`` (dict[str,
+        DataFrame]), ``predictions`` (DataFrame on original Y scale),
+        ``block_spe`` (dict[str, Series], per-block SPE of the new
+        observations) and ``hotellings_t2`` (Series of cumulative
+        Hotelling's T² over all components, per new observation).
         """
         check_is_fitted(self, "super_weights_")
         return self._project(X)

--- a/src/process_improve/multivariate/_tpls.py
+++ b/src/process_improve/multivariate/_tpls.py
@@ -544,8 +544,21 @@ class TPLS(RegressorMixin, BaseEstimator):
 
         Returns
         -------
-        y : dict
-            Returns an array of prediction objects. More details to come here later. Please ask.
+        sklearn.utils.Bunch
+            A bunch with the following fields:
+
+            - ``hat`` (dict[str, DataFrame]) : predicted Y per Y-group, on
+              the original (un-scaled) scale, indexed by the observation
+              names of ``X``.
+            - ``t_scores_super`` (DataFrame, shape ``(n_new, n_components)``)
+              : super-scores for the new observations.
+            - ``spe`` (dict[str, dict[str, DataFrame]]) : per-component
+              squared prediction error for the ``"Z"`` and ``"F"`` blocks,
+              keyed first by block name and then by group; each inner
+              DataFrame has shape ``(n_new, n_components)``.
+            - ``hotellings_t2`` (DataFrame, shape
+              ``(n_new, n_components)``) : cumulative Hotelling's T² per
+              new observation after each component.
         """
         check_is_fitted(self)  # Check if fit had been called
         if not isinstance(X, DataFrameDict):

--- a/src/process_improve/univariate/metrics.py
+++ b/src/process_improve/univariate/metrics.py
@@ -524,13 +524,14 @@ def median_absolute_deviation(
         function signature ``func(arr, axis)``.
     scale : scalar or str, optional
         The numerical value of scale will be divided out of the final
-        result. The default is 1.0. The string "normal" is also accepted,
-        and results in `scale` being the inverse of the standard normal
-        quantile function at 0.75, which is approximately 0.67449.
-        Array-like scale is also allowed, as long as it broadcasts correctly
-        to the output such that ``out / scale`` is a valid operation. The
-        output dimensions depend on the input array, `x`, and the `axis`
-        argument.
+        result. The default is ``"normal"``, which results in `scale` being
+        the inverse of the standard normal quantile function at 0.75,
+        which is approximately 0.67449 (so the returned value is
+        consistent with the standard deviation for normally distributed
+        data). Any positive float may also be passed. Array-like scale is
+        also allowed, as long as it broadcasts correctly to the output
+        such that ``out / scale`` is a valid operation. The output
+        dimensions depend on the input array, `x`, and the `axis` argument.
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when input contains nan.
         The following options are available (default is 'omit'):


### PR DESCRIPTION
## Summary

Docs-only audit of user-facing and computational functions across `multivariate/`, `univariate/`, `experiments/`, `monitoring/`, `batch/`, `regression/`, `bivariate/`, and `visualization/`. Fixes only docstrings; no behaviour changes.

Bumps `pyproject.toml` to `1.25.1`, `CITATION.cff` to `1.25.1` / `2026-06-05`, and adds a matching `## [1.25.1] - 2026-06-05` section to `CHANGELOG.md`.

## Findings (fixed)

- `src/process_improve/univariate/metrics.py:527` – `median_absolute_deviation` – docstring claimed `scale` default was `1.0`; the actual signature default is `"normal"`. Docstring rewritten to match and to explain the normal consistency factor.
- `src/process_improve/experiments/structures.py:205` – `c` – docstring claimed the helper returns a `DataFrame` and converts every entry to a float. It actually returns a `Column` (a `pandas.Series` subclass) and only coerces numeric entries; categorical entries (when `levels=` is passed, or when `float()` raises) are kept as-is.
- `src/process_improve/multivariate/_mbpls.py:796` – `MBPLS.predict` – docstring listed only 3 of the 5 fields in the returned `Bunch`. The actual Bunch also includes `block_spe` (per-block SPE) and `hotellings_t2` (cumulative T²) for new observations.
- `src/process_improve/multivariate/_tpls.py:524` – `TPLS.predict` – Returns section said `y : dict / Returns an array of prediction objects. More details to come here later. Please ask.`. The method actually returns a `sklearn.utils.Bunch` with four well-defined fields (`hat`, `t_scores_super`, `spe`, `hotellings_t2`); they are now described.
- `src/process_improve/experiments/_lm.py:315` – `Model.summary` – docstring said `Side effect: prints to the screen`. The method only returns the statsmodels summary instance and never calls `print()` (the `print(smry)` call was commented out long ago). Replaced with an accurate description; also notes the unused `alpha` / `print_to_screen` arguments are kept for backwards compatibility.

## Test plan

- [ ] No code paths changed, so no new tests required.
- [ ] CI lint + existing test suite should remain green.
