### PR TITLE
Security/maintenance audit pass: SEC-34..SEC-37 (v1.25.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ those changes.
 
 ## [Unreleased]
 
+## [1.25.2] - 2026-06-05
+
+### Added
+
+- **PEP 561 `py.typed` marker (SEC-36).** The package is fully type-annotated
+  and `mypy src/process_improve` runs as a blocking CI check, but the
+  distribution shipped no `py.typed` marker, so downstream type-checkers
+  (mypy / pyright) silently treated `process-improve` as untyped. The marker is
+  now bundled in the wheel and consumers get the published annotations.
+- **Security disclosure policy (`SECURITY.md`, SEC-37).** Documents the
+  supported version, the private vulnerability-reporting channels (GitHub
+  private advisories and email), the expected response timeline, and the
+  threat-model scope. Complements the existing `SECURITY_AUDIT.md` catalogue.
+
+### Fixed
+
+- **Malformed `items_to_highlight` keys now raise a clear error in the
+  multivariate plots (SEC-34).** `score_plot`, `spe_plot`, and `t2_plot` parsed
+  each highlight key with a bare `json.loads`, so a non-JSON key surfaced as a
+  confusing `json.JSONDecodeError` deep inside the trace loop. They now decode
+  via a shared helper that raises a clear `ValueError` at the API surface,
+  matching the SEC-32 guard already in `batch.plotting`.
+- **`ControlChart.calculate_limits` no longer accepts arbitrary keyword
+  arguments (SEC-35).** A blanket `setattr(self, key, val)` over `**kwargs` let
+  a caller silently overwrite internal state (`s`, `target`, `train_samples`,
+  even a bound method) and swallowed typos. Only the documented Holt-Winters
+  smoothing lambdas (`ld_1`, `ld_2`) are accepted now; any other keyword raises
+  a clear `ValueError`.
+
 ## [1.25.1] - 2026-06-05
 
 ### Fixed
@@ -1396,7 +1425,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.25.1...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.25.2...HEAD
+[1.25.2]: https://github.com/kgdunn/process-improve/compare/v1.25.1...v1.25.2
 [1.25.1]: https://github.com/kgdunn/process-improve/compare/v1.25.0...v1.25.1
 [1.25.0]: https://github.com/kgdunn/process-improve/compare/v1.24.34...v1.25.0
 [1.24.34]: https://github.com/kgdunn/process-improve/compare/v1.24.33...v1.24.34

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ those changes.
 
 ### Added
 
+- **`CODE_OF_CONDUCT.md`.** Adopts the Contributor Covenant 2.1, with the
+  maintainer as the enforcement contact, and is referenced from
+  `CONTRIBUTING.md`. Rounds out the community-health files alongside the new
+  `SECURITY.md`.
 - **PEP 561 `py.typed` marker (SEC-36).** The package is fully type-annotated
   and `mypy src/process_improve` runs as a blocking CI check, but the
   distribution shipped no `py.typed` marker, so downstream type-checkers

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.25.1
+version: 1.25.2
 date-released: "2026-06-05"
 keywords:
   - chemometrics

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at kgdunn@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,10 @@ Bug reports, feature requests, and pull requests are welcome. This guide
 covers how to set up a development environment and the conventions the
 project follows.
 
+By participating in this project you agree to abide by its
+[Code of Conduct](CODE_OF_CONDUCT.md). To report a security vulnerability,
+follow the [security policy](SECURITY.md) instead of opening a public issue.
+
 ## Development setup
 
 Clone the repository and install it in editable mode with the development

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,88 @@
+# Security Policy
+
+`process-improve` is a data-analysis library that can also expose its analysis
+registry as agent-callable tools over a
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io) server
+(`process_improve.mcp_server`). Because that surface can be driven by an LLM or,
+when deliberately fronted by HTTP, by remote callers, the project takes security
+reports seriously.
+
+## Supported versions
+
+Only the latest released version on
+[PyPI](https://pypi.org/project/process-improve/) receives security fixes. There
+are no long-term-support branches; please upgrade to the most recent release
+before reporting an issue, and pin a minimum version once a fix ships.
+
+| Version          | Supported          |
+| ---------------- | ------------------ |
+| Latest release   | :white_check_mark: |
+| Older releases   | :x:                |
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue, pull request, or discussion for a
+security vulnerability.** Public disclosure before a fix is available puts every
+user at risk.
+
+Instead, use one of these private channels:
+
+1. **GitHub private vulnerability reporting (preferred).** Go to the
+   [Security tab](https://github.com/kgdunn/process-improve/security/advisories)
+   and click **"Report a vulnerability"**. This opens a private advisory visible
+   only to you and the maintainers.
+2. **Email.** Write to the maintainer, Kevin Dunn, at
+   `kgdunn@gmail.com` with a subject line starting `[process-improve security]`.
+
+Please include, as far as you can:
+
+- the affected version (`python -c "import process_improve; print(process_improve.__name__)"`
+  plus the installed version from `pip show process-improve`),
+- a description of the vulnerability and its impact,
+- a minimal reproduction (a short script, the tool call, or the input payload),
+- and whether you believe it is reachable under the **untrusted** threat model
+  (MCP server reachable by hostile callers) or only the **local-trusted** model
+  (the server only ever drives the owner's own LLM on the owner's machine). See
+  [`SECURITY_AUDIT.md`](SECURITY_AUDIT.md) for how these two models are scored.
+
+## What to expect
+
+- **Acknowledgement** within 7 days that the report was received.
+- **An initial assessment** (severity, threat model, whether it reproduces)
+  within 14 days.
+- **A fix or mitigation plan** communicated before any public disclosure. Fixes
+  ship as a new PyPI release with an entry in
+  [`CHANGELOG.md`](CHANGELOG.md) and, where applicable, a published
+  [GitHub Security Advisory](https://github.com/kgdunn/process-improve/security/advisories).
+- **Credit** for the reporter in the advisory and changelog, unless you ask to
+  remain anonymous.
+
+We ask that you give us a reasonable opportunity to release a fix before any
+public disclosure (coordinated disclosure).
+
+## Scope and threat model
+
+The project's own catalogue of past findings, the threat models, and the
+hardening already in place live in [`SECURITY_AUDIT.md`](SECURITY_AUDIT.md).
+In summary:
+
+- Tool inputs are validated against per-tool pydantic models
+  (`extra="forbid"`), and the safe-execution path
+  (`PROCESS_IMPROVE_MCP_SAFE_MODE=1`) adds input-size caps, a wall-clock
+  timeout with worker termination, and a per-subprocess memory cap.
+- Model formulas are validated against a strict Wilkinson-subset allowlist
+  before they reach `patsy`/`statsmodels`, which would otherwise evaluate them
+  as arbitrary Python.
+
+Reports that demonstrate a bypass of any of these controls, or a new
+code-execution / information-disclosure / denial-of-service vector, are
+especially valuable.
+
+## Out of scope
+
+- Vulnerabilities in third-party dependencies (report those upstream; we will
+  bump the pin once a fixed version is available).
+- Denial of service that requires the **local-trusted** model only (a user
+  running the stdio server on their own machine can already run arbitrary code).
+- Findings that require a non-default, explicitly unsafe configuration that the
+  documentation warns against.

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -434,11 +434,10 @@ These are lower-priority maintenance / contribution-health items surfaced
 during the v1.26.1 audit pass. They are documented here rather than fixed in the
 same change because each is a maintainer judgement call.
 
-- **`CODE_OF_CONDUCT.md` is absent.** A code of conduct is a standard
-  community-health file that GitHub surfaces and that many contributors look for
-  before engaging. Adopting the Contributor Covenant (with the maintainer's
-  contact as the enforcement channel) would round out the community files
-  alongside `CONTRIBUTING.md` and the new `SECURITY.md`.
+- **`CODE_OF_CONDUCT.md`** (done, v1.26.1). Adopted the Contributor Covenant 2.1
+  with the maintainer as the enforcement contact, referenced from
+  `CONTRIBUTING.md`. Rounds out the community-health files alongside the new
+  `SECURITY.md`.
 - **`.pre-commit-config.yaml` runs `flake8` and `isort` alongside `ruff`.**
   `ruff` already replaces both (lint + import sorting via the `I` rules), and CI
   only runs `ruff`. Keeping `flake8` (plus a separate `.flake8` config) and

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -38,6 +38,14 @@ therefore ranked under two models:
 | SEC-15 | `reveal_simulator` gate bypassable via kwarg injection | Critical | Low | done (#264, v1.22.12) |
 | SEC-22 | Holt-Winters chart divides by zero on constant warm-up | High | High | done (#271, v1.22.13) |
 | SEC-23 | `regression.OLS.predict` accepts wrong-shape `X` silently | High | Medium | done (#272, v1.22.13) |
+| SEC-34 | Unguarded `json.loads` of highlight keys in multivariate plots | Low | Low | done (v1.25.2) |
+| SEC-35 | Blanket `setattr(**kwargs)` in `ControlChart.calculate_limits` | Low | Low | done (v1.25.2) |
+| SEC-36 | No PEP 561 `py.typed` marker; published types invisible | Low | Low | done (v1.25.2) |
+| SEC-37 | No security disclosure policy (`SECURITY.md`) | Low | Low | done (v1.25.2) |
+
+> Note: SEC-16 through SEC-33 were tracked in their own PRs / CHANGELOG
+> entries and are not all transcribed into this table; the rows above resume
+> the running ledger from the latest audit pass.
 
 ---
 
@@ -355,7 +363,91 @@ therefore ranked under two models:
   Tests: predict with the wrong column count raises a clear `ValueError`; predict
   with the correct shape still returns finite values.
 
+## SEC-34 - Unguarded `json.loads` of highlight keys in multivariate plots [RESOLVED]
+- **Status:** Fixed in v1.25.2. The three plot helpers decode highlight keys via
+  a shared `_decode_highlight_style` helper that raises a clear `ValueError`,
+  matching the SEC-32 guard already applied in `batch/plotting.py`.
+- **Severity:** U = Low, L = Low (robustness)
+- **Where:** `process_improve/multivariate/plots.py` `score_plot` (2D + 3D
+  branches), `spe_plot`, `t2_plot`.
+- **Issue:** Each `items_to_highlight` key is a JSON-encoded Plotly style spec
+  decoded with a bare `json.loads(key)`. A malformed key raised an uncaught
+  `json.JSONDecodeError` from deep inside the trace-building loop rather than a
+  clear error at the API boundary. SEC-32 (#281) fixed the identical pattern in
+  `batch/plotting.py` but the multivariate plot sites were missed.
+- **Fix:** Introduced `_decode_highlight_style(key)` which wraps `json.loads`
+  and re-raises as a `ValueError` with the offending key and an example of the
+  expected format. All four call sites now use it. Regression test:
+  `test_highlight_key_must_be_json` (parametrised over score/spe/t2).
+
+## SEC-35 - Blanket `setattr(**kwargs)` in `ControlChart.calculate_limits` [RESOLVED]
+- **Status:** Fixed in v1.25.2. `**kwargs` is now validated against an allowlist
+  (`ld_1`, `ld_2`) before any attribute is set.
+- **Severity:** U = Low, L = Low (defensive programming / footgun)
+- **Where:** `process_improve/monitoring/control_charts.py`
+  (`ControlChart.calculate_limits` -> `for key, val in kwargs.items():
+  setattr(self, key, val)`).
+- **Issue:** The method copied every keyword argument onto the instance with an
+  unrestricted `setattr`. The only legitimate kwargs are the Holt-Winters
+  smoothing lambdas `ld_1` / `ld_2`; any other key (a typo, or a deliberately
+  crafted name such as `target`, `s`, `train_samples`, or a method name) would
+  silently overwrite internal state and corrupt the fitted limits with no error.
+  The current tool wrapper passes no kwargs, so it was not reachable from the
+  MCP surface, but it is a footgun for direct API users.
+- **Fix:** Extracted `_apply_tuning_kwargs`, which rejects any key outside the
+  `_TUNING_KWARGS` allowlist with a clear `ValueError` before applying the
+  remaining (allowlisted) values. Regression test:
+  `test_calculate_limits_rejects_unknown_kwargs`.
+
+## SEC-36 - No PEP 561 `py.typed` marker; published types invisible [RESOLVED]
+- **Status:** Fixed in v1.25.2. `src/process_improve/py.typed` is added and ships
+  in the wheel (verified: the `uv_build` backend bundles all non-`.py` files in
+  the package tree).
+- **Severity:** U = Low, L = Low (maintenance / downstream usability)
+- **Where:** packaging (`src/process_improve/`).
+- **Issue:** The project is fully type-annotated and `mypy src/process_improve`
+  runs as a blocking CI gate (ENG-03 / ENG-20), yet the distribution carried no
+  `py.typed` marker. Under PEP 561 a type-checker therefore treated
+  `process-improve` as an untyped third-party package and ignored every
+  annotation, so downstream users got none of the benefit of the typing work.
+- **Fix:** Added the marker file. Downstream mypy / pyright now consume the
+  published annotations.
+
+## SEC-37 - No security disclosure policy (`SECURITY.md`) [RESOLVED]
+- **Status:** Fixed in v1.25.2. `SECURITY.md` added at the repo root.
+- **Severity:** U = Low, L = Low (process / community)
+- **Where:** repository root.
+- **Issue:** The project ships an agent-callable MCP tool surface and maintains
+  this detailed `SECURITY_AUDIT.md`, but provided no private channel for a
+  security researcher to report a vulnerability and no statement of supported
+  versions or response expectations. GitHub surfaces a repo's `SECURITY.md` as
+  its "Security policy"; its absence pushes reporters toward public issues.
+- **Fix:** Added `SECURITY.md` documenting private reporting (GitHub private
+  advisories + email), supported versions, response timeline, threat-model
+  scope, and out-of-scope items, cross-linked with this file.
+
 ---
+
+## Recommendations (not yet actioned)
+
+These are lower-priority maintenance / contribution-health items surfaced
+during the v1.25.2 audit pass. They are documented here rather than fixed in the
+same change because each is a maintainer judgement call.
+
+- **`CODE_OF_CONDUCT.md` is absent.** A code of conduct is a standard
+  community-health file that GitHub surfaces and that many contributors look for
+  before engaging. Adopting the Contributor Covenant (with the maintainer's
+  contact as the enforcement channel) would round out the community files
+  alongside `CONTRIBUTING.md` and the new `SECURITY.md`.
+- **`.pre-commit-config.yaml` runs `flake8` and `isort` alongside `ruff`.**
+  `ruff` already replaces both (lint + import sorting via the `I` rules), and CI
+  only runs `ruff`. Keeping `flake8` (plus a separate `.flake8` config) and
+  `mirrors-isort` in the pre-commit hooks is redundant and can produce
+  conflicting fixups. The stale comment `# Remove MyPy: conflicts in python 3.9
+  with pytz` also no longer applies (the project requires Python >= 3.10 and
+  mypy is an active hook). Consider trimming pre-commit to `ruff` + `ruff-format`
+  + the hygiene hooks, and either dropping `.flake8` or aligning it with the
+  120-character line length.
 
 ## Out of scope / checked clean
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.25.1"
+version = "1.25.2"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/monitoring/control_charts.py
+++ b/src/process_improve/monitoring/control_charts.py
@@ -1,6 +1,7 @@
 """Class for ControlChart: robust control charts with a balance between CUSUM and Shewhart properties."""
 
 import logging
+from typing import ClassVar
 
 import numpy as np
 import pandas as pd
@@ -146,8 +147,7 @@ class ControlChart:
         else:
             self.train_samples = [int(i) for i in np.arange(self.warm_up_M, self.N)]
 
-        for key, val in kwargs.items():
-            setattr(self, key, val)
+        self._apply_tuning_kwargs(kwargs)
 
         if self.variant.strip().lower() == "hw":
             if not hasattr(self, "ld_1"):
@@ -171,6 +171,28 @@ class ControlChart:
             )
         idx_bool = (self.df["y"] - self.target).abs() > 3.0 * self.s
         self.idx_outside_3S = np.nonzero(idx_bool.to_numpy())[0].tolist()
+
+    #: Instance attributes a caller may pin via ``calculate_limits(**kwargs)``:
+    #: the Holt-Winters smoothing lambdas. Everything else is internal state.
+    _TUNING_KWARGS: ClassVar[frozenset[str]] = frozenset({"ld_1", "ld_2"})
+
+    def _apply_tuning_kwargs(self, kwargs: dict[str, object]) -> None:
+        """Set caller-pinned tuning parameters, rejecting anything off the allowlist.
+
+        A blanket ``setattr(self, key, val)`` over ``**kwargs`` would let a caller
+        silently overwrite internal state (``self.s``, ``self.target``,
+        ``self.train_samples``, even a bound method) and would swallow typos. We
+        therefore accept only the documented Holt-Winters smoothing lambdas and
+        raise a clear ``ValueError`` otherwise.
+        """
+        unknown = set(kwargs) - self._TUNING_KWARGS
+        if unknown:
+            raise ValueError(
+                f"calculate_limits() got unexpected keyword argument(s) {sorted(unknown)}; "
+                f"only {sorted(self._TUNING_KWARGS)} (Holt-Winters smoothing lambdas) are accepted."
+            )
+        for key, val in kwargs.items():
+            setattr(self, key, val)
 
     def _xbar_no_subgroup_fit(self) -> None:
         """

--- a/src/process_improve/multivariate/plots.py
+++ b/src/process_improve/multivariate/plots.py
@@ -24,6 +24,25 @@ from process_improve.visualization.themes import (
 )
 
 
+def _decode_highlight_style(key: str) -> dict:
+    """Decode an ``items_to_highlight`` key into a Plotly marker-style dict.
+
+    Each key must be a JSON-encoded Plotly marker/line-style spec. Decoding it
+    here (rather than calling ``json.loads`` inline) means a malformed key
+    raises a clear ``ValueError`` at the API surface instead of a confusing
+    ``json.JSONDecodeError`` deep inside the trace-building loop. Mirrors the
+    SEC-32 guard already applied in ``process_improve.batch.plotting``.
+    """
+    try:
+        return json.loads(key)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"items_to_highlight: each key must be a JSON-encoded Plotly "
+            f'style spec (e.g. \'{{"color": "red", "symbol": "cross"}}\'). '
+            f"Got {key!r}."
+        ) from exc
+
+
 def plot_pre_checks(model: BaseEstimator, pc_horiz: int, pc_vert: int, pc_depth: int) -> bool:
     """Check the inputs for the plot functions are valid."""
     n_components = model.n_components if hasattr(model, "n_components") else model._parent.n_components
@@ -167,7 +186,7 @@ def score_plot(  # noqa: C901, PLR0913
         )
         # Items to highlight, if any
         for key, index in highlights.items():
-            styling = json.loads(key)
+            styling = _decode_highlight_style(key)
             fig.add_trace(
                 go.Scatter3d(
                     x=data_to_plot.loc[index, pc_horiz],
@@ -198,7 +217,7 @@ def score_plot(  # noqa: C901, PLR0913
         )
         # Items to highlight, if any
         for key, index in highlights.items():
-            styling = json.loads(key)
+            styling = _decode_highlight_style(key)
             fig.add_trace(
                 go.Scatter(
                     x=data_to_plot.loc[index, pc_horiz],
@@ -501,7 +520,7 @@ def spe_plot(  # noqa: C901
     )
     # Items to highlight, if any
     for key, index in highlights.items():
-        styling = json.loads(key)
+        styling = _decode_highlight_style(key)
         fig.add_trace(
             go.Scatter(
                 x=index,
@@ -651,7 +670,7 @@ def t2_plot(  # noqa: C901
     )
     # Items to highlight, if any
     for key, index in highlights.items():
-        styling = json.loads(key)
+        styling = _decode_highlight_style(key)
         fig.add_trace(
             go.Scatter(
                 x=index,

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -166,6 +166,33 @@ def test_hw_constant_warmup_raises_value_error() -> None:
         cc.calculate_limits(constant, ld_1=0.4, ld_2=0.7)
 
 
+def test_calculate_limits_rejects_unknown_kwargs() -> None:
+    """Only the Holt-Winters lambdas may be pinned via ``**kwargs``.
+
+    A blanket ``setattr`` previously let any kwarg silently overwrite internal
+    state (``s``, ``target``, ``train_samples``, even a method) and swallowed
+    typos. Unknown kwargs must now raise a clear ``ValueError`` and must not
+    mutate the instance.
+    """
+    rng = np.random.default_rng(0)
+    y = 50.0 + rng.standard_normal(40)
+
+    cc = ControlChart()
+    with pytest.raises(ValueError, match="unexpected keyword argument"):
+        cc.calculate_limits(y, ld_1=0.4, ld_2=0.7, train_samples=[0, 1])
+
+    # A typo of a real attribute is rejected rather than silently shadowing it.
+    cc2 = ControlChart()
+    with pytest.raises(ValueError, match="unexpected keyword argument"):
+        cc2.calculate_limits(y, target_value=999)
+
+    # The legitimate lambdas still flow through and fit succeeds.
+    cc3 = ControlChart()
+    cc3.calculate_limits(y, ld_1=0.4, ld_2=0.7)
+    assert cc3.ld_1 == pytest.approx(0.4)
+    assert cc3.ld_2 == pytest.approx(0.7)
+
+
 def test_cpk_well_centered_process() -> None:
     """Cpk for a well-centered process with wide specs should be high."""
     rng = np.random.default_rng(42)

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2927,6 +2927,17 @@ def test_score_plot_with_highlights(fixture_pca_for_plots: PCA) -> None:
     assert len(fig.data) >= 3
 
 
+def test_score_plot_3d_with_highlights(fixture_pca_for_plots: PCA) -> None:
+    """A 3D score plot must also decode and apply highlight styling."""
+    model = fixture_pca_for_plots
+    idx = model.scores_.index[:5].tolist()
+    highlights = {'{"color": "red", "symbol": "cross"}': idx}
+    fig = model.score_plot(pc_horiz=1, pc_vert=2, pc_depth=3, items_to_highlight=highlights)
+    assert isinstance(fig, go.Figure)
+    # Default scores trace + the highlighted trace (3D path has no ellipse).
+    assert len(fig.data) >= 2
+
+
 @pytest.mark.parametrize("plot_method", ["score_plot", "spe_plot", "t2_plot"])
 def test_highlight_key_must_be_json(fixture_pca_for_plots: PCA, plot_method: str) -> None:
     """A non-JSON ``items_to_highlight`` key raises a clear ValueError.

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2927,6 +2927,21 @@ def test_score_plot_with_highlights(fixture_pca_for_plots: PCA) -> None:
     assert len(fig.data) >= 3
 
 
+@pytest.mark.parametrize("plot_method", ["score_plot", "spe_plot", "t2_plot"])
+def test_highlight_key_must_be_json(fixture_pca_for_plots: PCA, plot_method: str) -> None:
+    """A non-JSON ``items_to_highlight`` key raises a clear ValueError.
+
+    Mirrors the SEC-32 guard in ``batch.plotting``: a malformed style key must
+    surface a clear ``ValueError`` at the API boundary instead of a confusing
+    ``json.JSONDecodeError`` deep inside the trace-building loop.
+    """
+    model = fixture_pca_for_plots
+    idx = model.scores_.index[:3].tolist()
+    bad_highlights = {"not-json": idx}  # plain string, not a JSON style spec
+    with pytest.raises(ValueError, match="JSON-encoded"):
+        getattr(model, plot_method)(items_to_highlight=bad_highlights)
+
+
 def test_loading_plot_pca(fixture_pca_for_plots: PCA) -> None:
     """loading_plot for PCA should return a Figure with P loadings."""
     fig = fixture_pca_for_plots.loading_plot()


### PR DESCRIPTION
## Summary

A fresh black-hat / white-hat audit pass over the repo. The headline finding is
that the codebase is **already very well hardened** - the existing
`SECURITY_AUDIT.md` (SEC-01..SEC-33) covers the high-impact vectors (patsy-formula
RCE, MCP input validation via per-tool pydantic models, subprocess isolation with
worker termination + memory caps, NIPALS div-by-zero, ReDoS, etc.), and `ruff`,
`mypy`, CodeQL, and `python -O` checks all gate CI.

This PR fixes the residual holes that surfaced, each with a regression test, and
bumps to **v1.25.2** (PATCH).

## Fixed

- **SEC-34 - Unguarded `json.loads` of highlight keys in multivariate plots.**
  `score_plot` / `spe_plot` / `t2_plot` parsed each `items_to_highlight` key with
  a bare `json.loads`, so a non-JSON key surfaced as a confusing
  `json.JSONDecodeError` deep inside the trace loop. They now decode via a shared
  `_decode_highlight_style` helper that raises a clear `ValueError` at the API
  surface - matching the SEC-32 guard already in `batch.plotting` (this was a
  missed follow-through of SEC-32).
- **SEC-35 - Blanket `setattr(**kwargs)` in `ControlChart.calculate_limits`.**
  An unrestricted `setattr(self, key, val)` over `**kwargs` let a caller silently
  overwrite internal state (`s`, `target`, `train_samples`, even a bound method)
  and swallowed typos. Only the documented Holt-Winters smoothing lambdas
  (`ld_1`, `ld_2`) are accepted now; anything else raises a clear `ValueError`.

## Added

- **SEC-36 - PEP 561 `py.typed` marker.** The package is fully type-annotated and
  `mypy src/process_improve` is a blocking CI check, but the wheel shipped no
  `py.typed`, so downstream type-checkers treated `process-improve` as untyped and
  ignored every annotation. The marker now ships in the wheel (verified the
  `uv_build` backend bundles it).
- **SEC-37 - `SECURITY.md` disclosure policy.** A project that exposes an
  agent-callable MCP tool surface had no private vulnerability-reporting channel,
  no supported-version statement, and no response-timeline expectations. Added a
  policy cross-linked with `SECURITY_AUDIT.md`.

## Documented (not fixed - maintainer judgement calls)

Recorded in a new "Recommendations (not yet actioned)" block in
`SECURITY_AUDIT.md`:

- `CODE_OF_CONDUCT.md` is absent (standard community-health file).
- `.pre-commit-config.yaml` runs `flake8` + `isort` alongside `ruff`, which
  already replaces both; CI only runs `ruff`. Plus a stale `# Remove MyPy:
  conflicts in python 3.9 with pytz` comment (project is now Python >= 3.10).

## Verification

- `ruff check .` - clean
- `mypy` on the changed modules - clean
- `pytest tests/test_monitoring.py tests/test_multivariate.py` - 146 passed, 1
  skipped (includes the two new regression tests:
  `test_highlight_key_must_be_json`, `test_calculate_limits_rejects_unknown_kwargs`)
- `python -m build --wheel` - builds `1.25.2`, confirms `py.typed` is in the wheel

## Bookkeeping

- Version bumped `1.25.1 -> 1.25.2` in `pyproject.toml`; `CITATION.cff` kept in
  sync.
- `CHANGELOG.md` updated (new `## [1.25.2]` section, fresh `## [Unreleased]`,
  link-ref footer).
- `SECURITY_AUDIT.md` ledger updated with SEC-34..SEC-37 rows + detail sections.

https://claude.ai/code/session_01LeLgLSgpRNuVHBzCbWdry3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeLgLSgpRNuVHBzCbWdry3)_