### PR TITLE
Fix multivariate scale/selector inconsistencies surfaced by ScorePilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ those changes.
 
 ## [Unreleased]
 
+## [1.26.0] - 2026-06-06
+
+### Added
+
+- `scale()` (`multivariate`) now takes an explicit `ddof` argument. It is
+  forwarded to `np.std` when the default scaling function is used, so callers
+  can request the sample standard deviation with `scale(center(X), ddof=1)`
+  (matching `MCUVScaler`) instead of relying on `**kwargs`.
+- `PCA.select_n_components` now returns a `q2` field: the cross-validated R2 of
+  X per component count (mean-cell PRESS normalised by the null-model
+  sum-of-squares). This mirrors `PLS.select_n_components`'s `r2y_validated` and
+  saves callers from normalising `press` by hand.
+- New `NotEnoughVarianceError` exception (exported from
+  `process_improve.multivariate`). It is raised by PCA / PLS NIPALS fitting when
+  the data runs out of variance before the requested number of components is
+  reached. It subclasses `RuntimeError`, so existing `except RuntimeError`
+  handlers keep working while callers can catch the narrower type.
+
+### Fixed
+
+- `scale()` no longer produces `inf` / `NaN` for constant (zero-variance)
+  columns; such columns are left unchanged, matching `MCUVScaler`.
+- `scale()`'s docstring no longer claims it divides by N-1 by default. The
+  default (`ddof=0`) divides by N; the docstring now documents this and points
+  to `MCUVScaler` / `ddof=1` for the sample standard deviation.
+
+### Changed
+
+- The `cv` parameter of `PCA.select_n_components` and
+  `PLS.select_n_components` is now type-annotated as
+  `int | BaseCrossValidator`, matching the documented (and already working)
+  behaviour of passing an sklearn splitter object.
+
 ## [1.25.1] - 2026-06-05
 
 ### Fixed
@@ -1396,7 +1429,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.25.1...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.26.0...HEAD
+[1.26.0]: https://github.com/kgdunn/process-improve/compare/v1.25.1...v1.26.0
 [1.25.1]: https://github.com/kgdunn/process-improve/compare/v1.25.0...v1.25.1
 [1.25.0]: https://github.com/kgdunn/process-improve/compare/v1.24.34...v1.25.0
 [1.24.34]: https://github.com/kgdunn/process-improve/compare/v1.24.33...v1.24.34

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.25.1
-date-released: "2026-06-05"
+version: 1.26.0
+date-released: "2026-06-06"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.25.1"
+version = "1.26.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_common.py
+++ b/src/process_improve/multivariate/_common.py
@@ -20,7 +20,7 @@ import pandas as pd
 # Names re-exported to the rest of the package. Declared explicitly so CodeQL
 # does not flag the ``DataMatrix`` type alias (only ever referenced in lazy
 # annotation strings under ``from __future__ import annotations``) as unused.
-__all__ = ["DataMatrix", "SpecificationWarning", "epsqrt"]
+__all__ = ["DataMatrix", "NotEnoughVarianceError", "SpecificationWarning", "epsqrt"]
 
 DataMatrix: TypeAlias = np.ndarray | pd.DataFrame
 
@@ -47,6 +47,20 @@ def _nz(denominator: float) -> float:
 
 class SpecificationWarning(UserWarning):
     """Parent warning class."""
+
+
+class NotEnoughVarianceError(RuntimeError):
+    """Raised when more components are requested than the data's variance supports.
+
+    During NIPALS extraction (PCA / PLS) the deflated data array can run out of
+    variance before the requested number of components is reached, even when that
+    count is within ``min(N, K)`` - for example with rank-deficient or perfectly
+    collinear data. The model cannot compute any further components in that case.
+
+    Subclasses :class:`RuntimeError` so existing ``except RuntimeError`` handlers
+    keep working, while callers that want to react specifically (e.g. trimming the
+    component count during cross-validation) can catch this narrower type.
+    """
 
 
 def _align_to_fit_features(X: pd.DataFrame, fit_feature_names: pd.Index) -> pd.DataFrame:

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -17,13 +17,13 @@ import warnings
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin, _fit_context
-from sklearn.model_selection import cross_val_score
+from sklearn.model_selection import BaseCrossValidator, cross_val_score
 from sklearn.utils import Bunch
 from sklearn.utils.validation import check_is_fitted
 
 from ..univariate.metrics import detect_outliers_esd
 from ._base import _LatentVariableModel, _LazyFrame
-from ._common import DataMatrix, SpecificationWarning, _align_to_fit_features, epsqrt
+from ._common import DataMatrix, NotEnoughVarianceError, SpecificationWarning, _align_to_fit_features, epsqrt
 from ._nipals import quick_regress, ssq, terminate_check
 
 logger = logging.getLogger(__name__)
@@ -320,7 +320,7 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
                     "There is no variance left in the data array: cannot "
                     f"compute any more components beyond component {a}."
                 )
-                raise RuntimeError(emsg)
+                raise NotEnoughVarianceError(emsg)
 
             # Seed the score from the column of X with the greatest
             # sum-of-squares (variance, for mean-centred data) rather than the
@@ -560,7 +560,7 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         X: DataMatrix,
         *,
         max_components: int | None = None,
-        cv: int = 5,
+        cv: int | BaseCrossValidator = 5,
         threshold: float = 0.95,
         **pca_kwargs,
     ) -> Bunch:
@@ -597,7 +597,23 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             - ``n_components`` - recommended number of components (int)
             - ``press`` - PRESS per component count (pd.Series, indexed 1..A_max)
             - ``press_ratio`` - PRESS_a / PRESS_{a-1} (pd.Series, indexed 2..A_max)
+            - ``q2`` - cross-validated R2 of X per component count, i.e. the
+              cross-validation analogue of ``r2_cumulative_``
+              (pd.Series, indexed 1..A_max). Computed as
+              ``1 - press / null_model_ss`` where ``null_model_ss`` is the
+              mean-cell sum-of-squares of ``X`` (which, for mean-centred data,
+              is the variance the model has to explain). Higher is better;
+              values near 1 indicate good predictive performance and negative
+              values indicate the component predicts worse than the column mean.
+              This mirrors ``PLS.select_n_components``'s ``r2y_validated`` and
+              saves callers from normalising ``press`` themselves.
             - ``cv_scores`` - per-fold scores (pd.DataFrame, A_max rows x cv cols)
+
+        Notes
+        -----
+        ``X`` is expected to be pre-centred (and usually scaled, e.g. with
+        ``MCUVScaler``); the ``q2`` normalisation uses the mean-cell
+        sum-of-squares of ``X`` as the null-model reference.
         """
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X)
@@ -617,6 +633,14 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
 
         press = pd.Series(press_values, name="PRESS")
         press.index.name = "n_components"
+
+        # Cross-validated R2 of X (Q2): normalise the mean-cell PRESS by the
+        # null-model mean-cell sum-of-squares, so it is directly comparable to
+        # the calibration ``r2_cumulative_`` and to PLS's ``r2y_validated``.
+        null_model_ss = float(np.nanmean(np.asarray(X, dtype=float) ** 2))
+        q2 = (1.0 - press / null_model_ss) if null_model_ss > epsqrt else press * np.nan
+        q2 = q2.rename("Q2")
+        q2.index.name = "n_components"
 
         # Wold's criterion: ratio of consecutive PRESS values
         ratio_values = {a: press[a] / press[a - 1] for a in range(2, max_components + 1)}
@@ -639,6 +663,7 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             n_components=recommended,
             press=press,
             press_ratio=press_ratio,
+            q2=q2,
             cv_scores=cv_scores,
         )
 

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -18,7 +18,7 @@ import pandas as pd
 from scipy.stats import t as t_dist
 from sklearn.base import BaseEstimator, RegressorMixin, TransformerMixin, clone
 from sklearn.metrics import r2_score
-from sklearn.model_selection import KFold, check_cv
+from sklearn.model_selection import BaseCrossValidator, KFold, check_cv
 from sklearn.utils import Bunch
 from sklearn.utils.validation import check_is_fitted
 from tqdm import tqdm
@@ -26,7 +26,14 @@ from tqdm import tqdm
 from .._linalg import safe_inverse
 from ..univariate.metrics import detect_outliers_esd
 from ._base import _LatentVariableModel, _LazyFrame
-from ._common import DataMatrix, SpecificationWarning, _align_to_fit_features, _model_method, epsqrt
+from ._common import (
+    DataMatrix,
+    NotEnoughVarianceError,
+    SpecificationWarning,
+    _align_to_fit_features,
+    _model_method,
+    epsqrt,
+)
 from ._nipals import quick_regress, ssq, terminate_check
 from .plots import (
     coefficient_plot as _coefficient_plot,
@@ -250,13 +257,13 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
                     "There is no variance left in the data array for X: cannot "
                     f"compute any more components beyond component {a}."
                 )
-                raise RuntimeError(emsg)
+                raise NotEnoughVarianceError(emsg)
             if np.sum(start_SSY_col) < epsqrt:
                 emsg = (
                     "There is no variance left in the data array for Y: cannot "
                     f"compute any more components beyond component {a}."
                 )
-                raise RuntimeError(emsg)
+                raise NotEnoughVarianceError(emsg)
 
             # Seed u_a from the column of Y with the greatest sum-of-squares
             # (variance, for mean-centred data) rather than the arbitrary first
@@ -612,7 +619,7 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         Y: DataMatrix,
         *,
         max_components: int | None = None,
-        cv: int = 5,
+        cv: int | BaseCrossValidator = 5,
         **pls_kwargs,
     ) -> Bunch:
         """Select the number of PLS components via cross-validation.

--- a/src/process_improve/multivariate/_preprocessing.py
+++ b/src/process_improve/multivariate/_preprocessing.py
@@ -81,7 +81,12 @@ def center(
 
 
 def scale(
-    X: DataMatrix, func: Callable = np.std, axis: int = 0, extra_output: bool = False, **kwargs
+    X: DataMatrix,
+    func: Callable = np.std,
+    axis: int = 0,
+    extra_output: bool = False,
+    ddof: int = 0,
+    **kwargs,
 ) -> DataMatrix | tuple[DataMatrix, np.ndarray]:
     """
     Scales the data (does NOT do any centering); scales to unit variance by
@@ -89,42 +94,48 @@ def scale(
 
 
     `func` [optional; default=np.std] {a function}
-        The default (np.std) will use NumPy to calculate the sample standard
-        deviation of the data, and use that as `scale`.
-
-        TODO: provide a scaling vector.
-        The sample standard deviation is computed along the required `axis`,
-        skipping over any missing data, and dividing by N-1, where N = number
-        of values which are present, i.e. not counting missing values.
+        The default (np.std) uses NumPy to calculate the standard deviation of
+        the data along the required `axis`, skipping over any missing data, and
+        uses that as `scale`.
 
     `axis` [optional; default=0] {integer}
         Transformations are applied on slices of data.  This specifies the
         axis along which the transformation will be applied.
 
-    #`markers` [optional; default=None]
-    #    A vector (or slice) used to store indices (the markers) where the
-    ##    variance needs to be replaced with the `low_variance_replacement`
-    #
-    #`variance_tolerance` [optional; default=1E-7] {floating point}
-    #    A slice is considered to have no variance when the actual variance of
-    #    that slice is smaller than this value.
-    #
-    #`low_variance_replacement` [optional; default=0.0] {floating point}
-    #    Used to replace values in the output where the `markers` indicates no
-    #    or low variance.
+    `ddof` [optional; default=0] {integer}
+        Delta degrees of freedom, forwarded to `np.std` when `func` is the
+        default `np.std`. The standard deviation is computed by dividing by
+        ``N - ddof``, where N is the number of values which are present. The
+        default (``ddof=0``) divides by N (the population standard deviation);
+        pass ``ddof=1`` for the sample standard deviation (dividing by N-1).
+
+        Note: :class:`MCUVScaler` uses ``ddof=1`` and is the preferred scaler
+        for fitting PCA / PLS models. Use ``scale(center(X), ddof=1)`` here to
+        match it. The ``ddof`` argument is ignored when a custom `func` is
+        supplied (forward your own keyword arguments via ``**kwargs`` instead).
+
+    Constant (zero-variance) columns are left unchanged: a zero entry in the
+    computed scaling vector is replaced by 1.0 before inversion, mirroring
+    :class:`MCUVScaler`, so no ``inf`` / ``NaN`` is introduced.
 
     Usage
     =====
 
     X = ...  # data matrix
     X = scale(center(X))
+    X = scale(center(X), ddof=1)  # sample standard deviation, matches MCUVScaler
     my_scale = np.mad
     X = scale(center(X), func=my_scale)
 
     """
+    if func is np.std and "ddof" not in kwargs:
+        kwargs["ddof"] = ddof
     # pandas-stubs types apply()'s axis as a Literal, so a plain ``int`` axis does
     # not match any overload; the call is valid at runtime.
     vector = pd.DataFrame(X).apply(func, axis=axis, **kwargs).to_numpy()  # type: ignore[call-overload]  # pandas-stubs axis is Literal
+    # Zero-variance (constant) columns are left as-is, mirroring MCUVScaler, so
+    # that ``1.0 / vector`` does not introduce inf/NaN.
+    vector = np.where(vector == 0, 1.0, vector)
     vector = 1.0 / vector
 
     if extra_output:

--- a/src/process_improve/multivariate/methods.py
+++ b/src/process_improve/multivariate/methods.py
@@ -16,7 +16,7 @@ from .._linalg import safe_inverse
 from .._random import check_random_state
 from ..univariate.metrics import detect_outliers_esd
 from ..visualization.themes import REFERENCE_LINE_COLOR
-from ._common import SpecificationWarning, epsqrt
+from ._common import NotEnoughVarianceError, SpecificationWarning, epsqrt
 from ._diagnostics import (
     eigenvalue_summary,
     observation_contributions,
@@ -69,6 +69,7 @@ __all__ = [
     "TPLS",
     "DataFrameDict",
     "MCUVScaler",
+    "NotEnoughVarianceError",
     "Plot",
     "Resampler",
     "SpecificationWarning",

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -359,6 +359,22 @@ def test_scale_ddof_matches_mcuvscaler() -> None:
     assert np.allclose(1.0 / divisor, np.asarray(center(X)).std(axis=0, ddof=0))
 
 
+def test_scale_with_custom_func() -> None:
+    """A custom scaling ``func`` is honoured and ``ddof`` is ignored for it."""
+    rng = np.random.default_rng(3)
+    X = pd.DataFrame(rng.normal(size=(6, 3)))
+
+    # Scale each column by its mean absolute value rather than the std. ``ddof``
+    # only applies to the default ``np.std`` path, so passing it here is a no-op
+    # and must not be forwarded to the (ddof-unaware) custom function.
+    mad = lambda col: np.abs(col).mean()  # noqa: E731
+    scaled, divisor = scale(X, func=mad, extra_output=True, ddof=1)
+
+    expected_divisor = X.apply(mad, axis=0).to_numpy()
+    assert np.allclose(1.0 / divisor, expected_divisor)
+    assert np.allclose(np.asarray(scaled, dtype=float), X.to_numpy() / expected_divisor)
+
+
 def test_scale_zero_variance_column_is_finite() -> None:
     """A constant (zero-variance) column is left as-is, not turned into inf/NaN."""
     X = pd.DataFrame({"varies": [1.0, 2.0, 3.0, 4.0], "constant": [5.0, 5.0, 5.0, 5.0]})

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -26,6 +26,7 @@ from process_improve.multivariate.methods import (
     TPLS,
     DataFrameDict,
     MCUVScaler,
+    NotEnoughVarianceError,
     SpecificationWarning,
     center,
     coefficient_plot,
@@ -344,6 +345,32 @@ def test_mcuv_scaling(fixture_tablet_spectra_data: tuple[pd.DataFrame, np.ndarra
     assert pytest.approx(X_mcuv.std(), 1e-10) == 1
 
 
+def test_scale_ddof_matches_mcuvscaler() -> None:
+    """``scale(center(X), ddof=1)`` must reproduce ``MCUVScaler`` (both use N-1)."""
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame(rng.normal(size=(8, 4)))
+
+    from_scale = np.asarray(scale(center(X), ddof=1), dtype=float)
+    from_mcuv = np.asarray(MCUVScaler().fit_transform(X), dtype=float)
+    assert np.allclose(from_scale, from_mcuv)
+
+    # The default (ddof=0) divides by N, i.e. the population standard deviation.
+    _, divisor = scale(center(X), extra_output=True)
+    assert np.allclose(1.0 / divisor, np.asarray(center(X)).std(axis=0, ddof=0))
+
+
+def test_scale_zero_variance_column_is_finite() -> None:
+    """A constant (zero-variance) column is left as-is, not turned into inf/NaN."""
+    X = pd.DataFrame({"varies": [1.0, 2.0, 3.0, 4.0], "constant": [5.0, 5.0, 5.0, 5.0]})
+    scaled, divisor = scale(center(X), extra_output=True)
+
+    assert np.isfinite(np.asarray(scaled, dtype=float)).all()
+    # The constant column maps to a scaling factor of 1.0 (divisor stored as 1/std).
+    assert divisor[1] == pytest.approx(1.0)
+    # ... and is therefore unchanged from its (already centred) input: all zeros.
+    assert np.allclose(np.asarray(scaled, dtype=float)[:, 1], 0.0)
+
+
 def test_pca_tablet_spectra(fixture_tablet_spectra_data: tuple[pd.DataFrame, np.ndarray]) -> None:
     r"""
     Check PCA characteristics.
@@ -617,7 +644,7 @@ def test_pca_select_n_components() -> None:
 
     # Returns a Bunch with the expected keys
     assert isinstance(result, Bunch)
-    assert set(result.keys()) == {"n_components", "press", "press_ratio", "cv_scores"}
+    assert set(result.keys()) == {"n_components", "press", "press_ratio", "q2", "cv_scores"}
 
     # With 2 true components and N < K, should recommend 2 (or at most 3)
     assert 2 <= result.n_components <= 3
@@ -635,6 +662,19 @@ def test_pca_select_n_components() -> None:
     assert isinstance(result.press_ratio, pd.Series)
     assert len(result.press_ratio) == max_comp - 1
     assert list(result.press_ratio.index) == list(range(2, max_comp + 1))
+
+    # Q2 (cross-validated R2 of X) is a Series indexed 1..max_components,
+    # finite, bounded above by 1, and increasing as the first true components
+    # are added (mirrors PLS.select_n_components's r2y_validated).
+    assert isinstance(result.q2, pd.Series)
+    assert len(result.q2) == max_comp
+    assert list(result.q2.index) == list(range(1, max_comp + 1))
+    assert np.isfinite(result.q2.to_numpy()).all()
+    assert (result.q2 <= 1.0 + 1e-9).all()
+    assert result.q2[2] > result.q2[1]
+    # Q2 is exactly the normalised PRESS, so it must match the manual computation.
+    null_model_ss = float(np.nanmean(np.asarray(X, dtype=float) ** 2))
+    assert result.q2.to_numpy() == pytest.approx(1.0 - result.press.to_numpy() / null_model_ss)
 
     # cv_scores is a DataFrame
     assert isinstance(result.cv_scores, pd.DataFrame)
@@ -2131,6 +2171,30 @@ def test_pls_select_n_components_caps_max_components() -> None:
     result = PLS.select_n_components(X_s, Y_s, max_components=1000, cv=5)
     assert len(result.rmsecv) == 24
     assert result.n_components <= 24
+
+
+def test_not_enough_variance_error_is_typed_and_runtimeerror() -> None:
+    """Rank overflow raises NotEnoughVarianceError, still catchable as RuntimeError."""
+    # NotEnoughVarianceError subclasses RuntimeError so existing broad
+    # ``except RuntimeError`` handlers keep working while callers can catch the
+    # narrower type (e.g. to trim the component count during cross-validation).
+    assert issubclass(NotEnoughVarianceError, RuntimeError)
+
+    # PLS: rank-1 X (two identical columns) cannot support a 2nd component.
+    X = pd.DataFrame({"a": [1.0, 2.0, 3.0, 4.0, 5.0], "b": [1.0, 2.0, 3.0, 4.0, 5.0]})
+    Y = pd.DataFrame({"y": [1.0, 2.0, 3.0, 4.0, 5.0]})
+    with pytest.raises(NotEnoughVarianceError):
+        PLS(n_components=2).fit(X, Y)
+    with pytest.raises(RuntimeError):  # the same error, caught broadly
+        PLS(n_components=2).fit(X, Y)
+
+    # PCA NIPALS path: rank-2 data (3rd column is a linear combination) has no
+    # variance left for a 3rd component even though 3 <= min(N, K).
+    a = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    b = np.array([2.0, 1.0, 4.0, 3.0, 6.0])
+    X3 = pd.DataFrame({"a": a, "b": b, "c": a + 2.0 * b})
+    with pytest.raises(NotEnoughVarianceError):
+        PCA(n_components=3, algorithm="nipals").fit(X3)
 
 
 def test_pls_cross_validate_jackknife() -> None:


### PR DESCRIPTION
## Context

While building ScorePilot on top of `process_improve`, six concrete
inconsistencies were flagged in the `multivariate` module. This PR lands the
five that are safe to fix now (all non-breaking). The sixth (new canonical
per-variable `t2_contributions` / `spe_contributions` diagnostics) is a larger
feature and is **deferred to its own PR**.

## Changes

### Bug fixes

- **`scale()` zero-variance guard** - constant (zero-variance) columns no longer
  produce `inf` / `NaN`; they are left unchanged, matching `MCUVScaler`.
- **`scale()` docstring** - previously claimed it divided by `N-1` by default,
  while the default (`func=np.std`, `ddof=0`) divides by `N`. The docstring now
  documents the real behaviour and points to `MCUVScaler` / `ddof=1` for the
  sample standard deviation.

### API additions / improvements

- **`scale(..., ddof=...)`** - explicit `ddof` argument, forwarded to `np.std`
  when the default scaling function is used, so `scale(center(X), ddof=1)`
  reproduces `MCUVScaler` without going through `**kwargs`. The default
  (`ddof=0`) is unchanged, so existing numeric output is unchanged.
- **`PCA.select_n_components` now returns `q2`** - cross-validated R2 of X per
  component count (mean-cell PRESS normalised by the null-model sum-of-squares),
  giving parity with `PLS.select_n_components`'s `r2y_validated`. Callers no
  longer have to normalise `press` by hand.
- **`cv` type hint widened** to `int | BaseCrossValidator` on both selectors,
  matching the already-supported (and documented) splitter objects.
- **`NotEnoughVarianceError`** - new typed exception (exported from
  `process_improve.multivariate`) raised by PCA / PLS NIPALS fitting when the
  data runs out of variance before the requested number of components is
  reached. It subclasses `RuntimeError`, so existing `except RuntimeError`
  handlers keep working while callers can catch the narrower type.

## Compatibility

All changes are non-breaking: `scale()`'s default divisor is unchanged, the new
`q2` key and `ddof` argument are additive, the `cv` change is type-hint only,
and `NotEnoughVarianceError` is a `RuntimeError` subclass.

## Tests

- `scale(center(X), ddof=1)` reproduces `MCUVScaler`; default stays `ddof=0`.
- A constant column maps to finite output (no `inf` / `NaN`).
- `PCA.select_n_components` returns a finite, bounded `q2` matching the manual
  PRESS normalisation.
- Rank-overflow raises `NotEnoughVarianceError` and is still catchable as
  `RuntimeError`, for both PLS and the PCA NIPALS path.

Full `tests/test_multivariate.py` suite passes (123 passed, 1 pre-existing
skip); `ruff check` is clean. Version bumped `1.25.1 -> 1.26.0` with
`CHANGELOG.md` and `CITATION.cff` synced.


---
_Generated by [Claude Code](https://claude.ai/code/session_0167VKhkdrMGTTHt25iAppHB)_