### PR TITLE
Add canonical T² and SPE per-variable contributions to PCA and PLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ those changes.
 
 ## [Unreleased]
 
+## [1.27.0] - 2026-06-06
+
+### Added
+
+- Canonical per-variable MSPC contributions for PCA and PLS:
+  `t2_contributions(model, X)` and `spe_contributions(model, X)`, also available
+  as methods (`model.t2_contributions(X)` / `model.spe_contributions(X)`).
+  `t2_contributions` decomposes each observation's Hotelling's T2 onto the
+  variables (signed; row sums equal the observation's T2, with an optional
+  1-based `components` subset), and `spe_contributions` returns the signed
+  per-variable residuals whose squares sum to the observation's SPE. Both work
+  for PCA (SVD and NIPALS) and PLS and reproduce the model's stored
+  `hotellings_t2_` / `spe_` when passed the training data.
+
 ## [1.26.1] - 2026-06-06
 
 ### Added
@@ -1462,7 +1476,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.26.1...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.27.0...HEAD
+[1.27.0]: https://github.com/kgdunn/process-improve/compare/v1.26.1...v1.27.0
 [1.26.1]: https://github.com/kgdunn/process-improve/compare/v1.26.0...v1.26.1
 [1.26.0]: https://github.com/kgdunn/process-improve/compare/v1.25.1...v1.26.0
 [1.25.1]: https://github.com/kgdunn/process-improve/compare/v1.25.0...v1.25.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.26.1
+version: 1.27.0
 date-released: "2026-06-06"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.26.1"
+version = "1.27.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/__init__.py
+++ b/src/process_improve/multivariate/__init__.py
@@ -12,7 +12,9 @@ from process_improve.multivariate.methods import (
     rv2_coefficient,
     rv_coefficient,
     scale,
+    spe_contributions,
     squared_cosine,
+    t2_contributions,
     vip,
 )
 from process_improve.multivariate.plots import (
@@ -44,8 +46,10 @@ __all__ = [
     "rv_coefficient",
     "scale",
     "score_plot",
+    "spe_contributions",
     "spe_plot",
     "squared_cosine",
+    "t2_contributions",
     "t2_plot",
     "vip",
 ]

--- a/src/process_improve/multivariate/_base.py
+++ b/src/process_improve/multivariate/_base.py
@@ -38,7 +38,13 @@ from ._diagnostics import (
     project_variables as _project_variables,
 )
 from ._diagnostics import (
+    spe_contributions as _spe_contributions,
+)
+from ._diagnostics import (
     squared_cosine as _squared_cosine,
+)
+from ._diagnostics import (
+    t2_contributions as _t2_contributions,
 )
 from ._diagnostics import (
     vip as _vip,
@@ -208,6 +214,8 @@ class _LatentVariableModel(_RenameGetattrMixin, _HotellingsT2LimitMixin, BaseEst
     vip = _model_method(_vip)
     squared_cosine = _model_method(_squared_cosine)
     observation_contributions = _model_method(_observation_contributions)
+    t2_contributions = _model_method(_t2_contributions)
+    spe_contributions = _model_method(_spe_contributions)
     eigenvalue_summary = _model_method(_eigenvalue_summary)
     project_variables = _model_method(_project_variables)
 

--- a/src/process_improve/multivariate/_diagnostics.py
+++ b/src/process_improve/multivariate/_diagnostics.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator
 
-from ._common import DataMatrix
+from ._common import DataMatrix, _align_to_fit_features, epsqrt
 from ._preprocessing import center
 
 # These diagnostics operate on a *fitted* PCA or PLS model via duck typing (they
@@ -247,6 +247,154 @@ def observation_contributions(model: BaseEstimator, n_components: int | None = N
     contributions[~np.isfinite(contributions)] = 0.0
 
     return pd.DataFrame(contributions, index=scores.index, columns=scores.columns[:n_components])
+
+
+def _contribution_inputs(model: BaseEstimator, X: DataMatrix) -> tuple[pd.DataFrame, np.ndarray, np.ndarray]:
+    """Align ``X`` to the fitted features and return ``(X_aligned, R, P)``.
+
+    ``R`` generates the scores (``T = X @ R``) and ``P`` reconstructs the X-block
+    (``X_hat = T @ P.T``). For PCA both are the loadings; for PLS ``R`` is the
+    direct (rotated) weights ``direct_weights_`` and ``P`` is ``x_loadings_``.
+    PLS is recognised by the presence of ``direct_weights_``.
+    """
+    if not hasattr(model, "scores_"):
+        msg = "Model is not fitted. Call fit() before computing contributions."
+        raise ValueError(msg)
+
+    is_pls = hasattr(model, "direct_weights_")
+    reconstruction = model.x_loadings_ if is_pls else model.loadings_
+    directions = model.direct_weights_ if is_pls else model.loadings_
+    P = np.asarray(reconstruction, dtype=float)
+    R = np.asarray(directions, dtype=float)
+
+    if not isinstance(X, pd.DataFrame):
+        X = pd.DataFrame(X)
+    X = _align_to_fit_features(X, reconstruction.index)
+    return X, R, P
+
+
+def t2_contributions(
+    model: BaseEstimator, X: DataMatrix, components: list[int] | None = None
+) -> pd.DataFrame:
+    r"""Per-variable contributions to Hotelling's :math:`T^2`.
+
+    Works with fitted :class:`PCA` and :class:`PLS` models. Decomposes each
+    observation's :math:`T^2` onto the original variables. The contribution of
+    variable :math:`k` for observation :math:`i` is
+
+    .. math::
+
+        c^{T^2}_{ik} = x_{ik} \sum_{a} \frac{t_{ia}}{s_a^2}\, R_{ka},
+
+    where :math:`t_{ia}` are the scores, :math:`s_a^2` is the score variance of
+    component :math:`a` (``scaling_factor_for_scores_`` squared) and :math:`R` is
+    the score-generating matrix (loadings for PCA, ``direct_weights_`` for PLS,
+    so that :math:`T = XR`). Summed over the variables this telescopes to
+    :math:`\sum_a t_{ia}^2 / s_a^2`, i.e. the observation's :math:`T^2`. The
+    values are signed; a large magnitude flags a variable that drives the
+    observation away from the model centre. This is the standard MSPC
+    diagnostic (Westerhuis, Gurden and Smilde, 2000).
+
+    Parameters
+    ----------
+    model : PCA or PLS
+        A fitted PCA or PLS model.
+    X : array-like of shape (n_samples, n_features)
+        Preprocessed data, scaled the same way as the training data (for
+        example with :class:`MCUVScaler`). Passing the training data reproduces
+        the model's stored ``hotellings_t2_``.
+    components : list of int, optional
+        **1-based** component indices to decompose over, matching the model's
+        column convention. ``None`` (default) uses all fitted components, so the
+        row sums equal the cumulative :math:`T^2`.
+
+    Returns
+    -------
+    pd.DataFrame
+        Signed contributions of shape (n_samples, n_features). Each row sums to
+        the observation's :math:`T^2` over the selected components.
+
+    Examples
+    --------
+    >>> pca = PCA(n_components=3).fit(X_scaled)
+    >>> contrib = pca.t2_contributions(X_scaled)
+    >>> contrib.sum(axis=1)  # equals pca.hotellings_t2_.iloc[:, -1]
+
+    See Also
+    --------
+    spe_contributions : The residual-space counterpart.
+    PCA.score_contributions : Decomposes a single score-space movement.
+    """
+    X_df, R, _ = _contribution_inputs(model, X)
+    X_values = X_df.to_numpy(dtype=float)
+    A = R.shape[1]
+
+    if components is None:
+        idx = np.arange(A)
+    else:
+        idx = np.asarray(components, dtype=int) - 1
+        if idx.size == 0 or idx.min() < 0 or idx.max() >= A:
+            msg = f"components must be 1-based indices within 1..{A}, got {components}."
+            raise ValueError(msg)
+
+    s = np.asarray(model.scaling_factor_for_scores_, dtype=float)[idx]
+    # ``s_a == 0`` for a degenerate component would give inf/NaN; clamp the
+    # divisor so such a component contributes nothing rather than poisoning the
+    # result (mirrors ``score_contributions(weighted=True)``).
+    s2 = np.where(s**2 > epsqrt, s**2, 1.0)
+
+    scores = X_values @ R[:, idx]  # (n, len(idx))
+    contributions = X_values * ((scores / s2) @ R[:, idx].T)
+    return pd.DataFrame(contributions, index=X_df.index, columns=X_df.columns)
+
+
+def spe_contributions(model: BaseEstimator, X: DataMatrix) -> pd.DataFrame:
+    r"""Per-variable squared-prediction-error (SPE / DModX) contributions.
+
+    Works with fitted :class:`PCA` and :class:`PLS` models. Returns the signed
+    residual of each variable after reconstructing the X-block from the full
+    model:
+
+    .. math::
+
+        e_{ik} = x_{ik} - \hat{x}_{ik}, \qquad \hat{X} = T P^\top,
+
+    where :math:`P` is the reconstruction loadings (``loadings_`` for PCA,
+    ``x_loadings_`` for PLS). The squared residuals sum across variables to the
+    observation's SPE; equivalently ``(spe_contributions(X) ** 2).sum(axis=1)``
+    equals the stored ``spe_`` (final column) squared. The signs show whether a
+    variable sits above or below its reconstruction, which is the standard SPE
+    contribution plot used to diagnose why an observation has a high residual.
+
+    Parameters
+    ----------
+    model : PCA or PLS
+        A fitted PCA or PLS model.
+    X : array-like of shape (n_samples, n_features)
+        Preprocessed data, scaled the same way as the training data. Passing the
+        training data reproduces the model's stored ``spe_``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Signed per-variable residuals of shape (n_samples, n_features). The
+        squared row sums equal the observation's SPE.
+
+    Examples
+    --------
+    >>> pca = PCA(n_components=2).fit(X_scaled)
+    >>> resid = pca.spe_contributions(X_scaled)
+    >>> (resid ** 2).sum(axis=1)  # equals pca.spe_.iloc[:, -1] ** 2
+
+    See Also
+    --------
+    t2_contributions : The :math:`T^2` (score-space) counterpart.
+    """
+    X_df, R, P = _contribution_inputs(model, X)
+    X_values = X_df.to_numpy(dtype=float)
+    scores = X_values @ R
+    residuals = X_values - scores @ P.T
+    return pd.DataFrame(residuals, index=X_df.index, columns=X_df.columns)
 
 
 def eigenvalue_summary(model: BaseEstimator) -> pd.DataFrame:

--- a/src/process_improve/multivariate/methods.py
+++ b/src/process_improve/multivariate/methods.py
@@ -23,7 +23,9 @@ from ._diagnostics import (
     project_variables,
     rv2_coefficient,
     rv_coefficient,
+    spe_contributions,
     squared_cosine,
+    t2_contributions,
     vip,
 )
 from ._limits import (
@@ -99,10 +101,12 @@ __all__ = [
     "score_limit",
     "score_plot",
     "spe_calculation",
+    "spe_contributions",
     "spe_limit",
     "spe_plot",
     "squared_cosine",
     "ssq",
+    "t2_contributions",
     "t2_plot",
     "terminate_check",
     "vip",

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -789,6 +789,10 @@ def test_pca_t2_spe_contributions() -> None:
         assert t2_contributions(pca, Xs).to_numpy() == pytest.approx(t2c.to_numpy())
         assert spe_contributions(pca, Xs).to_numpy() == pytest.approx(spec.to_numpy())
 
+        # Array-like input is accepted and gives the same result as the frame.
+        assert pca.t2_contributions(Xs.to_numpy()).to_numpy() == pytest.approx(t2c.to_numpy())
+        assert pca.spe_contributions(Xs.to_numpy()).to_numpy() == pytest.approx(spec.to_numpy())
+
     # --- Error handling ---
     with pytest.raises(ValueError, match="not fitted"):
         PCA(n_components=2).t2_contributions(Xs)

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -46,8 +46,10 @@ from process_improve.multivariate.methods import (
     scale,
     score_limit,
     spe_calculation,
+    spe_contributions,
     squared_cosine,
     ssq,
+    t2_contributions,
     terminate_check,
     vip,
 )
@@ -750,6 +752,81 @@ def test_pca_score_contributions() -> None:
     dt_w1 = -obs.values[0] / np.sqrt(pca.explained_variance_[0])
     expected_w1 = dt_w1 * P[:, 0]
     assert contrib_w2.values == pytest.approx(expected_w1, abs=1e-12)
+
+
+def test_pca_t2_spe_contributions() -> None:
+    """t2_contributions sum to T2; spe_contributions squares sum to SPE (PCA)."""
+    rng = np.random.default_rng(7)
+    X = pd.DataFrame(rng.standard_normal((35, 6)), columns=[f"V{i}" for i in range(1, 7)])
+    Xs = MCUVScaler().fit_transform(X)
+
+    for algorithm in ("svd", "nipals"):
+        pca = PCA(n_components=3, algorithm=algorithm).fit(Xs)
+
+        t2c = pca.t2_contributions(Xs)
+        spec = pca.spe_contributions(Xs)
+
+        # Shape / labels mirror the input block.
+        assert t2c.shape == (35, 6)
+        assert spec.shape == (35, 6)
+        assert list(t2c.columns) == list(Xs.columns)
+        assert list(t2c.index) == list(Xs.index)
+
+        # Invariant 1: per-observation T2 contributions sum to Hotelling's T2.
+        assert t2c.sum(axis=1).to_numpy() == pytest.approx(
+            pca.hotellings_t2_.iloc[:, -1].to_numpy(), abs=1e-9
+        )
+        # Invariant 2: squared SPE contributions sum to SPE**2.
+        assert (spec**2).sum(axis=1).to_numpy() == pytest.approx(
+            pca.spe_.iloc[:, -1].to_numpy() ** 2, abs=1e-9
+        )
+
+        # A component subset sums to the cumulative T2 of those components.
+        sub = pca.t2_contributions(Xs, components=[1, 2]).sum(axis=1).to_numpy()
+        assert sub == pytest.approx(pca.hotellings_t2_.iloc[:, 1].to_numpy(), abs=1e-9)
+
+        # The standalone functions match the bound methods.
+        assert t2_contributions(pca, Xs).to_numpy() == pytest.approx(t2c.to_numpy())
+        assert spe_contributions(pca, Xs).to_numpy() == pytest.approx(spec.to_numpy())
+
+    # --- Error handling ---
+    with pytest.raises(ValueError, match="not fitted"):
+        PCA(n_components=2).t2_contributions(Xs)
+    with pytest.raises(ValueError, match="components"):
+        PCA(n_components=3).fit(Xs).t2_contributions(Xs, components=[1, 9])
+
+
+def test_pls_t2_spe_contributions(
+    fixture_pls_ldpe_example: dict[str, pd.DataFrame | np.ndarray | float | int],
+) -> None:
+    """t2/spe contributions hold for PLS, on synthetic and the real LDPE data."""
+    # Synthetic PLS data with a known coefficient matrix.
+    rng = np.random.default_rng(21)
+    X = pd.DataFrame(rng.standard_normal((40, 6)), columns=[f"x{i}" for i in range(6)])
+    beta = rng.standard_normal((6, 2))
+    Y = pd.DataFrame(X.values @ beta + 0.3 * rng.standard_normal((40, 2)), columns=["y0", "y1"])
+    Xs = MCUVScaler().fit_transform(X)
+    Ys = MCUVScaler().fit_transform(Y)
+    pls = PLS(n_components=3).fit(Xs, Ys)
+
+    t2c = pls.t2_contributions(Xs)
+    spec = pls.spe_contributions(Xs)
+    assert t2c.sum(axis=1).to_numpy() == pytest.approx(pls.hotellings_t2_.iloc[:, -1].to_numpy(), abs=1e-9)
+    assert (spec**2).sum(axis=1).to_numpy() == pytest.approx(pls.spe_.iloc[:, -1].to_numpy() ** 2, abs=1e-9)
+    # SPE contributions carry signs (they are residuals, not magnitudes).
+    assert (spec.to_numpy() < 0).any()
+
+    # Real LDPE dataset (SIMCA reference data) - exercise the same invariants.
+    data = fixture_pls_ldpe_example
+    X_ldpe = MCUVScaler().fit_transform(data["X"])
+    Y_ldpe = MCUVScaler().fit_transform(data["Y"])
+    pls_ldpe = PLS(n_components=data["A"]).fit(X_ldpe, Y_ldpe)
+    assert pls_ldpe.t2_contributions(X_ldpe).sum(axis=1).to_numpy() == pytest.approx(
+        pls_ldpe.hotellings_t2_.iloc[:, -1].to_numpy(), abs=1e-6
+    )
+    assert (pls_ldpe.spe_contributions(X_ldpe) ** 2).sum(axis=1).to_numpy() == pytest.approx(
+        pls_ldpe.spe_.iloc[:, -1].to_numpy() ** 2, abs=1e-6
+    )
 
 
 def test_pca_detect_outliers() -> None:


### PR DESCRIPTION
## Context

Follow-up to #368 (issue #4 from the ScorePilot session). ScorePilot needed the
textbook MSPC per-variable diagnostics - **T² contributions** and **SPE/DModX
contributions** - but `process_improve` only had `score_contributions`
(score-space back-projection) and `observation_contributions` (per-observation
inertia share); neither is the canonical per-variable decomposition. The
multiblock estimators had a block-level `spe_contributions`, but single-block
PCA/PLS had nothing. This adds them upstream so ScorePilot can drop its bespoke
adapter (its well-tested `observation_contributions` was the reference for the
math here).

## What's added

Two functions in `multivariate/_diagnostics.py`, bound as methods on PCA and PLS
and re-exported from `methods.py` and the package:

- **`t2_contributions(model, X, components=None)`** - signed per-variable
  contributions to Hotelling's T².
  `c^{T²}_{ik} = x_{ik} · Σ_a (t_{ia}/s_a²) · R_{ka}`, where `R` generates the
  scores (`T = XR`: loadings for PCA, `direct_weights_` for PLS) and `s_a²` is
  the model's own score scaling (`scaling_factor_for_scores_²`). Row sums equal
  the observation's T² (cumulative, or over an optional **1-based** `components`
  subset).
- **`spe_contributions(model, X)`** - signed per-variable residuals after
  full-model reconstruction (`X̂ = T Pᵀ`; `P` = loadings for PCA, `x_loadings_`
  for PLS). Their squares sum to the observation's SPE.

Both work for PCA (SVD **and** NIPALS) and PLS, and reproduce the model's stored
`hotellings_t2_` / `spe_` when passed the training data.

## Design notes

- Bound on `_LatentVariableModel`, the shared PCA/PLS base. MBPCA/MBPLS use a
  different base and keep their existing block-level `spe_contributions` - no
  collision.
- Using `scaling_factor_for_scores_²` (not a recomputed `scores.var(ddof=1)`)
  guarantees the T² row-sum matches the stored `hotellings_t2_` exactly.
- Degenerate (zero-variance) components are clamped so they contribute nothing
  rather than producing `inf`/`NaN`, mirroring `score_contributions(weighted=True)`.

## Tests

`tests/test_multivariate.py`:
- PCA (SVD + NIPALS): shapes/labels, T² row-sum == `hotellings_t2_`, SPE
  squared row-sum == `spe_**2`, a `components` subset summing to the cumulative
  T², standalone == bound method, and error handling (unfitted, out-of-range
  components).
- PLS: same invariants on synthetic data **and** the real LDPE (SIMCA) dataset;
  asserts SPE contributions carry signs.

Full `tests/test_multivariate.py` passes (126 passed, 1 pre-existing skip);
`ruff check` and `mypy` clean. Version bumped `1.26.0 -> 1.27.0` (MINOR) with
`CHANGELOG.md` and `CITATION.cff` synced.


---
_Generated by [Claude Code](https://claude.ai/code/session_0167VKhkdrMGTTHt25iAppHB)_