### PR TITLE
Fix publish workflow SBOM flag so releases can ship (1.27.1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
           pip install "cyclonedx-bom>=5.0" "."
           cyclonedx-py environment \
             --output-format JSON \
-            --outfile "dist/sbom-${{ steps.read_version.outputs.version }}.cdx.json"
+            --output-file "dist/sbom-${{ steps.read_version.outputs.version }}.cdx.json"
 
       - name: Upload built artifacts
         uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ those changes.
 
 ## [Unreleased]
 
+## [1.27.1] - 2026-06-06
+
+### Fixed
+
+- **PyPI publish workflow (`publish.yml`).** The CycloneDX SBOM step called
+  `cyclonedx-py environment --outfile ...`, but `cyclonedx-bom` 6+ renamed that
+  flag, so the step failed (`unrecognized arguments: --outfile`) and blocked
+  every release. It now uses `--output-file`. CI/tooling only; no library
+  changes from 1.27.0.
+
 ## [1.27.0] - 2026-06-06
 
 ### Added
@@ -1476,7 +1486,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.27.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.27.1...HEAD
+[1.27.1]: https://github.com/kgdunn/process-improve/compare/v1.27.0...v1.27.1
 [1.27.0]: https://github.com/kgdunn/process-improve/compare/v1.26.1...v1.27.0
 [1.26.1]: https://github.com/kgdunn/process-improve/compare/v1.26.0...v1.26.1
 [1.26.0]: https://github.com/kgdunn/process-improve/compare/v1.25.1...v1.26.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.27.0
+version: 1.27.1
 date-released: "2026-06-06"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.27.0"
+version = "1.27.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Context

The PyPI publish workflow had never actually run before (no prior `v*` tags). On
its first real run (a `workflow_dispatch` to release 1.27.0) it failed at the
**Generate CycloneDX SBOM** step:

```
cyclonedx-py: error: unrecognized arguments: --outfile
```

The `cyclonedx-bom>=5.0` pin now resolves to 7.3.0, which renamed the output
flag from `--outfile` to `--output-file` (`-o`). The build and wheel succeeded;
only SBOM generation broke, which then skipped the `publish` job - so no release
ever shipped.

## Fix

`publish.yml`: `--outfile` -> `--output-file` (the current cyclonedx-py flag;
`--output-format` is unchanged). CI/tooling only - the library is identical to
1.27.0.

## Version

PATCH bump `1.27.0 -> 1.27.1` (CI fix) with `CHANGELOG.md` and `CITATION.cff`
synced, so the first actually-publishable patch in this line carries the fix.

This unblocks publishing the `t2_contributions` / `spe_contributions` (1.27.0)
and the earlier `scale`/selector/`NotEnoughVarianceError` work (1.26.0) to PyPI.


---
_Generated by [Claude Code](https://claude.ai/code/session_0167VKhkdrMGTTHt25iAppHB)_