### PR TITLE
Step up PLS cross-validation: 1-SE rule, repeated K-fold, in-fold scaling (supersedes #371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,42 @@ those changes.
 
 ## [Unreleased]
 
+## [1.28.0] - 2026-06-07
+
+### Changed
+
+- **`PLS.select_n_components` rebuilt around the one-standard-error rule on
+  repeated, shuffled K-fold CV with in-fold scaling**, replacing the
+  pre-1.28 argmin-RMSECV rule (which routinely ran to the maximum
+  component count because the validated error keeps drifting down by
+  noise-level amounts past the systematic components).
+  - New `selection_rule` kwarg: `"1se"` (default; Breiman/Friedman/
+    Olshen/Stone 1984; Hastie/Tibshirani/Friedman *ESL* sec.7.10),
+    `"min"` (the pre-1.28 default, preserved for explicit opt-in), and
+    `"q2_increment"` (a Wold's-R-style cumulative-:math:`Q^2` threshold).
+  - New `n_repeats` kwarg (default `10` when `cv` is an `int`) wires up
+    `sklearn.model_selection.RepeatedKFold` so the 1-SE rule's standard
+    error is estimated across `n_splits * n_repeats` fold errors;
+    `random_state` makes that selection reproducible.
+  - New `scale_inside_folds` kwarg (default `True`) fits `MCUVScaler` on
+    each training fold and inverse-transforms predictions to the
+    original Y scale, removing the centring/scaling leakage of the prior
+    implementation. Passing `False` emits a `SpecificationWarning`.
+  - The returned `Bunch` gains `per_fold_rmsecv`, `se_rmsecv` and
+    `selection_rule` fields; the existing fields keep their semantics.
+
+  Callers who relied on the old argmin behaviour can opt in via
+  `selection_rule="min"`; callers who relied on the pre-1.28 leaky
+  scaling can opt in via `scale_inside_folds=False` (which warns).
+
+- **`PCA.select_n_components` docstring now flags the trivial-fit
+  limitation** (Bro, Kjeldahl, Smilde & Kiers 2008, *Anal. Bioanal. Chem.*
+  390:1241-1251): the row-wise CV scheme makes PRESS shrink monotonically
+  with components, so the recommendation tends to over-select. A
+  proper element-wise k-fold (ekf) rewrite is tracked as a follow-up; for
+  now the docstring recommends cross-checking with parallel analysis or
+  Minka's MLE.
+
 ## [1.27.1] - 2026-06-06
 
 ### Fixed
@@ -1486,7 +1522,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.27.1...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.28.0...HEAD
+[1.28.0]: https://github.com/kgdunn/process-improve/compare/v1.27.1...v1.28.0
 [1.27.1]: https://github.com/kgdunn/process-improve/compare/v1.27.0...v1.27.1
 [1.27.0]: https://github.com/kgdunn/process-improve/compare/v1.26.1...v1.27.0
 [1.26.1]: https://github.com/kgdunn/process-improve/compare/v1.26.0...v1.26.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.27.1
-date-released: "2026-06-06"
+version: 1.28.0
+date-released: "2026-06-07"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.27.1"
+version = "1.28.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_common.py
+++ b/src/process_improve/multivariate/_common.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Callable
-from typing import Any, TypeAlias
+from typing import Any, Literal, TypeAlias
 
 import numpy as np
 import pandas as pd
@@ -20,7 +20,39 @@ import pandas as pd
 # Names re-exported to the rest of the package. Declared explicitly so CodeQL
 # does not flag the ``DataMatrix`` type alias (only ever referenced in lazy
 # annotation strings under ``from __future__ import annotations``) as unused.
-__all__ = ["DataMatrix", "NotEnoughVarianceError", "SpecificationWarning", "epsqrt"]
+__all__ = [
+    "Q2_MIN_INCREMENT",
+    "DataMatrix",
+    "NotEnoughVarianceError",
+    "SelectionRule",
+    "SpecificationWarning",
+    "epsqrt",
+]
+
+#: Component-selection rules supported by ``PLS.select_n_components``.
+#:
+#: ``"1se"`` (the current default) applies the one-standard-error rule of
+#: Breiman, Friedman, Olshen & Stone (1984, *CART* sec.3.4.3), endorsed by
+#: Hastie, Tibshirani & Friedman (*The Elements of Statistical Learning*,
+#: sec.7.10): pick the smallest component count whose mean cross-validated
+#: error is within one standard error of the lowest. Needs per-fold errors,
+#: so repeated K-fold is recommended.
+#:
+#: ``"min"`` returns the component count with the lowest cross-validated error.
+#: On data sets where the validated error keeps drifting down by noise-level
+#: amounts after the systematic components are exhausted, this routinely runs
+#: to (or near) the maximum component count.
+#:
+#: ``"q2_increment"`` keeps adding components while each one raises the
+#: cumulative cross-validated :math:`Q^2` by at least ``min_q2_increase``;
+#: it is a Wold's-R-style heuristic with an absolute (not relative) threshold.
+SelectionRule = Literal["1se", "min", "q2_increment"]
+
+#: Default minimum increase in the cross-validated :math:`Q^2` for an extra
+#: component to be judged worth keeping under the ``"q2_increment"`` selection
+#: rule. ``0.01`` means "must add at least one percentage point of
+#: cross-validated explained variance".
+Q2_MIN_INCREMENT = 0.01
 
 DataMatrix: TypeAlias = np.ndarray | pd.DataFrame
 
@@ -132,6 +164,116 @@ def _align_to_fit_features(X: pd.DataFrame, fit_feature_names: pd.Index) -> pd.D
         # positional projection lines up.
         X = X[fit_names]
     return X
+
+
+def _recommend_n_components_q2(
+    q2_cumulative: np.ndarray | pd.Series | list[float],
+    *,
+    min_increment: float = Q2_MIN_INCREMENT,
+) -> int:
+    r"""Recommend a component count from a cumulative cross-validated :math:`Q^2` curve.
+
+    Walks outward from one component, keeping component ``a`` only if it lifts
+    the cumulative :math:`Q^2` by at least ``min_increment`` (with an implied
+    :math:`Q^2` of ``0`` before any component). The first component that fails
+    that test - a plateau, a drop, or a non-finite entry - stops the search,
+    and the recommendation is the last component that passed (never fewer than
+    one, since a model needs at least one component).
+
+    This is a Wold's-R-style heuristic: parsimonious and cheap, but the
+    threshold is absolute and hand-tuned. Prefer the 1-SE rule
+    (:func:`_recommend_n_components_one_se`) when per-fold errors are available.
+    """
+    q2 = np.asarray(q2_cumulative, dtype=float)
+    recommended = 1
+    previous = 0.0
+    for a, value in enumerate(q2, start=1):
+        if not np.isfinite(value) or (value - previous) < min_increment:
+            break
+        recommended = a
+        previous = float(value)
+    return recommended
+
+
+def _recommend_n_components_one_se(
+    mean_error: np.ndarray | pd.Series | list[float],
+    se_error: np.ndarray | pd.Series | list[float],
+) -> int:
+    r"""Recommend a component count by the one-standard-error rule.
+
+    Given the mean cross-validated error per component count (``mean_error``,
+    e.g. RMSECV across folds and repeats) and its standard error
+    (``se_error``), find ``a* = nanargmin(mean_error)`` and return the
+    *smallest* component count ``a`` whose ``mean_error[a]`` is no larger than
+    ``mean_error[a*] + se_error[a*]``.
+
+    The 1-SE rule (Breiman, Friedman, Olshen & Stone 1984, *CART* sec.3.4.3;
+    Hastie, Tibshirani & Friedman, *ESL* sec.7.10) trades a tiny amount of
+    fit for a more parsimonious model whose error is statistically
+    indistinguishable from the best. It is the cheapest robustness upgrade for
+    integer hyperparameters like the number of latent variables.
+
+    Non-finite entries in ``mean_error`` are skipped. The selection always
+    returns at least ``1``. If ``se_error`` at the minimum is non-finite or
+    zero, the rule degenerates to the argmin.
+    """
+    mean = np.asarray(mean_error, dtype=float)
+    se = np.asarray(se_error, dtype=float)
+    if mean.shape != se.shape:
+        raise ValueError(
+            f"mean_error and se_error must have the same shape; "
+            f"got {mean.shape} and {se.shape}."
+        )
+    if mean.ndim != 1:
+        raise ValueError("mean_error must be 1-D.")
+    finite = np.isfinite(mean)
+    if not finite.any():
+        # Caller should already have raised before now; fall through to 1 so
+        # this helper never returns a sentinel.
+        return 1
+    masked = np.where(finite, mean, np.inf)
+    best = int(np.argmin(masked))
+    se_best = se[best] if np.isfinite(se[best]) else 0.0
+    threshold = masked[best] + se_best
+    for a, value in enumerate(masked, start=1):
+        if value <= threshold:
+            return a
+    return best + 1
+
+
+def _select_n_components(
+    rule: SelectionRule,
+    *,
+    mean_error: np.ndarray | pd.Series | list[float],
+    se_error: np.ndarray | pd.Series | list[float] | None = None,
+    q2_cumulative: np.ndarray | pd.Series | list[float] | None = None,
+    min_q2_increase: float = Q2_MIN_INCREMENT,
+) -> int:
+    """Dispatch component selection to one of the supported rules.
+
+    See :data:`SelectionRule` for the rule semantics. Raises ``ValueError`` if
+    a rule is requested without the data it needs (``"1se"`` needs
+    ``se_error``; ``"q2_increment"`` needs ``q2_cumulative``).
+    """
+    if rule == "min":
+        mean = np.asarray(mean_error, dtype=float)
+        if not np.isfinite(mean).any():
+            return 1
+        return int(np.nanargmin(mean)) + 1
+    if rule == "1se":
+        if se_error is None:
+            raise ValueError("selection_rule='1se' requires per-component standard errors.")
+        return _recommend_n_components_one_se(mean_error, se_error)
+    if rule == "q2_increment":
+        if q2_cumulative is None:
+            raise ValueError(
+                "selection_rule='q2_increment' requires a cumulative Q^2 curve."
+            )
+        return _recommend_n_components_q2(q2_cumulative, min_increment=min_q2_increase)
+    raise ValueError(
+        f"Unknown selection_rule {rule!r}; expected one of "
+        f"'1se', 'min', 'q2_increment'."
+    )
 
 
 def _model_method(fn: Callable[..., Any]) -> Callable[..., Any]:

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -614,6 +614,22 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         ``X`` is expected to be pre-centred (and usually scaled, e.g. with
         ``MCUVScaler``); the ``q2`` normalisation uses the mean-cell
         sum-of-squares of ``X`` as the null-model reference.
+
+        .. warning::
+
+           The row-wise CV scheme used here suffers from the *trivial-fit*
+           problem identified by Bro, Kjeldahl, Smilde & Kiers (2008,
+           *Anal. Bioanal. Chem.* 390:1241-1251): the held-out row's own
+           values flow into the prediction through :meth:`transform`, so
+           PRESS shrinks monotonically with the component count and the
+           recommendation tends to over-select. A robust replacement
+           requires element-wise k-fold (ekf) CV with EM-style imputation
+           of the held-out cells. Until that lands (see the project issue
+           tracker), prefer comparing this result with cross-checks such as
+           variance-explained thresholds, Horn's parallel analysis, or
+           Minka's MLE, and treat the recommendation as a starting point
+           rather than a closing verdict. The PLS analogue at
+           :meth:`PLS.select_n_components` is not affected by this issue.
         """
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X)

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -18,7 +18,7 @@ import pandas as pd
 from scipy.stats import t as t_dist
 from sklearn.base import BaseEstimator, RegressorMixin, TransformerMixin, clone
 from sklearn.metrics import r2_score
-from sklearn.model_selection import BaseCrossValidator, KFold, check_cv
+from sklearn.model_selection import BaseCrossValidator, KFold, RepeatedKFold, check_cv
 from sklearn.utils import Bunch
 from sklearn.utils.validation import check_is_fitted
 from tqdm import tqdm
@@ -27,13 +27,17 @@ from .._linalg import safe_inverse
 from ..univariate.metrics import detect_outliers_esd
 from ._base import _LatentVariableModel, _LazyFrame
 from ._common import (
+    Q2_MIN_INCREMENT,
     DataMatrix,
     NotEnoughVarianceError,
+    SelectionRule,
     SpecificationWarning,
     _align_to_fit_features,
     _model_method,
+    _select_n_components,
     epsqrt,
 )
+from ._preprocessing import MCUVScaler
 from ._nipals import quick_regress, ssq, terminate_check
 from .plots import (
     coefficient_plot as _coefficient_plot,
@@ -613,39 +617,87 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         return Bunch(scores=scores, hotellings_t2=t2, spe=spe_values, y_hat=y_hat)
 
     @classmethod
-    def select_n_components(  # noqa: C901
+    def select_n_components(  # noqa: C901, PLR0913, PLR0915
         cls,
         X: DataMatrix,
         Y: DataMatrix,
         *,
         max_components: int | None = None,
         cv: int | BaseCrossValidator = 5,
+        n_repeats: int | None = None,
+        random_state: int | None = None,
+        selection_rule: SelectionRule = "1se",
+        scale_inside_folds: bool = True,
+        min_q2_increase: float = Q2_MIN_INCREMENT,
         **pls_kwargs,
     ) -> Bunch:
         """Select the number of PLS components via cross-validation.
 
         Fits PLS models on cross-validation training folds and evaluates the
-        out-of-fold prediction error for every component count ``1, 2, ...,
-        max_components``. Reports RMSECV and validated explained variance, and
-        recommends the component count with the lowest overall RMSECV.
+        out-of-fold prediction error for every component count
+        ``1, 2, ..., max_components``. Reports per-fold and pooled RMSECV plus
+        the validated cumulative R² curves, and recommends a component count
+        from one of three rules (see ``selection_rule`` below).
+
+        The defaults are the research-backed combination: the
+        one-standard-error rule on top of repeated, shuffled K-fold CV, with
+        :class:`MCUVScaler` re-fit inside every training fold so test data
+        never leaks into the centring/scaling estimates.
 
         Unlike the calibration statistics stored on a fitted model
-        (``rmse_``, ``r2_cumulative_``), these metrics estimate performance on
-        unseen data and are therefore suitable for choosing ``n_components``.
+        (``rmse_``, ``r2_cumulative_``), the metrics returned here estimate
+        performance on unseen data and are therefore suitable for choosing
+        ``n_components``.
 
         Parameters
         ----------
         X : array-like of shape (n_samples, n_features)
-            Training data. Should already be scaled (e.g. with ``MCUVScaler``).
+            Training X. With the default ``scale_inside_folds=True`` the raw,
+            unscaled X may be passed; scaling is fit inside every training
+            fold.
         Y : array-like of shape (n_samples, n_targets)
-            Target data, scaled in the same way as ``X``.
+            Training Y. Same treatment as ``X`` under ``scale_inside_folds``.
         max_components : int, optional
             Maximum number of components to evaluate. Default is the largest
             value supported by every cross-validation training fold,
             ``min(min_fold_size, n_features)``.
         cv : int or sklearn CV splitter, default 5
-            Number of K-fold splits, or an sklearn splitter object (e.g.
-            ``KFold(n_splits=10, shuffle=True)`` or ``LeaveOneOut()``).
+            If an integer, used as the ``n_splits`` of a shuffled
+            :class:`~sklearn.model_selection.KFold` (or
+            :class:`~sklearn.model_selection.RepeatedKFold` when
+            ``n_repeats > 1``). Any sklearn splitter object (e.g.
+            ``KFold(10, shuffle=True)`` or ``LeaveOneOut()``) is also accepted
+            and is used as-is (``n_repeats`` is then ignored).
+        n_repeats : int, optional
+            Number of times the K-fold split is repeated with a fresh shuffle,
+            used only when ``cv`` is an integer. Default ``10`` (giving a
+            ``cv * 10`` per-fold sample for the 1-SE rule); pass ``1`` to
+            disable repeats. Repeated K-fold's standard errors are slightly
+            optimistic because test folds overlap across repeats; that is fine
+            for the 1-SE *selection* rule but should not be reported as an
+            unbiased generalisation variance.
+        random_state : int, optional
+            Seed forwarded to ``KFold`` / ``RepeatedKFold`` for reproducible
+            shuffling. Ignored when ``cv`` is a pre-built splitter.
+        selection_rule : {"1se", "min", "q2_increment"}, default "1se"
+            How the recommended component count is chosen from the per-fold
+            RMSECV curve. See :data:`~process_improve.multivariate._common.SelectionRule`
+            for the rule semantics. ``"1se"`` is the default; ``"min"`` is the
+            argmin RMSECV (the pre-1.28 default, prone to running to the
+            maximum component count); ``"q2_increment"`` is the Wold's-R-style
+            cumulative-Q² threshold.
+        scale_inside_folds : bool, default True
+            When True (the default), fit a fresh :class:`MCUVScaler` on each
+            training fold's X and Y, apply it to the held-out rows, fit PLS in
+            scaled space, then inverse-transform the predictions so RMSECV is
+            reported on the original Y scale. This removes the centring /
+            scaling leakage of the prior default. Set to False to keep the
+            pre-1.28 behaviour, in which case ``X`` and ``Y`` should already
+            be scaled; a :class:`SpecificationWarning` is emitted.
+        min_q2_increase : float, default 0.01
+            Threshold used only when ``selection_rule="q2_increment"``: the
+            smallest increase in cumulative validated :math:`Q^2_Y` that
+            justifies keeping an extra component.
         **pls_kwargs
             Additional keyword arguments passed to the ``PLS()`` constructor
             (e.g. ``missing_data_settings``).
@@ -655,40 +707,53 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         result : sklearn.utils.Bunch
             With keys:
 
-            - ``n_components`` - recommended number of components (int): the
-              count with the lowest overall RMSECV.
-            - ``rmsecv`` - root-mean-square error of cross-validation
-              (pd.DataFrame, indexed 1..A; columns are the Y-variable names
-              plus ``"total"``).
-            - ``r2y_validated`` - validated cumulative R² of Y (pd.DataFrame,
-              same shape as ``rmsecv``).
-            - ``r2x_validated`` - validated cumulative R² of X (pd.DataFrame,
-              indexed 1..A; columns are the X-variable names plus ``"total"``).
-            - ``press`` - overall Y prediction error sum of squares per
-              component count (pd.Series, indexed 1..A).
+            - ``n_components`` - recommended number of components (int).
+            - ``rmsecv`` - pooled RMSECV per component count
+              (pd.DataFrame, indexed ``1..A``; columns are the Y-variable
+              names plus ``"total"``).
+            - ``per_fold_rmsecv`` - per-fold total RMSECV (pd.DataFrame,
+              indexed ``1..A``; one column per fold across all repeats).
+              Drives the 1-SE rule.
+            - ``se_rmsecv`` - standard error of the per-fold RMSECV per
+              component count (pd.Series, indexed ``1..A``).
+            - ``r2y_validated`` - validated cumulative :math:`R^2_Y`
+              (pd.DataFrame, same shape as ``rmsecv``).
+            - ``r2x_validated`` - validated cumulative :math:`R^2_X`
+              (pd.DataFrame, indexed ``1..A``; columns are the X-variable
+              names plus ``"total"``).
+            - ``press`` - pooled Y prediction error sum of squares per
+              component count (pd.Series, indexed ``1..A``).
             - ``cv_predictions`` - out-of-fold predictions of Y at the
-              recommended component count (pd.DataFrame).
+              recommended component count, on the original Y scale
+              (pd.DataFrame). For repeated K-fold, the *first* repeat's
+              held-out predictions are reported so each row appears exactly
+              once.
+            - ``selection_rule`` - the rule used to pick ``n_components``.
 
         Notes
         -----
-        Like :meth:`PCA.select_n_components`, this expects ``X`` and ``Y`` to
-        be pre-scaled and refits PLS on each fold without re-deriving the
-        scaling inside the fold. Folds therefore share the scaling of the full
-        dataset, which makes the reported errors slightly optimistic compared
-        with scaling each training fold independently.
+        The pooled RMSECV in ``rmsecv["total"]`` is the square root of the
+        total PRESS over all fold-test rows divided by ``(N_eff * M)`` where
+        ``N_eff = N * n_repeats`` under repeated CV; the ``per_fold_rmsecv``
+        column for fold *f* is the square root of fold-*f*'s sum-of-squared
+        residuals over its own test rows.
 
-        The recommendation uses the minimum overall RMSECV. A more
-        conservative choice is Wold's criterion: stop adding components once
-        RMSECV stops improving appreciably. That can be applied directly to
-        the returned ``rmsecv["total"]`` curve.
+        References
+        ----------
+        Breiman, Friedman, Olshen & Stone (1984), *CART*, sec.3.4.3 (1-SE rule).
+        Hastie, Tibshirani & Friedman, *ESL*, sec.7.10. Kohavi (1995, IJCAI)
+        recommends 10-fold stratified CV for model selection.
 
         Examples
         --------
         >>> from sklearn.model_selection import KFold
-        >>> result = PLS.select_n_components(X_scaled, Y_scaled, max_components=6)
-        >>> result.n_components
-        >>> result.rmsecv["total"]
-        >>> PLS.select_n_components(X_scaled, Y_scaled, cv=KFold(10, shuffle=True))
+        >>> # Default: 1-SE on 10 x 5-fold repeated CV with in-fold scaling.
+        >>> result = PLS.select_n_components(X, Y, max_components=6, random_state=0)
+        >>> result.n_components, result.selection_rule
+        >>> # Opt-in to the older argmin-RMSECV rule:
+        >>> PLS.select_n_components(X, Y, max_components=6, selection_rule="min")
+        >>> # Caller-supplied splitter (n_repeats is ignored here):
+        >>> PLS.select_n_components(X, Y, cv=KFold(10, shuffle=True, random_state=0))
         """
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X)
@@ -697,15 +762,43 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         elif not isinstance(Y, pd.DataFrame):
             Y = pd.DataFrame(Y)
 
+        if not scale_inside_folds:
+            warnings.warn(
+                "scale_inside_folds=False leaks centring/scaling estimated on the "
+                "full dataset into every CV fold, making the reported RMSECV "
+                "optimistic. The default scale_inside_folds=True is preferred.",
+                SpecificationWarning,
+                stacklevel=2,
+            )
+
         N, K = X.shape
         M = Y.shape[1]
 
-        splits = list(check_cv(cv).split(X, Y))
+        if isinstance(cv, int):
+            if cv < 2:
+                raise ValueError(f"cv must be >= 2 when given as an int; got {cv}.")
+            repeats = 10 if n_repeats is None else int(n_repeats)
+            if repeats < 1:
+                raise ValueError(f"n_repeats must be >= 1; got {repeats}.")
+            splitter: BaseCrossValidator
+            if repeats == 1:
+                splitter = KFold(n_splits=cv, shuffle=True, random_state=random_state)
+            else:
+                splitter = RepeatedKFold(n_splits=cv, n_repeats=repeats, random_state=random_state)
+            splits = list(splitter.split(X, Y))
+            first_repeat_fold_count = cv
+        else:
+            splits = list(check_cv(cv).split(X, Y))
+            first_repeat_fold_count = len(splits)
         if not splits:
             raise ValueError("The cross-validation splitter produced no folds.")
+        n_folds_total = len(splits)
         min_train_size = min(len(train_idx) for train_idx, _ in splits)
 
-        upper = min(min_train_size, K)
+        # Centring inside a fold removes one DoF, so a globally-centred matrix
+        # restricted to (min_train_size) rows and re-centred has rank at most
+        # min_train_size - 1. Cap A accordingly when in-fold scaling is on.
+        upper = min(min_train_size - (1 if scale_inside_folds else 0), K)
         if max_components is None:
             max_components = upper
         A = min(int(max_components), upper)
@@ -716,54 +809,121 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
 
         press_y = np.zeros((A, M))
         press_x = np.zeros((A, K))
+        # Per-fold total-RMSECV across every fold-fit (n_folds_total columns).
+        # Drives the 1-SE rule's standard error.
+        per_fold_rmse = np.full((A, n_folds_total), np.nan)
+        # Out-of-fold predictions: with repeated K-fold each row appears in
+        # multiple test folds, so populate only from the *first* repeat (which
+        # covers every row exactly once) to preserve the existing semantic that
+        # cv_predictions has one row per observation.
         oof = np.full((A, N, M), np.nan)
 
-        for train_idx, test_idx in splits:
-            model = cls(n_components=A, **pls_kwargs).fit(X.iloc[train_idx], Y.iloc[train_idx])
-            scores_test = X.iloc[test_idx].to_numpy() @ model.direct_weights_.to_numpy()
-            y_test = Y.iloc[test_idx].to_numpy()
-            x_test = X.iloc[test_idx].to_numpy()
-            # After fit(), y_loadings_ is always the public DataFrame.
+        x_columns = list(X.columns)
+        y_columns = list(Y.columns)
+        x_values = X.to_numpy()
+        y_values = Y.to_numpy()
+        for fold_idx, (train_idx, test_idx) in enumerate(splits):
+            X_train_raw = X.iloc[train_idx]
+            Y_train_raw = Y.iloc[train_idx]
+            X_test_raw = X.iloc[test_idx]
+            if scale_inside_folds:
+                scaler_x = MCUVScaler().fit(X_train_raw)
+                scaler_y = MCUVScaler().fit(Y_train_raw)
+                X_train = scaler_x.transform(X_train_raw)
+                Y_train = scaler_y.transform(Y_train_raw)
+                X_test_scaled = scaler_x.transform(X_test_raw).to_numpy()
+                y_centre = scaler_y.center_.to_numpy()
+                y_scale = scaler_y.scale_.to_numpy()
+                x_centre = scaler_x.center_.to_numpy()
+                x_scale = scaler_x.scale_.to_numpy()
+            else:
+                X_train = X_train_raw
+                Y_train = Y_train_raw
+                X_test_scaled = X_test_raw.to_numpy()
+                y_centre = np.zeros(M)
+                y_scale = np.ones(M)
+                x_centre = np.zeros(K)
+                x_scale = np.ones(K)
+
+            model = cls(n_components=A, **pls_kwargs).fit(X_train, Y_train)
+            scores_test = X_test_scaled @ model.direct_weights_.to_numpy()
+            # ``y_values`` and ``x_values`` are on the ORIGINAL (un-scaled)
+            # input data: RMSECV / r2y_validated / r2x_validated are all
+            # reported on the input scale.
+            y_test = y_values[test_idx]
+            x_test = x_values[test_idx]
+            n_test = len(test_idx)
             y_loadings = typing.cast("pd.DataFrame", model.y_loadings_).to_numpy()  # shape (M, A)
             x_loadings = model.x_loadings_.to_numpy()  # shape (K, A)
             for a in range(1, A + 1):
-                y_hat = scores_test[:, :a] @ y_loadings[:, :a].T
-                x_hat = scores_test[:, :a] @ x_loadings[:, :a].T
-                press_y[a - 1] += np.nansum((y_test - y_hat) ** 2, axis=0)
+                y_hat_scaled = scores_test[:, :a] @ y_loadings[:, :a].T
+                x_hat_scaled = scores_test[:, :a] @ x_loadings[:, :a].T
+                # inverse-transform: x_scale[None, :] broadcasts (n_test, K).
+                y_hat = y_hat_scaled * y_scale + y_centre
+                x_hat = x_hat_scaled * x_scale + x_centre
+                residuals_y = y_test - y_hat
+                press_y[a - 1] += np.nansum(residuals_y ** 2, axis=0)
                 press_x[a - 1] += np.nansum((x_test - x_hat) ** 2, axis=0)
-                oof[a - 1, test_idx, :] = y_hat
+                per_fold_rmse[a - 1, fold_idx] = np.sqrt(
+                    np.nansum(residuals_y ** 2) / max(1, n_test * M)
+                )
+                if fold_idx < first_repeat_fold_count:
+                    oof[a - 1, test_idx, :] = y_hat
 
-        tss_y = np.nansum((Y.to_numpy() - np.nanmean(Y.to_numpy(), axis=0)) ** 2, axis=0)
-        tss_x = np.nansum((X.to_numpy() - np.nanmean(X.to_numpy(), axis=0)) ** 2, axis=0)
+        # With repeated CV the total PRESS sums residuals across n_repeats
+        # passes over every observation; divide by N_eff = N * n_repeats to
+        # keep the RMSECV scale comparable to a single-pass CV.
+        n_eff = N * max(1, n_folds_total // max(1, first_repeat_fold_count))
+
+        tss_y = np.nansum((y_values - np.nanmean(y_values, axis=0)) ** 2, axis=0)
+        tss_x = np.nansum((x_values - np.nanmean(x_values, axis=0)) ** 2, axis=0)
 
         rmsecv = pd.DataFrame(
-            np.column_stack([np.sqrt(press_y / N), np.sqrt(press_y.sum(axis=1) / (N * M))]),
+            np.column_stack([np.sqrt(press_y / n_eff), np.sqrt(press_y.sum(axis=1) / (n_eff * M))]),
             index=component_index,
-            columns=[*Y.columns, "total"],
+            columns=[*y_columns, "total"],
         )
 
         def _validated_r2(press: np.ndarray, tss: np.ndarray) -> np.ndarray:
-            per_var = np.where(tss > 0, 1.0 - press / tss, np.nan)
-            total = np.where(tss.sum() > 0, 1.0 - press.sum(axis=1) / tss.sum(), np.nan)
+            per_var = np.where(tss > 0, 1.0 - press / (tss * max(1, n_folds_total // first_repeat_fold_count)), np.nan)
+            total = np.where(
+                tss.sum() > 0,
+                1.0 - press.sum(axis=1) / (tss.sum() * max(1, n_folds_total // first_repeat_fold_count)),
+                np.nan,
+            )
             return np.column_stack([per_var, total])
 
         r2y_validated = pd.DataFrame(
             _validated_r2(press_y, tss_y),
             index=component_index,
-            columns=[*Y.columns, "total"],
+            columns=[*y_columns, "total"],
         )
         r2x_validated = pd.DataFrame(
             _validated_r2(press_x, tss_x),
             index=component_index,
-            columns=[*X.columns, "total"],
+            columns=[*x_columns, "total"],
         )
         press = pd.Series(press_y.sum(axis=1), index=component_index, name="PRESS")
 
-        # If every CV fold produced NaN (e.g. zero-variance Y per fold)
-        # ``np.argmin`` warns and returns 0; the silent ``recommended = 1``
-        # was indistinguishable from a legitimate "1 component is best"
-        # result. Raise instead so the caller knows the CV did not converge
-        # to a recommendation. SEC-21 (#270) sub-item 8.
+        per_fold_rmsecv = pd.DataFrame(
+            per_fold_rmse,
+            index=component_index,
+            columns=[f"fold_{i + 1}" for i in range(n_folds_total)],
+        )
+        # Standard error across folds (and repeats). ``ddof=1`` for the
+        # sample SE; with a single fold (n_folds_total == 1) the SE is NaN
+        # and the 1-SE rule degenerates to argmin gracefully.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            se_values = np.nanstd(per_fold_rmse, axis=1, ddof=1) / np.sqrt(
+                np.maximum(1, np.sum(~np.isnan(per_fold_rmse), axis=1))
+            )
+        se_rmsecv = pd.Series(se_values, index=component_index, name="SE(RMSECV)")
+
+        # If every CV fold produced NaN (e.g. zero-variance Y per fold) the
+        # cross-validation never converged to anything we can judge. Raise so
+        # the caller knows, rather than silently returning ``1``.
+        # SEC-21 (#270) sub-item 8.
         total_rmsecv = rmsecv["total"].to_numpy()
         if np.all(np.isnan(total_rmsecv)):
             raise RuntimeError(
@@ -771,16 +931,25 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
                 "no recommendation can be made. Likely cause: a per-fold zero-variance Y "
                 "column, or every fold trivially degenerate."
             )
-        recommended = int(np.nanargmin(total_rmsecv)) + 1
+        recommended = _select_n_components(
+            selection_rule,
+            mean_error=total_rmsecv,
+            se_error=se_values,
+            q2_cumulative=r2y_validated["total"].to_numpy(),
+            min_q2_increase=min_q2_increase,
+        )
         cv_predictions = pd.DataFrame(oof[recommended - 1], index=Y.index, columns=Y.columns)
 
         return Bunch(
             n_components=recommended,
             rmsecv=rmsecv,
+            per_fold_rmsecv=per_fold_rmsecv,
+            se_rmsecv=se_rmsecv,
             r2y_validated=r2y_validated,
             r2x_validated=r2x_validated,
             press=press,
             cv_predictions=cv_predictions,
+            selection_rule=selection_rule,
         )
 
     def score_contributions(

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -37,8 +37,8 @@ from ._common import (
     _select_n_components,
     epsqrt,
 )
-from ._preprocessing import MCUVScaler
 from ._nipals import quick_regress, ssq, terminate_check
+from ._preprocessing import MCUVScaler
 from .plots import (
     coefficient_plot as _coefficient_plot,
 )
@@ -617,7 +617,7 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         return Bunch(scores=scores, hotellings_t2=t2, spe=spe_values, y_hat=y_hat)
 
     @classmethod
-    def select_n_components(  # noqa: C901, PLR0913, PLR0915
+    def select_n_components(  # noqa: C901, PLR0912, PLR0913, PLR0915
         cls,
         X: DataMatrix,
         Y: DataMatrix,

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2278,6 +2278,28 @@ def test_pls_select_n_components_caps_max_components() -> None:
     assert result.n_components <= 23
 
 
+def test_recommend_n_components_one_se_rejects_non_1d() -> None:
+    """2-D mean_error fails fast - the helper is 1-D only."""
+    from process_improve.multivariate._common import _recommend_n_components_one_se
+
+    with pytest.raises(ValueError, match="1-D"):
+        _recommend_n_components_one_se(
+            np.array([[0.5, 0.4], [0.3, 0.2]]),
+            np.array([[0.05, 0.05], [0.05, 0.05]]),
+        )
+
+
+def test_pls_select_n_components_argument_validation() -> None:
+    """The new kwargs validate their inputs up front."""
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame(rng.standard_normal((20, 4)), columns=[f"x{i}" for i in range(4)])
+    Y = pd.DataFrame(rng.standard_normal((20, 1)), columns=["y"])
+    with pytest.raises(ValueError, match=">= 2"):
+        PLS.select_n_components(X, Y, cv=1)
+    with pytest.raises(ValueError, match="n_repeats must be >= 1"):
+        PLS.select_n_components(X, Y, cv=5, n_repeats=0)
+
+
 def test_pls_select_n_components_1se_default_picks_parsimony() -> None:
     """The default (1-SE rule) is more parsimonious than argmin RMSECV on noise-padded data.
 

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2174,17 +2174,21 @@ def test_pls_select_n_components_synthetic() -> None:
     X_s = MCUVScaler().fit_transform(X)
     Y_s = MCUVScaler().fit_transform(Y)
 
-    result = PLS.select_n_components(X_s, Y_s, max_components=10)
+    result = PLS.select_n_components(X_s, Y_s, max_components=10, random_state=0)
 
     assert isinstance(result, Bunch)
     assert set(result.keys()) == {
         "n_components",
         "rmsecv",
+        "per_fold_rmsecv",
+        "se_rmsecv",
         "r2y_validated",
         "r2x_validated",
         "press",
         "cv_predictions",
+        "selection_rule",
     }
+    assert result.selection_rule == "1se"
 
     # The clear RMSECV minimum is at the true rank of 2.
     assert result.n_components == 2
@@ -2263,11 +2267,123 @@ def test_pls_select_n_components_caps_max_components() -> None:
     X_s = MCUVScaler().fit_transform(X)
     Y_s = MCUVScaler().fit_transform(Y)
 
-    # 5-fold CV leaves a training fold of 24 rows, so at most 24 components
-    # can be evaluated despite the absurdly large request.
-    result = PLS.select_n_components(X_s, Y_s, max_components=1000, cv=5)
-    assert len(result.rmsecv) == 24
-    assert result.n_components <= 24
+    # 5-fold CV leaves a training fold of 24 rows; in-fold mean-centring
+    # removes one DoF, so at most 23 components can be evaluated despite the
+    # absurdly large request. (n_repeats=1 keeps the cap-vs-singularity test
+    # focused on the cap; the rank-boundary fit is fragile by nature.)
+    result = PLS.select_n_components(
+        X_s, Y_s, max_components=1000, cv=5, n_repeats=1, random_state=0
+    )
+    assert len(result.rmsecv) == 23
+    assert result.n_components <= 23
+
+
+def test_pls_select_n_components_1se_default_picks_parsimony() -> None:
+    """The default (1-SE rule) is more parsimonious than argmin RMSECV on noise-padded data.
+
+    Eight latent factors of geometrically decaying influence drive Y; later
+    factors contribute progressively less. Argmin chases noise-level
+    improvements; the 1-SE rule should land near the true effective rank.
+    """
+    rng = np.random.default_rng(0)
+    N, K, n_factors = 80, 50, 8
+    scales = np.array([6.0, 5.0, 4.0, 3.0, 2.0, 1.2, 0.8, 0.5])
+    T_true = rng.normal(size=(N, n_factors)) * scales
+    P_true = rng.normal(size=(K, n_factors))
+    X = pd.DataFrame(T_true @ P_true.T + 0.4 * rng.normal(size=(N, K)), columns=[f"x{i}" for i in range(K)])
+    gamma = rng.normal(size=(n_factors, 1))
+    Y = pd.DataFrame(T_true @ gamma + 0.3 * rng.normal(size=(N, 1)), columns=["y"])
+
+    res_1se = PLS.select_n_components(X, Y, max_components=12, cv=7, n_repeats=5, random_state=0)
+    res_min = PLS.select_n_components(
+        X, Y, max_components=12, cv=7, n_repeats=5, random_state=0, selection_rule="min"
+    )
+    assert res_1se.selection_rule == "1se"
+    assert res_min.selection_rule == "min"
+    # The 1-SE rule never picks more components than argmin RMSECV, and on this
+    # noise-padded design it picks meaningfully fewer.
+    assert res_1se.n_components <= res_min.n_components
+    assert res_1se.n_components <= 8
+
+
+def test_pls_select_n_components_repeated_kfold_stability() -> None:
+    """Repeated K-fold gives reproducible answers given a random_state and
+    narrows the per-component standard error as repeats grow."""
+    rng = np.random.default_rng(13)
+    N, K = 50, 12
+    X = pd.DataFrame(rng.standard_normal((N, K)), columns=[f"x{i}" for i in range(K)])
+    beta = rng.standard_normal((K, 1))
+    Y = pd.DataFrame(X.values @ beta + 0.4 * rng.standard_normal((N, 1)), columns=["y"])
+
+    a = PLS.select_n_components(X, Y, max_components=6, cv=5, n_repeats=3, random_state=42)
+    b = PLS.select_n_components(X, Y, max_components=6, cv=5, n_repeats=3, random_state=42)
+    # Same seed -> identical numerical result.
+    np.testing.assert_allclose(a.rmsecv.to_numpy(), b.rmsecv.to_numpy())
+    np.testing.assert_allclose(a.se_rmsecv.to_numpy(), b.se_rmsecv.to_numpy())
+
+    few = PLS.select_n_components(X, Y, max_components=6, cv=5, n_repeats=2, random_state=0)
+    many = PLS.select_n_components(X, Y, max_components=6, cv=5, n_repeats=20, random_state=0)
+    # 2 repeats -> 10 folds; 20 repeats -> 100 folds; SE narrows ~sqrt(10).
+    assert few.per_fold_rmsecv.shape == (6, 10)
+    assert many.per_fold_rmsecv.shape == (6, 100)
+    assert (many.se_rmsecv < few.se_rmsecv).all()
+
+
+def test_pls_select_n_components_in_fold_scaling_no_leakage() -> None:
+    """In-fold scaling is the default; raw, unscaled X/Y produce sensible RMSECV."""
+    rng = np.random.default_rng(99)
+    N, K, n_factors = 40, 8, 3
+    # Low-rank X on an arbitrary, non-zero-mean / non-unit-variance scale; Y
+    # depends on the latent factors plus noise. Keeping K > n_factors and well
+    # under N avoids the rank-boundary fragility this test isn't about.
+    T_true = rng.standard_normal((N, n_factors))
+    P_true = rng.standard_normal((n_factors, K))
+    column_scales = np.array([10.0, 0.1, 100.0, 1.0, 5.0, 0.5, 2.0, 20.0])
+    X_raw = pd.DataFrame(
+        (T_true @ P_true + 0.4 * rng.standard_normal((N, K))) * column_scales + 7.0,
+        columns=[f"x{i}" for i in range(K)],
+    )
+    Y_raw = pd.DataFrame(T_true @ rng.standard_normal((n_factors, 1)) + 0.3 * rng.standard_normal((N, 1)) + 50.0, columns=["y"])
+
+    # Default: scale inside folds. Caller passes raw data.
+    raw = PLS.select_n_components(X_raw, Y_raw, max_components=5, cv=5, n_repeats=4, random_state=0)
+    # RMSECV is reported on the original Y scale.
+    assert (raw.rmsecv["total"] > 0).all()
+    assert raw.cv_predictions.shape == (N, 1)
+    # First-repeat predictions cover every row.
+    assert not raw.cv_predictions.isna().any().any()
+
+    # Opt-out: scale outside, warn, and reproduce the leakage-prone path.
+    X_s = MCUVScaler().fit_transform(X_raw)
+    Y_s = MCUVScaler().fit_transform(Y_raw)
+    with pytest.warns(SpecificationWarning, match="leaks"):
+        leaky = PLS.select_n_components(
+            X_s, Y_s, max_components=5, cv=5, n_repeats=4, random_state=0,
+            scale_inside_folds=False,
+        )
+    # Both runs choose sensible component counts under the 1-SE default.
+    assert 1 <= raw.n_components <= 5
+    assert 1 <= leaky.n_components <= 5
+
+
+def test_pls_select_n_components_q2_increment_rule() -> None:
+    """The Q2-increment rule (from PR #371) is preserved as an opt-in."""
+    rng = np.random.default_rng(2025)
+    N, K = 60, 20
+    T = rng.standard_normal((N, 3)) * np.array([5.0, 3.0, 1.5])
+    P = rng.standard_normal((3, K))
+    X = pd.DataFrame(T @ P + 0.3 * rng.standard_normal((N, K)), columns=[f"x{i}" for i in range(K)])
+    Y = pd.DataFrame(T @ rng.standard_normal((3, 1)) + 0.2 * rng.standard_normal((N, 1)), columns=["y"])
+    res = PLS.select_n_components(
+        X, Y, max_components=8, cv=5, n_repeats=3, random_state=0,
+        selection_rule="q2_increment", min_q2_increase=0.02,
+    )
+    assert res.selection_rule == "q2_increment"
+    assert 1 <= res.n_components <= 4
+
+    # Unknown rule -> ValueError from the dispatcher.
+    with pytest.raises(ValueError, match="Unknown selection_rule"):
+        PLS.select_n_components(X, Y, max_components=3, cv=3, selection_rule="bogus")  # type: ignore[arg-type]
 
 
 def test_recommend_n_components_q2_rule() -> None:

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2308,7 +2308,8 @@ def test_pls_select_n_components_1se_default_picks_parsimony() -> None:
 
 def test_pls_select_n_components_repeated_kfold_stability() -> None:
     """Repeated K-fold gives reproducible answers given a random_state and
-    narrows the per-component standard error as repeats grow."""
+    narrows the per-component standard error as repeats grow.
+    """
     rng = np.random.default_rng(13)
     N, K = 50, 12
     X = pd.DataFrame(rng.standard_normal((N, K)), columns=[f"x{i}" for i in range(K)])
@@ -2343,7 +2344,10 @@ def test_pls_select_n_components_in_fold_scaling_no_leakage() -> None:
         (T_true @ P_true + 0.4 * rng.standard_normal((N, K))) * column_scales + 7.0,
         columns=[f"x{i}" for i in range(K)],
     )
-    Y_raw = pd.DataFrame(T_true @ rng.standard_normal((n_factors, 1)) + 0.3 * rng.standard_normal((N, 1)) + 50.0, columns=["y"])
+    Y_raw = pd.DataFrame(
+        T_true @ rng.standard_normal((n_factors, 1)) + 0.3 * rng.standard_normal((N, 1)) + 50.0,
+        columns=["y"],
+    )
 
     # Default: scale inside folds. Caller passes raw data.
     raw = PLS.select_n_components(X_raw, Y_raw, max_components=5, cv=5, n_repeats=4, random_state=0)

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2270,6 +2270,76 @@ def test_pls_select_n_components_caps_max_components() -> None:
     assert result.n_components <= 24
 
 
+def test_recommend_n_components_q2_rule() -> None:
+    """Q2-increment helper stops at the first non-meaningful component."""
+    from process_improve.multivariate._common import (
+        Q2_MIN_INCREMENT,
+        _recommend_n_components_q2,
+    )
+
+    # Two systematic components, then a plateau and a drop: stop at 2.
+    assert _recommend_n_components_q2([0.40, 0.62, 0.625, 0.50]) == 2
+    # A single strong component then a fractional (noise-level) gain: stop at 1.
+    assert _recommend_n_components_q2([0.55, 0.553]) == 1
+    # Monotonically improving but each step below the threshold: still stop at 1.
+    assert _recommend_n_components_q2([0.30, 0.305, 0.309, 0.312]) == 1
+    # NaN stops the search.
+    assert _recommend_n_components_q2([0.4, np.nan, 0.9]) == 1
+    # min_increment=0 reproduces the permissive "any improvement" behaviour.
+    assert _recommend_n_components_q2([0.30, 0.305, 0.309, 0.312], min_increment=0.0) == 4
+    # A larger threshold is more conservative.
+    assert _recommend_n_components_q2([0.40, 0.62, 0.70], min_increment=0.1) == 2
+    assert Q2_MIN_INCREMENT == 0.01
+
+
+def test_recommend_n_components_one_se_rule() -> None:
+    """1-SE helper picks the smallest model within one SE of the best."""
+    from process_improve.multivariate._common import _recommend_n_components_one_se
+
+    # Argmin is at 3; SE at the argmin is 0.05; components 2 and 3 both lie at
+    # or below 0.40 + 0.05 = 0.45, so the parsimonious 2 wins.
+    mean = [0.60, 0.42, 0.40, 0.41, 0.40, 0.405]
+    se = [0.04, 0.03, 0.05, 0.05, 0.05, 0.05]
+    assert _recommend_n_components_one_se(mean, se) == 2
+
+    # If only the argmin itself is within 1 SE, the 1-SE rule returns argmin.
+    mean = [0.80, 0.70, 0.40, 0.55]
+    se = [0.02, 0.02, 0.02, 0.02]
+    assert _recommend_n_components_one_se(mean, se) == 3
+
+    # A degenerate (zero) SE collapses to argmin.
+    assert _recommend_n_components_one_se([0.5, 0.4, 0.3], [0.0, 0.0, 0.0]) == 3
+
+    # NaN entries in mean_error are skipped, not allowed to win.
+    assert _recommend_n_components_one_se([0.5, np.nan, 0.4, 0.41], [0.05, np.nan, 0.05, 0.05]) == 3
+
+    # All-NaN input falls back to 1 (callers should have raised already).
+    assert _recommend_n_components_one_se([np.nan, np.nan], [np.nan, np.nan]) == 1
+
+    with pytest.raises(ValueError, match="same shape"):
+        _recommend_n_components_one_se([0.4, 0.3], [0.05])
+
+
+def test_select_n_components_dispatcher() -> None:
+    """The selection-rule dispatcher routes to the right helper and validates inputs."""
+    from process_improve.multivariate._common import _select_n_components
+
+    mean = [0.60, 0.42, 0.40, 0.41]
+    se = [0.03, 0.03, 0.05, 0.05]
+    q2 = [0.30, 0.62, 0.625, 0.50]
+
+    assert _select_n_components("min", mean_error=mean) == 3
+    assert _select_n_components("1se", mean_error=mean, se_error=se) == 2
+    assert _select_n_components("q2_increment", mean_error=mean, q2_cumulative=q2) == 2
+
+    with pytest.raises(ValueError, match="standard errors"):
+        _select_n_components("1se", mean_error=mean)
+    with pytest.raises(ValueError, match="Q\\^2 curve"):
+        _select_n_components("q2_increment", mean_error=mean)
+    with pytest.raises(ValueError, match="Unknown selection_rule"):
+        _select_n_components("not_a_rule", mean_error=mean)  # type: ignore[arg-type]
+
+
 def test_not_enough_variance_error_is_typed_and_runtimeerror() -> None:
     """Rank overflow raises NotEnoughVarianceError, still catchable as RuntimeError."""
     # NotEnoughVarianceError subclasses RuntimeError so existing broad


### PR DESCRIPTION
## Summary

Step up the cross-validation capability of `PLS.select_n_components`, based on the research summary in [this chat session](https://claude.ai/code/session_01CD8jKbCmCEsa3qN8XGcRcs).

Supersedes #371. PR #371 changes the selection rule on top of a CV pipeline that has two larger problems the research flagged - (1) no per-fold standard error, so the 1-SE rule (Breiman et al. 1984; Hastie/Tibshirani/Friedman *ESL* sec.7.10) is not available; (2) centring/scaling fitted on the full dataset, leaking test information into every fold. For PCA, the research is also clear that the existing row-wise CV scheme is invalid (Bro, Kjeldahl, Smilde & Kiers 2008 - the trivial-fit problem); a stricter selection rule on top of an invalid PRESS curve masks the symptom but does not fix the cause. This PR rebuilds the PLS side; PCA stays unchanged here and gets a follow-up issue for the ekf rewrite (#377).

## What this PR does

- [x] Adds `_recommend_n_components_one_se`, `_recommend_n_components_q2`, `_select_n_components` helpers in `_common.py`, with unit tests.
- [x] Rebuilds `PLS.select_n_components` fold loop: per-fold RMSE tracking, dispatcher on `selection_rule` (`"1se"` default, `"min"` / `"q2_increment"` opt-in).
- [x] Adds repeated K-fold support (`n_repeats` default 10 when `cv` is an `int`, `random_state`); surfaces `per_fold_rmsecv` and `se_rmsecv` on the result.
- [x] Fits `MCUVScaler` inside each train fold by default (`scale_inside_folds=True`) and inverse-transforms predictions so RMSECV is reported on the original Y scale. Opt-out emits a `SpecificationWarning`.
- [x] Adds a `.. warning::` block on `PCA.select_n_components` flagging the trivial-fit limitation and pointing at #377.
- [x] Version bumped 1.27.1 -> 1.28.0; `CITATION.cff` and `CHANGELOG.md` updated; ruff clean.

## Follow-up issues opened (out of scope for this PR)

- #377 - Replace row-wise PCA CV with element-wise k-fold (ekf) per Bro 2008.
- #378 - Add Minka MLE and Horn parallel analysis as PCA component-count cross-checks.
- #379 - Add Van der Voet's randomization test as a PLS selection rule.
- #380 - Stability selection: report the distribution of chosen component count across CV repeats.
- #381 - Add nested CV for an honest, optimism-free PLS performance estimate.
- #382 - Port these CV upgrades to `PCA.select_n_components` (after #377 lands).
- #383 - Verify and document sklearn `Pipeline` / `GridSearchCV` interop for `MCUVScaler` + `PCA` / `PLS`.

## Test plan

- [x] `pytest tests/test_multivariate.py -v -k "select_n_components or recommend_n_components or dispatcher" -o "addopts="` - 12 passed locally.
- [x] Full multivariate suite green locally: `pytest tests/test_multivariate.py -o "addopts="` (137 passed, 1 skipped).
- [x] `ruff check .` clean.
- [ ] CI green on push (lint failure on a prior commit fixed in 4baeadf).

https://claude.ai/code/session_01CD8jKbCmCEsa3qN8XGcRcs