### PR TITLE
Port repeated K-fold + in-fold scaling from PR #376 to PCA ekf CV (closes #382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ those changes.
 
 ## [Unreleased]
 
+## [1.30.0] - 2026-06-07
+
+### Changed
+
+- **`PCA.select_n_components` (under `cv_scheme="ekf"`) gains repeated-CV
+  averaging and in-fold scaling**, finishing the port of PR #376's PLS CV
+  upgrades to PCA.
+  - New `n_repeats` kwarg (default `1`). Each repeat re-shuffles the
+    element-fold permutation and contributes a fresh batch of
+    per-fold PRESS columns; the pooled PRESS is averaged across repeats
+    so it stays on the per-cell scale. `n_repeats > 1` narrows the
+    per-component standard error (helpful on borderline 1-SE
+    selections) at roughly linear extra runtime.
+  - New `scale_inside_folds` kwarg (default `True`). Mean-centring and
+    unit-variance scaling constants are now fit per-column on each
+    fold's in-fold cells and applied to the whole matrix before EM,
+    removing the centring/scaling leakage of the prior implementation.
+    Set to `False` to reproduce the previous behaviour (the column mean
+    is recomputed each EM iteration from the imputed matrix; no unit-
+    variance scaling).
+  - Callers who relied on the prior contract ("X must be pre-scaled,
+    EM recomputes centring each iteration") can opt in via
+    `scale_inside_folds=False`; the pre-existing scaled-input flow keeps
+    working without code changes because per-fold MCUVScaler on already-
+    centred-and-scaled data is approximately a no-op.
+
 ## [1.29.0] - 2026-06-07
 
 ### Changed
@@ -1554,7 +1580,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.29.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.30.0...HEAD
+[1.30.0]: https://github.com/kgdunn/process-improve/compare/v1.29.0...v1.30.0
 [1.29.0]: https://github.com/kgdunn/process-improve/compare/v1.28.0...v1.29.0
 [1.28.0]: https://github.com/kgdunn/process-improve/compare/v1.27.1...v1.28.0
 [1.27.1]: https://github.com/kgdunn/process-improve/compare/v1.27.0...v1.27.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.29.0
+version: 1.30.0
 date-released: "2026-06-07"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.29.0"
+version = "1.30.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -144,12 +144,13 @@ def _pca_ekf_press(  # noqa: PLR0913, PLR0915, PLR0912, C901
                 fold_counter += 1
                 continue
 
-            # Fit per-column centring/scaling on the in-fold cells. With
-            # scale_inside_folds=False the constants degenerate to (0, 1) and
-            # the algorithm reduces to the prior behaviour.
+            # Fit per-column centring/scaling on the in-fold cells. Only
+            # consumed under scale_inside_folds=True; the False path uses
+            # in_fold_vals.mean() for the initial imputation and recomputes
+            # the column mean inside EM, so we skip the work here.
+            col_centre = np.zeros(p)
+            col_scale = np.ones(p)
             if scale_inside_folds:
-                col_centre = np.zeros(p)
-                col_scale = np.ones(p)
                 for j in range(p):
                     in_fold = X[~mask[:, j], j]
                     if in_fold.size > 1:
@@ -158,9 +159,6 @@ def _pca_ekf_press(  # noqa: PLR0913, PLR0915, PLR0912, C901
                         col_scale[j] = sd if sd > epsqrt else 1.0
                     elif in_fold.size == 1:
                         col_centre[j] = float(in_fold[0])
-            else:
-                col_centre = np.zeros(p)
-                col_scale = np.ones(p)
 
             # Initial imputation in original space: held-out cells take the
             # in-fold column mean (which is ``col_centre`` under

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -38,13 +38,15 @@ from ._nipals import quick_regress, ssq, terminate_check
 logger = logging.getLogger(__name__)
 
 
-def _pca_ekf_press(  # noqa: PLR0913
+def _pca_ekf_press(  # noqa: PLR0913, PLR0915, PLR0912, C901
     X: np.ndarray,
     max_components: int,
     *,
     n_folds: int = 5,
+    n_repeats: int = 1,
     n_iter: int = 50,
     tol: float = 1e-6,
+    scale_inside_folds: bool = True,
     random_state: int | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Element-wise k-fold (ekf) PCA cross-validation.
@@ -62,29 +64,46 @@ def _pca_ekf_press(  # noqa: PLR0913
     Parameters
     ----------
     X : np.ndarray of shape (n_samples, n_features)
-        Data matrix. Should already be on the analysis scale (e.g. mean-
-        centred and unit-variance via :class:`MCUVScaler`).
+        Data matrix. With the default ``scale_inside_folds=True`` the raw
+        unscaled matrix may be passed; with ``False`` the caller is expected
+        to have mean-centred (and usually unit-variance scaled) it.
     max_components : int
         Maximum number of components to evaluate; PRESS is computed for
         ``1 .. max_components``.
     n_folds : int, default 5
         Number of element-folds. Bro 2008 uses 7 as a typical default; 5 is
         a faster choice that still gives a stable curve.
+    n_repeats : int, default 1
+        Number of times to repeat the ekf pass with a fresh random fold
+        permutation. Each repeat covers every cell exactly once; ``n_repeats
+        > 1`` averages over different element-fold partitions, narrowing
+        the per-component PRESS standard error at extra runtime.
     n_iter : int, default 50
         Maximum number of EM iterations per fold and component count.
     tol : float, default 1e-6
         Relative change in the held-out cell predictions below which EM
         stops early.
+    scale_inside_folds : bool, default True
+        If True, fit per-column mean and unit-variance constants on each
+        fold's in-fold cells and apply them to the whole matrix before
+        running EM; predictions are inverse-transformed before PRESS is
+        accumulated. This removes the centring/scaling leakage of the
+        previous default (which used a single set of constants iteratively
+        recomputed from the imputed matrix). If False, the scheme reverts
+        to the prior behaviour (caller is responsible for scaling, and the
+        in-loop column-mean is allowed to drift with the EM imputation).
     random_state : int, optional
-        Seed for the element-fold permutation, for reproducibility.
+        Seed for the element-fold permutation, for reproducibility across
+        repeats.
 
     Returns
     -------
     press : np.ndarray of shape (max_components,)
-        Pooled PRESS per component count.
-    per_fold_press : np.ndarray of shape (max_components, n_folds)
-        Per-fold PRESS contributions; columns sum to ``press`` and drive
-        the 1-SE rule's standard error.
+        Per-cell PRESS per component count, averaged over ``n_repeats``
+        passes so the scale is comparable to a single-pass run.
+    per_fold_press : np.ndarray of shape (max_components, n_folds * n_repeats)
+        Per-fold PRESS contributions across every fold of every repeat;
+        drives the 1-SE rule's standard error.
 
     References
     ----------
@@ -100,62 +119,99 @@ def _pca_ekf_press(  # noqa: PLR0913
     n, p = X.shape
     rng = np.random.default_rng(random_state)
 
-    # Element-fold assignment: a balanced permutation so every fold has
-    # ~n*p/n_folds cells (not all the same column, not all the same row).
+    total_folds = n_folds * n_repeats
+    per_fold_press = np.zeros((max_components, total_folds))
+    fold_counter = 0
+
     n_cells = n * p
-    perm = rng.permutation(n_cells)
-    fold = np.empty(n_cells, dtype=np.int64)
     fold_size = n_cells // n_folds
-    for k in range(n_folds):
-        start = k * fold_size
-        end = (k + 1) * fold_size if k < n_folds - 1 else n_cells
-        fold[perm[start:end]] = k
-    fold = fold.reshape(n, p)
 
-    per_fold_press = np.zeros((max_components, n_folds))
+    for _ in range(n_repeats):
+        # Assign cells to folds via a balanced random permutation so every
+        # fold has ~n*p/n_folds cells (not all the same column, not the
+        # same row).
+        perm = rng.permutation(n_cells)
+        fold = np.empty(n_cells, dtype=np.int64)
+        for k in range(n_folds):
+            start = k * fold_size
+            end = (k + 1) * fold_size if k < n_folds - 1 else n_cells
+            fold[perm[start:end]] = k
+        fold = fold.reshape(n, p)
 
-    for k in range(n_folds):
-        mask = fold == k  # (n, p) bool, True where the cell is held out
-        if not mask.any():
-            continue
-        # Initial imputation: in-fold column means. A column where every cell
-        # is held out (degenerate; very rare with n_folds > 1 unless p < n_folds)
-        # is initialised to zero, which is the centred column mean.
-        Xtr = X.copy()
-        for j in range(p):
-            m_j = mask[:, j]
-            if m_j.any():
-                in_fold_vals = X[~m_j, j]
-                Xtr[m_j, j] = in_fold_vals.mean() if in_fold_vals.size > 0 else 0.0
+        for k in range(n_folds):
+            mask = fold == k  # (n, p) bool, True where the cell is held out
+            if not mask.any():
+                fold_counter += 1
+                continue
 
-        # For this fold, refine the imputation for each component count
-        # *separately*: lower a's converge to a coarser reconstruction than
-        # higher a's, and chaining them would couple their errors.
-        for a in range(1, max_components + 1):
-            Xa = Xtr.copy()
-            prev_held = Xa[mask].copy()
-            for _ in range(n_iter):
-                col_mean = Xa.mean(axis=0)
-                Xc = Xa - col_mean
-                # SciPy / NumPy SVD: economical (full_matrices=False).
-                _, S, Vt = np.linalg.svd(Xc, full_matrices=False)
-                # Re-project Xc onto its rank-a truncation. Using ``Xc @ Vt[:a].T``
-                # rather than ``U[:, :a] * S[:a]`` is mathematically identical
-                # for the truncated SVD but slightly more numerically stable
-                # when later S values are small.
-                rank = min(a, S.shape[0])
-                recon_centred = (Xc @ Vt[:rank].T) @ Vt[:rank]
-                recon = recon_centred + col_mean
-                Xa[mask] = recon[mask]
-                delta = np.linalg.norm(Xa[mask] - prev_held)
-                scale = max(1.0, float(np.linalg.norm(prev_held)))
-                if delta < tol * scale:
-                    break
+            # Fit per-column centring/scaling on the in-fold cells. With
+            # scale_inside_folds=False the constants degenerate to (0, 1) and
+            # the algorithm reduces to the prior behaviour.
+            if scale_inside_folds:
+                col_centre = np.zeros(p)
+                col_scale = np.ones(p)
+                for j in range(p):
+                    in_fold = X[~mask[:, j], j]
+                    if in_fold.size > 1:
+                        col_centre[j] = float(in_fold.mean())
+                        sd = float(in_fold.std(ddof=1))
+                        col_scale[j] = sd if sd > epsqrt else 1.0
+                    elif in_fold.size == 1:
+                        col_centre[j] = float(in_fold[0])
+            else:
+                col_centre = np.zeros(p)
+                col_scale = np.ones(p)
+
+            # Initial imputation in original space: held-out cells take the
+            # in-fold column mean (which is ``col_centre`` under
+            # ``scale_inside_folds=True``, and the same value under False).
+            Xtr = X.copy()
+            for j in range(p):
+                m_j = mask[:, j]
+                if m_j.any():
+                    if scale_inside_folds:
+                        Xtr[m_j, j] = col_centre[j]
+                    else:
+                        in_fold_vals = X[~m_j, j]
+                        Xtr[m_j, j] = in_fold_vals.mean() if in_fold_vals.size > 0 else 0.0
+
+            for a in range(1, max_components + 1):
+                Xa = Xtr.copy()
                 prev_held = Xa[mask].copy()
+                for _iteration in range(n_iter):
+                    if scale_inside_folds:
+                        # Centre and scale by the FIXED in-fold constants; the
+                        # in-fold cells now sit on the analysis scale and the
+                        # held-out cells move under EM.
+                        Xs = (Xa - col_centre) / col_scale
+                        _, S, Vt = np.linalg.svd(Xs, full_matrices=False)
+                        rank = min(a, S.shape[0])
+                        recon_s = (Xs @ Vt[:rank].T) @ Vt[:rank]
+                        recon = recon_s * col_scale + col_centre
+                    else:
+                        # Prior behaviour: recompute the column mean each
+                        # iteration. The mean drifts slightly as the held-out
+                        # cells are updated.
+                        col_mean = Xa.mean(axis=0)
+                        Xc = Xa - col_mean
+                        _, S, Vt = np.linalg.svd(Xc, full_matrices=False)
+                        rank = min(a, S.shape[0])
+                        recon_centred = (Xc @ Vt[:rank].T) @ Vt[:rank]
+                        recon = recon_centred + col_mean
+                    Xa[mask] = recon[mask]
+                    delta = np.linalg.norm(Xa[mask] - prev_held)
+                    scale = max(1.0, float(np.linalg.norm(prev_held)))
+                    if delta < tol * scale:
+                        break
+                    prev_held = Xa[mask].copy()
 
-            per_fold_press[a - 1, k] = float(np.sum((X[mask] - Xa[mask]) ** 2))
+                per_fold_press[a - 1, fold_counter] = float(
+                    np.sum((X[mask] - Xa[mask]) ** 2)
+                )
+            fold_counter += 1
 
-    press = per_fold_press.sum(axis=1)
+    # Average over repeats so PRESS stays on the per-cell scale.
+    press = per_fold_press.sum(axis=1) / max(1, n_repeats)
     return press, per_fold_press
 
 
@@ -692,8 +748,10 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         max_components: int | None = None,
         cv: int | BaseCrossValidator = 5,
         cv_scheme: typing.Literal["row_wise", "ekf"] = "ekf",
+        n_repeats: int = 1,
         selection_rule: SelectionRule = "min",
         min_q2_increase: float = Q2_MIN_INCREMENT,
+        scale_inside_folds: bool = True,
         n_iter: int = 50,
         tol: float = 1e-6,
         random_state: int | None = None,
@@ -730,6 +788,13 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             ``"row_wise"`` scheme is preserved for back-compat but emits a
             :class:`SpecificationWarning` because it over-selects (see the
             warning admonition below).
+        n_repeats : int, default 1
+            Repeat the ekf pass with a fresh random fold permutation this
+            many times. Each repeat covers every cell exactly once;
+            ``n_repeats > 1`` narrows the per-component PRESS standard
+            error (helpful when the 1-SE rule sits on a borderline) at
+            roughly linear extra runtime. Ignored under
+            ``cv_scheme="row_wise"``.
         selection_rule : {"min", "1se", "q2_increment"}, default "min"
             How the recommended component count is chosen. ``"min"`` is the
             GlobalMin criterion Bro 2008 pairs with ekf - the component
@@ -740,6 +805,15 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             sets the threshold.
         min_q2_increase : float, default 0.01
             Threshold used only when ``selection_rule="q2_increment"``.
+        scale_inside_folds : bool, default True
+            With the default, mean-centring and unit-variance scaling
+            constants are fit on each fold's in-fold cells and applied to
+            the whole matrix before EM, removing the centring/scaling
+            leakage of the prior implementation. Set to ``False`` to
+            reproduce the previous behaviour (column mean recomputed each
+            EM iteration from the imputed matrix, no scaling); this is
+            useful only when ``X`` is already pre-scaled. Ignored under
+            ``cv_scheme="row_wise"``.
         n_iter, tol : int and float, default 50 and 1e-6
             EM iteration cap and convergence tolerance for the ekf imputation
             step. Ignored under ``cv_scheme="row_wise"``.
@@ -827,19 +901,25 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
 
         if cv_scheme == "ekf":
             n_folds = cv if isinstance(cv, int) else 5
+            if n_repeats < 1:
+                raise ValueError(f"n_repeats must be >= 1; got {n_repeats}.")
             press_arr, per_fold_press_arr = _pca_ekf_press(
                 X_arr,
                 max_components,
                 n_folds=n_folds,
+                n_repeats=n_repeats,
                 n_iter=n_iter,
                 tol=tol,
+                scale_inside_folds=scale_inside_folds,
                 random_state=random_state,
             )
             press = pd.Series(press_arr, index=component_index, name="PRESS")
             per_fold_press = pd.DataFrame(
                 per_fold_press_arr,
                 index=component_index,
-                columns=[f"fold_{i + 1}" for i in range(n_folds)],
+                columns=[
+                    f"fold_{i + 1}" for i in range(per_fold_press_arr.shape[1])
+                ],
             )
             cv_scores = per_fold_press
             # Q^2 normalisation: total sum-of-squares of X (the null-model

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -788,6 +788,61 @@ def test_pca_select_n_components_rule_dispatch() -> None:
         PCA.select_n_components(X_s, max_components=3, cv=3, cv_scheme="bogus")  # type: ignore[arg-type]
 
 
+def test_pca_select_n_components_n_repeats_narrows_se() -> None:
+    """Repeated ekf gives reproducible answers and a narrower per-component SE."""
+    rng = np.random.default_rng(2026)
+    N, K, true_rank = 50, 25, 3
+    T = rng.standard_normal((N, true_rank)) * np.array([6.0, 4.0, 2.5])
+    P = rng.standard_normal((true_rank, K))
+    X = pd.DataFrame(T @ P + 0.4 * rng.standard_normal((N, K)))
+    X_s = MCUVScaler().fit_transform(X)
+
+    one = PCA.select_n_components(X_s, max_components=8, cv=5, n_repeats=1, random_state=0)
+    many = PCA.select_n_components(X_s, max_components=8, cv=5, n_repeats=8, random_state=0)
+    # 1 repeat -> 5 fold columns; 8 repeats -> 40.
+    assert one.per_fold_press.shape == (8, 5)
+    assert many.per_fold_press.shape == (8, 40)
+    # PRESS stays on the per-cell scale (averaged over repeats).
+    assert (many.press > 0).all()
+    # SE narrows with more repeats (more samples of fold-PRESS).
+    assert (many.se_press <= one.se_press + 1e-9).all()
+    # Reproducible given a fixed seed.
+    again = PCA.select_n_components(X_s, max_components=8, cv=5, n_repeats=8, random_state=0)
+    np.testing.assert_allclose(many.press.to_numpy(), again.press.to_numpy())
+    np.testing.assert_allclose(many.per_fold_press.to_numpy(), again.per_fold_press.to_numpy())
+
+    with pytest.raises(ValueError, match="n_repeats must be >= 1"):
+        PCA.select_n_components(X_s, max_components=3, cv=3, n_repeats=0)
+
+
+def test_pca_select_n_components_scale_inside_folds_no_leakage() -> None:
+    """In-fold scaling lets the caller pass raw (unscaled) X without leakage."""
+    rng = np.random.default_rng(0)
+    N, K, true_rank = 40, 12, 2
+    T = rng.standard_normal((N, true_rank))
+    P = rng.standard_normal((true_rank, K))
+    # X on an arbitrary, non-zero-mean / non-unit-variance scale per column.
+    column_scales = np.array([10.0, 0.1, 100.0, 1.0, 5.0, 0.5, 2.0, 20.0, 0.3, 7.0, 1.5, 0.05])
+    X_raw = pd.DataFrame(
+        (T @ P + 0.3 * rng.standard_normal((N, K))) * column_scales + 5.0,
+    )
+
+    # Default: scale inside folds. Caller passes the raw matrix.
+    raw = PCA.select_n_components(X_raw, max_components=6, cv=5, n_repeats=2, random_state=0)
+    assert (raw.press > 0).all()
+    assert 1 <= raw.n_components <= 6
+
+    # Opt-out path: caller pre-scales (the prior contract) and asks for the
+    # legacy iterative-recentering EM behaviour. Both should converge to a
+    # comparable recommendation on this clean low-rank data.
+    X_s = MCUVScaler().fit_transform(X_raw)
+    legacy = PCA.select_n_components(
+        X_s, max_components=6, cv=5, n_repeats=2, random_state=0,
+        scale_inside_folds=False,
+    )
+    assert 1 <= legacy.n_components <= 6
+
+
 def test_pca_score_contributions() -> None:
     """Test score_contributions method on a simple dataset."""
     rng = np.random.default_rng(42)


### PR DESCRIPTION
Closes #382.

## Summary

Finishes the PCA CV story started in #384 (which landed the ekf algorithm itself). Brings `PCA.select_n_components` to feature parity with `PLS.select_n_components` from PR #376: repeated-K-fold averaging for narrower 1-SE bands, and in-fold MCUVScaler so callers can pass raw unscaled `X` without leaking centring/scaling estimates into the folds.

## What changes

- **`_pca_ekf_press` gains `n_repeats` (default 1) and `scale_inside_folds` (default True)**:
  - `n_repeats > 1` reshuffles the element-fold permutation each pass; per-fold PRESS columns are concatenated, pooled PRESS is averaged over passes so it stays on the per-cell scale.
  - `scale_inside_folds=True` fits per-column mean+std on each fold's in-fold cells, applies them to the whole matrix before EM, inverse-transforms predictions before PRESS accumulates. Removes the centring/scaling leakage of the prior implementation. `False` reproduces the previous behaviour.
- **`PCA.select_n_components` surfaces both kwargs** and validates `n_repeats >= 1`. Docstring updated.

## Test plan

- [x] New: `n_repeats` narrows `se_press`, runs reproducible given `random_state`, per-fold column count is `n_folds * n_repeats`; `ValueError` raised for `n_repeats < 1`.
- [x] New: raw (unscaled) `X` passes cleanly under default `scale_inside_folds=True`; the `False` path still works on pre-scaled `X`.
- [x] All 5 pre-existing PCA `select_n_components` tests still pass without modification.
- [x] Full multivariate suite green (`145 passed, 1 skipped`).
- [x] `ruff check .` clean.

## Backwards compat

Pre-scaled callers (the prior contract) are unaffected: per-fold MCUVScaler on already-MCUV-scaled data is approximately a no-op, so RMSECV/PRESS shifts are within numerical noise.

## Cross-validation follow-ups still open

- #378 Minka MLE + Horn parallel analysis cross-checks (now unblocked - both #377 and #382 done)
- #379 Van der Voet randomization test for PLS
- #380 Stability selection
- #381 Nested CV
- #383 sklearn Pipeline interop verification

https://claude.ai/code/session_01CD8jKbCmCEsa3qN8XGcRcs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GygLHnZrhbRXYj7JsPu1hL)_