### PR TITLE
Add Minka MLE and Horn parallel analysis as PCA cross-checks (closes #378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ those changes.
 
 ## [Unreleased]
 
+## [1.31.0] - 2026-06-07
+
+### Added
+
+- **`PCA.minka_mle(X)`** classmethod: Minka (2000) automatic-dimensionality
+  estimate via the PPCA evidence (Laplace approximation on the covariance
+  eigenvalues). Cheap closed-form cross-check for the ekf-CV
+  recommendation. Mean-centres `X` internally but does *not* unit-variance
+  scale, because the MLE's eigenvalue model misreads scaled noise as
+  additional signal.
+- **`PCA.parallel_analysis(X)`** classmethod: Horn (1965) parallel
+  analysis. Generates `n_simulations` random matrices of the same shape,
+  retains every observed component whose eigenvalue exceeds the
+  `quantile` (default 95th-percentile) of the null distribution at the
+  same rank. Returns a Bunch with the observed eigenvalues and null
+  threshold so callers can inspect the spectrum.
+- **`PCA.select_n_components(..., return_consensus=True)`**: alongside
+  the ekf recommendation, also reports Minka MLE and Horn parallel
+  analysis counts on the returned Bunch as `minka_n_components`,
+  `parallel_analysis_n_components`, `consensus_counts` (3-tuple) and
+  `consensus` (`"agree"` when all three counts sit within 1 of each other,
+  `"disagree"` otherwise). A clean low-rank dataset typically returns
+  `consensus="agree"`; downstream tooling can use that as a high-
+  confidence signal and route disagreements to human review.
+
 ## [1.30.0] - 2026-06-07
 
 ### Changed
@@ -1580,7 +1605,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.30.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.31.0...HEAD
+[1.31.0]: https://github.com/kgdunn/process-improve/compare/v1.30.0...v1.31.0
 [1.30.0]: https://github.com/kgdunn/process-improve/compare/v1.29.0...v1.30.0
 [1.29.0]: https://github.com/kgdunn/process-improve/compare/v1.28.0...v1.29.0
 [1.28.0]: https://github.com/kgdunn/process-improve/compare/v1.27.1...v1.28.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.30.0
+version: 1.31.0
 date-released: "2026-06-07"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.30.0"
+version = "1.31.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -17,6 +17,7 @@ import warnings
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin, _fit_context
+from sklearn.decomposition import PCA as _SkPCA  # noqa: N811
 from sklearn.model_selection import BaseCrossValidator, cross_val_score
 from sklearn.utils import Bunch
 from sklearn.utils.validation import check_is_fitted
@@ -34,6 +35,7 @@ from ._common import (
     epsqrt,
 )
 from ._nipals import quick_regress, ssq, terminate_check
+from ._preprocessing import MCUVScaler
 
 logger = logging.getLogger(__name__)
 
@@ -739,7 +741,158 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         return -float(np.mean(residuals**2))
 
     @classmethod
-    def select_n_components(  # noqa: PLR0913, PLR0915
+    def minka_mle(cls, X: DataMatrix) -> int:
+        """Minka (2000) automatic-dimensionality estimate for PCA.
+
+        Closed-form Bayesian model selection on the PPCA evidence (Minka,
+        T. P. 2000. *Automatic Choice of Dimensionality for PCA*. NIPS 13,
+        pp. 598-604). Operates only on the covariance eigenvalues of ``X``
+        and is therefore very cheap; in the simulations Minka reports it
+        beats cross-validation. Use it alongside the ekf-CV recommendation
+        from :meth:`select_n_components` as a fast cross-check.
+
+        Internally ``X`` is mean-centred before estimation (a PPCA
+        assumption); it is **not** unit-variance scaled, because dividing
+        each column by its standard deviation compresses the noise
+        eigenvalues to near-zero values the MLE misreads as additional
+        latent signal. If your columns are on wildly different scales,
+        pass the analysis-scale ``X`` produced by your own preprocessing
+        (e.g. SNV for spectral data) and accept the centring this method
+        applies.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Data matrix.
+
+        Returns
+        -------
+        n_components : int
+            The MLE estimate of the effective dimensionality.
+
+        References
+        ----------
+        Minka, T. P. (2000). Automatic Choice of Dimensionality for PCA.
+        Advances in Neural Information Processing Systems, 13, 598-604.
+
+        See Also
+        --------
+        parallel_analysis : Horn (1965) eigenvalue-vs-null retention.
+        select_n_components : ekf cross-validation; pass
+            ``return_consensus=True`` to report all three side by side.
+        """
+        if not isinstance(X, pd.DataFrame):
+            X = pd.DataFrame(X)
+        X_arr = np.asarray(X, dtype=float)
+        Xc = X_arr - X_arr.mean(axis=0)
+        # ``svd_solver="full"`` is the only solver that supports
+        # ``n_components="mle"`` in sklearn.
+        sk = _SkPCA(n_components="mle", svd_solver="full")
+        sk.fit(Xc)
+        return int(sk.n_components_)
+
+    @classmethod
+    def parallel_analysis(
+        cls,
+        X: DataMatrix,
+        *,
+        n_simulations: int = 200,
+        quantile: float = 0.95,
+        scale: bool = True,
+        random_state: int | None = None,
+    ) -> Bunch:
+        """Horn (1965) parallel analysis component-count estimate.
+
+        Generates ``n_simulations`` random matrices of the same shape as
+        ``X``, computes their eigenvalues, and retains every observed
+        component whose eigenvalue exceeds the ``quantile`` of the null
+        distribution at the same rank. Widely regarded in psychometrics
+        as the best simple retention rule for PCA.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Data matrix.
+        n_simulations : int, default 200
+            Number of random matrices drawn to build the null
+            eigenvalue distribution.
+        quantile : float, default 0.95
+            Quantile of the null eigenvalues used as the retention
+            threshold. Horn's original proposal was the mean (0.5);
+            the more conservative 95th-percentile threshold is the
+            modern recommendation.
+        scale : bool, default True
+            Mean-centre and unit-variance scale ``X`` before estimation
+            (matches :meth:`minka_mle`).
+        random_state : int, optional
+            Seed for the null-matrix simulations.
+
+        Returns
+        -------
+        result : sklearn.utils.Bunch
+            With keys:
+
+            - ``n_components`` - number of components retained (can be 0
+              on pure noise).
+            - ``observed_eigenvalues`` - eigenvalues of ``X`` after
+              centring/scaling (np.ndarray of length ``min(n, p)``).
+            - ``null_threshold`` - per-rank ``quantile`` of the null
+              eigenvalue distribution (same length as
+              ``observed_eigenvalues``).
+
+        References
+        ----------
+        Horn, J. L. (1965). A rationale and test for the number of
+        factors in factor analysis. *Psychometrika*, 30(2), 179-185.
+
+        See Also
+        --------
+        minka_mle : closed-form PPCA evidence rule.
+        select_n_components : ekf cross-validation; pass
+            ``return_consensus=True`` to report all three side by side.
+        """
+        if not isinstance(X, pd.DataFrame):
+            X = pd.DataFrame(X)
+        if scale:
+            X = MCUVScaler().fit_transform(X)
+        X_arr = np.asarray(X, dtype=float)
+        n, p = X_arr.shape
+        k = min(n, p)
+
+        # Observed eigenvalues from the centred X. Centring removes one DoF
+        # so the smallest singular value is at-or-near zero; that's expected.
+        Xc = X_arr - X_arr.mean(axis=0)
+        _, S, _ = np.linalg.svd(Xc, full_matrices=False)
+        observed = (S**2) / max(1, n - 1)
+
+        rng = np.random.default_rng(random_state)
+        null_eigs = np.zeros((n_simulations, k))
+        for i in range(n_simulations):
+            R = rng.standard_normal((n, p))
+            Rc = R - R.mean(axis=0)
+            _, S_r, _ = np.linalg.svd(Rc, full_matrices=False)
+            null_eigs[i, : S_r.shape[0]] = (S_r**2) / max(1, n - 1)
+
+        null_threshold = np.quantile(null_eigs, quantile, axis=0)
+        # Standard PA: retain consecutive components from the top while
+        # observed > null. Components past the first failure are not
+        # retained even if their observed eigenvalue happens to exceed
+        # the null (a rare numerical coincidence on real data).
+        n_retained = 0
+        for obs, thr in zip(observed, null_threshold, strict=False):
+            if obs > thr:
+                n_retained += 1
+            else:
+                break
+
+        return Bunch(
+            n_components=int(n_retained),
+            observed_eigenvalues=observed,
+            null_threshold=null_threshold,
+        )
+
+    @classmethod
+    def select_n_components(  # noqa: PLR0913, PLR0915, C901
         cls,
         X: DataMatrix,
         *,
@@ -753,6 +906,7 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         n_iter: int = 50,
         tol: float = 1e-6,
         random_state: int | None = None,
+        return_consensus: bool = False,
         threshold: float | None = None,
         **pca_kwargs,
     ) -> Bunch:
@@ -987,6 +1141,24 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             min_q2_increase=min_q2_increase,
         )
 
+        consensus_fields: dict[str, object] = {}
+        if return_consensus:
+            # Two cheap cross-checks: Minka's PPCA MLE (mean-centred input,
+            # no unit-variance scaling) and Horn's parallel analysis (which
+            # accepts the same scaling convention as the rest of the method).
+            minka_n = cls.minka_mle(X)
+            pa_result = cls.parallel_analysis(
+                X, scale=scale_inside_folds, random_state=random_state
+            )
+            counts = (int(recommended), int(minka_n), int(pa_result.n_components))
+            consensus = "agree" if max(counts) - min(counts) <= 1 else "disagree"
+            consensus_fields = {
+                "minka_n_components": int(minka_n),
+                "parallel_analysis_n_components": int(pa_result.n_components),
+                "consensus": consensus,
+                "consensus_counts": counts,
+            }
+
         return Bunch(
             n_components=recommended,
             press=press,
@@ -997,6 +1169,7 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             cv_scores=cv_scores,
             cv_scheme=cv_scheme,
             selection_rule=selection_rule,
+            **consensus_fields,
         )
 
     def score_contributions(

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -843,6 +843,72 @@ def test_pca_select_n_components_scale_inside_folds_no_leakage() -> None:
     assert 1 <= legacy.n_components <= 6
 
 
+def test_pca_minka_mle_recovers_known_rank() -> None:
+    """Minka's MLE picks a plausible rank on clean low-rank data."""
+    rng = np.random.default_rng(1)
+    N, K, true_rank = 60, 25, 3
+    T = rng.standard_normal((N, true_rank)) * np.array([8.0, 5.0, 3.0])
+    P = rng.standard_normal((true_rank, K))
+    X = pd.DataFrame(T @ P + 0.3 * rng.standard_normal((N, K)))
+    # MLE should sit close to the true rank; sklearn is conservative on noisy
+    # data so allow a 2-component slack on either side.
+    n = PCA.minka_mle(X)
+    assert isinstance(n, int)
+    assert true_rank - 1 <= n <= true_rank + 2
+
+
+def test_pca_parallel_analysis_recovers_known_rank() -> None:
+    """Horn's parallel analysis picks the true rank on a clean dataset."""
+    rng = np.random.default_rng(2)
+    N, K, true_rank = 60, 20, 3
+    T = rng.standard_normal((N, true_rank)) * np.array([7.0, 5.0, 3.0])
+    P = rng.standard_normal((true_rank, K))
+    X = pd.DataFrame(T @ P + 0.3 * rng.standard_normal((N, K)))
+    pa = PCA.parallel_analysis(X, n_simulations=100, random_state=0)
+    assert pa.n_components == true_rank
+    assert pa.observed_eigenvalues.shape == (min(N, K),)
+    assert pa.null_threshold.shape == (min(N, K),)
+    # The first ``true_rank`` observed eigenvalues exceed the null.
+    assert (pa.observed_eigenvalues[:true_rank] > pa.null_threshold[:true_rank]).all()
+
+
+def test_pca_parallel_analysis_pure_noise_returns_zero() -> None:
+    """On pure noise PA correctly retains few components (and may return 0)."""
+    rng = np.random.default_rng(3)
+    X = pd.DataFrame(rng.standard_normal((50, 15)))
+    pa = PCA.parallel_analysis(X, n_simulations=100, random_state=0)
+    # On a Gaussian noise matrix the first observed eigenvalue is at or
+    # below the 95th-percentile null - parallel analysis correctly trims to
+    # a handful of components at most.
+    assert pa.n_components <= 1
+
+
+def test_pca_select_n_components_consensus_mode() -> None:
+    """return_consensus=True surfaces Minka MLE + parallel analysis alongside ekf."""
+    rng = np.random.default_rng(4)
+    N, K, true_rank = 60, 20, 3
+    T = rng.standard_normal((N, true_rank)) * np.array([7.0, 5.0, 3.0])
+    P = rng.standard_normal((true_rank, K))
+    X = pd.DataFrame(T @ P + 0.3 * rng.standard_normal((N, K)))
+
+    result = PCA.select_n_components(
+        X, max_components=8, cv=5, n_repeats=2, random_state=0,
+        return_consensus=True,
+    )
+    assert {"minka_n_components", "parallel_analysis_n_components",
+            "consensus", "consensus_counts"} <= set(result.keys())
+    assert result.consensus in {"agree", "disagree"}
+    # On clean low-rank data the three rules should agree.
+    assert result.consensus == "agree"
+    assert result.consensus_counts[0] == result.n_components
+
+    # Backwards compat: without return_consensus the consensus fields are
+    # absent (the existing API is unchanged).
+    plain = PCA.select_n_components(X, max_components=8, cv=5, random_state=0)
+    assert "minka_n_components" not in plain
+    assert "consensus" not in plain
+
+
 def test_pca_score_contributions() -> None:
     """Test score_contributions method on a simple dataset."""
     rng = np.random.default_rng(42)


### PR DESCRIPTION
Closes #378.

## Summary

Two cheap, principled cross-checks for the ekf-CV recommendation, plus a consensus mode that surfaces all three side by side.

## What changes

- **`PCA.minka_mle(X)`** classmethod (Minka 2000, NIPS 13): closed-form Bayesian model selection on the PPCA evidence. Wraps sklearn's `PCA(n_components='mle')`. Mean-centres `X` internally but does **not** unit-variance scale, because that compresses noise eigenvalues to near-zero values the MLE misreads as signal (verified empirically: on a rank-3 dataset, Minka picks 3 on centred-only data but 11 on MCUV-scaled data).
- **`PCA.parallel_analysis(X, *, n_simulations=200, quantile=0.95, scale=True, random_state=None)`** classmethod (Horn 1965): returns a `Bunch` with `n_components`, `observed_eigenvalues`, and per-rank `null_threshold` so callers can inspect the spectrum.
- **`PCA.select_n_components(..., return_consensus=True)`**: also computes Minka and PA, adds `minka_n_components`, `parallel_analysis_n_components`, `consensus_counts` (3-tuple), and `consensus` (`"agree"` iff `max - min <= 1` across the three) to the returned Bunch. Without `return_consensus` the existing API is unchanged.

## Test plan

- [x] `minka_mle` recovers a plausible rank on rank-3 data.
- [x] `parallel_analysis` recovers the true rank on clean low-rank data and retains ≤ 1 component on pure Gaussian noise.
- [x] `return_consensus=True` surfaces all three counts and `consensus="agree"` on clean data; default API has no consensus fields.
- [x] Full multivariate suite green (`149 passed, 1 skipped`).
- [x] `ruff check .` clean.

## Cross-validation follow-ups still open

- #379 Van der Voet randomization test for PLS
- #380 Stability selection
- #381 Nested CV
- #383 sklearn Pipeline interop verification

https://claude.ai/code/session_01CD8jKbCmCEsa3qN8XGcRcs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GygLHnZrhbRXYj7JsPu1hL)_