### PR TITLE
Add Van der Voet's randomization test as a PLS selection rule (closes #379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ those changes.
 
 ## [Unreleased]
 
+## [1.32.0] - 2026-06-07
+
+### Added
+
+- **`PLS.select_n_components(..., selection_rule="randomization")`**:
+  Van der Voet's (1994, *Chemom. Intell. Lab. Syst.* 25(2):313-323)
+  randomization test as a new fourth selection rule, joining `"1se"`,
+  `"min"`, and `"q2_increment"`.
+  - For each candidate model, the paired squared-residual differences
+    against the argmin-RMSECV reference model are randomly sign-flipped
+    `n_permutations` (default 999) times; the right-tail *p*-value is
+    the share of permutation sums at least as large as observed (with
+    the standard `+1`/`+1` correction so *p* is strictly positive).
+  - The smallest component count whose *p*-value exceeds `alpha`
+    (default 0.01, matching R's `pls::selectNcomp`) is recommended -
+    statistically indistinguishable from the best, but more parsimonious.
+  - Smaller `alpha` is more parsimonious; the reference model itself has
+    `p = 1` by construction.
+  - Returned `Bunch` gains `randomization_pvalues` (`pd.Series`,
+    indexed 1..A) when the rule is selected, `None` otherwise.
+
 ## [1.31.0] - 2026-06-07
 
 ### Added
@@ -1605,7 +1626,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.31.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.32.0...HEAD
+[1.32.0]: https://github.com/kgdunn/process-improve/compare/v1.31.0...v1.32.0
 [1.31.0]: https://github.com/kgdunn/process-improve/compare/v1.30.0...v1.31.0
 [1.30.0]: https://github.com/kgdunn/process-improve/compare/v1.29.0...v1.30.0
 [1.29.0]: https://github.com/kgdunn/process-improve/compare/v1.28.0...v1.29.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.31.0
+version: 1.32.0
 date-released: "2026-06-07"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.31.0"
+version = "1.32.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_common.py
+++ b/src/process_improve/multivariate/_common.py
@@ -46,7 +46,15 @@ __all__ = [
 #: ``"q2_increment"`` keeps adding components while each one raises the
 #: cumulative cross-validated :math:`Q^2` by at least ``min_q2_increase``;
 #: it is a Wold's-R-style heuristic with an absolute (not relative) threshold.
-SelectionRule = Literal["1se", "min", "q2_increment"]
+#:
+#: ``"randomization"`` is Van der Voet's (1994, *Chemom. Intell. Lab. Syst.*
+#: 25(2):313-323) randomization test: under the null that two PLS models have
+#: the same predictive ability, randomly flip the sign of each observation's
+#: paired squared-residual difference between a candidate model and the
+#: argmin-RMSECV reference. The smallest model whose *p*-value exceeds
+#: ``alpha`` (i.e. fails to reject the null) is chosen - statistically
+#: indistinguishable from the best, but more parsimonious.
+SelectionRule = Literal["1se", "min", "q2_increment", "randomization"]
 
 #: Default minimum increase in the cross-validated :math:`Q^2` for an extra
 #: component to be judged worth keeping under the ``"q2_increment"`` selection

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -49,6 +49,90 @@ from .plots import (
 logger = logging.getLogger(__name__)
 
 
+def _vandervoet_randomization(
+    per_obs_sse: np.ndarray,
+    *,
+    total_rmsecv: np.ndarray,
+    n_permutations: int = 999,
+    alpha: float = 0.01,
+    random_state: int | None = None,
+) -> tuple[int, np.ndarray]:
+    """Van der Voet (1994) randomization test for PLS component selection.
+
+    Compares every candidate model against the reference (argmin-RMSECV)
+    model under the null that the two have the same predictive ability.
+    For each observation the paired difference of squared residuals
+    ``D_i = sse[a, i] - sse[a*, i]`` is computed; under the null its sign
+    is random, so the permutation distribution of ``T = sum_i D_i`` is
+    obtained by flipping each ``D_i``'s sign with probability 1/2 over
+    ``n_permutations`` draws. The *p*-value is the right-tail probability
+    of seeing a sum as large as the observed one (``T_obs >= T_perm``);
+    the recommendation is the smallest ``a`` whose ``p > alpha`` -
+    statistically indistinguishable from the reference, but more
+    parsimonious.
+
+    Parameters
+    ----------
+    per_obs_sse : np.ndarray of shape (n_components, n_samples)
+        Out-of-fold per-observation squared total residual at every
+        component count, summed across Y columns. Rows that are NaN
+        (observation never held out) are dropped.
+    total_rmsecv : np.ndarray of shape (n_components,)
+        Pooled total RMSECV per component count; used to pick the
+        reference model ``a*`` = ``nanargmin(total_rmsecv) + 1``.
+    n_permutations : int, default 999
+        Number of sign-flip permutations.
+    alpha : float, default 0.01
+        Significance level. Smaller values are more parsimonious.
+    random_state : int, optional
+        Seed for reproducible permutations.
+
+    Returns
+    -------
+    recommended : int
+        Smallest 1-based component count with ``p > alpha``.
+    p_values : np.ndarray of shape (n_components,)
+        Right-tail *p*-value per candidate; the reference model gets
+        ``1.0`` by construction (paired differences are all zero).
+
+    References
+    ----------
+    Van der Voet, H. (1994). Comparing the predictive accuracy of
+    models using a simple randomization test. *Chemom. Intell. Lab.
+    Syst.*, 25(2), 313-323.
+    """
+    a_count = per_obs_sse.shape[0]
+    a_ref = int(np.nanargmin(total_rmsecv))
+    rng = np.random.default_rng(random_state)
+    p_values = np.zeros(a_count)
+    p_values[a_ref] = 1.0
+    sse_ref = per_obs_sse[a_ref]
+    for a in range(a_count):
+        if a == a_ref:
+            continue
+        d = per_obs_sse[a] - sse_ref
+        # Drop observations with NaN (a custom splitter may have left some
+        # rows unheld), since the paired difference is undefined there.
+        d = d[np.isfinite(d)]
+        if d.size == 0:
+            p_values[a] = 1.0
+            continue
+        t_obs = float(d.sum())
+        signs = rng.choice([-1.0, 1.0], size=(n_permutations, d.size))
+        t_perm = (signs * d).sum(axis=1)
+        # Right-tail probability under the null. Add 1 to both numerator
+        # and denominator (the "permutation test +1" correction) so the
+        # p-value is strictly positive even at the extreme.
+        p_values[a] = float((np.sum(t_perm >= t_obs) + 1) / (n_permutations + 1))
+
+    recommended = a_ref + 1  # fall back to the reference if nothing qualifies
+    for a in range(a_count):
+        if p_values[a] > alpha:
+            recommended = a + 1
+            break
+    return recommended, p_values
+
+
 class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator):
     """Projection to Latent Structures (PLS) regression with diagnostics.
 
@@ -629,6 +713,8 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         selection_rule: SelectionRule = "1se",
         scale_inside_folds: bool = True,
         min_q2_increase: float = Q2_MIN_INCREMENT,
+        n_permutations: int = 999,
+        alpha: float = 0.01,
         **pls_kwargs,
     ) -> Bunch:
         """Select the number of PLS components via cross-validation.
@@ -679,13 +765,17 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         random_state : int, optional
             Seed forwarded to ``KFold`` / ``RepeatedKFold`` for reproducible
             shuffling. Ignored when ``cv`` is a pre-built splitter.
-        selection_rule : {"1se", "min", "q2_increment"}, default "1se"
-            How the recommended component count is chosen from the per-fold
-            RMSECV curve. See :data:`~process_improve.multivariate._common.SelectionRule`
+        selection_rule : {"1se", "min", "q2_increment", "randomization"}, default "1se"
+            How the recommended component count is chosen.
+            See :data:`~process_improve.multivariate._common.SelectionRule`
             for the rule semantics. ``"1se"`` is the default; ``"min"`` is the
             argmin RMSECV (the pre-1.28 default, prone to running to the
             maximum component count); ``"q2_increment"`` is the Wold's-R-style
-            cumulative-Q² threshold.
+            cumulative-Q² threshold; ``"randomization"`` is Van der Voet's
+            (1994) permutation test (uses ``n_permutations`` and ``alpha``)
+            that picks the smallest model whose predictive ability is
+            statistically indistinguishable from the reference (argmin
+            RMSECV) one.
         scale_inside_folds : bool, default True
             When True (the default), fit a fresh :class:`MCUVScaler` on each
             training fold's X and Y, apply it to the held-out rows, fit PLS in
@@ -698,6 +788,14 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             Threshold used only when ``selection_rule="q2_increment"``: the
             smallest increase in cumulative validated :math:`Q^2_Y` that
             justifies keeping an extra component.
+        n_permutations : int, default 999
+            Used only when ``selection_rule="randomization"``: number of
+            sign-flip permutations driving the Van der Voet test.
+        alpha : float, default 0.01
+            Used only when ``selection_rule="randomization"``: significance
+            level. The smallest component count whose Van der Voet *p*-value
+            exceeds ``alpha`` is recommended. R's ``pls::selectNcomp`` uses
+            the same default; smaller values pick more parsimonious models.
         **pls_kwargs
             Additional keyword arguments passed to the ``PLS()`` constructor
             (e.g. ``missing_data_settings``).
@@ -729,6 +827,9 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
               held-out predictions are reported so each row appears exactly
               once.
             - ``selection_rule`` - the rule used to pick ``n_components``.
+            - ``randomization_pvalues`` - per-component Van der Voet
+              right-tail *p*-values when ``selection_rule="randomization"``;
+              ``None`` otherwise.
 
         Notes
         -----
@@ -931,13 +1032,33 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
                 "no recommendation can be made. Likely cause: a per-fold zero-variance Y "
                 "column, or every fold trivially degenerate."
             )
-        recommended = _select_n_components(
-            selection_rule,
-            mean_error=total_rmsecv,
-            se_error=se_values,
-            q2_cumulative=r2y_validated["total"].to_numpy(),
-            min_q2_increase=min_q2_increase,
-        )
+        # Per-observation squared total residual at every component count.
+        # Drives Van der Voet's randomization test; cheap to compute and
+        # otherwise diagnostic (rows of oof[a] that are NaN - typically
+        # because some custom splitter never held them out - are skipped via
+        # nansum).
+        per_obs_sse = np.nansum((y_values[None, :, :] - oof) ** 2, axis=2)  # (A, N)
+
+        randomization_pvalues: pd.Series | None = None
+        if selection_rule == "randomization":
+            recommended, p_values = _vandervoet_randomization(
+                per_obs_sse,
+                total_rmsecv=total_rmsecv,
+                n_permutations=n_permutations,
+                alpha=alpha,
+                random_state=random_state,
+            )
+            randomization_pvalues = pd.Series(
+                p_values, index=component_index, name="p-value (Van der Voet)"
+            )
+        else:
+            recommended = _select_n_components(
+                selection_rule,
+                mean_error=total_rmsecv,
+                se_error=se_values,
+                q2_cumulative=r2y_validated["total"].to_numpy(),
+                min_q2_increase=min_q2_increase,
+            )
         cv_predictions = pd.DataFrame(oof[recommended - 1], index=Y.index, columns=Y.columns)
 
         return Bunch(
@@ -950,6 +1071,7 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             press=press,
             cv_predictions=cv_predictions,
             selection_rule=selection_rule,
+            randomization_pvalues=randomization_pvalues,
         )
 
     def score_contributions(

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2390,6 +2390,7 @@ def test_pls_select_n_components_synthetic() -> None:
         "r2y_validated",
         "r2x_validated",
         "press",
+        "randomization_pvalues",
         "cv_predictions",
         "selection_rule",
     }
@@ -2615,6 +2616,58 @@ def test_pls_select_n_components_q2_increment_rule() -> None:
     # Unknown rule -> ValueError from the dispatcher.
     with pytest.raises(ValueError, match="Unknown selection_rule"):
         PLS.select_n_components(X, Y, max_components=3, cv=3, selection_rule="bogus")  # type: ignore[arg-type]
+
+
+def test_pls_select_n_components_randomization_rule() -> None:
+    """Van der Voet's randomization test picks a parsimonious model."""
+    rng = np.random.default_rng(2026)
+    N, K, n_factors = 80, 30, 4
+    scales = np.array([6.0, 4.0, 2.5, 1.5])
+    T = rng.normal(size=(N, n_factors)) * scales
+    P = rng.normal(size=(K, n_factors))
+    X = pd.DataFrame(T @ P.T + 0.4 * rng.normal(size=(N, K)), columns=[f"x{i}" for i in range(K)])
+    gamma = rng.normal(size=(n_factors, 1))
+    Y = pd.DataFrame(T @ gamma + 0.3 * rng.normal(size=(N, 1)), columns=["y"])
+
+    res = PLS.select_n_components(
+        X, Y, max_components=10, cv=5, n_repeats=2, random_state=0,
+        selection_rule="randomization", n_permutations=399, alpha=0.01,
+    )
+    assert res.selection_rule == "randomization"
+    assert res.randomization_pvalues is not None
+    assert list(res.randomization_pvalues.index) == list(range(1, 11))
+    # The reference (argmin-RMSECV) model has p-value exactly 1.0.
+    a_ref = int(np.nanargmin(res.rmsecv["total"].to_numpy())) + 1
+    assert res.randomization_pvalues.loc[a_ref] == 1.0
+    # Recommendation is no larger than the argmin reference and at least 1.
+    assert 1 <= res.n_components <= a_ref
+
+    # Reproducible given a fixed seed.
+    again = PLS.select_n_components(
+        X, Y, max_components=10, cv=5, n_repeats=2, random_state=0,
+        selection_rule="randomization", n_permutations=399, alpha=0.01,
+    )
+    np.testing.assert_allclose(
+        res.randomization_pvalues.to_numpy(),
+        again.randomization_pvalues.to_numpy(),
+    )
+
+    # A more permissive alpha (closer to 1) walks further up the curve
+    # before declaring a model "equivalent", so it can pick MORE components
+    # than a stricter alpha.
+    res_strict = PLS.select_n_components(
+        X, Y, max_components=10, cv=5, n_repeats=2, random_state=0,
+        selection_rule="randomization", n_permutations=399, alpha=0.001,
+    )
+    res_lax = PLS.select_n_components(
+        X, Y, max_components=10, cv=5, n_repeats=2, random_state=0,
+        selection_rule="randomization", n_permutations=399, alpha=0.5,
+    )
+    assert res_strict.n_components <= res_lax.n_components
+
+    # Without the randomization rule, randomization_pvalues is None.
+    plain = PLS.select_n_components(X, Y, max_components=4, cv=5, random_state=0)
+    assert plain.randomization_pvalues is None
 
 
 def test_recommend_n_components_q2_rule() -> None:


### PR DESCRIPTION
Closes #379.

## Summary

Adds Van der Voet's (1994) randomization test as a fourth `selection_rule` for `PLS.select_n_components`, alongside `"1se"`, `"min"`, and `"q2_increment"`. The test compares each candidate model against the argmin-RMSECV reference under the null that the two have the same predictive ability, and picks the smallest model whose right-tail *p*-value exceeds `alpha` - statistically indistinguishable from the best, but more parsimonious.

## What changes

- **`_vandervoet_randomization`** helper in `_pls.py`: per-observation squared-residual paired differences, sign-flip permutations (`+1`/`+1` correction so *p* stays positive at the extremes).
- **`PLS.select_n_components`** new kwargs:
  - `selection_rule="randomization"` routes to the new branch (uses per-obs residuals from the existing fold loop's `oof` array).
  - `n_permutations` (default 999) and `alpha` (default 0.01) - same defaults as R's `pls::selectNcomp`.
- **Returned `Bunch`** gains `randomization_pvalues` (`pd.Series` indexed 1..A) under the new rule; `None` otherwise.
- **`SelectionRule`** `Literal` in `_common.py` extended.

## Test plan

- [x] Reference (argmin-RMSECV) model has *p* = 1 by construction.
- [x] Recommendation is never larger than the reference and at least 1.
- [x] Same `random_state` → identical *p*-values.
- [x] Stricter `alpha` is no less parsimonious than a permissive one (`alpha=0.001` vs `alpha=0.5`).
- [x] `randomization_pvalues` is `None` under the other rules.
- [x] Existing synthetic-test keys assertion updated.
- [x] Full multivariate suite green (`150 passed, 1 skipped`).
- [x] `ruff check .` clean.

## Cross-validation follow-ups still open

- #380 Stability selection
- #381 Nested CV
- #383 sklearn Pipeline interop verification

https://claude.ai/code/session_01CD8jKbCmCEsa3qN8XGcRcs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GygLHnZrhbRXYj7JsPu1hL)_