### PR TITLE
Stability-selection diagnostic on PLS.select_n_components (closes #380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ those changes.
 
 ## [Unreleased]
 
+## [1.33.0] - 2026-06-07
+
+### Added
+
+- **Stability-selection diagnostic on `PLS.select_n_components`**:
+  when ``selection_rule`` is ``"1se"`` or ``"min"`` and ``n_repeats > 1``,
+  the chosen rule is re-applied to each repeat's slice of per-fold RMSE
+  values and the distribution of votes is reported. A concentrated
+  distribution flags a confident recommendation; a flat or multi-modal
+  one flags it for review (Meinshausen & Bühlmann 2010 stability
+  selection, adapted from the variable-selection setting to the
+  component-count setting).
+  - Returned `Bunch` gains `selection_distribution` (per-component
+    vote share, `pd.Series` indexed `1..A`), `selection_mode` (the
+    most-voted count), and `selection_is_stable` (`True` iff the modal
+    share meets ``stability_threshold``).
+  - New ``stability_threshold`` kwarg (default `0.6`); fields are `None`
+    when stability is not computed (single repeat, or rules that don't
+    decompose cleanly per repeat: ``"q2_increment"`` /
+    ``"randomization"``).
+
 ## [1.32.0] - 2026-06-07
 
 ### Added
@@ -1626,7 +1647,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.32.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.33.0...HEAD
+[1.33.0]: https://github.com/kgdunn/process-improve/compare/v1.32.0...v1.33.0
 [1.32.0]: https://github.com/kgdunn/process-improve/compare/v1.31.0...v1.32.0
 [1.31.0]: https://github.com/kgdunn/process-improve/compare/v1.30.0...v1.31.0
 [1.30.0]: https://github.com/kgdunn/process-improve/compare/v1.29.0...v1.30.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.32.0
+version: 1.33.0
 date-released: "2026-06-07"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.32.0"
+version = "1.33.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -715,6 +715,7 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         min_q2_increase: float = Q2_MIN_INCREMENT,
         n_permutations: int = 999,
         alpha: float = 0.01,
+        stability_threshold: float = 0.6,
         **pls_kwargs,
     ) -> Bunch:
         """Select the number of PLS components via cross-validation.
@@ -796,6 +797,14 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             level. The smallest component count whose Van der Voet *p*-value
             exceeds ``alpha`` is recommended. R's ``pls::selectNcomp`` uses
             the same default; smaller values pick more parsimonious models.
+        stability_threshold : float, default 0.6
+            For the per-repeat stability-selection diagnostic (``"1se"`` /
+            ``"min"`` rules with ``n_repeats > 1`` only): the recommendation
+            is judged ``selection_is_stable=True`` iff the modal vote share
+            in ``selection_distribution`` is at least this fraction.
+            Meinshausen & Bühlmann (2010, *JRSS-B*) suggest 0.6-0.9 for
+            their variable-selection analogue; we default to the
+            permissive end.
         **pls_kwargs
             Additional keyword arguments passed to the ``PLS()`` constructor
             (e.g. ``missing_data_settings``).
@@ -830,6 +839,17 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             - ``randomization_pvalues`` - per-component Van der Voet
               right-tail *p*-values when ``selection_rule="randomization"``;
               ``None`` otherwise.
+            - ``selection_distribution`` - per-repeat *vote share* over
+              candidate component counts (pd.Series indexed ``1..A``).
+              Populated only for ``selection_rule in {"1se", "min"}`` and
+              ``n_repeats > 1``; ``None`` otherwise. A concentrated
+              distribution signals a confident recommendation; a flat or
+              multi-modal one flags it for review.
+            - ``selection_mode`` - the most-voted component count, or
+              ``None`` when ``selection_distribution`` is.
+            - ``selection_is_stable`` - ``True`` iff the modal vote share
+              meets ``stability_threshold``; ``None`` when no distribution
+              was computed.
 
         Notes
         -----
@@ -1061,6 +1081,53 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             )
         cv_predictions = pd.DataFrame(oof[recommended - 1], index=Y.index, columns=Y.columns)
 
+        # Stability selection: re-apply the chosen rule per repeat and
+        # tabulate how often each component count wins. A multi-modal or
+        # flat distribution flags the recommendation as low-confidence.
+        # Only meaningful when the rule operates on the per-fold RMSE
+        # curve (1se/min) and we ran more than one repeat; q2_increment
+        # and randomization don't decompose per repeat without more
+        # bookkeeping than they're worth at this stage.
+        n_repeats_effective = max(1, n_folds_total // max(1, first_repeat_fold_count))
+        selection_distribution: pd.Series | None = None
+        selection_mode: int | None = None
+        selection_is_stable: bool | None = None
+        if (
+            selection_rule in ("1se", "min")
+            and n_repeats_effective > 1
+            and not np.all(np.isnan(per_fold_rmse))
+        ):
+            votes: list[int] = []
+            for r in range(n_repeats_effective):
+                cols = slice(r * first_repeat_fold_count, (r + 1) * first_repeat_fold_count)
+                fold_subset = per_fold_rmse[:, cols]
+                if np.all(np.isnan(fold_subset)):
+                    continue
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", RuntimeWarning)
+                    mean_r = np.nanmean(fold_subset, axis=1)
+                    se_r = np.nanstd(fold_subset, axis=1, ddof=1) / np.sqrt(
+                        np.maximum(1, np.sum(~np.isnan(fold_subset), axis=1))
+                    )
+                # The dispatcher needs q2_cumulative even for non-q2 rules;
+                # pass a dummy zeros array since 1se/min don't read it.
+                pick = _select_n_components(
+                    selection_rule,
+                    mean_error=mean_r,
+                    se_error=se_r,
+                    q2_cumulative=np.zeros_like(mean_r),
+                    min_q2_increase=min_q2_increase,
+                )
+                votes.append(int(pick))
+            if votes:
+                counts = pd.Series(votes).value_counts().sort_index()
+                dist = (counts / counts.sum()).reindex(component_index, fill_value=0.0)
+                dist.name = "vote_share"
+                dist.index.name = "n_components"
+                selection_distribution = dist
+                selection_mode = int(dist.idxmax())
+                selection_is_stable = bool(dist.max() >= stability_threshold)
+
         return Bunch(
             n_components=recommended,
             rmsecv=rmsecv,
@@ -1072,6 +1139,9 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             cv_predictions=cv_predictions,
             selection_rule=selection_rule,
             randomization_pvalues=randomization_pvalues,
+            selection_distribution=selection_distribution,
+            selection_mode=selection_mode,
+            selection_is_stable=selection_is_stable,
         )
 
     def score_contributions(

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2391,6 +2391,9 @@ def test_pls_select_n_components_synthetic() -> None:
         "r2x_validated",
         "press",
         "randomization_pvalues",
+        "selection_distribution",
+        "selection_mode",
+        "selection_is_stable",
         "cv_predictions",
         "selection_rule",
     }
@@ -2616,6 +2619,55 @@ def test_pls_select_n_components_q2_increment_rule() -> None:
     # Unknown rule -> ValueError from the dispatcher.
     with pytest.raises(ValueError, match="Unknown selection_rule"):
         PLS.select_n_components(X, Y, max_components=3, cv=3, selection_rule="bogus")  # type: ignore[arg-type]
+
+
+def test_pls_select_n_components_stability_signal() -> None:
+    """Per-repeat vote distribution flags confident vs. uncertain recommendations."""
+    rng = np.random.default_rng(0)
+    N, K, true_rank = 60, 12, 2
+    T = rng.standard_normal((N, true_rank)) * np.array([6.0, 3.5])
+    P = rng.standard_normal((true_rank, K))
+    X = pd.DataFrame(T @ P + 0.3 * rng.standard_normal((N, K)), columns=[f"x{i}" for i in range(K)])
+    Y = pd.DataFrame(T @ rng.standard_normal((true_rank, 1)) + 0.2 * rng.standard_normal((N, 1)), columns=["y"])
+
+    # Multiple repeats + clean signal -> the distribution concentrates and
+    # the recommendation is stable.
+    confident = PLS.select_n_components(
+        X, Y, max_components=6, cv=5, n_repeats=8, random_state=0,
+    )
+    assert confident.selection_distribution is not None
+    assert isinstance(confident.selection_distribution, pd.Series)
+    assert list(confident.selection_distribution.index) == list(range(1, 7))
+    assert np.isclose(confident.selection_distribution.sum(), 1.0)
+    assert confident.selection_mode == confident.n_components
+    assert confident.selection_is_stable is True
+
+    # A single repeat: no per-repeat distribution to report.
+    single = PLS.select_n_components(
+        X, Y, max_components=6, cv=5, n_repeats=1, random_state=0,
+    )
+    assert single.selection_distribution is None
+    assert single.selection_mode is None
+    assert single.selection_is_stable is None
+
+    # q2_increment doesn't decompose per repeat in this implementation -
+    # stability is None even with many repeats. (Documented in the docstring.)
+    q2 = PLS.select_n_components(
+        X, Y, max_components=6, cv=5, n_repeats=5, random_state=0,
+        selection_rule="q2_increment",
+    )
+    assert q2.selection_distribution is None
+    assert q2.selection_is_stable is None
+
+    # The threshold knob: a > 1 threshold trips ``is_stable`` to False even
+    # on a fully concentrated distribution. (Exercised here because the
+    # synthetic data is clean enough that every repeat votes for the same
+    # count; ``stability_threshold > 1.0`` is the only way to force False.)
+    strict = PLS.select_n_components(
+        X, Y, max_components=6, cv=5, n_repeats=8, random_state=0,
+        stability_threshold=1.01,
+    )
+    assert strict.selection_is_stable is False
 
 
 def test_pls_select_n_components_randomization_rule() -> None:


### PR DESCRIPTION
Closes #380.

## Summary

Adds a stability-selection diagnostic to `PLS.select_n_components`. When `selection_rule` is `"1se"` or `"min"` and `n_repeats > 1`, the chosen rule is re-applied to each repeat's slice of per-fold RMSE values and the distribution of votes is reported. A concentrated distribution signals a confident recommendation; a flat or multi-modal one flags it for review — exactly the signal downstream tooling (e.g. ScorePilot) wants when deciding whether to auto-accept or escalate to a human.

The pooled `n_components` recommendation stays primary; the distribution is informational.

## What changes

- **New kwarg** `stability_threshold` (default `0.6`; Meinshausen & Bühlmann 2010 stability selection, permissive end).
- **Returned `Bunch`** gains:
  - `selection_distribution` (`pd.Series` indexed `1..A`, per-component vote share summing to 1).
  - `selection_mode` (the most-voted count).
  - `selection_is_stable` (`True` iff the modal share meets `stability_threshold`).
- All three are `None` when stability isn't computed: single repeat, or rules that don't decompose cleanly per repeat (`"q2_increment"`, `"randomization"`).

## Test plan

- [x] Clean low-rank synthetic with `n_repeats=8`: distribution concentrates, `mode == n_components`, `is_stable=True`.
- [x] Single repeat: distribution / mode / is_stable all `None`.
- [x] `q2_increment` with multiple repeats: still `None` (documented limitation).
- [x] `stability_threshold > 1.0` forces `is_stable=False` even on a fully concentrated distribution.
- [x] Existing synthetic-test keys assertion updated.
- [x] Full multivariate suite green (`151 passed, 1 skipped`).
- [x] `ruff check .` clean.

## Cross-validation follow-ups still open

- #381 Nested CV for PLS
- #383 sklearn Pipeline interop verification

https://claude.ai/code/session_01CD8jKbCmCEsa3qN8XGcRcs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GygLHnZrhbRXYj7JsPu1hL)_