### PR TITLE
tools: add check_estimator audit script + main-branch baseline

### DIFF
--- a/SKLEARN_COMPATIBILITY.md
+++ b/SKLEARN_COMPATIBILITY.md
@@ -1,0 +1,169 @@
+# scikit-learn compatibility
+
+This document tracks the state of `process_improve`'s interop with
+scikit-learn as of v1.35.0. It is a living document — refresh the audit
+numbers and re-read the "What doesn't work yet" section before each
+release that touches the multivariate package.
+
+## TL;DR
+
+- **Cross-validation:** complete. Repeated K-fold, 1-SE rule, in-fold
+  scaling, ekf for PCA, randomization test, stability selection, nested
+  CV. Closed in PRs #376 → #390 across issues #377, #378, #379, #380,
+  #381, #382, #383.
+- **Pipeline / `cross_val_score` / `GridSearchCV` / `clone`:** the
+  blocking PLS contract issue is fixed (PR #390): `PLS.predict(X)` returns
+  the predicted Y as a `pd.DataFrame`, satisfying `RegressorMixin`; the
+  rich diagnostic view moved to `PLS.diagnose(X)`. `MCUVScaler.fit` now
+  accepts the `y` kwarg that Pipeline threads through, and `PLS.fit`
+  accepts a 1-D Y.
+- **Everything else:** see the `check_estimator` baseline below. Three
+  estimators sit at 60–66% pass on the sklearn 1.6+ convention battery;
+  40 distinct failures, scoped into five tracked issues.
+
+## What works today
+
+### Cross-validation
+
+| Capability | Estimator | Reference |
+|---|---|---|
+| Repeated K-fold + 1-SE rule + in-fold scaling | `PLS.select_n_components` | #376 |
+| Element-wise k-fold (ekf) CV (Bro 2008) | `PCA.select_n_components` | #384 closes #377 |
+| ekf + repeated K-fold + in-fold scaling | `PCA.select_n_components` | #385 closes #382 |
+| Minka MLE + Horn parallel analysis + consensus mode | `PCA.minka_mle`, `PCA.parallel_analysis`, `return_consensus=True` | #386 closes #378 |
+| Van der Voet randomization test | `PLS.select_n_components(selection_rule="randomization")` | #387 closes #379 |
+| Stability-selection signal across CV repeats | `PLS.select_n_components` `selection_distribution` / `selection_is_stable` | #388 closes #380 |
+| Nested CV for honest RMSEP | `PLS.nested_cv` | #389 closes #381 |
+
+### sklearn Pipeline composition
+
+The following compositions are verified by tests in
+`tests/test_multivariate.py` (search for `test_pipeline_*`):
+
+| Pattern | Status | Reference |
+|---|---|---|
+| `Pipeline([MCUVScaler(), PCA(n_components=k)]).fit_transform(X)` | ✅ | #390 |
+| `Pipeline([MCUVScaler(), PLS(n_components=k)]).fit(X, y).predict(X)` | ✅ | #390 |
+| `cross_val_score(pipe, X, y, cv=RepeatedKFold(...))` | ✅ | #390 |
+| `GridSearchCV(pipe, {"pls__n_components": [...]}).fit(X, y)` | ✅ | #390 |
+| `clone(pipe).fit(X, y)` | ✅ | #390 |
+
+### API conventions
+
+- `MCUVScaler.fit(X, y=None)` and `.transform(X, y=None)` accept and
+  ignore `y` — needed for Pipeline.
+- `PLS.fit(X, Y)` accepts 1-D `Y` (the shape sklearn pipelines pass for
+  single-target regression); promoted to `(N, 1)` internally.
+- `PLS.predict(X)` returns a `pd.DataFrame` (sklearn-compatible).
+- `PLS.diagnose(X)` returns the rich `Bunch(scores, hotellings_t2, spe,
+  y_hat)` that `predict()` used to return before 1.35.0.
+- `PLS.score(X, Y, sample_weight=...)` accepts `sample_weight` (forwards
+  to `sklearn.metrics.r2_score`). Note `fit` does *not* accept
+  `sample_weight` — tracked in #394.
+
+## What doesn't work yet
+
+### `check_estimator` baseline (v1.35.0)
+
+Run `python tools/check_estimator_audit.py` (preserved in
+`tools/check_estimator_audit_main.log`) to refresh. As of v1.35.0:
+
+| Estimator | Passing | Total | Pass % | Issues that close failures |
+|---|---|---|---|---|
+| `MCUVScaler` | 18 | 29 | 62% | #401, #393 |
+| `PCA(n_components=2)` | 28 | 47 | 60% | #401, #391, #393, #396 |
+| `PLS(n_components=2)` | 19 | 29 | 66% | #401, #393 |
+
+`TPLS` / `MBPLS` / `MBPCA` are not in this audit — they take
+`dict[str, DataFrame]` for X, which is outside `check_estimator`'s
+fixture scope. Pipeline interop for those classes is tracked in #395.
+
+### Tracked issues by capability
+
+#### High-leverage (close many `check_estimator` failures at once)
+
+- **#401** — Route `fit` / `predict` / `transform` through
+  `sklearn.utils.validation.validate_data`. Single biggest yield:
+  ~22 of 40 audit failures across all three estimators. Closes the
+  cluster around `n_features_in_`, sparse rejection, complex/object
+  dtype, empty data, NaN/inf, and error-message wording.
+- **#391** — `get_feature_names_out` on `MCUVScaler` / `PCA` / `PLS`,
+  plus making `transform()` return `ndarray` so `set_output("pandas")`
+  drives the column-label decoration. Closes 2 PCA failures
+  (`check_transformer_data_not_an_array`,
+  `check_transformer_preserve_dtypes`) on top of unlocking
+  `set_output` and `pipe.get_feature_names_out()`.
+- **#393** — `__sklearn_tags__` declarations and the `MCUVScaler` mixin
+  inheritance order fix. Closes `check_estimator_sparse_tag` (×3),
+  `check_mixin_order`, and the setup-time `transformer_tags`
+  `RuntimeError`.
+- **#396** — `PCA.predict` returning `Bunch` and mutating `self.__dict__`
+  via the `_LazyFrame` cache. Closes
+  `check_estimators_pickle` (×2), `check_fit_idempotent`, and
+  `check_dict_unchanged`.
+
+#### Other ecosystem gaps
+
+- **#392** — Set `feature_names_in_` (with trailing underscore, sklearn
+  convention) on every estimator. Unblocks SHAP, eli5, model-card tools.
+- **#394** — Support `sample_weight` in `PLS.fit` and forward it through
+  `cross_validate` / `nested_cv` / `select_n_components`.
+- **#395** — `TPLS.predict` / `MBPLS.predict` / `MBPCA.predict` still
+  return `Bunch`. Same architectural choice as PR #390 needs to be
+  applied to the multiblock classes.
+- **#397** — `TransformedTargetRegressor` composition with
+  `MCUVScaler` + `PLS` Pipeline. Untested.
+- **#398** — `HalvingGridSearchCV` / `HalvingRandomSearchCV` interop.
+  Untested.
+- **#399** — `make_column_transformer` with `MCUVScaler` + `OneHotEncoder`
+  on disjoint column subsets. Untested.
+
+### Outstanding unscoped finding
+
+The PLS audit reports one `<setup>` `IndexError: list index out of range`
+on `check_estimator`. The root cause is undiagnosed (likely a
+`check_classifiers_classes` or `check_regressor_data_not_an_array` that
+constructs a degenerate Y). Likely to resolve incidentally when #401
+lands; revisit afterward.
+
+## Refreshing the audit
+
+```bash
+python tools/check_estimator_audit.py | tee tools/check_estimator_audit_main.log
+```
+
+The output is grouped by reason so identical failures across multiple
+checks are bucketed together. Compare against the previous log to see
+which checks moved from FAIL to PASS.
+
+## Suggested order to land the follow-ups
+
+Pure ordering by yield-per-risk, not a dependency graph (all of these
+land independently; #391 benefits from #393 landing first because tags
+inform the `set_output` behaviour, but it's not a hard requirement):
+
+1. **#401** (`validate_data` sweep). Biggest single yield (~22 audit
+   failures). Mechanical. Smallest blast radius.
+2. **#393** (`__sklearn_tags__` + mixin order). Unlocks the NaN-through-
+   Pipeline path for the NIPALS-based PCA and the multi-output scorer
+   dispatch for PLS.
+3. **#391** (`get_feature_names_out` + ndarray `transform`). Closes the
+   transformer cluster and unlocks `set_output("pandas")`.
+4. **#396** (`PCA.predict` → ndarray, drop `__dict__` mutation). Closes
+   the pickle / idempotent / dict-unchanged cluster on PCA. This was
+   intentionally scoped out of PR #390 because PCA inherits
+   `TransformerMixin` (not `RegressorMixin`) so the Bunch return isn't
+   a Pipeline blocker.
+5. **#392** (`feature_names_in_`). Single mechanical assignment per
+   `fit`; downstream tools benefit.
+6. **#395** (multiblock `predict` rename). Same architectural decision
+   as PR #390, applied to `TPLS` / `MBPLS`. Lower priority than PCA/PLS
+   because users multi-pipeline these less often.
+7. **#394** (`sample_weight` in `PLS.fit`). Real new behaviour, not
+   just a contract fix.
+8. **#397** (`TransformedTargetRegressor`), **#398**
+   (`HalvingGridSearchCV`), **#399** (`make_column_transformer`).
+   Verification work: add tests, fix whatever falls out.
+
+After (1)–(4) the audit should sit comfortably above 90% pass on every
+estimator; re-run the audit and refine remaining issues at that point.

--- a/tools/check_estimator_audit.py
+++ b/tools/check_estimator_audit.py
@@ -1,0 +1,85 @@
+"""One-off audit: run sklearn.utils.estimator_checks.check_estimator on every
+public estimator in process_improve.multivariate and tally pass/fail per check.
+
+Uses the sklearn 1.6+ callback API to collect every check's outcome rather
+than aborting on the first failure.
+"""
+from __future__ import annotations
+
+import warnings
+from collections import defaultdict
+
+from sklearn.utils.estimator_checks import check_estimator
+
+from process_improve.multivariate.methods import (
+    PCA,
+    PLS,
+    MCUVScaler,
+)
+
+ESTIMATORS = [
+    ("MCUVScaler", MCUVScaler()),
+    ("PCA(n_components=2)", PCA(n_components=2)),
+    ("PLS(n_components=2)", PLS(n_components=2)),
+]
+
+
+def audit(name: str, est):  # noqa: ANN001
+    """Run check_estimator with a callback that records each check's outcome."""
+    results: list[tuple[str, str, str]] = []  # (check_name, status, reason)
+
+    def callback(*, estimator, check_name, exception=None, status=None, **_) -> None:  # noqa: ANN001, ANN003, ARG001
+        if exception is None:
+            results.append((check_name, "PASS", ""))
+        else:
+            short = str(exception).splitlines()[0][:240]
+            results.append(
+                (check_name, "FAIL", f"{type(exception).__name__}: {short}")
+            )
+
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            check_estimator(est, on_fail="warn", on_skip="warn", callback=callback)
+    except Exception as exc:  # noqa: BLE001
+        results.append(("<setup>", "ERROR", f"{type(exc).__name__}: {exc}"))
+
+    return results
+
+
+def main() -> None:
+    summary: dict[str, dict[str, int]] = defaultdict(lambda: {"pass": 0, "fail": 0})
+    failure_details: dict[str, list[tuple[str, str]]] = defaultdict(list)
+
+    for name, est in ESTIMATORS:
+        print(f"\n===== {name} =====")
+        for check_name, status, reason in audit(name, est):
+            if status == "PASS":
+                summary[name]["pass"] += 1
+            else:
+                summary[name]["fail"] += 1
+                failure_details[name].append((check_name, reason))
+
+    print("\n\n===== SUMMARY =====")
+    for name in summary:
+        s = summary[name]
+        total = s["pass"] + s["fail"]
+        pct = (s["pass"] / total * 100) if total else 0.0
+        print(f"{name}: {s['pass']}/{total} passed ({pct:.1f}%)")
+
+    print("\n===== FAILURES (grouped by reason) =====")
+    for name, fails in failure_details.items():
+        print(f"\n--- {name} ({len(fails)} failures) ---")
+        bucketed: dict[str, list[str]] = defaultdict(list)
+        for check_name, reason in fails:
+            bucketed[reason].append(check_name)
+        for reason, checks in sorted(bucketed.items(), key=lambda kv: -len(kv[1])):
+            print(f"\n  [{len(checks)}x] {reason}")
+            for c in sorted(checks)[:6]:
+                print(f"     - {c}")
+            if len(checks) > 6:
+                print(f"     ... and {len(checks) - 6} more")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_estimator_audit_main.log
+++ b/tools/check_estimator_audit_main.log
@@ -1,0 +1,130 @@
+
+===== MCUVScaler =====
+
+===== PCA(n_components=2) =====
+
+===== PLS(n_components=2) =====
+
+
+===== SUMMARY =====
+MCUVScaler: 18/29 passed (62.1%)
+PCA(n_components=2): 28/47 passed (59.6%)
+PLS(n_components=2): 19/29 passed (65.5%)
+
+===== FAILURES (grouped by reason) =====
+
+--- MCUVScaler (11 failures) ---
+
+  [2x] AssertionError: Estimator MCUVScaler doesn't seem to fail gracefully on sparse data: error message should state explicitly that sparse input is not supported if this is not the case, e.g. by using check_array(X, accept_sparse=False).
+     - check_estimator_sparse_array
+     - check_estimator_sparse_matrix
+
+  [1x] AssertionError: `MCUVScaler.fit()` does not set the `n_features_in_` attribute. You might want to use `sklearn.utils.validation.validate_data` instead of `check_array` in `MCUVScaler.fit()` which takes care of setting the attribute.
+     - check_n_features_in_after_fitting
+
+  [1x] AssertionError: MCUVScaler is inheriting from mixins in the wrong order. In general, in mixin inheritance, more specialized mixins must come before more general ones. This means, for instance, `BaseEstimator` should be on the right side of most other mixin
+     - check_mixin_order
+
+  [1x] AssertionError: Did not raise: [<class 'ValueError'>]
+     - check_complex_data
+
+  [1x] AssertionError: The error message should contain one of the following patterns:
+     - check_dtype_object
+
+  [1x] AssertionError: The estimator MCUVScaler does not raise a ValueError when an empty data is used to train. Perhaps use check_array in train.
+     - check_estimators_empty_data_messages
+
+  [1x] AssertionError: Estimator MCUVScaler doesn't check for NaN and inf in fit.
+     - check_estimators_nan_inf
+
+  [1x] AssertionError: Estimator MCUVScaler didn't fail when fitted on sparse data but should have according to its tag self.input_tags.sparse=False. The tag is inconsistent and must be fixed.
+     - check_estimator_sparse_tag
+
+  [1x] SkipTest: SCIPY_ARRAY_API is not set: not checking array_api input
+     - check_array_api_input
+
+  [1x] RuntimeError: Estimator MCUVScaler seems to be a Transformer, but the `transformer_tags` tag is not set. Either set the tag manually or inherit from the TransformerMixin. Note that the order of inheritance matters, the TransformerMixin should come before BaseEstimator.
+     - <setup>
+
+--- PCA(n_components=2) (19 failures) ---
+
+  [3x] TypeError: unsupported operand type(s) for -: 'Bunch' and 'Bunch'
+     - check_estimators_pickle
+     - check_estimators_pickle
+     - check_fit_idempotent
+
+  [2x] AssertionError: Estimator PCA doesn't seem to fail gracefully on sparse data: error message should state explicitly that sparse input is not supported if this is not the case, e.g. by using check_array(X, accept_sparse=False).
+     - check_estimator_sparse_array
+     - check_estimator_sparse_matrix
+
+  [1x] AssertionError: `PCA.predict()` does not check for consistency between input number
+     - check_n_features_in_after_fitting
+
+  [1x] TypeError: Invalid value '0    0.076203-0.219042j
+     - check_complex_data
+
+  [1x] UFuncTypeError: Cannot cast ufunc 'svd_s' input from dtype('O') to dtype('float64') with casting rule 'same_kind'
+     - check_dtype_object
+
+  [1x] AssertionError: The estimator PCA does not raise a ValueError when an empty data is used to train. Perhaps use check_array in train.
+     - check_estimators_empty_data_messages
+
+  [1x] AssertionError: Estimator PCA doesn't check for NaN and inf in fit.
+     - check_estimators_nan_inf
+
+  [1x] AssertionError: Estimator PCA didn't fail when fitted on sparse data but should have according to its tag self.input_tags.sparse=False. The tag is inconsistent and must be fixed.
+     - check_estimator_sparse_tag
+
+  [1x] SkipTest: SCIPY_ARRAY_API is not set: not checking array_api input
+     - check_array_api_input
+
+  [1x] ValueError: DataFrame constructor not properly called!
+     - check_transformer_data_not_an_array
+
+  [1x] AttributeError: 'DataFrame' object has no attribute 'dtype'
+     - check_transformer_preserve_dtypes
+
+  [1x] KeyError: np.int64(6)
+     - check_methods_sample_order_invariance
+
+  [1x] AssertionError: 
+     - check_methods_subset_invariance
+
+  [1x] AssertionError: Estimator changes __dict__ during predict
+     - check_dict_unchanged
+
+  [1x] AssertionError: Did not raise: [<class 'ValueError'>]
+     - check_fit1d
+
+  [1x] AssertionError: The error message should contain one of the following patterns:
+     - check_fit2d_predict1d
+
+--- PLS(n_components=2) (10 failures) ---
+
+  [2x] AssertionError: Estimator PLS doesn't seem to fail gracefully on sparse data: error message should state explicitly that sparse input is not supported if this is not the case, e.g. by using check_array(X, accept_sparse=False).
+     - check_estimator_sparse_array
+     - check_estimator_sparse_matrix
+
+  [1x] AssertionError: `PLS.predict()` does not check for consistency between input number
+     - check_n_features_in_after_fitting
+
+  [1x] TypeError: Invalid value '[0.32721032+0.81147437j]' for dtype 'float64'
+     - check_complex_data
+
+  [1x] TypeError: loop of ufunc does not support argument 0 of type float which has no callable sqrt method
+     - check_dtype_object
+
+  [1x] AssertionError: The error message should contain one of the following patterns:
+     - check_estimators_empty_data_messages
+
+  [1x] AssertionError: Estimator PLS doesn't check for NaN and inf in fit.
+     - check_estimators_nan_inf
+
+  [1x] AssertionError: Estimator PLS didn't fail when fitted on sparse data but should have according to its tag self.input_tags.sparse=False. The tag is inconsistent and must be fixed.
+     - check_estimator_sparse_tag
+
+  [1x] SkipTest: SCIPY_ARRAY_API is not set: not checking array_api input
+     - check_array_api_input
+
+  [1x] IndexError: list index out of range
+     - <setup>


### PR DESCRIPTION
Adds a one-off audit runner under tools/ that calls
sklearn.utils.estimator_checks.check_estimator on every public
2D-input multivariate estimator (MCUVScaler, PCA, PLS) and groups
failures by reason. TPLS / MBPLS / MBPCA take dict-of-DataFrames so
they're outside check_estimator's fixture scope; skipped for now.

Captures the current main-branch baseline as
tools/check_estimator_audit_main.log so subsequent commits can be
measured against it.

Headline pass rates against main:
- MCUVScaler: 18/29 (62%)
- PCA(n_components=2): 28/47 (60%)
- PLS(n_components=2): 19/29 (66%)

Most failures cluster around four root causes:
1. fit/predict/transform do their own X-coercion instead of going
   through sklearn.utils.validation.validate_data; that one helper
   provides n_features_in_ setting, sparse rejection, complex
   rejection, NaN/inf rejection, empty-data rejection, and the
   sklearn-style error messages check_estimator looks for.
2. Mixin inheritance order (BaseEstimator should be rightmost).
3. PCA.predict returns Bunch (Bunch - Bunch errors in pickle /
   idempotent checks; tracked in #396).
4. __sklearn_tags__ defaults misclassify sparse / multioutput
   capabilities (tracked in #393).

The audit is a runnable script (not a pytest test) so it stays
opt-in.

https://claude.ai/code/session_01CD8jKbCmCEsa3qN8XGcRcs