### PR TITLE
__sklearn_tags__ for MCUVScaler / PCA / PLS + fix PLS NaN-fit TSR bug (closes #393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,50 @@ those changes.
 
 ## [Unreleased]
 
+## [1.37.0] - 2026-06-07
+
+### Added
+
+- **`__sklearn_tags__` declarations on `MCUVScaler`, `PCA`, and `PLS`**
+  for sklearn 1.6+ capability dispatch:
+  - `MCUVScaler`: `input_tags.allow_nan = True`. `fit` / `transform`
+    use `np.nanmean` / `np.nanstd` and pass NaN through unchanged.
+  - `PCA`: `input_tags.allow_nan = True`. The NIPALS / TSR algorithm
+    paths handle missing data; the SVD path still raises explicitly.
+    Inside a `Pipeline`, sklearn's `check_array` no longer rejects
+    NaN before the algorithm has a chance to see it.
+  - `PLS`: `input_tags.allow_nan = True` and
+    `target_tags.multi_output = True`. The first unblocks the missing-
+    data path through a Pipeline; the second tells multi-output scorers
+    and cross-validators to dispatch correctly on multi-target Y (the
+    default chemometric PLS case).
+
+### Fixed
+
+- **`PLS.fit` on data with missing values no longer raises
+  `NotImplementedError`.** When NaN was detected in X or Y, the missing-
+  data settings defaulted to `md_method="tsr"`, but TSR for PLS is
+  raised as `NotImplementedError` in `_fit_nipals`. The default now
+  routes to `md_method="nipals"`, which handles per-cell NaN directly
+  via skipna sums inside the NIPALS iterations and was the intended
+  behaviour all along. Surfaced by `check_estimator` when the new
+  `allow_nan=True` tag let sklearn send NaN-containing data through to
+  `PLS.fit`.
+
+### Audit movement (`tools/check_estimator_audit.py`)
+
+| Estimator | Before #393 | After #393 |
+|---|---|---|
+| `MCUVScaler` | 44/47 (94%) | 44/46 (96%) |
+| `PCA(n_components=2)` | 38/47 (81%) | 38/46 (83%) |
+| `PLS(n_components=2)` | 24/29 (83%) | 24/28 (86%) |
+
+Total check counts drop by 1 each because `__sklearn_tags__` declares
+`allow_nan=True`, so sklearn skips the "do you reject NaN?" check
+(it's no longer the contract). Net behavioural change: the NaN-
+through-Pipeline path that #391 / #393 unblock now actually works
+on PLS too (not just MCUVScaler / PCA).
+
 ## [1.36.0] - 2026-06-07
 
 ### Changed
@@ -1759,7 +1803,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.36.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.37.0...HEAD
+[1.37.0]: https://github.com/kgdunn/process-improve/compare/v1.36.0...v1.37.0
 [1.36.0]: https://github.com/kgdunn/process-improve/compare/v1.35.0...v1.36.0
 [1.35.0]: https://github.com/kgdunn/process-improve/compare/v1.34.0...v1.35.0
 [1.34.0]: https://github.com/kgdunn/process-improve/compare/v1.33.0...v1.34.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.36.0
+version: 1.37.0
 date-released: "2026-06-07"
 keywords:
   - chemometrics

--- a/SKLEARN_COMPATIBILITY.md
+++ b/SKLEARN_COMPATIBILITY.md
@@ -63,19 +63,19 @@ The following compositions are verified by tests in
 
 ## What doesn't work yet
 
-### `check_estimator` baseline (v1.36.0)
+### `check_estimator` baseline (v1.37.0)
 
 Run `python tools/check_estimator_audit.py` (preserved in
-`tools/check_estimator_audit_main.log`) to refresh. As of v1.36.0
-(after the `validate_data` sweep in #401):
+`tools/check_estimator_audit_main.log`) to refresh. As of v1.37.0
+(after the `__sklearn_tags__` declarations in #393):
 
 | Estimator | Passing | Total | Pass % | Issues that close remaining |
 |---|---|---|---|---|
-| `MCUVScaler` | 44 | 47 | 94% | #391, #393 |
-| `PCA(n_components=2)` | 38 | 47 | 81% | #391, #393, #396 |
-| `PLS(n_components=2)` | 24 | 29 | 83% | #391, #393 |
+| `MCUVScaler` | 44 | 46 | 96% | #391 |
+| `PCA(n_components=2)` | 38 | 46 | 83% | #391, #396 |
+| `PLS(n_components=2)` | 24 | 28 | 86% | (small remaining: `score()` validation, `dtype_object`) |
 
-(Pre-#401 baseline was 18/29, 28/47, 19/29.)
+(Pre-#401 baseline was 18/29, 28/47, 19/29; pre-#393 was 44/47, 38/47, 24/29. Total counts drop slightly when `__sklearn_tags__` declares `allow_nan=True` because sklearn skips the "do you reject NaN?" check.)
 
 `TPLS` / `MBPLS` / `MBPCA` are not in this audit — they take
 `dict[str, DataFrame]` for X, which is outside `check_estimator`'s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.36.0"
+version = "1.37.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -307,6 +307,21 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
     loadings_ = _LazyFrame("_loadings", index="_feature_names", columns="_component_names")
     spe_ = _LazyFrame("_spe", index="_sample_index", columns="_component_names")
 
+    def __sklearn_tags__(self):
+        """Declare sklearn capability tags (sklearn 1.6+).
+
+        ``allow_nan=True`` because the NIPALS / TSR algorithm paths
+        thread missing data through; the SVD path raises explicitly
+        when NaN is supplied. The default for any one ``PCA(...)``
+        instance therefore allows NaN at the Pipeline / ``check_array``
+        boundary and lets the fitting algorithm reject it later if
+        needed (the user-facing error message is more informative than
+        the sklearn check-array one).
+        """
+        tags = super().__sklearn_tags__()
+        tags.input_tags.allow_nan = True
+        return tags
+
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X: DataMatrix, y: DataMatrix | None = None) -> PCA:  # noqa: ARG002, PLR0912, PLR0915, C901
         """Fit a principal component analysis (PCA) model to the data.

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -245,6 +245,21 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         self.copy = copy
         self.missing_data_settings = missing_data_settings
 
+    def __sklearn_tags__(self):
+        """Declare sklearn capability tags (sklearn 1.6+).
+
+        - ``input_tags.allow_nan=True`` because the NIPALS fit threads
+          missing data through; ``fit`` and ``predict`` both pass
+          ``ensure_all_finite="allow-nan"`` to ``validate_data``.
+        - ``target_tags.multi_output=True`` because the X / Y blocks
+          can both be multi-column (multi-target Y is the default
+          chemometric PLS case).
+        """
+        tags = super().__sklearn_tags__()
+        tags.input_tags.allow_nan = True
+        tags.target_tags.multi_output = True
+        return tags
+
     # ENG-17: the 13 shared convenience methods, hotellings_t2_limit,
     # ellipse_coordinates and the rename __getattr__ are inherited from
     # _LatentVariableModel. PLS keeps only its two PLS-specific plot methods and
@@ -516,7 +531,10 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
 
         if np.any(Y.isna()) or np.any(X.isna()):
             self.has_missing_data_ = True
-            default_mds = dict(md_method="tsr", md_tol=epsqrt, md_max_iter=self.max_iter)
+            # Default to the NIPALS path because TSR / PMP for PLS are still
+            # NotImplementedError in _fit_nipals; NIPALS handles per-cell NaN
+            # directly via skipna sums inside the NIPALS iterations.
+            default_mds = dict(md_method="nipals", md_tol=epsqrt, md_max_iter=self.max_iter)
             if isinstance(self.missing_data_settings, dict):
                 default_mds.update(self.missing_data_settings)
             self.missing_data_settings = default_mds

--- a/src/process_improve/multivariate/_preprocessing.py
+++ b/src/process_improve/multivariate/_preprocessing.py
@@ -36,6 +36,18 @@ class MCUVScaler(TransformerMixin, BaseEstimator):
     def __init__(self):
         pass
 
+    def __sklearn_tags__(self):
+        """Declare sklearn capability tags (sklearn 1.6+).
+
+        ``allow_nan=True`` because :meth:`fit` and :meth:`transform` use
+        ``np.nanmean`` / ``np.nanstd``: NaN cells flow through, get
+        re-NaN'd by the centring/scaling arithmetic, and reach the
+        downstream NIPALS estimator that knows how to handle them.
+        """
+        tags = super().__sklearn_tags__()
+        tags.input_tags.allow_nan = True
+        return tags
+
     def fit(self, X: DataMatrix, y=None) -> MCUVScaler:  # noqa: ANN001, ARG002
         """Compute the column means and sample standard deviations.
 

--- a/tools/check_estimator_audit_main.log
+++ b/tools/check_estimator_audit_main.log
@@ -7,16 +7,13 @@
 
 
 ===== SUMMARY =====
-MCUVScaler: 44/47 passed (93.6%)
-PCA(n_components=2): 38/47 passed (80.9%)
-PLS(n_components=2): 24/29 passed (82.8%)
+MCUVScaler: 44/46 passed (95.7%)
+PCA(n_components=2): 38/46 passed (82.6%)
+PLS(n_components=2): 24/28 passed (85.7%)
 
 ===== FAILURES (grouped by reason) =====
 
---- MCUVScaler (3 failures) ---
-
-  [1x] AssertionError: Estimator MCUVScaler doesn't check for NaN and inf in fit.
-     - check_estimators_nan_inf
+--- MCUVScaler (2 failures) ---
 
   [1x] SkipTest: SCIPY_ARRAY_API is not set: not checking array_api input
      - check_array_api_input
@@ -24,23 +21,20 @@ PLS(n_components=2): 24/29 passed (82.8%)
   [1x] AttributeError: 'DataFrame' object has no attribute 'dtype'
      - check_transformer_preserve_dtypes
 
---- PCA(n_components=2) (9 failures) ---
+--- PCA(n_components=2) (8 failures) ---
 
   [3x] TypeError: unsupported operand type(s) for -: 'Bunch' and 'Bunch'
      - check_estimators_pickle
      - check_estimators_pickle
      - check_fit_idempotent
 
-  [1x] AssertionError: Estimator PCA doesn't check for NaN and inf in fit.
-     - check_estimators_nan_inf
-
   [1x] SkipTest: SCIPY_ARRAY_API is not set: not checking array_api input
      - check_array_api_input
 
   [1x] AttributeError: 'DataFrame' object has no attribute 'dtype'
      - check_transformer_preserve_dtypes
 
-  [1x] KeyError: np.int64(6)
+  [1x] KeyError: np.int64(1)
      - check_methods_sample_order_invariance
 
   [1x] AssertionError: 
@@ -49,16 +43,13 @@ PLS(n_components=2): 24/29 passed (82.8%)
   [1x] AssertionError: Estimator changes __dict__ during predict
      - check_dict_unchanged
 
---- PLS(n_components=2) (5 failures) ---
+--- PLS(n_components=2) (4 failures) ---
 
   [1x] AssertionError: `PLS.score()` does not check for consistency between input number
      - check_n_features_in_after_fitting
 
   [1x] AssertionError: y with unknown label type is passed, but an error with no proper message is raised. You can use `type_of_target(..., raise_unknown=True)` to check and raise the right error, or include 'Unknown label type' in the error message.
      - check_dtype_object
-
-  [1x] AssertionError: Estimator PLS doesn't check for NaN and inf in fit.
-     - check_estimators_nan_inf
 
   [1x] SkipTest: SCIPY_ARRAY_API is not set: not checking array_api input
      - check_array_api_input


### PR DESCRIPTION
Closes #393.

## Summary

Adds `__sklearn_tags__` overrides to `MCUVScaler`, `PCA`, and `PLS` so sklearn 1.6+ resolves their capability tags correctly. Also fixes a real PLS NaN-fit bug uncovered as soon as the new `allow_nan=True` tag let sklearn route NaN-containing data through to `PLS.fit`.

## What's declared

| Class | `input_tags.allow_nan` | `target_tags.multi_output` | Why |
|---|---|---|---|
| `MCUVScaler` | `True` | (n/a, transformer) | `fit` / `transform` use `np.nanmean` / `np.nanstd` and pass NaN through unchanged. |
| `PCA` | `True` | (n/a, transformer) | NIPALS / TSR paths handle missing data; SVD path still raises explicitly. |
| `PLS` | `True` | `True` | NIPALS-based fit threads missing data; multi-target Y is the default chemometric case. |

The mixin-order half of #393 already landed in PR #402 (folded in because the audit couldn't even complete on `MCUVScaler` without the flip), so this PR is just the tag declarations + the PLS bug fix.

## Real bug fix in passing

- **`PLS.fit` on NaN-containing X or Y was raising `NotImplementedError("TSR for PLS not implemented yet")`** because the missing-data settings defaulted to `md_method="tsr"`, but TSR for PLS is raised as `NotImplementedError` in `_fit_nipals`. The default now routes to `md_method="nipals"`, which handles per-cell NaN directly via skipna sums inside the NIPALS iterations and was the intended behaviour all along.

## `check_estimator` audit movement

| Estimator | Before #393 | After #393 |
|---|---|---|
| `MCUVScaler` | 44/47 (94%) | 44/46 (96%) |
| `PCA(n_components=2)` | 38/47 (81%) | 38/46 (83%) |
| `PLS(n_components=2)` | 24/29 (83%) | 24/28 (86%) |

Total check counts drop by 1 each because `allow_nan=True` removes the "do you reject NaN?" check from the contract.

## Test plan

- [x] Full multivariate suite green locally: `pytest tests/test_multivariate.py -o "addopts="` → `161 passed, 1 skipped`.
- [x] `ruff check .` clean.
- [x] `mypy src/process_improve` clean.
- [x] Re-ran `tools/check_estimator_audit.py` and updated `tools/check_estimator_audit_main.log` + `SKLEARN_COMPATIBILITY.md` with the v1.37.0 numbers.

https://claude.ai/code/session_01CD8jKbCmCEsa3qN8XGcRcs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GygLHnZrhbRXYj7JsPu1hL)_