### PR TITLE
Replace over-fitting CV component criterion with a Q2-increment rule (v1.28.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ those changes.
 
 ## [Unreleased]
 
+## [1.28.0] - 2026-06-06
+
+### Changed
+
+- **Cross-validated component selection now uses a sequential Q2-increment
+  rule** for both `PCA.select_n_components` and `PLS.select_n_components`. A
+  component is kept only if it raises the cumulative cross-validated Q2 by at
+  least `min_q2_increase` (default `0.01`, i.e. one percentage point of
+  predicted variance); the search stops at the first component that does not.
+  This follows the guidance in *Process Improvement using Data* (keep
+  components while Q2 meaningfully increases; stop when it plateaus or
+  decreases) and is consistent across PCA and PLS.
+
+  Previously `PLS.select_n_components` recommended the component count with the
+  single lowest RMSECV (`argmin`). Because the cross-validated error keeps
+  drifting down by noise-level amounts after the systematic components are
+  exhausted, that minimum routinely landed at (or near) the maximum component
+  count, recommending models padded with components that predict no better than
+  the column mean. `PCA.select_n_components` previously used Wold's PRESS-ratio
+  cutoff, which is relative to the shrinking residual and has the same tendency
+  to over-select. Both now require a real Q2 increment, which is the
+  scientifically defensible criterion.
+
+- `PCA.select_n_components` and `PLS.select_n_components` gain a
+  `min_q2_increase` parameter (default `0.01`) to tune that threshold; pass
+  `0.0` to recover the old permissive "any improvement" behaviour. The
+  `threshold` (Wold PRESS-ratio) argument of `PCA.select_n_components` is
+  **deprecated and ignored**; passing it emits a `DeprecationWarning`. The
+  `press_ratio` series is still returned for inspection.
+
 ## [1.27.1] - 2026-06-06
 
 ### Fixed
@@ -1486,7 +1516,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.27.1...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.28.0...HEAD
+[1.28.0]: https://github.com/kgdunn/process-improve/compare/v1.27.1...v1.28.0
 [1.27.1]: https://github.com/kgdunn/process-improve/compare/v1.27.0...v1.27.1
 [1.27.0]: https://github.com/kgdunn/process-improve/compare/v1.26.1...v1.27.0
 [1.26.1]: https://github.com/kgdunn/process-improve/compare/v1.26.0...v1.26.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.27.1
+version: 1.28.0
 date-released: "2026-06-06"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.27.1"
+version = "1.28.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_common.py
+++ b/src/process_improve/multivariate/_common.py
@@ -20,11 +20,84 @@ import pandas as pd
 # Names re-exported to the rest of the package. Declared explicitly so CodeQL
 # does not flag the ``DataMatrix`` type alias (only ever referenced in lazy
 # annotation strings under ``from __future__ import annotations``) as unused.
-__all__ = ["DataMatrix", "NotEnoughVarianceError", "SpecificationWarning", "epsqrt"]
+__all__ = [
+    "Q2_MIN_INCREMENT",
+    "DataMatrix",
+    "NotEnoughVarianceError",
+    "SpecificationWarning",
+    "epsqrt",
+]
 
 DataMatrix: TypeAlias = np.ndarray | pd.DataFrame
 
 epsqrt = np.sqrt(np.finfo(float).eps)
+
+#: Default minimum increase in the cross-validated :math:`Q^2` for an extra
+#: component to be judged worth keeping. A component that lifts the cumulative
+#: :math:`Q^2` by less than this (or lowers it) is treated as fitting noise,
+#: not systematic variation. ``0.01`` means "must add at least one percentage
+#: point of cross-validated explained variance". See
+#: :func:`_recommend_n_components`.
+Q2_MIN_INCREMENT = 0.01
+
+
+def _recommend_n_components(
+    q2_cumulative: np.ndarray | pd.Series | list[float],
+    *,
+    min_increment: float = Q2_MIN_INCREMENT,
+) -> int:
+    r"""Recommend a component count from a cumulative cross-validated :math:`Q^2` curve.
+
+    Implements the cross-validation stopping rule taught in *Process Improvement
+    using Data* (`Determining the number of components ... with cross-validation
+    <https://learnche.org/pid/latent-variable-modelling/principal-component-analysis/determining-the-number-of-components-to-use-in-the-model-with-cross-validation>`_):
+    keep adding components while each one *meaningfully* raises the
+    cross-validated :math:`Q^2`, and stop as soon as one does not, because a
+    component that fails to lift :math:`Q^2` is fitting noise rather than
+    systematic variation.
+
+    Walking outward from a single component, component ``a`` is retained only if
+    it increases the cumulative :math:`Q^2` over ``a - 1`` components by at least
+    ``min_increment`` (with an implied :math:`Q^2` of ``0`` before any
+    component). The first component that fails that test - a plateau or a drop -
+    stops the search, and the recommendation is the last component that passed
+    (never fewer than one, since a model needs at least one component).
+
+    This is deliberately a *sequential* rule, not a global optimum. Choosing the
+    component count with the single best :math:`Q^2` (equivalently the lowest
+    PRESS or RMSECV via ``argmin`` / ``argmax``) routinely runs to the maximum,
+    because the cross-validated curve keeps drifting by noise-level amounts after
+    the systematic components are exhausted; a near-zero or fractional final
+    improvement is then enough to select one more component. Requiring a real
+    increment at every step rejects those non-systematic components and is the
+    scientifically defensible criterion.
+
+    Parameters
+    ----------
+    q2_cumulative : array-like of shape (A,)
+        Cumulative cross-validated :math:`Q^2` after ``1, 2, ..., A``
+        components. Non-finite entries (``NaN``/``inf``) are treated as "no
+        improvement" and stop the search.
+    min_increment : float, default :data:`Q2_MIN_INCREMENT`
+        Smallest increase in cumulative :math:`Q^2` that justifies keeping the
+        next component. ``0`` reproduces the permissive "any improvement"
+        behaviour; larger values are more conservative (fewer components).
+
+    Returns
+    -------
+    int
+        Recommended number of components, at least 1.
+    """
+    q2 = np.asarray(q2_cumulative, dtype=float)
+    recommended = 1
+    previous = 0.0
+    for a, value in enumerate(q2, start=1):
+        if not np.isfinite(value) or (value - previous) < min_increment:
+            break
+        recommended = a
+        previous = float(value)
+    return recommended
+
 
 #: Smallest positive float; used to floor NIPALS denominators away from zero.
 _DENOM_FLOOR = float(np.finfo(float).tiny)

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -23,7 +23,15 @@ from sklearn.utils.validation import check_is_fitted
 
 from ..univariate.metrics import detect_outliers_esd
 from ._base import _LatentVariableModel, _LazyFrame
-from ._common import DataMatrix, NotEnoughVarianceError, SpecificationWarning, _align_to_fit_features, epsqrt
+from ._common import (
+    Q2_MIN_INCREMENT,
+    DataMatrix,
+    NotEnoughVarianceError,
+    SpecificationWarning,
+    _align_to_fit_features,
+    _recommend_n_components,
+    epsqrt,
+)
 from ._nipals import quick_regress, ssq, terminate_check
 
 logger = logging.getLogger(__name__)
@@ -561,15 +569,27 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         *,
         max_components: int | None = None,
         cv: int | BaseCrossValidator = 5,
-        threshold: float = 0.95,
+        min_q2_increase: float = Q2_MIN_INCREMENT,
+        threshold: float | None = None,
         **pca_kwargs,
     ) -> Bunch:
         """Select the number of components via PRESS cross-validation.
 
         Fits PCA models with 1, 2, ..., ``max_components`` components,
-        evaluates each with K-fold cross-validation, and recommends the
-        optimal number using Wold's criterion: stop adding components when
-        PRESS_a / PRESS_{a-1} > ``threshold``.
+        evaluates each with K-fold cross-validation, and recommends a component
+        count using the sequential :math:`Q^2`-increment rule (see
+        :func:`~process_improve.multivariate._common._recommend_n_components`):
+        keep adding components while each meaningfully raises the
+        cross-validated :math:`Q^2_X`, and stop at the first one that does not.
+
+        This replaces the earlier recommendation based purely on Wold's
+        PRESS-ratio (``PRESS_a / PRESS_{a-1}``). The PRESS ratio is *relative* to
+        the shrinking residual, so a fixed ratio cutoff keeps accepting
+        components whose absolute predictive gain has become negligible, and the
+        selection tends to run on too far. Requiring a real :math:`Q^2`
+        increment is the scientifically defensible criterion and is consistent
+        with :meth:`PLS.select_n_components`. The ``press_ratio`` series is still
+        returned for inspection.
 
         Parameters
         ----------
@@ -581,10 +601,18 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         cv : int or sklearn CV splitter, default 5
             Number of cross-validation folds, or an sklearn splitter object
             (e.g., ``KFold(n_splits=10, shuffle=True)``).
-        threshold : float, default 0.95
-            Wold's criterion threshold. If PRESS_a / PRESS_{a-1} exceeds
-            this value, component ``a`` is deemed not significant. Lower
-            values are more aggressive (fewer components).
+        min_q2_increase : float, default ``0.01``
+            Smallest increase in the cumulative cross-validated :math:`Q^2_X`
+            (the ``q2`` series) that justifies keeping an extra component.
+            Components whose marginal :math:`Q^2` gain falls below this are
+            judged to fit noise and stop the search. ``0`` reproduces the old
+            permissive "any improvement" behaviour; larger values are more
+            conservative (fewer components).
+        threshold : float, optional
+            Deprecated and ignored. Previously the Wold PRESS-ratio cutoff used
+            to pick the component count; the recommendation now uses
+            ``min_q2_increase`` instead. Passing this emits a
+            :class:`DeprecationWarning`.
         **pca_kwargs
             Additional keyword arguments passed to the ``PCA()`` constructor
             (e.g., ``algorithm="nipals"`` for data with missing values).
@@ -615,6 +643,16 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         ``MCUVScaler``); the ``q2`` normalisation uses the mean-cell
         sum-of-squares of ``X`` as the null-model reference.
         """
+        if threshold is not None:
+            warnings.warn(
+                "The `threshold` (Wold PRESS-ratio) argument of "
+                "PCA.select_n_components is deprecated and ignored; the "
+                "recommendation now uses the `min_q2_increase` Q2-increment "
+                "rule. Remove `threshold` and tune `min_q2_increase` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(X)
 
@@ -642,18 +680,15 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         q2 = q2.rename("Q2")
         q2.index.name = "n_components"
 
-        # Wold's criterion: ratio of consecutive PRESS values
+        # Wold's PRESS ratio (consecutive PRESS values) is still reported for
+        # inspection, but the recommendation no longer keys off it.
         ratio_values = {a: press[a] / press[a - 1] for a in range(2, max_components + 1)}
         press_ratio = pd.Series(ratio_values, name="PRESS ratio")
         press_ratio.index.name = "n_components"
 
-        # Recommend: last component where ratio <= threshold
-        recommended = 1
-        for a in range(2, max_components + 1):
-            if press_ratio[a] <= threshold:
-                recommended = a
-            else:
-                break
+        # Sequential Q^2-increment rule: keep components while each meaningfully
+        # raises the cross-validated Q^2_X, and stop at the first that does not.
+        recommended = _recommend_n_components(q2.to_numpy(), min_increment=min_q2_increase)
 
         cv_scores = pd.DataFrame(all_cv_scores).T
         cv_scores.index.name = "n_components"

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -27,11 +27,13 @@ from .._linalg import safe_inverse
 from ..univariate.metrics import detect_outliers_esd
 from ._base import _LatentVariableModel, _LazyFrame
 from ._common import (
+    Q2_MIN_INCREMENT,
     DataMatrix,
     NotEnoughVarianceError,
     SpecificationWarning,
     _align_to_fit_features,
     _model_method,
+    _recommend_n_components,
     epsqrt,
 )
 from ._nipals import quick_regress, ssq, terminate_check
@@ -620,6 +622,7 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         *,
         max_components: int | None = None,
         cv: int | BaseCrossValidator = 5,
+        min_q2_increase: float = Q2_MIN_INCREMENT,
         **pls_kwargs,
     ) -> Bunch:
         """Select the number of PLS components via cross-validation.
@@ -627,7 +630,19 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         Fits PLS models on cross-validation training folds and evaluates the
         out-of-fold prediction error for every component count ``1, 2, ...,
         max_components``. Reports RMSECV and validated explained variance, and
-        recommends the component count with the lowest overall RMSECV.
+        recommends a component count using the sequential :math:`Q^2`-increment
+        rule (see :func:`~process_improve.multivariate._common._recommend_n_components`):
+        keep adding components while each meaningfully raises the cross-validated
+        :math:`Q^2_Y`, and stop at the first one that does not.
+
+        The recommendation deliberately does **not** pick the single lowest
+        RMSECV (the ``argmin``). On many data sets the cross-validated error
+        keeps drifting down by noise-level amounts after the systematic
+        components are exhausted, so the global minimum sits at (or near) the
+        maximum component count even though those last components predict no
+        better than the column mean. Requiring a real :math:`Q^2` increment at
+        each step is the scientifically defensible criterion and avoids that
+        over-fitting.
 
         Unlike the calibration statistics stored on a fitted model
         (``rmse_``, ``r2_cumulative_``), these metrics estimate performance on
@@ -646,6 +661,13 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         cv : int or sklearn CV splitter, default 5
             Number of K-fold splits, or an sklearn splitter object (e.g.
             ``KFold(n_splits=10, shuffle=True)`` or ``LeaveOneOut()``).
+        min_q2_increase : float, default ``0.01``
+            Smallest increase in the cumulative cross-validated :math:`Q^2_Y`
+            (the ``"total"`` column of ``r2y_validated``) that justifies keeping
+            an extra component. Components whose marginal :math:`Q^2` gain falls
+            below this threshold are judged to fit noise and stop the search.
+            ``0`` reproduces the old permissive "any improvement" behaviour;
+            larger values are more conservative (fewer components).
         **pls_kwargs
             Additional keyword arguments passed to the ``PLS()`` constructor
             (e.g. ``missing_data_settings``).
@@ -656,7 +678,8 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             With keys:
 
             - ``n_components`` - recommended number of components (int): the
-              count with the lowest overall RMSECV.
+              largest count reached before the cross-validated :math:`Q^2_Y`
+              stops improving by at least ``min_q2_increase``.
             - ``rmsecv`` - root-mean-square error of cross-validation
               (pd.DataFrame, indexed 1..A; columns are the Y-variable names
               plus ``"total"``).
@@ -677,10 +700,12 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         dataset, which makes the reported errors slightly optimistic compared
         with scaling each training fold independently.
 
-        The recommendation uses the minimum overall RMSECV. A more
-        conservative choice is Wold's criterion: stop adding components once
-        RMSECV stops improving appreciably. That can be applied directly to
-        the returned ``rmsecv["total"]`` curve.
+        The recommendation applies the sequential :math:`Q^2`-increment rule to
+        the cumulative validated :math:`Q^2_Y` (the ``"total"`` column of
+        ``r2y_validated``). The full ``rmsecv`` and ``r2y_validated`` curves are
+        returned so callers can apply their own stopping rule or inspect a few
+        components either side of the recommendation, as good practice
+        suggests.
 
         Examples
         --------
@@ -759,11 +784,10 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         )
         press = pd.Series(press_y.sum(axis=1), index=component_index, name="PRESS")
 
-        # If every CV fold produced NaN (e.g. zero-variance Y per fold)
-        # ``np.argmin`` warns and returns 0; the silent ``recommended = 1``
-        # was indistinguishable from a legitimate "1 component is best"
-        # result. Raise instead so the caller knows the CV did not converge
-        # to a recommendation. SEC-21 (#270) sub-item 8.
+        # If every CV fold produced NaN (e.g. zero-variance Y per fold) the
+        # cross-validation never converged to anything we can judge. Raise so
+        # the caller knows, rather than silently returning ``1``. SEC-21 (#270)
+        # sub-item 8.
         total_rmsecv = rmsecv["total"].to_numpy()
         if np.all(np.isnan(total_rmsecv)):
             raise RuntimeError(
@@ -771,7 +795,12 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
                 "no recommendation can be made. Likely cause: a per-fold zero-variance Y "
                 "column, or every fold trivially degenerate."
             )
-        recommended = int(np.nanargmin(total_rmsecv)) + 1
+        # Sequential Q^2-increment rule on the cumulative validated Q^2_Y, not
+        # the global RMSECV minimum (which over-fits to the maximum component
+        # count when the error keeps drifting down by noise-level amounts).
+        recommended = _recommend_n_components(
+            r2y_validated["total"].to_numpy(), min_increment=min_q2_increase
+        )
         cv_predictions = pd.DataFrame(oof[recommended - 1], index=Y.index, columns=Y.columns)
 
         return Bunch(

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2270,6 +2270,98 @@ def test_pls_select_n_components_caps_max_components() -> None:
     assert result.n_components <= 24
 
 
+def test_recommend_n_components_q2_rule() -> None:
+    """The shared Q2-increment rule stops at the first non-meaningful component."""
+    from process_improve.multivariate._common import Q2_MIN_INCREMENT, _recommend_n_components
+
+    # Two systematic components, then a plateau and a drop: stop at 2, never 4.
+    assert _recommend_n_components([0.40, 0.62, 0.625, 0.50]) == 2
+    # A single strong component then a fractional (noise-level) gain: stop at 1.
+    assert _recommend_n_components([0.55, 0.553]) == 1
+    # Monotonically improving but each step below the threshold: still stop at 1.
+    assert _recommend_n_components([0.30, 0.305, 0.309, 0.312]) == 1
+    # A genuinely worthless first component recommends 1 (a model needs >= 1).
+    assert _recommend_n_components([0.0001, -0.2]) == 1
+    # NaN (degenerate fold) stops the search.
+    assert _recommend_n_components([0.4, np.nan, 0.9]) == 1
+    # min_increment=0 reproduces the old permissive "any improvement" behaviour.
+    assert _recommend_n_components([0.30, 0.305, 0.309, 0.312], min_increment=0.0) == 4
+    # A larger threshold is more conservative.
+    assert _recommend_n_components([0.40, 0.62, 0.70], min_increment=0.1) == 2
+    assert Q2_MIN_INCREMENT == 0.01
+
+
+def test_pls_select_n_components_does_not_run_to_max() -> None:
+    """Noise-level extra components must not be selected (the reported bug).
+
+    Eight latent factors of geometrically decaying influence drive Y; later
+    factors contribute progressively less. The cross-validated RMSECV keeps
+    drifting down by noise-level amounts after the systematic factors are
+    captured, so the old ``argmin(RMSECV)`` rule chases that minimum far up the
+    curve. The Q2-increment rule stops once the marginal Q2 gain falls below the
+    threshold, near the true effective rank.
+    """
+    rng = np.random.default_rng(0)
+    N, K, n_factors = 80, 50, 8
+    scales = np.array([6.0, 5.0, 4.0, 3.0, 2.0, 1.2, 0.8, 0.5])
+    T_true = rng.normal(size=(N, n_factors)) * scales
+    P_true = rng.normal(size=(K, n_factors))
+    X = pd.DataFrame(T_true @ P_true.T + 0.4 * rng.normal(size=(N, K)), columns=[f"x{i}" for i in range(K)])
+    gamma = rng.normal(size=(n_factors, 1))
+    Y = pd.DataFrame(T_true @ gamma + 0.3 * rng.normal(size=(N, 1)), columns=["y"])
+    X_s = MCUVScaler().fit_transform(X)
+    Y_s = MCUVScaler().fit_transform(Y)
+
+    max_comp = 12
+    folds = KFold(7, shuffle=True, random_state=0)
+    result = PLS.select_n_components(X_s, Y_s, max_components=max_comp, cv=folds)
+
+    # The global RMSECV minimum lies far up the curve (the old behaviour); the
+    # Q2-increment rule recommends meaningfully fewer components.
+    argmin_choice = int(np.nanargmin(result.rmsecv["total"].to_numpy())) + 1
+    assert argmin_choice >= 8  # argmin chases noise-level improvements
+    assert result.n_components < argmin_choice  # the regression guard
+    assert result.n_components <= 6
+
+    # Every retained component cleared the Q2 bar; the next one did not.
+    q2 = result.r2y_validated["total"].to_numpy()
+    rec = result.n_components
+    increments = np.diff(np.concatenate([[0.0], q2]))
+    assert (increments[:rec] >= 0.01 - 1e-12).all()
+    assert increments[rec] < 0.01
+
+    # The permissive setting (any improvement) reverts to the over-fit choice,
+    # confirming the threshold is what trims the noise components.
+    permissive = PLS.select_n_components(X_s, Y_s, max_components=max_comp, cv=folds, min_q2_increase=0.0)
+    assert permissive.n_components > result.n_components
+
+
+def test_pca_select_n_components_does_not_run_to_max() -> None:
+    """PCA selection stops once extra components stop lifting Q2X meaningfully."""
+    rng = np.random.default_rng(2025)
+    N, K = 60, 40
+    T_true = rng.standard_normal((N, 3)) * np.array([12.0, 7.0, 4.0])
+    P_true = rng.standard_normal((3, K))
+    P_true /= np.linalg.norm(P_true, axis=1, keepdims=True)
+    X = pd.DataFrame(T_true @ P_true + rng.standard_normal((N, K)))
+    X_s = MCUVScaler().fit_transform(X)
+
+    max_comp = 20
+    result = PCA.select_n_components(X_s, max_components=max_comp, cv=KFold(7, shuffle=True, random_state=0))
+    assert result.n_components < max_comp
+    assert result.n_components <= 5  # near the true rank of 3
+
+
+def test_pca_select_n_components_threshold_is_deprecated() -> None:
+    """Passing the legacy Wold-ratio ``threshold`` warns but still returns a result."""
+    rng = np.random.default_rng(5)
+    X = pd.DataFrame(rng.standard_normal((30, 8)))
+    X_s = MCUVScaler().fit_transform(X)
+    with pytest.warns(DeprecationWarning, match="threshold"):
+        result = PCA.select_n_components(X_s, max_components=4, cv=3, threshold=0.95)
+    assert 1 <= result.n_components <= 4
+
+
 def test_not_enough_variance_error_is_typed_and_runtimeerror() -> None:
     """Rank overflow raises NotEnoughVarianceError, still catchable as RuntimeError."""
     # NotEnoughVarianceError subclasses RuntimeError so existing broad


### PR DESCRIPTION
## Why

ScorePilot surfaced that cross-validated component selection routinely runs to
(or near) the maximum number of components: `PLS.select_n_components` picked the
single lowest RMSECV (`argmin`), and `PCA.select_n_components` used Wold's
PRESS-ratio cutoff. Both keep accepting components whose absolute predictive
gain has become negligible, because the cross-validated error keeps drifting
down by noise-level amounts after the systematic components are exhausted.

## What changed

- **Both `PCA.select_n_components` and `PLS.select_n_components` now recommend a
  component count with a sequential Q2-increment rule** (`_recommend_n_components`
  in `_common.py`): keep a component only if it raises the cumulative
  cross-validated Q2 by at least `min_q2_increase` (default `0.01`), and stop at
  the first one that does not. This is the scientifically defensible criterion
  and is now consistent across PCA and PLS.
- New `min_q2_increase` parameter (default `0.01`) on both selectors to tune the
  threshold; `0.0` recovers the old permissive "any improvement" behaviour.
- `PCA.select_n_components`'s `threshold` (Wold PRESS-ratio) argument is
  deprecated and ignored; passing it emits a `DeprecationWarning`. The
  `press_ratio` series is still returned for inspection.
- The full `rmsecv` / `r2y_validated` / `q2` curves are still returned so callers
  can apply their own stopping rule.

## Version / housekeeping

- Version bumped to **1.28.0** (`pyproject.toml` + `CITATION.cff` in sync).
- `CHANGELOG.md` updated under a new `## [1.28.0]` section.
- 92 lines of new tests in `tests/test_multivariate.py`.

## Tests

```
pytest tests/test_multivariate.py -k "select_n_components or q2_increment or recommend or component"
# 16 passed
```

## Note for the maintainer

This is the upstream half of a coordinated change with ScorePilot. ScorePilot is
currently locked to `process-improve==1.27.1` and cannot adopt the fix (nor the
new `min_q2_increase` knob) until **1.28.0 is published to PyPI**. Once this
merges and the `v1.28.0` tag is pushed (publish is manually gated), the
ScorePilot adoption PR will follow against the real release.

https://claude.ai/code/session_01KHx2ai8JtjRVUhW3ZMwWN8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHx2ai8JtjRVUhW3ZMwWN8)_