### PR TITLE
get_feature_names_out on MCUVScaler / PCA / PLS (closes #391, additive scope)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,41 @@ those changes.
 
 ## [Unreleased]
 
+## [1.38.0] - 2026-06-07
+
+### Added
+
+- **`get_feature_names_out` on `MCUVScaler`, `PCA`, and `PLS`** for
+  sklearn 1.2+ `set_output` and Pipeline introspection. Three small
+  additions, no breaking changes:
+  - `MCUVScaler.get_feature_names_out()` is column-preserving:
+    returns the fit-time `feature_names_in_` (sklearn's standard
+    fallback when an `input_features` argument is supplied).
+  - `PCA.get_feature_names_out()` returns
+    `np.array(["PC1", "PC2", ..., "PC{n_components}"])` - the score
+    column names.
+  - `PLS.get_feature_names_out()` returns
+    `np.array(["T1", "T2", ..., "T{n_components}"])` - the X-score
+    column names.
+
+  These unblock:
+  - `pipe.get_feature_names_out()` for any Pipeline containing one of
+    these estimators (previously would raise `AttributeError`).
+  - `pipe.set_output(transform="pandas")` correctly labels the
+    resulting DataFrame's columns; sklearn's `_SetOutputMixin` wraps
+    the ndarray with our component names.
+  - SHAP / eli5 / model-card libraries that introspect output column
+    names of pipeline components.
+
+  Note: `transform()` itself still returns a `pd.DataFrame` by default
+  (the chemometric idiom this package has used since v1.0). Users who
+  prefer sklearn-canonical ndarray output can opt in via
+  `pca.set_output(transform="default")` or work through a
+  `Pipeline(...).set_output(transform="pandas")` and let sklearn drive
+  the type. A future major-version revisit may flip the default; the
+  scaffolding (`get_feature_names_out`) is in place so the switch is
+  one-line when chosen.
+
 ## [1.37.0] - 2026-06-07
 
 ### Added
@@ -1803,7 +1838,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.37.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.38.0...HEAD
+[1.38.0]: https://github.com/kgdunn/process-improve/compare/v1.37.0...v1.38.0
 [1.37.0]: https://github.com/kgdunn/process-improve/compare/v1.36.0...v1.37.0
 [1.36.0]: https://github.com/kgdunn/process-improve/compare/v1.35.0...v1.36.0
 [1.35.0]: https://github.com/kgdunn/process-improve/compare/v1.34.0...v1.35.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.37.0
+version: 1.38.0
 date-released: "2026-06-07"
 keywords:
   - chemometrics

--- a/SKLEARN_COMPATIBILITY.md
+++ b/SKLEARN_COMPATIBILITY.md
@@ -63,19 +63,29 @@ The following compositions are verified by tests in
 
 ## What doesn't work yet
 
-### `check_estimator` baseline (v1.37.0)
+### `check_estimator` baseline (v1.38.0)
 
 Run `python tools/check_estimator_audit.py` (preserved in
-`tools/check_estimator_audit_main.log`) to refresh. As of v1.37.0
-(after the `__sklearn_tags__` declarations in #393):
+`tools/check_estimator_audit_main.log`) to refresh. As of v1.38.0
+(after `get_feature_names_out` added in #391):
 
 | Estimator | Passing | Total | Pass % | Issues that close remaining |
 |---|---|---|---|---|
-| `MCUVScaler` | 44 | 46 | 96% | #391 |
-| `PCA(n_components=2)` | 38 | 46 | 83% | #391, #396 |
-| `PLS(n_components=2)` | 24 | 28 | 86% | (small remaining: `score()` validation, `dtype_object`) |
+| `MCUVScaler` | 44 | 46 | 96% | #391-leftover (transformer-dtype: ndarray transform) |
+| `PCA(n_components=2)` | 38 | 46 | 83% | #391-leftover, #396 |
+| `PLS(n_components=2)` | 24 | 28 | 86% | (small: `score()` validation, `dtype_object`) |
 
-(Pre-#401 baseline was 18/29, 28/47, 19/29; pre-#393 was 44/47, 38/47, 24/29. Total counts drop slightly when `__sklearn_tags__` declares `allow_nan=True` because sklearn skips the "do you reject NaN?" check.)
+`get_feature_names_out` itself doesn't close audit failures (it's purely
+additive ecosystem support), but it unblocks
+`pipe.set_output(transform="pandas")`, `pipe.get_feature_names_out()`,
+SHAP / eli5 introspection, and similar tooling that keys off output
+column names. The two remaining transformer failures
+(`check_transformer_data_not_an_array`,
+`check_transformer_preserve_dtypes`) require `transform()` to return an
+ndarray by default - that's a breaking change to the package's
+DataFrame-everywhere idiom and is left for a future major-version
+refactor; the scaffolding (`get_feature_names_out`) is in place so the
+switch lands cleanly when chosen.
 
 `TPLS` / `MBPLS` / `MBPCA` are not in this audit — they take
 `dict[str, DataFrame]` for X, which is outside `check_estimator`'s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.37.0"
+version = "1.38.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -322,6 +322,24 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         tags.input_tags.allow_nan = True
         return tags
 
+    def get_feature_names_out(self, input_features=None) -> np.ndarray:  # noqa: ANN001, ARG002
+        """Return the output column names of :meth:`transform`.
+
+        :class:`PCA`'s ``transform`` produces scores, one column per
+        component, named ``["PC1", "PC2", ..., "PC{n_components}"]``.
+        The ``input_features`` argument is accepted (Pipeline
+        introspection passes it through) but unused: the output column
+        count is the fitted ``n_components``, not the input feature
+        count.
+
+        Used by :meth:`set_output` (sklearn 1.2+) to label the
+        :class:`~pandas.DataFrame` view of the scores when
+        ``set_output(transform="pandas")`` is on, and by Pipeline
+        introspection.
+        """
+        check_is_fitted(self, "loadings_")
+        return np.asarray([f"PC{a}" for a in self._component_names])
+
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X: DataMatrix, y: DataMatrix | None = None) -> PCA:  # noqa: ARG002, PLR0912, PLR0915, C901
         """Fit a principal component analysis (PCA) model to the data.

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -260,6 +260,23 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         tags.target_tags.multi_output = True
         return tags
 
+    def get_feature_names_out(self, input_features=None) -> np.ndarray:  # noqa: ANN001, ARG002
+        """Return the output column names of :meth:`transform`.
+
+        :class:`PLS`'s ``transform`` returns the X scores (T matrix),
+        labelled ``["T1", "T2", ..., "T{n_components}"]``. The
+        ``input_features`` argument is accepted (Pipeline introspection
+        passes it through) but unused: the output column count is the
+        fitted ``n_components``, not the input feature count.
+
+        Used by :meth:`set_output` (sklearn 1.2+) to label the
+        :class:`~pandas.DataFrame` view of the scores when
+        ``set_output(transform="pandas")`` is on, and by Pipeline
+        introspection.
+        """
+        check_is_fitted(self, "direct_weights_")
+        return np.asarray([f"T{a}" for a in self._component_names])
+
     # ENG-17: the 13 shared convenience methods, hotellings_t2_limit,
     # ellipse_coordinates and the rename __getattr__ are inherited from
     # _LatentVariableModel. PLS keeps only its two PLS-specific plot methods and

--- a/src/process_improve/multivariate/_preprocessing.py
+++ b/src/process_improve/multivariate/_preprocessing.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils.validation import check_is_fitted, validate_data
+from sklearn.utils.validation import _check_feature_names_in, check_is_fitted, validate_data
 
 from ._common import DataMatrix
 
@@ -47,6 +47,23 @@ class MCUVScaler(TransformerMixin, BaseEstimator):
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         return tags
+
+    def get_feature_names_out(self, input_features=None) -> np.ndarray:  # noqa: ANN001
+        """Return the output column names of :meth:`transform`.
+
+        :class:`MCUVScaler` is column-preserving (centring + scaling
+        leave the X column layout unchanged), so the returned names
+        mirror those captured during :meth:`fit` (or the
+        ``input_features`` argument when no ``feature_names_in_`` was
+        captured - the standard sklearn fallback for ndarray-fit
+        estimators).
+
+        Used by :meth:`set_output` (sklearn 1.2+) to label the
+        :class:`~pandas.DataFrame` view of the output when
+        ``set_output(transform="pandas")`` is on, and by Pipeline
+        introspection.
+        """
+        return _check_feature_names_in(self, input_features)
 
     def fit(self, X: DataMatrix, y=None) -> MCUVScaler:  # noqa: ANN001, ARG002
         """Compute the column means and sample standard deviations.

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2872,6 +2872,48 @@ def test_pipeline_gridsearchcv_selects_components() -> None:
     assert grid.best_score_ > 0.5
 
 
+def test_get_feature_names_out_mcuv_pca_pls() -> None:
+    """get_feature_names_out works on each estimator and threads through Pipeline.set_output."""
+    from sklearn.pipeline import Pipeline
+
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame(rng.standard_normal((30, 4)), columns=["A", "B", "C", "D"])
+    Y = pd.DataFrame(rng.standard_normal((30, 1)), columns=["y"])
+
+    # MCUVScaler is column-preserving: returns the fit-time feature names.
+    sc = MCUVScaler().fit(X)
+    assert list(sc.get_feature_names_out()) == ["A", "B", "C", "D"]
+    # Passing matching input_features explicitly also works (sklearn convention).
+    assert list(sc.get_feature_names_out(["A", "B", "C", "D"])) == ["A", "B", "C", "D"]
+
+    # PCA labels its scores PC1..PCn.
+    pca = PCA(n_components=3).fit(MCUVScaler().fit_transform(X))
+    assert list(pca.get_feature_names_out()) == ["PC1", "PC2", "PC3"]
+
+    # PLS labels its X-scores T1..Tn.
+    pls = PLS(n_components=2).fit(
+        MCUVScaler().fit_transform(X), MCUVScaler().fit_transform(Y),
+    )
+    assert list(pls.get_feature_names_out()) == ["T1", "T2"]
+
+    # Pipeline introspection: composed get_feature_names_out follows the last
+    # transform step's labels.
+    pipe = Pipeline([("sc", MCUVScaler()), ("pca", PCA(n_components=2))])
+    pipe.fit(X)
+    assert list(pipe.get_feature_names_out()) == ["PC1", "PC2"]
+
+    # set_output(transform="pandas") wraps the ndarray transform output in a
+    # DataFrame labelled with our get_feature_names_out.
+    pipe_pd = (
+        Pipeline([("sc", MCUVScaler()), ("pca", PCA(n_components=2))])
+        .set_output(transform="pandas")
+    )
+    out = pipe_pd.fit_transform(X)
+    assert isinstance(out, pd.DataFrame)
+    assert list(out.columns) == ["PC1", "PC2"]
+    assert out.shape == (30, 2)
+
+
 def test_pls_select_n_components_randomization_rule() -> None:
     """Van der Voet's randomization test picks a parsimonious model."""
     rng = np.random.default_rng(2026)

--- a/tools/check_estimator_audit_main.log
+++ b/tools/check_estimator_audit_main.log
@@ -34,7 +34,7 @@ PLS(n_components=2): 24/28 passed (85.7%)
   [1x] AttributeError: 'DataFrame' object has no attribute 'dtype'
      - check_transformer_preserve_dtypes
 
-  [1x] KeyError: np.int64(1)
+  [1x] KeyError: np.int64(7)
      - check_methods_sample_order_invariance
 
   [1x] AssertionError: 


### PR DESCRIPTION
Closes #391 (additive scope).

## Summary

Adds three small `get_feature_names_out` methods on `MCUVScaler`, `PCA`, and `PLS` so sklearn 1.2+'s `set_output` mechanism, Pipeline introspection, and ecosystem tooling (SHAP, eli5, model-card libraries) can resolve the output column names of these estimators.

## What lands

- **`MCUVScaler.get_feature_names_out()`**: column-preserving — returns the fit-time `feature_names_in_` (sklearn's `_check_feature_names_in` fallback handles the `input_features` argument).
- **`PCA.get_feature_names_out()`**: `["PC1", "PC2", ..., "PC{n_components}"]`.
- **`PLS.get_feature_names_out()`**: `["T1", "T2", ..., "T{n_components}"]`.

End-to-end verification (in the new test):
```python
pipe = Pipeline([("sc", MCUVScaler()), ("pca", PCA(n_components=2))]).set_output(transform="pandas")
pipe.fit_transform(X).columns  # → ["PC1", "PC2"]  (sklearn wraps the ndarray for us)
pipe.get_feature_names_out()    # → ["PC1", "PC2"]
```

## Scope decision

The issue body proposed *two* changes: (a) `get_feature_names_out`, and (b) flip `transform()` to return ndarray so sklearn's `set_output` drives the output type.

Path (b) cascaded into **21 existing-test failures** on a sibling WIP branch — internal `PCA.predict` / `PCA.score` / `PLS.diagnose` / `cross_validate` / `nested_cv` / plot helpers all rely on `transform()` returning a DataFrame (the chemometric idiom this package has used since v1.0). Pushing it through is a real refactor across docs, tests, and several internal source paths.

This PR ships **only (a)**, captures most of the practical ecosystem value, and leaves the bigger transform return-type decision for a future major-version revisit. The scaffolding (`get_feature_names_out`) is in place so the flip is one-line when that decision lands.

## `check_estimator` audit movement

Unchanged from #393 (`get_feature_names_out` doesn't close transformer-dtype failures — that's the (b) scope above):

| Estimator | Pass rate |
|---|---|
| `MCUVScaler` | 44/46 (96%) |
| `PCA(n_components=2)` | 38/46 (83%) |
| `PLS(n_components=2)` | 24/28 (86%) |

Remaining `check_transformer_data_not_an_array` and `check_transformer_preserve_dtypes` failures both want ndarray `transform()` output — they re-open as a "transform return-type flip" issue when we're ready.

## Test plan

- [x] New `test_get_feature_names_out_mcuv_pca_pls` covering per-estimator return values, `_check_feature_names_in` passthrough, `Pipeline.get_feature_names_out()`, and `Pipeline.set_output(transform="pandas")` column labelling.
- [x] Full multivariate suite green: `162 passed, 1 skipped`.
- [x] `ruff check .` and `mypy src/process_improve` clean.

https://claude.ai/code/session_01CD8jKbCmCEsa3qN8XGcRcs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GygLHnZrhbRXYj7JsPu1hL)_