### PR TITLE
PCA.diagnose (alias of predict, deprecate predict) - closes #396

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ those changes.
 
 ## [Unreleased]
 
+## [1.38.1] - 2026-06-07
+
+### Added
+
+- **`PCA.diagnose(X)`** as the canonical name for the existing diagnostics
+  Bunch (`scores`, `hotellings_t2`, `spe`). Matches `PLS.diagnose`.
+
+### Deprecated
+
+- **`PCA.predict(X)`** is now a thin shim that forwards to
+  `PCA.diagnose(X)` and emits a `DeprecationWarning`. Behaviour and return
+  shape are unchanged; the rename clears the `predict` name for a future
+  contract that matches its sklearn-convention meaning (regression-style
+  prediction), and removes the asymmetry with `PLS.predict` / `PLS.diagnose`
+  (#396). Slated for removal in 2.0.0.
+
 ## [1.38.0] - 2026-06-07
 
 ### Added
@@ -1838,7 +1854,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.38.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.38.1...HEAD
+[1.38.1]: https://github.com/kgdunn/process-improve/compare/v1.38.0...v1.38.1
 [1.38.0]: https://github.com/kgdunn/process-improve/compare/v1.37.0...v1.38.0
 [1.37.0]: https://github.com/kgdunn/process-improve/compare/v1.36.0...v1.37.0
 [1.36.0]: https://github.com/kgdunn/process-improve/compare/v1.35.0...v1.36.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.38.0
+version: 1.38.1
 date-released: "2026-06-07"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.38.0"
+version = "1.38.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -738,8 +738,14 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         self.fit(X)
         return self.scores_
 
-    def predict(self, X: DataMatrix) -> Bunch:
+    def diagnose(self, X: DataMatrix) -> Bunch:
         """Project new data and compute diagnostics (scores, Hotelling's T², SPE).
+
+        The same logic that historically lived in :meth:`predict`. The rename
+        (since 1.38.1, #396) matches :meth:`PLS.diagnose` and clears the
+        ``predict`` name for a future return-type contract that does what its
+        sklearn-convention name implies (a regression-style prediction).
+        :meth:`predict` is kept as a deprecation shim for now.
 
         Parameters
         ----------
@@ -751,10 +757,10 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             With keys ``scores``, ``hotellings_t2``, ``spe``.
         """
         check_is_fitted(self, "loadings_")
-        # predict() delegates to transform() which already runs validate_data;
-        # call it once here so the rest of predict can work with the aligned
+        # diagnose() delegates to transform() which already runs validate_data;
+        # call it once here so the rest can work with the aligned
         # DataFrame view (and so the validate_data error pathways fire on
-        # the predict() call directly, not on the recursive transform() one).
+        # the diagnose() call directly, not on the recursive transform() one).
         scores = self.transform(X)
         # transform's output is indexed by the validated X's row index;
         # recover an aligned DataFrame for the diagnostics below.
@@ -777,6 +783,23 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         spe_values = pd.Series(np.sqrt(np.sum(residuals**2, axis=1)), index=X.index, name="SPE")
 
         return Bunch(scores=scores, hotellings_t2=t2, spe=spe_values)
+
+    def predict(self, X: DataMatrix) -> Bunch:
+        """Forward to :meth:`diagnose`; emits a :class:`DeprecationWarning`.
+
+        .. deprecated:: 1.38.1
+            Use :meth:`PCA.diagnose` instead. ``predict`` matches the
+            sklearn-convention name (a regression-style prediction), but PCA
+            isn't a regressor; the historical return is a diagnostics Bunch.
+            The rename aligns with :meth:`PLS.diagnose` and frees the name
+            for a future contract. Will be removed in 2.0.0.
+        """
+        warnings.warn(
+            "PCA.predict is deprecated and will be removed in 2.0.0; use PCA.diagnose instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.diagnose(X)
 
     def score(self, X: DataMatrix, y: DataMatrix | None = None) -> float:  # noqa: ARG002
         """Negative mean squared reconstruction error (higher is better).

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -3635,8 +3635,8 @@ def manual_cross_validation(tpls_model: TPLS, full_datadict: dict, cv: int = 5, 
 # ---- Additional coverage tests for multivariate/methods.py ----
 
 
-def test_pca_predict_new_data() -> None:
-    """PCA.predict() should return scores, T2, and SPE for new observations."""
+def test_pca_diagnose_new_data() -> None:
+    """PCA.diagnose() should return scores, T2, and SPE for new observations."""
     rng = np.random.default_rng(42)
     N, K = 100, 5
     X = pd.DataFrame(rng.standard_normal((N, K)), columns=[f"V{i}" for i in range(K)])
@@ -3646,9 +3646,9 @@ def test_pca_predict_new_data() -> None:
     model = PCA(n_components=2)
     model.fit(X_scaled)
 
-    # Predict on a subset of the data
+    # Diagnose on a subset of the data
     X_new = scaler.transform(X.iloc[:10])
-    result = model.predict(X_new)
+    result = model.diagnose(X_new)
 
     assert isinstance(result, Bunch)
     assert result.scores.shape == (10, 2)
@@ -3657,8 +3657,8 @@ def test_pca_predict_new_data() -> None:
     assert (result.spe >= 0).all()
 
 
-def test_pca_predict_numpy_input() -> None:
-    """PCA.predict() should accept numpy arrays as well as DataFrames."""
+def test_pca_diagnose_numpy_input() -> None:
+    """PCA.diagnose() should accept numpy arrays as well as DataFrames."""
     rng = np.random.default_rng(42)
     X = pd.DataFrame(rng.standard_normal((50, 4)))
     X_scaled = MCUVScaler().fit_transform(X)
@@ -3666,8 +3666,25 @@ def test_pca_predict_numpy_input() -> None:
     model = PCA(n_components=2)
     model.fit(X_scaled)
 
-    result = model.predict(X_scaled.values[:5])
+    result = model.diagnose(X_scaled.values[:5])
     assert result.scores.shape == (5, 2)
+
+
+def test_pca_predict_is_deprecated_alias_for_diagnose() -> None:
+    """PCA.predict still works but emits a DeprecationWarning and returns the same Bunch."""
+    rng = np.random.default_rng(42)
+    X = pd.DataFrame(rng.standard_normal((50, 4)), columns=list("ABCD"))
+    X_scaled = MCUVScaler().fit_transform(X)
+    model = PCA(n_components=2).fit(X_scaled)
+
+    with pytest.warns(DeprecationWarning, match=r"PCA\.predict.*deprecated.*diagnose"):
+        deprecated = model.predict(X_scaled.iloc[:5])
+    canonical = model.diagnose(X_scaled.iloc[:5])
+
+    # Identical Bunch contents.
+    np.testing.assert_allclose(deprecated.scores.values, canonical.scores.values)
+    np.testing.assert_allclose(deprecated.hotellings_t2.values, canonical.hotellings_t2.values)
+    np.testing.assert_allclose(deprecated.spe.values, canonical.spe.values)
 
 
 def test_pca_score_method() -> None:


### PR DESCRIPTION
Closes #396.

## Summary

Renames `PCA.predict`'s existing logic to `PCA.diagnose` (matching `PLS.diagnose`), keeps `PCA.predict` as a thin forwarding shim with a `DeprecationWarning`. Behaviour and return shape unchanged until 2.0.0.

### Why this path

The issue asked: do we (1) flip `PCA.predict` to return `X_hat` so the *contract* matches `PLS.predict` (regression-style), (2) just rename the existing diagnostics-Bunch logic so the *name* matches `PLS.diagnose`, or (3) document the asymmetry and live with it?

(1) forces an answer to "what does PCA predict?" - the issue body itself flags that `X_hat = scores @ loadings.T` is already a one-liner and the rich Bunch is the actually-useful surface. (3) leaves the inconsistency in the public API.

(2) closes the inconsistency without committing to a contested semantic. `predict` keeps working with a clear migration path; `diagnose` is the canonical name from now on.

### What lands

- `PCA.diagnose(X) -> Bunch(scores, hotellings_t2, spe)` is the renamed implementation - same logic as today's `PCA.predict`, same return.
- `PCA.predict(X)` is a 3-line shim: `warn(DeprecationWarning); return self.diagnose(X)`.
- Tests rewired: the two existing predict tests are renamed to `test_pca_diagnose_*`; a new `test_pca_predict_is_deprecated_alias_for_diagnose` asserts the warning fires and both methods return identical Bunches.
- Version bump 1.38.0 → 1.38.1 (PATCH; deprecation only, no removal yet). CHANGELOG.md / CITATION.cff updated in the same commit.

## Test plan

- [x] `pytest tests/test_multivariate.py -k "diagnose or predict"` (10 passed).
- [x] Full multivariate suite green.
- [x] `ruff check .` and `mypy src/process_improve` clean.

https://claude.ai/code/session_01CD8jKbCmCEsa3qN8XGcRcs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GygLHnZrhbRXYj7JsPu1hL)_