### PR TITLE
Add q2_se (Q² standard error) to PCA/PLS component selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ those changes.
 
 ## [Unreleased]
 
+## [1.39.0] - 2026-06-07
+
+### Added
+
+- **`q2_se` in the component selectors.** `PCA.select_n_components` and
+  `PLS.select_n_components` now return a per-component `q2_se` series: the
+  standard error on the Q2 scale (the half-width of a +/-1 SE band around the
+  validated Q2 curve). For PCA it is the existing `se_press` rescaled by the
+  constant null-model sum-of-squares; for PLS it is the per-fold total-PRESS
+  standard error divided by the total Y sum-of-squares. This lets callers draw
+  a Q2 uncertainty band without re-deriving the normalisation themselves.
+
 ## [1.38.4] - 2026-06-07
 
 ### Added
@@ -1925,7 +1937,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.38.4...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.39.0...HEAD
+[1.39.0]: https://github.com/kgdunn/process-improve/compare/v1.38.4...v1.39.0
 [1.38.4]: https://github.com/kgdunn/process-improve/compare/v1.38.3...v1.38.4
 [1.38.3]: https://github.com/kgdunn/process-improve/compare/v1.38.2...v1.38.3
 [1.38.2]: https://github.com/kgdunn/process-improve/compare/v1.38.1...v1.38.2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.38.4
+version: 1.39.0
 date-released: "2026-06-07"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.38.4"
+version = "1.39.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -1090,6 +1090,9 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
               (pd.DataFrame, ``A_max`` rows x ``n_folds`` columns).
             - ``se_press`` - standard error of the per-fold PRESS curve
               (pd.Series, indexed ``1..A_max``). Drives the 1-SE rule.
+            - ``q2_se`` - the same standard error rescaled onto the Q2 scale
+              (``se_press / null_model_ss``, pd.Series indexed ``1..A_max``),
+              i.e. the half-width of a +/-1 SE band around ``q2``.
             - ``press_ratio`` - ``PRESS_a / PRESS_{a-1}`` for inspection
               (pd.Series, indexed ``2..A_max``).
             - ``q2`` - cross-validated :math:`R^2_X` per component count
@@ -1223,6 +1226,13 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             se_values = np.nanstd(per_fold_arr, axis=1, ddof=1) / np.sqrt(n_folds_per_a)
         se_press = pd.Series(se_values, index=component_index, name="SE(PRESS)")
 
+        # The same constant null-model sum-of-squares that normalises Q2
+        # (Q2 = 1 - PRESS / null_model_ss) also rescales the PRESS standard
+        # error onto the Q2 scale, giving a directly usable +/-1 SE band around
+        # the Q2 curve without callers having to re-derive the normalisation.
+        q2_se_values = se_values / null_model_ss if null_model_ss > epsqrt else se_values * np.nan
+        q2_se = pd.Series(q2_se_values, index=component_index, name="SE(Q2)")
+
         press_arr_final = press.to_numpy()
         if np.all(np.isnan(press_arr_final)):
             raise RuntimeError(
@@ -1260,6 +1270,7 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             press=press,
             per_fold_press=per_fold_press,
             se_press=se_press,
+            q2_se=q2_se,
             press_ratio=press_ratio,
             q2=q2,
             cv_scores=cv_scores,

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -952,6 +952,10 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
               Drives the 1-SE rule.
             - ``se_rmsecv`` - standard error of the per-fold RMSECV per
               component count (pd.Series, indexed ``1..A``).
+            - ``q2_se`` - standard error on the Q2 scale (the per-fold total
+              PRESS standard error divided by the total Y sum-of-squares),
+              i.e. the half-width of a +/-1 SE band around
+              ``r2y_validated["total"]`` (pd.Series, indexed ``1..A``).
             - ``r2y_validated`` - validated cumulative :math:`R^2_Y`
               (pd.DataFrame, same shape as ``rmsecv``).
             - ``r2x_validated`` - validated cumulative :math:`R^2_X`
@@ -1062,6 +1066,10 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         # Per-fold total-RMSECV across every fold-fit (n_folds_total columns).
         # Drives the 1-SE rule's standard error.
         per_fold_rmse = np.full((A, n_folds_total), np.nan)
+        # Per-fold total PRESS (sum of squared Y residuals over the fold), on the
+        # same linear scale as the Q2 normalisation; used to put a +/-1 SE band
+        # on the Q2 curve, mirroring PCA's se_press -> q2_se rescaling.
+        per_fold_press_total = np.full((A, n_folds_total), np.nan)
         # Out-of-fold predictions: with repeated K-fold each row appears in
         # multiple test folds, so populate only from the *first* repeat (which
         # covers every row exactly once) to preserve the existing semantic that
@@ -1112,11 +1120,11 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
                 y_hat = y_hat_scaled * y_scale + y_centre
                 x_hat = x_hat_scaled * x_scale + x_centre
                 residuals_y = y_test - y_hat
+                fold_press = float(np.nansum(residuals_y ** 2))
                 press_y[a - 1] += np.nansum(residuals_y ** 2, axis=0)
                 press_x[a - 1] += np.nansum((x_test - x_hat) ** 2, axis=0)
-                per_fold_rmse[a - 1, fold_idx] = np.sqrt(
-                    np.nansum(residuals_y ** 2) / max(1, n_test * M)
-                )
+                per_fold_rmse[a - 1, fold_idx] = np.sqrt(fold_press / max(1, n_test * M))
+                per_fold_press_total[a - 1, fold_idx] = fold_press
                 if fold_idx < first_repeat_fold_count:
                     oof[a - 1, test_idx, :] = y_hat
 
@@ -1169,6 +1177,20 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
                 np.maximum(1, np.sum(~np.isnan(per_fold_rmse), axis=1))
             )
         se_rmsecv = pd.Series(se_values, index=component_index, name="SE(RMSECV)")
+
+        # Q2 standard error: the standard error of the per-fold total PRESS,
+        # rescaled by the same total Y sum-of-squares that normalises the
+        # validated Q2 (Q2_Y_total = 1 - PRESS / tss_y.sum()). This is the
+        # half-width of a +/-1 SE band around the ``r2y_validated["total"]``
+        # curve, computed the same way as PCA's ``q2_se``.
+        ss_y_total = float(tss_y.sum())
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            se_press_total = np.nanstd(per_fold_press_total, axis=1, ddof=1) / np.sqrt(
+                np.maximum(1, np.sum(~np.isnan(per_fold_press_total), axis=1))
+            )
+        q2_se_values = se_press_total / ss_y_total if ss_y_total > 0 else se_press_total * np.nan
+        q2_se = pd.Series(q2_se_values, index=component_index, name="SE(Q2)")
 
         # If every CV fold produced NaN (e.g. zero-variance Y per fold) the
         # cross-validation never converged to anything we can judge. Raise so
@@ -1262,6 +1284,7 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             rmsecv=rmsecv,
             per_fold_rmsecv=per_fold_rmsecv,
             se_rmsecv=se_rmsecv,
+            q2_se=q2_se,
             r2y_validated=r2y_validated,
             r2x_validated=r2x_validated,
             press=press,

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -668,6 +668,15 @@ def test_pca_select_n_components() -> None:
     assert result.cv_scheme == "ekf"
     assert result.selection_rule == "min"
 
+    # q2_se is the per-component Q2-scale standard error (the +/-1 SE band): an
+    # exact rescale of se_press by the constant null-model sum-of-squares.
+    assert "q2_se" in result
+    assert (result.q2_se >= 0).all()
+    null_ss = float(np.nansum(np.asarray(X, dtype=float) ** 2))
+    np.testing.assert_allclose(
+        result.q2_se.to_numpy(), result.se_press.to_numpy() / null_ss, rtol=1e-9
+    )
+
     # With 2 true components and N < K, should recommend 2 (or at most 3)
     assert 2 <= result.n_components <= 3
 
@@ -2387,6 +2396,7 @@ def test_pls_select_n_components_synthetic() -> None:
         "rmsecv",
         "per_fold_rmsecv",
         "se_rmsecv",
+        "q2_se",
         "r2y_validated",
         "r2x_validated",
         "press",
@@ -2398,6 +2408,12 @@ def test_pls_select_n_components_synthetic() -> None:
         "selection_rule",
     }
     assert result.selection_rule == "1se"
+
+    # q2_se is the per-component +/-1 SE band on the Q2 scale: a finite,
+    # non-negative series aligned to the r2y_validated["total"] curve.
+    assert isinstance(result.q2_se, pd.Series)
+    assert list(result.q2_se.index) == list(range(1, 11))
+    assert ((result.q2_se >= 0) & np.isfinite(result.q2_se)).all()
 
     # The clear RMSECV minimum is at the true rank of 2.
     assert result.n_components == 2


### PR DESCRIPTION
## What

`PCA.select_n_components` and `PLS.select_n_components` now return a per-component **`q2_se`** series: the standard error on the **Q²** scale — the half-width of a ±1 SE band around the validated Q² curve.

- **PCA:** `q2_se = se_press / null_model_ss` — the existing per-fold PRESS standard error rescaled by the same constant null-model sum-of-squares that normalises `q2`. Exact: a test asserts it equals `se_press / sum(X**2)`.
- **PLS:** the standard error of a new per-fold total-PRESS accumulator, divided by the total Y sum-of-squares that normalises `r2y_validated["total"]` — computed the same way as PCA's, alongside the existing per-fold RMSECV.

## Why

Downstream callers (ScorePilot's R²/Q² plot) want to shade a ±1 SE band on the Q² curve, but the selectors previously reported the error SE only on the PRESS / RMSECV scale, forcing the consumer to re-derive the Q² normalisation locally. Exposing `q2_se` here removes that duplicated, approximate adapter and makes the library the single source of truth. (This is the top open item from ScorePilot's `docs/COMPONENT_SELECTION.md`.)

## Notes

- Purely **additive**: a new key in the returned `Bunch`; no existing field changes. The PCA test's key-set check uses `<=`; the PLS test's exact-set check was updated to include `q2_se`.
- `q2_se` is finite and non-negative, aligned to `1..A`, and `NaN` only when the null sum-of-squares is degenerate (no variance to cross-validate).

## Tests

- Extended `test_pca_select_n_components` (exactness vs `se_press / sum(X**2)`) and `test_pls_select_n_components_synthetic` (key set + finite, non-negative band).
- Full selector suite (`-k "select_n_components or recommend_n_components"`): **23 passed**. `ruff check` clean.

MINOR bump 1.38.3 → 1.39.0; CHANGELOG and CITATION.cff updated in the same commit.

## Follow-up (separate, not in this PR)

Once this is released to PyPI, ScorePilot will consume `q2_se` directly and delete its local `_q2_standard_error` adapter.

https://claude.ai/code/session_01KHx2ai8JtjRVUhW3ZMwWN8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHx2ai8JtjRVUhW3ZMwWN8)_