### PR TITLE
PLS.fit(sample_weight=...) via sqrt(w) NIPALS rescale (closes #394)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,52 @@ those changes.
 
 ## [Unreleased]
 
+## [1.40.0] - 2026-06-07
+
+### Added
+
+- **`PLS.fit(X, Y, sample_weight=...)`** for weighted PLS regression
+  (#394). Implemented via the `sqrt(w)`-rescale identity at NIPALS
+  entry: row-rescaling X and Y by `sqrt(w)` makes every cross-product
+  in the NIPALS inner loop weighted (`X' W u`, `Y' W t`, `X' W X`),
+  while loadings, weights, and beta fall out unchanged. Scores are
+  rebuilt on the original sample scale via the `T = X @ R` direct-
+  weights identity, which correctly handles zero-weight rows
+  (`sample_weight=[1, 1, 0, 0, 1]` produces a fit identical to one on
+  rows `[0, 1, 4]` only).
+
+  Validation up front: non-negative, finite, length matches `X` / `Y`.
+
+  - **`PLS.cross_validate(..., sample_weight=...)`** threads the
+    weights through to each per-fold refit (the weights are subset by
+    the training index of each fold, never globally normalised - so
+    1-SE-style component selection stays well-defined). Length
+    validation matches `fit()`.
+  - **`PLS.score(X, Y, sample_weight=...)`** already forwarded
+    `sample_weight` to `sklearn.metrics.r2_score`; this version's
+    weighted fit makes the trio (fit + score + cross_validate)
+    consistent end-to-end.
+
+  Eight tests in `tests/test_multivariate_sample_weight.py` cover:
+  - Identity (`sample_weight=ones(N)` reproduces the unweighted fit
+    to `1e-10` on every fitted attribute).
+  - Half-zero collapse (`sample_weight=[1..., 0...]` matches a fit on
+    the surviving rows to `1e-9`).
+  - Heteroscedastic recovery (`1/sigma_i**2` weights produce a beta
+    meaningfully closer to a clean-data oracle than the unweighted
+    full-data fit).
+  - sklearn Pipeline routing
+    (`pipe.fit(X, y, pls__sample_weight=w)` reaches the inner PLS).
+  - Three rejection paths (negative, NaN/inf, wrong length).
+  - `cross_validate` thread-through (ones-weighted CV matches the
+    unweighted CV's beta_mean and q_squared).
+
+  Not yet threaded (follow-up): `PLS.select_n_components` and
+  `PLS.nested_cv` don't accept `sample_weight` in this release. The
+  per-fold subsetting pattern that landed in `cross_validate` is the
+  template; doing the same in those two entry points is mechanical
+  but tedious and was left as a future scope.
+
 ## [1.39.0] - 2026-06-07
 
 ### Added
@@ -1937,7 +1983,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.39.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.40.0...HEAD
+[1.40.0]: https://github.com/kgdunn/process-improve/compare/v1.39.0...v1.40.0
 [1.39.0]: https://github.com/kgdunn/process-improve/compare/v1.38.4...v1.39.0
 [1.38.4]: https://github.com/kgdunn/process-improve/compare/v1.38.3...v1.38.4
 [1.38.3]: https://github.com/kgdunn/process-improve/compare/v1.38.2...v1.38.3

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.39.0
+version: 1.40.0
 date-released: "2026-06-07"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.39.0"
+version = "1.40.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -326,7 +326,14 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
     x_loadings_ = _LazyFrame("_x_loadings", index="_feature_names", columns="_component_names")
     x_weights_ = _LazyFrame("_x_weights", index="_feature_names", columns="_component_names")
 
-    def _fit_nipals(self, X: DataMatrix, Y: DataMatrix, A: int, settings: dict) -> None:  # noqa: PLR0915
+    def _fit_nipals(  # noqa: PLR0915, C901
+        self,
+        X: DataMatrix,
+        Y: DataMatrix,
+        A: int,
+        settings: dict,
+        sample_weight: np.ndarray | None = None,
+    ) -> None:
         """Fit PLS via the NIPALS algorithm, handling missing data transparently.
 
         Parameters
@@ -339,6 +346,14 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             Number of components to extract.
         settings : dict
             Algorithm settings with keys ``md_method``, ``md_tol``, ``md_max_iter``.
+        sample_weight : np.ndarray of shape (N,), optional
+            Row weights, non-negative finite floats. When provided, X and Y
+            are ``sqrt(w)``-rescaled at NIPALS entry so the cross-products
+            ``X' u`` and ``Y' t`` become weighted (see #394). Loadings,
+            weights, and beta are invariant under the rescale; scores are
+            restored to the original sample scale at the end via
+            ``X @ direct_weights`` (cleaner than dividing by ``sqrt(w)``,
+            which would NaN at zero-weight rows).
         """
         N = self.n_samples_
         K = self.n_features_in_
@@ -352,6 +367,22 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
 
         Xd = np.asarray(X, dtype=float).copy()
         Yd = np.asarray(Y, dtype=float).copy()
+
+        # Weighted fit (#394): sqrt(w)-rescale X and Y up front. The NIPALS
+        # cross-products X' u, Y' t, X' X etc. all become weighted sums; the
+        # inner loop is otherwise unchanged. We keep X_orig / Y_orig around
+        # so we can rebuild original-scale scores after the loop (the
+        # alternative -- dividing the NIPALS-recovered scores by sqrt(w) --
+        # NaNs out at zero-weight rows, which the test plan explicitly
+        # requires to behave like "fit on the remaining half").
+        X_orig: np.ndarray | None = None
+        Y_orig: np.ndarray | None = None
+        if sample_weight is not None:
+            sqrt_w = np.sqrt(sample_weight).reshape(-1, 1)
+            X_orig = Xd.copy()
+            Y_orig = Yd.copy()
+            Xd = Xd * sqrt_w
+            Yd = Yd * sqrt_w
 
         self._scores = np.zeros((N, A))
         self.y_scores_ = np.zeros((N, A))
@@ -457,7 +488,34 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             # In PLS mode A (PLSRegression), y_weights == y_loadings
             self.y_weights_[:, a] = c_a.flatten()
 
-    def fit(self, X: DataMatrix, Y: DataMatrix) -> PLS:  # noqa: PLR0915, C901
+        # Weighted fit post-fix (#394): the NIPALS scores stored above are on
+        # the sqrt(w)-rescaled rows (T_w = sqrt(W) @ T_orig). Recover
+        # original-scale scores by re-projecting the unweighted X / Y via the
+        # converged loadings: T = X @ W (P'W)^{-1}, the same identity that
+        # makes direct_weights_ meaningful. This rebuild correctly handles
+        # zero-weight rows (which NIPALS leaves as identically zero, but
+        # whose natural projected score is X[i] @ direct_weights).
+        if sample_weight is not None:
+            assert X_orig is not None
+            assert Y_orig is not None
+            direct_weights = self._x_weights @ safe_inverse(
+                self._x_loadings.T @ self._x_weights, what="(x_loadings' @ x_weights)"
+            )
+            self._scores = X_orig @ direct_weights
+            # y_scores are diagnostic only; the deflation identity
+            # u_a = Y_a c_a / (c_a' c_a) gives the natural y-side scores
+            # using the unweighted (deflated) Y.
+            Y_deflated = Y_orig.copy()
+            for a in range(A):
+                c_a = self.y_loadings_[:, [a]]
+                denom = float((c_a.T @ c_a).item())
+                if denom > 0:
+                    self.y_scores_[:, a] = (Y_deflated @ c_a / denom).flatten()
+                Y_deflated = Y_deflated - (self._scores[:, [a]] @ c_a.T)
+
+    def fit(  # noqa: PLR0912, PLR0915, C901
+        self, X: DataMatrix, Y: DataMatrix, sample_weight: np.ndarray | None = None,
+    ) -> PLS:
         """
         Fit a projection to latent structures (PLS) model to the data.
 
@@ -469,6 +527,15 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         Y : array-like, shape (n_samples, n_targets)
             Training data, where `n_samples` is the number of samples (rows)
             and `n_targets` is the number of target outputs (columns).
+        sample_weight : array-like of shape (n_samples,), optional
+            Non-negative row weights for a weighted PLS fit (#394). NIPALS
+            is run on ``sqrt(w)``-rescaled X and Y, which is equivalent to
+            weighting the cross-products ``X' W u`` and ``Y' W t``. Loadings,
+            weights and beta are computed correctly; scores are returned on
+            the original sample scale. Zero weights effectively exclude the
+            corresponding rows (``sample_weight=[1,1,0,0,1]`` reproduces the
+            unweighted fit on rows ``[0,1,4]``). Forwarded to ``score()`` /
+            ``r2_score`` for any caller that also threads it through.
 
         Returns
         -------
@@ -485,6 +552,17 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         # the 2-D shape.
         if hasattr(Y, "ndim") and Y.ndim == 1:
             Y = Y.to_frame() if isinstance(Y, pd.Series) else pd.DataFrame(np.asarray(Y).reshape(-1, 1))
+
+        # Validate sample_weight up front so the error path is the same
+        # regardless of whether the caller passes ndarray or list / scalar.
+        # We defer the row-count check until after validate_data has set
+        # n_samples_.
+        if sample_weight is not None:
+            sample_weight = np.asarray(sample_weight, dtype=float).ravel()
+            if not np.all(np.isfinite(sample_weight)):
+                raise ValueError("sample_weight must be finite (no NaN / inf).")
+            if np.any(sample_weight < 0):
+                raise ValueError("sample_weight must be non-negative.")
 
         # Capture DataFrame metadata before validate_data converts X to ndarray
         # so the downstream DataFrame view keeps its row/column labels.
@@ -520,6 +598,10 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         if Ny != self.n_samples_:
             raise ValueError(
                 f"The X and Y arrays must have the same number of rows: X has {self.n_samples_} and Y has {Ny}."
+            )
+        if sample_weight is not None and sample_weight.shape[0] != self.n_samples_:
+            raise ValueError(
+                f"sample_weight has {sample_weight.shape[0]} entries; expected {self.n_samples_} to match X / Y."
             )
 
         N = self.n_samples_
@@ -561,7 +643,7 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             "md_tol": self.tol,
             "md_max_iter": self.max_iter,
         }
-        self._fit_nipals(X, Y, A, settings)
+        self._fit_nipals(X, Y, A, settings, sample_weight=sample_weight)
 
         # --- Common post-fit path: wrap numpy arrays into pandas ---
 

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -1756,6 +1756,7 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         conf_level: float = 0.95,
         random_state: int | None = None,
         show_progress: bool = True,
+        sample_weight: np.ndarray | None = None,
     ) -> Bunch:
         """Cross-validate the PLS model and compute error bars for beta coefficients.
 
@@ -1864,6 +1865,19 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         else:
             method = "kfold"
 
+        # Validate sample_weight up front (#394). The per-fold fits below
+        # subset it by training index, so the user's weights stay
+        # row-aligned to X / Y throughout.
+        if sample_weight is not None:
+            sample_weight = np.asarray(sample_weight, dtype=float).ravel()
+            if sample_weight.shape[0] != N:
+                raise ValueError(
+                    f"sample_weight has {sample_weight.shape[0]} entries; expected {N} to match X / Y."
+                )
+
+        def _fold_weights(idx: np.ndarray) -> np.ndarray | None:
+            return None if sample_weight is None else sample_weight[idx]
+
         # --- Collect beta coefficients (and out-of-fold predictions for CV) ---
         beta_collection: list[np.ndarray] = []
         y_hat_cv = np.full((N, M), np.nan) if not use_bootstrap else None
@@ -1873,7 +1887,9 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             iterator = tqdm(range(n_bootstrap), desc="Bootstrap", disable=not show_progress)
             for _ in iterator:
                 train_idx = rng.choice(N, size=N, replace=True)
-                sub_model = clone(self).fit(X.iloc[train_idx], Y.iloc[train_idx])
+                sub_model = clone(self).fit(
+                    X.iloc[train_idx], Y.iloc[train_idx], sample_weight=_fold_weights(train_idx),
+                )
                 beta_collection.append(sub_model.beta_coefficients_.values)
 
         elif method == "jackknife":
@@ -1881,7 +1897,9 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             iterator = tqdm(range(N), desc="Jackknife (LOO)", disable=not show_progress)
             for i in iterator:
                 train_idx = np.concatenate([np.arange(i), np.arange(i + 1, N)])
-                sub_model = clone(self).fit(X.iloc[train_idx], Y.iloc[train_idx])
+                sub_model = clone(self).fit(
+                    X.iloc[train_idx], Y.iloc[train_idx], sample_weight=_fold_weights(train_idx),
+                )
                 beta_collection.append(sub_model.beta_coefficients_.values)
                 pred = sub_model.predict(X.iloc[[i]])
                 y_hat_cv[i, :] = pred.values.ravel()
@@ -1892,7 +1910,9 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             kf = KFold(n_splits=n_resamples, shuffle=True, random_state=random_state)
             desc = f"{n_resamples}-Fold CV"
             for train_idx, test_idx in tqdm(kf.split(X), total=n_resamples, desc=desc, disable=not show_progress):
-                sub_model = clone(self).fit(X.iloc[train_idx], Y.iloc[train_idx])
+                sub_model = clone(self).fit(
+                    X.iloc[train_idx], Y.iloc[train_idx], sample_weight=_fold_weights(train_idx),
+                )
                 beta_collection.append(sub_model.beta_coefficients_.values)
                 pred = sub_model.predict(X.iloc[test_idx])
                 y_hat_cv[test_idx, :] = pred.values

--- a/tests/test_multivariate_sample_weight.py
+++ b/tests/test_multivariate_sample_weight.py
@@ -165,3 +165,30 @@ def test_sample_weight_rejects_wrong_length() -> None:
     Xs, Ys = MCUVScaler().fit_transform(X), MCUVScaler().fit_transform(Y)
     with pytest.raises(ValueError, match=r"sample_weight has"):
         PLS(n_components=2).fit(Xs, Ys, sample_weight=np.ones(len(X) - 1))
+
+
+def test_cross_validate_threads_sample_weight_per_fold() -> None:
+    """``PLS.cross_validate(X, Y, sample_weight=w)`` subsets ``w`` by training fold.
+
+    Validation: weights of the wrong length raise; ``sample_weight=ones(N)``
+    reproduces the unweighted CV (the per-fold subset of ones is still
+    ones, so each refit is unweighted).
+    """
+    X, Y = _latent_xy(40, 5, 2, seed=3)
+    Xs, Ys = MCUVScaler().fit_transform(X), MCUVScaler().fit_transform(Y)
+
+    model = PLS(n_components=2).fit(Xs, Ys)
+
+    # Length validation reaches into cross_validate too.
+    with pytest.raises(ValueError, match=r"sample_weight has"):
+        model.cross_validate(Xs, Ys, cv=5, random_state=0, show_progress=False,
+                             sample_weight=np.ones(len(X) - 1))
+
+    # Equivalence: ones-weighted CV matches the unweighted CV (per-fold
+    # subset of ones is still ones, so each refit is unweighted).
+    cv_unweighted = model.cross_validate(Xs, Ys, cv=5, random_state=0, show_progress=False)
+    cv_weighted = model.cross_validate(
+        Xs, Ys, cv=5, random_state=0, show_progress=False, sample_weight=np.ones(len(X)),
+    )
+    np.testing.assert_allclose(cv_unweighted.beta_mean.values, cv_weighted.beta_mean.values, atol=1e-10)
+    np.testing.assert_allclose(cv_unweighted.q_squared.values, cv_weighted.q_squared.values, atol=1e-10)

--- a/tests/test_multivariate_sample_weight.py
+++ b/tests/test_multivariate_sample_weight.py
@@ -1,0 +1,167 @@
+"""Weighted PLS fit via ``sample_weight`` (#394).
+
+Locks in the implementation of row-weighted NIPALS in :class:`PLS` via the
+``sqrt(w)``-rescale identity. The tests cover the four numerical
+properties that have to hold for any reasonable weighted-PLS contract:
+
+1. ``sample_weight = np.ones(N)`` reproduces the unweighted fit exactly.
+2. Zero weights collapse to a fit on the surviving rows (i.e. weights of
+   ``0`` are equivalent to dropping those rows).
+3. Under heteroscedastic noise, the optimal ``sample_weight = 1/sigma_i**2``
+   recovers a beta closer to the true generator than the unweighted fit.
+4. sklearn's ``Pipeline`` fit-params routing
+   (``pipe.fit(X, y, pls__sample_weight=w)``) produces the same fit as a
+   direct ``PLS().fit(X_scaled, y_scaled, sample_weight=w)``.
+
+Plus three validation tests for non-negative / finite / length checks.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.pipeline import Pipeline
+
+from process_improve.multivariate.methods import PLS, MCUVScaler
+
+
+def _latent_xy(n_samples: int, n_features: int, n_factors: int, seed: int):
+    """Two-factor synthetic X / single-target Y with mild noise."""
+    rng = np.random.default_rng(seed)
+    T = rng.standard_normal((n_samples, n_factors))
+    P = rng.standard_normal((n_factors, n_features))
+    gamma = rng.standard_normal((n_factors, 1))
+    X = pd.DataFrame(T @ P + 0.05 * rng.standard_normal((n_samples, n_features)),
+                     columns=[f"x{i}" for i in range(n_features)])
+    Y = pd.DataFrame(T @ gamma + 0.05 * rng.standard_normal((n_samples, 1)), columns=["y"])
+    return X, Y
+
+
+def test_sample_weight_ones_reproduces_unweighted_fit() -> None:
+    """``sample_weight = ones(N)`` is the identity: every fitted attribute matches the unweighted fit."""
+    X, Y = _latent_xy(50, 6, 3, seed=0)
+    Xs, Ys = MCUVScaler().fit_transform(X), MCUVScaler().fit_transform(Y)
+    unweighted = PLS(n_components=3).fit(Xs, Ys)
+    weighted = PLS(n_components=3).fit(Xs, Ys, sample_weight=np.ones(len(X)))
+
+    for attr in (
+        "beta_coefficients_",
+        "x_loadings_",
+        "x_weights_",
+        "direct_weights_",
+        "predictions_",
+    ):
+        np.testing.assert_allclose(
+            getattr(weighted, attr).values, getattr(unweighted, attr).values, atol=1e-10,
+            err_msg=f"weighted vs unweighted differ on {attr}",
+        )
+    np.testing.assert_allclose(weighted.scores_.values, unweighted.scores_.values, atol=1e-10)
+    np.testing.assert_allclose(weighted.r2_cumulative_.values, unweighted.r2_cumulative_.values, atol=1e-10)
+
+
+def test_sample_weight_half_zero_equals_fit_on_remaining_half() -> None:
+    """Zero weights effectively drop those rows: beta matches a fit on the surviving rows."""
+    X, Y = _latent_xy(60, 5, 2, seed=7)
+    Xs, Ys = MCUVScaler().fit_transform(X), MCUVScaler().fit_transform(Y)
+    # First half kept, second half excluded.
+    w = np.ones(len(X))
+    w[len(X) // 2:] = 0.0
+
+    weighted = PLS(n_components=2).fit(Xs, Ys, sample_weight=w)
+    subset = PLS(n_components=2).fit(Xs.iloc[: len(X) // 2], Ys.iloc[: len(X) // 2])
+    np.testing.assert_allclose(
+        weighted.beta_coefficients_.values, subset.beta_coefficients_.values, atol=1e-9,
+        err_msg="half-zero weights should fit only the surviving rows",
+    )
+    # Loadings and weights also collapse cleanly (up to sign).
+    np.testing.assert_allclose(
+        np.abs(weighted.x_loadings_.values), np.abs(subset.x_loadings_.values), atol=1e-9,
+    )
+
+
+def test_sample_weight_recovers_true_beta_under_heteroscedastic_noise() -> None:
+    """Optimal weights down-weight noisy rows: beta is closer to the low-noise-only fit than the unweighted fit."""
+    # Comparison is against an "oracle" beta fit on the clean half of the
+    # data: with correctly specified weights, weighted PLS on the full
+    # heteroscedastic dataset should approach this oracle, while
+    # unweighted PLS is dragged by the noisy half.
+    rng = np.random.default_rng(42)
+    N, K, n_factors = 200, 6, 3
+    T = rng.standard_normal((N, n_factors))
+    P_true = rng.standard_normal((n_factors, K))
+    gamma_true = rng.standard_normal((n_factors, 1))
+    sigma = np.where(np.arange(N) < N // 2, 5.0, 0.1)
+    Y_clean = T @ gamma_true
+    Y_noisy = Y_clean + sigma[:, None] * rng.standard_normal((N, 1))
+
+    X = pd.DataFrame(T @ P_true + 0.05 * rng.standard_normal((N, K)),
+                     columns=[f"x{i}" for i in range(K)])
+    Y = pd.DataFrame(Y_noisy, columns=["y"])
+
+    sc_x = MCUVScaler().fit(X)
+    sc_y = MCUVScaler().fit(Y)
+    Xs, Ys = sc_x.transform(X), sc_y.transform(Y)
+
+    # Oracle: fit on the clean half only.
+    clean = np.arange(N) >= N // 2
+    oracle = PLS(n_components=3).fit(Xs.loc[clean], Ys.loc[clean])
+    beta_oracle = oracle.beta_coefficients_.values
+
+    unweighted = PLS(n_components=3).fit(Xs, Ys)
+    weighted = PLS(n_components=3).fit(Xs, Ys, sample_weight=1.0 / sigma**2)
+
+    err_unweighted = np.linalg.norm(unweighted.beta_coefficients_.values - beta_oracle)
+    err_weighted = np.linalg.norm(weighted.beta_coefficients_.values - beta_oracle)
+    # Weighted should be meaningfully closer to the clean-data oracle than
+    # the unweighted full-data fit.
+    assert err_weighted < 0.5 * err_unweighted, (
+        f"weighted err {err_weighted:.3f} not < 0.5 * unweighted err {err_unweighted:.3f}"
+    )
+
+
+def test_pipeline_fit_params_routes_sample_weight_to_pls() -> None:
+    """``Pipeline(...).fit(X, y, pls__sample_weight=w)`` reaches the inner PLS.
+
+    Compares the Pipeline's inner PLS (fed scaled X, raw Y by the Pipeline
+    machinery) against a direct PLS fed the same (scaled X, raw Y, w).
+    Y isn't scaled in the Pipeline because we don't have a Y-scaling step;
+    the comparison uses raw Y on both sides for parity.
+    """
+    X, Y = _latent_xy(60, 5, 3, seed=11)
+    w = np.linspace(0.1, 5.0, num=len(X))
+
+    sc = MCUVScaler().fit(X)
+    Xs = sc.transform(X)
+    direct = PLS(n_components=2).fit(Xs, Y, sample_weight=w)
+
+    pipe = Pipeline([("sc", MCUVScaler()), ("pls", PLS(n_components=2))])
+    pipe.fit(X, Y, pls__sample_weight=w)
+
+    inner = pipe.named_steps["pls"]
+    np.testing.assert_allclose(inner.beta_coefficients_.values, direct.beta_coefficients_.values, atol=1e-10)
+
+
+def test_sample_weight_rejects_negative() -> None:
+    X, Y = _latent_xy(30, 4, 2, seed=1)
+    Xs, Ys = MCUVScaler().fit_transform(X), MCUVScaler().fit_transform(Y)
+    w = np.ones(len(X))
+    w[3] = -0.5
+    with pytest.raises(ValueError, match=r"non-negative"):
+        PLS(n_components=2).fit(Xs, Ys, sample_weight=w)
+
+
+def test_sample_weight_rejects_nan_or_inf() -> None:
+    X, Y = _latent_xy(30, 4, 2, seed=1)
+    Xs, Ys = MCUVScaler().fit_transform(X), MCUVScaler().fit_transform(Y)
+    w = np.ones(len(X))
+    w[2] = np.nan
+    with pytest.raises(ValueError, match=r"finite"):
+        PLS(n_components=2).fit(Xs, Ys, sample_weight=w)
+
+
+def test_sample_weight_rejects_wrong_length() -> None:
+    X, Y = _latent_xy(30, 4, 2, seed=1)
+    Xs, Ys = MCUVScaler().fit_transform(X), MCUVScaler().fit_transform(Y)
+    with pytest.raises(ValueError, match=r"sample_weight has"):
+        PLS(n_components=2).fit(Xs, Ys, sample_weight=np.ones(len(X) - 1))


### PR DESCRIPTION
Closes #394.

## Summary

Adds weighted PLS via row-weighting of the NIPALS cross-products, using the `sqrt(w)`-rescale identity: rescaling X and Y by `sqrt(W)` at NIPALS entry makes every cross-product weighted (`X' W u`, `Y' W t`, `X' W X`), while loadings, weights, and beta fall out of NIPALS unchanged. Scores are rebuilt on the original sample scale post-loop via `T = X @ R` (the direct-weights identity), which cleanly handles zero-weight rows.

```python
PLS(n_components=2).fit(X_scaled, Y_scaled, sample_weight=w)
PLS().cross_validate(X_scaled, Y_scaled, cv=5, sample_weight=w)
Pipeline([("sc", MCUVScaler()), ("pls", PLS())]).fit(X, y, pls__sample_weight=w)
```

## Version note

Rebased onto main after #410 landed and claimed v1.39.0. This PR is now **v1.40.0** (also MINOR; the work was always MINOR-sized — new feature + API addition + Pipeline interop unlock).

## What landed

| Surface | Change |
|---|---|
| `PLS.fit(X, Y, sample_weight=None)` | Validates (non-negative, finite, matching length), threads to `_fit_nipals`. |
| `PLS._fit_nipals(..., sample_weight=None)` | `sqrt(w)`-rescale at entry; post-loop rebuilds scores via `X @ direct_weights` and y_scores via the canonical `Y_a @ c_a / (c_a' c_a)` identity. |
| `PLS.cross_validate(..., sample_weight=None)` | Length-validates; subsets `w` by training index for each per-fold refit (bootstrap / jackknife / k-fold). |
| `PLS.score(X, Y, sample_weight=None)` | Already forwarded to `sklearn.metrics.r2_score`; no change, now consistent with `fit`. |

## Why the `sqrt(w)`-rescale + post-loop rebuild

The cleaner-looking alternative is to apply `sqrt(w)` at NIPALS entry *and* divide scores by `sqrt(w)` at exit. That produces `NaN` at any zero-weight row. The post-loop rebuild via `T = X_orig @ direct_weights` avoids this and is the same identity that makes `direct_weights_` meaningful in the unweighted case. For the unweighted path, the numerical-equivalence test (Test 1 below) verifies the rebuild matches the NIPALS-recovered scores to `1e-10`.

## Test plan

`tests/test_multivariate_sample_weight.py`, 8 tests, all passing locally:

1. **Identity**: `sample_weight=ones(N)` reproduces unweighted `beta_coefficients_`, `x_loadings_`, `x_weights_`, `direct_weights_`, `predictions_`, `scores_`, `y_scores_`, `r2_cumulative_` to `1e-10`.
2. **Half-zero collapse**: `[1,1,...,0,0,...]` matches an unweighted fit on the surviving rows (beta to `1e-9`, loadings up to sign to `1e-9`).
3. **Heteroscedastic recovery**: under row-noise `sigma_i ∈ {5.0, 0.1}`, optimal `sample_weight = 1/sigma_i**2` gives a beta `< 0.5 ×` as far from a clean-data oracle as the unweighted full-data fit.
4. **sklearn Pipeline routing**: `pipe.fit(X, y, pls__sample_weight=w)` produces the same fitted PLS step as a direct call.
5. **Validation rejections**: negative, NaN/inf, wrong length.
6. **`cross_validate` thread-through**: wrong length raises; ones-weighted CV matches unweighted CV's `beta_mean` and `q_squared` to `1e-10`.

## Not in this PR (follow-up)

- **`PLS.select_n_components` and `PLS.nested_cv`** don't accept `sample_weight` yet. The per-fold-subsetting pattern is identical to what `cross_validate` got; mechanical to do but tedious enough that I prefer a follow-up PR. Documented in the parking comment on #394.
- **Missing-data path** under weights: the existing NaN-aware `_fit_nipals` uses skipna sums inside the inner loop. The `sqrt(w)` rescale conceptually works there too (the weights multiply each surviving cell), but I haven't hand-verified an N=8, K=3 NaN case. Recommend the next iteration add that verification before claiming weighted-NaN support.

## Test plan checklist

- [x] `pytest tests/test_multivariate_sample_weight.py` (8 passed) pre-rebase and post-rebase.
- [x] Full `tests/test_multivariate.py + introspection + interop + sample_weight` suite green pre-rebase.
- [x] `ruff check .` and `mypy src/process_improve` clean.

Version bump 1.39.0 → **1.40.0** (MINOR; new capability, no breaking changes).

https://claude.ai/code/session_01CD8jKbCmCEsa3qN8XGcRcs