### PR TITLE
Stop mutating global Plotly default template on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ those changes.
 
 ## [Unreleased]
 
+## [1.40.1] - 2026-06-11
+
+### Fixed
+
+- Importing `process_improve` (or `process_improve.visualization`) no
+  longer changes Plotly's global default template. Previously the
+  package set `plotly.io.templates.default = "pi_journal"` on import,
+  which silently restyled every other Plotly figure created in the same
+  process. The `pi_*` themes are still registered on import (additive,
+  namespaced), and the library's own plots are unchanged because they
+  request the `pi_journal` template explicitly. Call
+  `process_improve.visualization.set_theme()` to opt a whole session
+  into a process-improve theme as before.
+
 ## [1.40.0] - 2026-06-07
 
 ### Added
@@ -1983,7 +1997,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.40.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.40.1...HEAD
+[1.40.1]: https://github.com/kgdunn/process-improve/compare/v1.40.0...v1.40.1
 [1.40.0]: https://github.com/kgdunn/process-improve/compare/v1.39.0...v1.40.0
 [1.39.0]: https://github.com/kgdunn/process-improve/compare/v1.38.4...v1.39.0
 [1.38.4]: https://github.com/kgdunn/process-improve/compare/v1.38.3...v1.38.4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.40.0
-date-released: "2026-06-07"
+version: 1.40.1
+date-released: "2026-06-11"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.40.0"
+version = "1.40.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/visualization/__init__.py
+++ b/src/process_improve/visualization/__init__.py
@@ -35,8 +35,16 @@ from process_improve.visualization.types import (
     ScaleType,
 )
 
-# Register the base themes and apply the package default on import. When
-# the ``[plotting]`` extra is not installed (ENG-13 / #295), plotly is
+# Register the base themes on import, but deliberately do NOT change
+# ``plotly.io.templates.default``. Setting the global default would
+# silently restyle every other Plotly figure in the same process (the
+# library's own plots pass ``template="pi_journal"`` explicitly, so they
+# never relied on the global default). Registration is additive and the
+# theme names are ``pi_``-namespaced, so it is safe on import. Callers who
+# want a process-improve theme as their global default can opt in with
+# :func:`set_theme`.
+#
+# When the ``[plotting]`` extra is not installed (ENG-13 / #295), plotly is
 # absent and the registration is silently skipped; calling ``raincloud``
 # or any other plot helper will then raise the documented "install the
 # extra" ImportError.
@@ -46,7 +54,6 @@ except ImportError:  # pragma: no cover - exercised via env-without-plotly
     pass
 else:
     register_themes()
-    set_theme(DEFAULT_THEME)
 
 __all__ = [
     "DEFAULT_THEME",

--- a/src/process_improve/visualization/themes.py
+++ b/src/process_improve/visualization/themes.py
@@ -2,8 +2,11 @@
 
 This module registers a small family of Plotly templates so that every
 figure produced by the library shares a consistent, professional look.
-Importing :mod:`process_improve.visualization` registers the templates and
-sets the package default.
+Importing :mod:`process_improve.visualization` registers the templates but
+does **not** change ``plotly.io.templates.default``: doing so would
+silently restyle every other Plotly figure in the same process. The
+library's own plots request :data:`DEFAULT_THEME` explicitly. Call
+:func:`set_theme` to opt a whole session into a process-improve theme.
 
 Four themes are provided:
 
@@ -38,6 +41,7 @@ try:
     import plotly.io as pio
 except ImportError:  # pragma: no cover - exercised via env-without-plotly
     from process_improve._extras import _MissingExtra
+
     go = _MissingExtra("plotly", "plotting")  # type: ignore[assignment]
     pio = _MissingExtra("plotly", "plotting")  # type: ignore[assignment]
 

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
+
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
@@ -34,9 +37,29 @@ def test_all_themes_registered() -> None:
         assert isinstance(pio.templates[name], go.layout.Template)
 
 
-def test_default_theme_applied_on_import() -> None:
-    """Importing the package sets the default Plotly template."""
-    assert pio.templates.default == DEFAULT_THEME
+def test_import_does_not_change_global_default() -> None:
+    """Importing the package registers themes but leaves the global default alone.
+
+    Run in a subprocess so the check is immune to other tests (or this
+    module's own imports) having already touched ``pio.templates.default``.
+    """
+    code = (
+        "import plotly.io as pio;"
+        "before = pio.templates.default;"
+        "import process_improve;"  # triggers the visualization package import
+        "import process_improve.visualization;"
+        "assert pio.templates.default == before, ("
+        "    f'import changed default: {before!r} -> {pio.templates.default!r}');"
+        # registration is still additive and must have happened
+        "assert 'pi_journal' in pio.templates"
+    )
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_set_theme_changes_default() -> None:


### PR DESCRIPTION
## Problem

Importing `process_improve` (even just `from process_improve import PCA`) silently changes Plotly's process-wide default template:

```
default BEFORE: 'plotly'
default AFTER : 'pi_journal'      # just from `import process_improve`
```

`visualization/__init__.py` calls `set_theme(DEFAULT_THEME)` on import, which sets `plotly.io.templates.default = "pi_journal"`. Any other code in the same Python process that builds a Plotly figure without an explicit template then gets restyled with process-improve's journal theme, with no opt-in. This is a library-mutates-global-state-on-import antipattern that affects other Plotly users.

The chain fires on the top-level import: `import process_improve` -> `multivariate/methods.py` does `from ..visualization.themes import REFERENCE_LINE_COLOR`, which executes the `visualization` package body.

## Fix

Keep the additive, `pi_`-namespaced template **registration** on import, but stop setting the global default:

- `register_themes()` stays (additive, namespaced; safe).
- `set_theme(DEFAULT_THEME)` on import is removed.

The library's own plots are unaffected: every plot in `multivariate/plots.py` passes `template="pi_journal"` (`DEFAULT_THEME`) explicitly, so they never relied on the global default. Users who want the journal look as their global default can still opt in with `from process_improve.visualization import set_theme; set_theme()`.

## Changes

- `visualization/__init__.py`: drop `set_theme(DEFAULT_THEME)` on import; keep `register_themes()`.
- `tests/test_themes.py`: assert the import no longer changes `pio.templates.default`, and that explicit `set_theme()` still works.
- Version bump 1.40.0 -> 1.40.1 (`pyproject.toml`, `CITATION.cff`), CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)