### PR TITLE
Add OMARS designs: constructive generator and property verifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ those changes.
 
 ## [Unreleased]
 
+## [1.41.0] - 2026-06-15
+
+### Added
+
+- OMARS (Orthogonal Minimally Aliased Response Surface) designs are now a
+  first-class design type: `generate_design(..., design_type="omars")`
+  constructs the conference-matrix foldover family (the definitive screening
+  design is its minimal member). New `omars_properties()` and `is_omars()`
+  verifiers check the defining OMARS properties (three-level, balanced, main
+  effects mutually orthogonal and orthogonal to all second-order terms) on any
+  coded design matrix, so generated or externally supplied designs can be
+  validated without network access. An `omars` knowledge node is included in
+  the DOE knowledge base.
+
 ## [1.40.2] - 2026-06-12
 
 ### Fixed
@@ -2010,7 +2024,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.40.2...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.41.0...HEAD
+[1.41.0]: https://github.com/kgdunn/process-improve/compare/v1.40.2...v1.41.0
 [1.40.2]: https://github.com/kgdunn/process-improve/compare/v1.40.1...v1.40.2
 [1.40.1]: https://github.com/kgdunn/process-improve/compare/v1.40.0...v1.40.1
 [1.40.0]: https://github.com/kgdunn/process-improve/compare/v1.39.0...v1.40.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.40.2
-date-released: "2026-06-12"
+version: 1.41.0
+date-released: "2026-06-15"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.40.2"
+version = "1.41.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/experiments/__init__.py
+++ b/src/process_improve/experiments/__init__.py
@@ -4,6 +4,7 @@ from process_improve.experiments.analysis import analyze_experiment
 from process_improve.experiments.augment import augment_design
 from process_improve.experiments.designs import generate_design
 from process_improve.experiments.designs_factorial import full_factorial
+from process_improve.experiments.designs_omars import is_omars, omars_properties
 from process_improve.experiments.evaluate import evaluate_design
 from process_improve.experiments.factor import Constraint, DesignResult, Factor, Response, ResponseGoal
 from process_improve.experiments.knowledge import doe_knowledge
@@ -38,8 +39,10 @@ __all__ = [
     "full_factorial",
     "gather",
     "generate_design",
+    "is_omars",
     "lm",
     "main_effects_plot",
+    "omars_properties",
     "optimize_responses",
     "predict",
     "recommend_strategy",

--- a/src/process_improve/experiments/designs.py
+++ b/src/process_improve/experiments/designs.py
@@ -104,6 +104,15 @@ def _dispatch_dsd(
     return dispatch_dsd(factors)
 
 
+def _dispatch_omars(
+    factors: list[Factor],
+    **kwargs: Any,  # noqa: ANN401
+) -> tuple[np.ndarray, dict]:
+    from process_improve.experiments.designs_omars import dispatch_omars  # noqa: PLC0415
+
+    return dispatch_omars(factors)
+
+
 def _dispatch_d_optimal(
     factors: list[Factor],
     **kwargs: Any,  # noqa: ANN401
@@ -178,6 +187,7 @@ _DESIGN_REGISTRY: dict[str, Callable[..., tuple[np.ndarray, dict]]] = {
     "box_behnken": _dispatch_box_behnken,
     "ccd": _dispatch_ccd,
     "dsd": _dispatch_dsd,
+    "omars": _dispatch_omars,
     "d_optimal": _dispatch_d_optimal,
     "i_optimal": _dispatch_i_optimal,
     "a_optimal": _dispatch_a_optimal,
@@ -271,8 +281,8 @@ def generate_design(  # noqa: PLR0913
     design_type : str or None
         One of ``"full_factorial"``, ``"fractional_factorial"``,
         ``"plackett_burman"``, ``"box_behnken"``, ``"ccd"``, ``"dsd"``,
-        ``"d_optimal"``, ``"i_optimal"``, ``"a_optimal"``, ``"mixture"``,
-        ``"taguchi"``.
+        ``"omars"``, ``"d_optimal"``, ``"i_optimal"``, ``"a_optimal"``,
+        ``"mixture"``, ``"taguchi"``.
         If ``None``, the design type is chosen automatically based on the
         factor count, budget, and constraints.
     budget : int or None
@@ -355,7 +365,16 @@ def generate_design(  # noqa: PLR0913
     # --- Determine center-point handling -----------------------------------
     # Designs that embed their own center points (CCD, Box-Behnken)
     # already include them; don't add more.
-    designs_with_embedded_centers = {"ccd", "box_behnken", "dsd", "mixture", "d_optimal", "i_optimal", "a_optimal"}
+    designs_with_embedded_centers = {
+        "ccd",
+        "box_behnken",
+        "dsd",
+        "omars",
+        "mixture",
+        "d_optimal",
+        "i_optimal",
+        "a_optimal",
+    }
 
     # Optimal designs from pyoptex produce a pre-optimized run order
     # (especially important for split-plot).  Skip randomization for these.

--- a/src/process_improve/experiments/designs_omars.py
+++ b/src/process_improve/experiments/designs_omars.py
@@ -1,0 +1,274 @@
+# (c) Kevin Dunn, 2010-2026. MIT License.
+
+"""OMARS (Orthogonal Minimally Aliased Response Surface) designs.
+
+OMARS designs are three-level designs (coded ``-1 / 0 / +1``) in which every
+main effect is orthogonal to every other main effect **and** to all
+second-order terms (the pure quadratics and the two-factor interactions),
+confining all aliasing to the second-order block.  They occupy the middle
+ground between screening designs and full response-surface designs.
+
+This module provides two things:
+
+* :func:`dispatch_omars` - a constructive generator wired into
+  :func:`process_improve.experiments.generate_design` as
+  ``design_type="omars"``.  It builds the conference-matrix foldover family of
+  OMARS designs; the definitive screening design (DSD) is the minimal member
+  of that family, so the construction is shared with
+  :func:`process_improve.experiments.designs_response_surface.dispatch_dsd`.
+* :func:`omars_properties` and :func:`is_omars` - dependency-free verifiers
+  that check the defining OMARS properties on *any* coded design matrix.  Use
+  them to validate designs we generate, designs produced by a future
+  enumerator, or designs supplied from an external source.
+
+A public catalogue of enumerated OMARS designs exists, but it is unlicensed
+and is therefore **not** redistributed with this package.  The verifiers here
+let a user cross-check a generated design against such a catalogue offline.
+
+References
+----------
+.. [1] Nunez Ares, J. and Goos, P. (2020).  "Enumeration and multicriteria
+   selection of orthogonal minimally aliased response surface designs."
+   *Technometrics*, 62(1):21-36.
+.. [2] Jones, B. and Nachtsheim, C. J. (2011).  "A class of three-level
+   designs for definitive screening in the presence of second-order
+   effects."  *Journal of Quality Technology*, 43(1):1-15.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from process_improve.experiments.factor import Factor
+
+# Default numerical tolerance for treating an inner product as zero.  The
+# constructive designs are integer-valued so exact-zero comparisons would also
+# work, but a small tolerance keeps the verifiers usable on floating-point or
+# slightly perturbed matrices.
+_DEFAULT_TOL = 1e-9
+
+
+def _second_order_terms(matrix: np.ndarray) -> tuple[np.ndarray, list[str]]:
+    """Build the second-order model terms (quadratics + two-factor interactions).
+
+    Parameters
+    ----------
+    matrix : np.ndarray
+        Coded design matrix of shape ``(n_runs, n_factors)``.
+
+    Returns
+    -------
+    tuple[np.ndarray, list[str]]
+        An ``(n_runs, n_terms)`` array whose columns are the ``k`` pure
+        quadratics ``x_i^2`` followed by the ``k (k - 1) / 2`` two-factor
+        interactions ``x_i x_j``, and a matching list of human-readable term
+        names.
+    """
+    n_factors = matrix.shape[1]
+    columns: list[np.ndarray] = []
+    names: list[str] = []
+    for i in range(n_factors):
+        columns.append(matrix[:, i] * matrix[:, i])
+        names.append(f"x{i + 1}^2")
+    for i, j in itertools.combinations(range(n_factors), 2):
+        columns.append(matrix[:, i] * matrix[:, j])
+        names.append(f"x{i + 1}*x{j + 1}")
+    if not columns:  # pragma: no cover - guarded by callers (k >= 1)
+        return np.empty((matrix.shape[0], 0)), names
+    return np.column_stack(columns), names
+
+
+def _max_abs_correlation(terms: np.ndarray) -> float:
+    """Return the largest absolute pairwise correlation among the columns of *terms*.
+
+    Constant columns (zero variance) are skipped.  Returns ``0.0`` when fewer
+    than two non-constant columns are present.
+    """
+    if terms.shape[1] < 2:
+        return 0.0
+    centered = terms - terms.mean(axis=0, keepdims=True)
+    norms = np.linalg.norm(centered, axis=0)
+    keep = norms > 0
+    if keep.sum() < 2:
+        return 0.0
+    unit = centered[:, keep] / norms[keep]
+    corr = unit.T @ unit
+    off_diagonal = corr - np.diag(np.diag(corr))
+    return float(np.abs(off_diagonal).max())
+
+
+def omars_properties(matrix: np.ndarray, *, tol: float = _DEFAULT_TOL) -> dict:
+    """Compute the OMARS-defining properties of a coded design matrix.
+
+    The three properties that define an OMARS design are:
+
+    1. **Three levels** - every entry is one of ``-1``, ``0`` or ``+1``.
+    2. **Orthogonal main effects** - the main-effect columns are mutually
+       orthogonal and balanced (each column sums to zero).
+    3. **Minimally aliased** - every main effect is orthogonal to every
+       second-order term (all quadratics and all two-factor interactions);
+       aliasing is confined to the second-order block.
+
+    Parameters
+    ----------
+    matrix : np.ndarray
+        Coded design matrix of shape ``(n_runs, n_factors)``.
+    tol : float
+        Absolute tolerance below which an inner product is treated as zero.
+
+    Returns
+    -------
+    dict
+        A report with the keys ``n_runs``, ``n_factors``, ``levels``,
+        ``is_three_level``, ``quadratics_estimable``, ``is_balanced``,
+        ``main_effects_orthogonal``, ``main_effects_clear_of_second_order``,
+        ``max_main_effect_inner_product``,
+        ``max_main_vs_second_order_inner_product``,
+        ``max_second_order_correlation`` and ``is_omars``.
+
+    Notes
+    -----
+    ``quadratics_estimable`` is ``True`` only when every factor takes the
+    middle (``0``) level at least once.  A two-level design (e.g. a full
+    factorial) would otherwise pass the orthogonality checks but has constant,
+    inestimable quadratic terms, so it is not an OMARS design.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> # The minimal 3-factor OMARS / DSD (conference-matrix foldover).
+    >>> from process_improve.experiments.factor import Factor
+    >>> from process_improve.experiments.designs_omars import dispatch_omars
+    >>> coded, _ = dispatch_omars([Factor(name=n, low=-1, high=1) for n in "ABC"])
+    >>> omars_properties(coded)["is_omars"]
+    True
+    """
+    matrix = np.asarray(matrix, dtype=float)
+    n_runs, n_factors = matrix.shape
+
+    levels = sorted({round(float(v), 9) for v in np.unique(matrix)})
+
+    # Three-level validity: every entry is within tol of one of {-1, 0, +1}.
+    nearest = np.round(matrix)
+    is_three_level = bool(
+        np.all(np.abs(matrix - nearest) <= tol) and np.all(np.isin(nearest, (-1.0, 0.0, 1.0)))
+    )
+
+    # OMARS factors are genuinely three-level: each must take the middle (0)
+    # level at least once, otherwise its pure quadratic is a constant column
+    # and cannot be estimated (as in a two-level factorial).
+    uses_middle_level = np.any(np.abs(matrix) <= tol, axis=0)
+    quadratics_estimable = bool(np.all(uses_middle_level))
+
+    column_sums = np.abs(matrix.sum(axis=0))
+    is_balanced = bool(np.all(column_sums <= tol))
+
+    # Main-effect orthogonality: off-diagonal of X'X.
+    gram = matrix.T @ matrix
+    me_off_diagonal = gram - np.diag(np.diag(gram))
+    max_me_inner = float(np.abs(me_off_diagonal).max()) if n_factors > 1 else 0.0
+    main_effects_orthogonal = max_me_inner <= tol
+
+    # Main effects clear of all second-order terms.
+    second_order, _ = _second_order_terms(matrix)
+    if second_order.shape[1] > 0:
+        cross = matrix.T @ second_order
+        max_me_vs_so = float(np.abs(cross).max())
+    else:  # pragma: no cover - k >= 1 always yields a quadratic term
+        max_me_vs_so = 0.0
+    main_effects_clear = max_me_vs_so <= tol
+
+    max_so_corr = _max_abs_correlation(second_order)
+
+    is_omars = bool(
+        is_three_level
+        and quadratics_estimable
+        and is_balanced
+        and main_effects_orthogonal
+        and main_effects_clear
+    )
+
+    return {
+        "n_runs": int(n_runs),
+        "n_factors": int(n_factors),
+        "levels": levels,
+        "is_three_level": is_three_level,
+        "quadratics_estimable": quadratics_estimable,
+        "is_balanced": is_balanced,
+        "main_effects_orthogonal": main_effects_orthogonal,
+        "main_effects_clear_of_second_order": main_effects_clear,
+        "max_main_effect_inner_product": max_me_inner,
+        "max_main_vs_second_order_inner_product": max_me_vs_so,
+        "max_second_order_correlation": max_so_corr,
+        "is_omars": is_omars,
+    }
+
+
+def is_omars(matrix: np.ndarray, *, tol: float = _DEFAULT_TOL) -> bool:
+    """Return ``True`` iff *matrix* satisfies the OMARS-defining properties.
+
+    Convenience wrapper around :func:`omars_properties`.
+
+    Parameters
+    ----------
+    matrix : np.ndarray
+        Coded design matrix of shape ``(n_runs, n_factors)``.
+    tol : float
+        Absolute tolerance below which an inner product is treated as zero.
+
+    Returns
+    -------
+    bool
+        ``True`` if the design is three-level with orthogonal main effects
+        that are clear of all second-order terms.
+    """
+    return omars_properties(matrix, tol=tol)["is_omars"]
+
+
+def dispatch_omars(factors: list[Factor], *, verify: bool = True) -> tuple[np.ndarray, dict]:
+    """Generate an OMARS design via the conference-matrix foldover construction.
+
+    The construction is shared with :func:`dispatch_dsd`: for ``k`` factors it
+    folds a conference matrix ``C`` of order ``m`` over its negative and adds a
+    center run, giving ``[C; -C; 0]``.  ``m = k`` for even ``k`` (``2k + 1``
+    runs) and ``m = k + 1`` with the last column dropped for odd ``k``
+    (``2k + 3`` runs).  This yields the minimal OMARS design for ``k`` factors;
+    a future enumerator will expand coverage to the larger, non-foldover
+    members of the OMARS family.
+
+    Parameters
+    ----------
+    factors : list[Factor]
+        Continuous factors (at least three).
+    verify : bool
+        When ``True`` (default) the generated matrix is checked with
+        :func:`is_omars` and the result is recorded in the metadata under
+        ``"omars_verified"``.  The check is cheap and guards against the
+        degraded orthogonality of the cyclic conference-matrix fallback.
+
+    Returns
+    -------
+    tuple[np.ndarray, dict]
+        The coded design matrix and metadata.  Metadata includes
+        ``"construction"`` (the conference-matrix construction used),
+        ``"family"`` and, when *verify* is ``True``, ``"omars_verified"``.
+
+    Raises
+    ------
+    ValueError
+        If fewer than three factors are supplied.
+    """
+    from process_improve.experiments.designs_response_surface import dispatch_dsd  # noqa: PLC0415
+
+    if len(factors) < 3:
+        raise ValueError("OMARS designs require at least 3 factors.")
+
+    coded_matrix, dsd_meta = dispatch_dsd(factors)
+    meta = {**dsd_meta, "family": "conference_foldover"}
+    if verify:
+        meta["omars_verified"] = is_omars(coded_matrix)
+    return coded_matrix, meta

--- a/src/process_improve/experiments/designs_omars.py
+++ b/src/process_improve/experiments/designs_omars.py
@@ -77,7 +77,7 @@ def _second_order_terms(matrix: np.ndarray) -> tuple[np.ndarray, list[str]]:
     for i, j in itertools.combinations(range(n_factors), 2):
         columns.append(matrix[:, i] * matrix[:, j])
         names.append(f"x{i + 1}*x{j + 1}")
-    if not columns:  # pragma: no cover - guarded by callers (k >= 1)
+    if not columns:  # defensive: a zero-factor matrix has no second-order terms
         return np.empty((matrix.shape[0], 0)), names
     return np.column_stack(columns), names
 
@@ -178,7 +178,7 @@ def omars_properties(matrix: np.ndarray, *, tol: float = _DEFAULT_TOL) -> dict:
     if second_order.shape[1] > 0:
         cross = matrix.T @ second_order
         max_me_vs_so = float(np.abs(cross).max())
-    else:  # pragma: no cover - k >= 1 always yields a quadratic term
+    else:  # defensive: a zero-factor matrix has no second-order terms
         max_me_vs_so = 0.0
     main_effects_clear = max_me_vs_so <= tol
 

--- a/src/process_improve/experiments/designs_omars.py
+++ b/src/process_improve/experiments/designs_omars.py
@@ -27,7 +27,7 @@ let a user cross-check a generated design against such a catalogue offline.
 
 References
 ----------
-.. [1] Nunez Ares, J. and Goos, P. (2020).  "Enumeration and multicriteria
+.. [1] Núñez Ares, J. and Goos, P. (2020).  "Enumeration and multicriteria
    selection of orthogonal minimally aliased response surface designs."
    *Technometrics*, 62(1):21-36.
 .. [2] Jones, B. and Nachtsheim, C. J. (2011).  "A class of three-level

--- a/src/process_improve/experiments/knowledge/data/design_types.yaml
+++ b/src/process_improve/experiments/knowledge/data/design_types.yaml
@@ -334,7 +334,7 @@
       curvature and interaction effects, while using fewer runs than a full
       response-surface design.
     intermediate: >
-      OMARS designs (Nunez Ares & Goos, 2020) are three-level designs in which
+      OMARS designs (Núñez Ares & Goos, 2020) are three-level designs in which
       all main effects are mutually orthogonal and orthogonal to every
       second-order term (pure quadratics and two-factor interactions). Aliasing
       is confined to the second-order block, so screening and response-surface
@@ -376,5 +376,5 @@
   common_misconceptions:
     - "OMARS designs are unrelated to DSDs - in fact the DSD is the minimal OMARS design"
   references:
-    - "Nunez Ares & Goos (2020), Technometrics 62(1):21-36"
+    - "Núñez Ares & Goos (2020), Technometrics 62(1):21-36"
     - "Jones & Nachtsheim (2011)"

--- a/src/process_improve/experiments/knowledge/data/design_types.yaml
+++ b/src/process_improve/experiments/knowledge/data/design_types.yaml
@@ -324,3 +324,57 @@
   references:
     - "Jones & Nachtsheim (2011)"
     - "Jones & Nachtsheim (2013) - categorical factors"
+
+- id: omars
+  display_name: "Orthogonal Minimally Aliased Response Surface (OMARS)"
+  category: response_surface
+  description:
+    novice: >
+      A three-level design that keeps every main effect cleanly separated from
+      curvature and interaction effects, while using fewer runs than a full
+      response-surface design.
+    intermediate: >
+      OMARS designs (Nunez Ares & Goos, 2020) are three-level designs in which
+      all main effects are mutually orthogonal and orthogonal to every
+      second-order term (pure quadratics and two-factor interactions). Aliasing
+      is confined to the second-order block, so screening and response-surface
+      goals can be pursued in a single design with a flexible run count.
+    expert: >
+      OMARS designs generalise definitive screening designs: the DSD
+      (conference-matrix foldover) is the minimal member of the OMARS family.
+      The full family is obtained by enumeration, trading off run size against
+      second-order aliasing, projection, and estimation efficiency. This
+      package constructs the conference-foldover family directly and provides
+      omars_properties() / is_omars() to verify the defining orthogonality
+      properties of any candidate design.
+  suitable_for:
+    - "3+ continuous factors needing both screening and curvature information"
+    - "When main effects must be clear of all two-factor interactions and quadratics"
+    - "When a flexible run count between screening and full RSM is desired"
+  properties:
+    resolution: "Main effects clear of all second-order terms"
+    orthogonal: "Main effects mutually orthogonal and orthogonal to 2FI and quadratic"
+    rotatable: false
+    supports_quadratic: "Partial (depends on run size and active factors)"
+    supports_interaction: "Partial (second-order terms are mutually aliased)"
+  min_runs:
+    formula: "2k + 1 (even k) or 2k + 3 (odd k) for the minimal conference-foldover member"
+    examples: {"3": 13, "4": 9, "5": 13, "6": 13}
+  supports_models:
+    - main_effects
+    - "quadratic (limited active factors)"
+  can_augment_to:
+    - {target: ccd, method: "Follow up active factors with RSM"}
+  advantages:
+    - "Main effects orthogonal to each other and to all second-order terms"
+    - "Three-level, so curvature is detectable"
+    - "Flexible run count across the enumerated family"
+  disadvantages:
+    - "Requires three levels per factor"
+    - "Second-order terms are mutually aliased"
+    - "Larger members require enumeration rather than a closed-form construction"
+  common_misconceptions:
+    - "OMARS designs are unrelated to DSDs - in fact the DSD is the minimal OMARS design"
+  references:
+    - "Nunez Ares & Goos (2020), Technometrics 62(1):21-36"
+    - "Jones & Nachtsheim (2011)"

--- a/tests/test_experiments_omars.py
+++ b/tests/test_experiments_omars.py
@@ -1,0 +1,129 @@
+"""Tests for OMARS (Orthogonal Minimally Aliased Response Surface) designs."""
+
+from __future__ import annotations
+
+import itertools
+
+import numpy as np
+import pytest
+
+from process_improve.experiments.designs import generate_design
+from process_improve.experiments.designs_omars import dispatch_omars, is_omars, omars_properties
+from process_improve.experiments.factor import Factor
+
+
+def _continuous_factors(n: int, names: str | None = None) -> list[Factor]:
+    """Create n continuous factors with default ranges."""
+    if names and len(names) >= n:
+        return [Factor(name=names[i], low=0, high=10) for i in range(n)]
+    return [Factor(name=f"X{i + 1}", low=0, high=10) for i in range(n)]
+
+
+def _manual_omars_check(matrix: np.ndarray, tol: float = 1e-9) -> None:
+    """Independently assert the OMARS properties (does not call omars_properties)."""
+    matrix = np.asarray(matrix, dtype=float)
+    n_factors = matrix.shape[1]
+
+    # Three-level and balanced.
+    assert set(np.unique(matrix).tolist()) <= {-1.0, 0.0, 1.0}
+    assert np.all(np.abs(matrix.sum(axis=0)) <= tol)
+
+    # Main effects mutually orthogonal.
+    gram = matrix.T @ matrix
+    off_diagonal = gram - np.diag(np.diag(gram))
+    assert np.abs(off_diagonal).max() <= tol
+
+    # Main effects orthogonal to every second-order term.
+    second_order = [matrix[:, i] * matrix[:, i] for i in range(n_factors)]
+    second_order += [matrix[:, i] * matrix[:, j] for i, j in itertools.combinations(range(n_factors), 2)]
+    for me in range(n_factors):
+        for term in second_order:
+            assert abs(float(matrix[:, me] @ term)) <= tol
+
+
+class TestOMARSProperties:
+    """Unit tests for the dependency-free OMARS verifier."""
+
+    def test_minimal_3_factor_design_is_omars(self) -> None:
+        """The minimal conference-foldover 3-factor design is a valid OMARS."""
+        coded, meta = dispatch_omars(_continuous_factors(3, "ABC"))
+        props = omars_properties(coded)
+        assert props["is_omars"] is True
+        assert props["is_three_level"] is True
+        assert props["is_balanced"] is True
+        assert props["main_effects_orthogonal"] is True
+        assert props["main_effects_clear_of_second_order"] is True
+        assert meta["omars_verified"] is True
+
+    def test_full_factorial_is_not_omars(self) -> None:
+        """A 2-level full factorial has inestimable quadratics, so it is not OMARS."""
+        # 2^3 factorial: never takes the middle level -> quadratics are constant.
+        ff = np.array(list(itertools.product([-1, 1], repeat=3)), dtype=float)
+        props = omars_properties(ff)
+        assert props["quadratics_estimable"] is False
+        assert props["is_omars"] is False
+        assert is_omars(ff) is False
+
+    def test_main_effect_aliased_with_interaction_fails(self) -> None:
+        """A design whose main effect correlates with an interaction is not OMARS."""
+        # x3 deliberately equals x1*x2 on the non-zero rows -> ME3 aliased with x1:x2.
+        bad = np.array(
+            [
+                [1, 1, 1],
+                [1, -1, -1],
+                [-1, 1, -1],
+                [-1, -1, 1],
+                [0, 0, 0],
+                [0, 0, 0],
+            ],
+            dtype=float,
+        )
+        props = omars_properties(bad)
+        assert props["main_effects_clear_of_second_order"] is False
+        assert props["is_omars"] is False
+
+    def test_tolerance_is_respected(self) -> None:
+        """A tiny perturbation below tol still verifies; above tol does not."""
+        coded, _ = dispatch_omars(_continuous_factors(4))
+        perturbed = coded.copy()
+        perturbed[0, 0] += 1e-6
+        assert is_omars(perturbed, tol=1e-3) is True
+        assert is_omars(perturbed, tol=1e-12) is False
+
+
+class TestOMARSDispatch:
+    """Tests for dispatch_omars and the generate_design integration."""
+
+    @pytest.mark.parametrize("k", [3, 4, 5, 6])
+    def test_generated_designs_are_omars(self, k: int) -> None:
+        """Designs generated for k=3..6 factors satisfy the OMARS properties."""
+        coded, meta = dispatch_omars(_continuous_factors(k))
+        _manual_omars_check(coded)
+        assert meta["omars_verified"] is True
+        assert meta["family"] == "conference_foldover"
+
+    def test_run_counts_match_conference_foldover(self) -> None:
+        """Even k -> 2k+1 runs; odd k -> 2k+3 runs (the DSD family)."""
+        even, _ = dispatch_omars(_continuous_factors(4))
+        odd, _ = dispatch_omars(_continuous_factors(5))
+        assert even.shape == (2 * 4 + 1, 4)
+        assert odd.shape == (2 * 5 + 3, 5)
+
+    def test_requires_3_factors(self) -> None:
+        """OMARS designs require at least three factors."""
+        with pytest.raises(ValueError, match="at least 3"):
+            dispatch_omars(_continuous_factors(2, "AB"))
+
+    def test_generate_design_integration(self) -> None:
+        """generate_design(design_type='omars') returns a verified OMARS design."""
+        result = generate_design(_continuous_factors(5), design_type="omars", center_points=0)
+        assert result.design_type == "omars"
+        assert result.metadata["omars_verified"] is True
+        x = result.design[result.factor_names].values.astype(float)
+        _manual_omars_check(x)
+
+    def test_values_in_range(self) -> None:
+        """Coded OMARS values lie within [-1, +1]."""
+        result = generate_design(_continuous_factors(5), design_type="omars", center_points=0)
+        for col in result.factor_names:
+            assert np.all(np.abs(result.design[col].values) <= 1.0 + 1e-10)

--- a/tests/test_experiments_omars.py
+++ b/tests/test_experiments_omars.py
@@ -91,6 +91,35 @@ class TestOMARSProperties:
         assert is_omars(perturbed, tol=1e-12) is False
 
 
+class TestOMARSVerifierEdgeCases:
+    """Edge cases that exercise the verifier's defensive branches."""
+
+    def test_single_factor_is_trivially_omars(self) -> None:
+        """A single three-level factor has no aliasing and is trivially OMARS."""
+        props = omars_properties(np.array([[-1.0], [0.0], [1.0]]))
+        assert props["n_factors"] == 1
+        # Only one quadratic term, so there is no second-order correlation.
+        assert props["max_second_order_correlation"] == 0.0
+        assert props["is_omars"] is True
+
+    def test_all_constant_second_order_terms(self) -> None:
+        """An all-zero design has only constant second-order terms (no correlation)."""
+        props = omars_properties(np.zeros((4, 2)))
+        assert props["max_second_order_correlation"] == 0.0
+
+    def test_zero_factor_matrix(self) -> None:
+        """A matrix with no factors has no second-order terms to alias."""
+        props = omars_properties(np.zeros((3, 0)))
+        assert props["n_factors"] == 0
+        assert props["max_main_vs_second_order_inner_product"] == 0.0
+
+    def test_verify_false_skips_verification(self) -> None:
+        """dispatch_omars(verify=False) does not record the omars_verified flag."""
+        _, meta = dispatch_omars(_continuous_factors(4), verify=False)
+        assert "omars_verified" not in meta
+        assert meta["family"] == "conference_foldover"
+
+
 class TestOMARSDispatch:
     """Tests for dispatch_omars and the generate_design integration."""
 


### PR DESCRIPTION
## What

Adds OMARS (Orthogonal Minimally Aliased Response Surface) designs as a first-class design type in `process_improve.experiments`. This is groundwork for OMARS support; it ships a constructive generator plus dependency-free verifiers now, with a small-case enumerator planned as a follow-up.

## Why

OMARS designs are three-level designs in which every main effect is mutually orthogonal **and** orthogonal to all second-order terms (the pure quadratics and every two-factor interaction), confining aliasing to the second-order block. They sit between screening and full response-surface designs and complement the existing `dsd`, `ccd`, and `box_behnken` dispatchers.

A public catalogue of enumerated OMARS designs exists (the Bitbucket `josenunezares/omars` repo - 5,399 designs for 5 factors alone), but it carries **no license**, so it is deliberately **not** vendored or fetched. Instead we generate designs ourselves and verify them against the defining mathematical properties (network-free), which the maintainer can additionally cross-check against the catalogue offline.

## Changes

- **`experiments/designs_omars.py`** (new)
  - `dispatch_omars(factors)` - builds the conference-matrix foldover family. The definitive screening design is the minimal member, so the construction is shared with `dispatch_dsd` (full reuse, no duplicated Paley/conference code). Even `k` -> `2k+1` runs; odd `k` -> `2k+3` runs.
  - `omars_properties(matrix)` / `is_omars(matrix)` - dependency-free verifiers checking: three-level with the middle level actually used (so quadratics are estimable), balanced columns, main effects mutually orthogonal, and main effects clear of all second-order terms. Tolerance-aware.
- **`experiments/designs.py`** - register `"omars"` in the dispatch registry, the embedded-centers set, and the `generate_design` docstring.
- **`experiments/__init__.py`** - export `is_omars` and `omars_properties`.
- **`knowledge/data/design_types.yaml`** - add an `omars` node to the DOE knowledge base.
- **`tests/test_experiments_omars.py`** (new) - 12 tests: generation for `k=3..6`, `generate_design` integration, and the verifier (non-OMARS rejection for a 2-level factorial and an aliased design, plus tolerance handling).
- Version bump `1.40.2` -> `1.41.0` (new feature); `CITATION.cff` and `CHANGELOG.md` kept in sync.

## Verification

```
pytest tests/test_experiments_omars.py tests/test_design_generation.py tests/test_doe_knowledge.py -o "addopts="
# 135 passed, 8 skipped (pyoptex)
ruff check .   # All checks passed
```

The OMARS property was confirmed empirically against a catalogue design (`bd-5-12-2-4-1`): balanced columns, levels `{-1,0,+1}`, main effects orthogonal to each other and to all second-order terms - exactly what `omars_properties` checks.

## Follow-up (not in this PR)

A small-case enumerator (`k <= 5`, low run sizes) via an optional `[omars]` MIP-solver extra, to reach the larger, non-foldover members of the OMARS family.

https://claude.ai/code/session_012woAz24NX2qgkcy3f9CT5a

---
_Generated by [Claude Code](https://claude.ai/code/session_012woAz24NX2qgkcy3f9CT5a)_