### PR TITLE
Fix docstring inconsistencies across multivariate and monitoring modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ those changes.
 
 ## [Unreleased]
 
+## [1.41.1] - 2026-06-19
+
+### Fixed
+
+- Clarified PCA/PLS `spe_` attribute docstring (it stores the square root of
+  the row sum-of-squared X-residuals, so it is on the residual scale, not the
+  squared scale).
+- Corrected the TPLS `d_matrix` docstring type from
+  `dict[str, dict[str, pd.DataFrame]]` to `dict[str, pd.DataFrame]` so it
+  matches the flat-dict shape that the constructor actually validates.
+- Fixed a typo in the `center()` docstring ("but return" -> "must return")
+  and added a NumPy-style Returns section to `scale()` describing the two
+  return shapes (with and without `extra_output=True`).
+- Documented `ControlChart` variant strings in lowercase (`'hw'`,
+  `'xbar.no.subgroup'`, `'cusum'`) and noted that the comparison is
+  case-insensitive, matching the `.strip().lower()` normalisation applied on
+  assignment.
+
 ## [1.41.0] - 2026-06-15
 
 ### Added
@@ -2024,7 +2042,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.41.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.41.1...HEAD
+[1.41.1]: https://github.com/kgdunn/process-improve/compare/v1.41.0...v1.41.1
 [1.41.0]: https://github.com/kgdunn/process-improve/compare/v1.40.2...v1.41.0
 [1.40.2]: https://github.com/kgdunn/process-improve/compare/v1.40.1...v1.40.2
 [1.40.1]: https://github.com/kgdunn/process-improve/compare/v1.40.0...v1.40.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.41.0
-date-released: "2026-06-15"
+version: 1.41.1
+date-released: "2026-06-19"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.41.0"
+version = "1.41.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/monitoring/control_charts.py
+++ b/src/process_improve/monitoring/control_charts.py
@@ -45,19 +45,21 @@ class ControlChart:
             Other choice is 'regular' (i.e. not-robust) calculations. User should then ensure that
             no outliers are present in the data.
 
-            variant (str, optional): Many variants of control charts are available.
+            variant (str, optional): Many variants of control charts are available. The variant
+                string is compared case-insensitively (it is normalised via ``.strip().lower()``
+                on assignment), so ``'HW'``, ``'hw'``, and ``'Hw'`` are all equivalent.
 
-                The default is a Holt-Winters (HW) chart, with automatic determination of control
-                chart parameters. This chart is a blend of infinite history (CUSUM) charts, and an
-                instantaneous (no history taken into account) Shewhart chart. The exact blend is
-                specified by parameters `ld_1` (lambda 1) and `ld_2` (lambda 2).
+                The default is a Holt-Winters (`'hw'`) chart, with automatic determination of
+                control chart parameters. This chart is a blend of infinite history (CUSUM)
+                charts, and an instantaneous (no history taken into account) Shewhart chart. The
+                exact blend is specified by parameters `ld_1` (lambda 1) and `ld_2` (lambda 2).
 
                 Other variants are:
 
                 'xbar.no.subgroup' [Shewhart chart, with no subgroups]. In other words, each
                 observation is independently plotted on the control chart.
 
-                'CUSUM' (CUmulative SUM) chart, which uses all the history of the chart.
+                'cusum' (CUmulative SUM) chart, which uses all the history of the chart.
         """
         self.style = style.strip()
         self.variant = variant.strip().lower()

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -247,7 +247,9 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
     r2_per_variable_ : pd.DataFrame of shape (n_features, n_components)
         Per-variable cumulative R² after each component.
     spe_ : pd.DataFrame of shape (n_samples, n_components)
-        Squared Prediction Error (stored as sqrt of row sum-of-squares).
+        Per-row SPE diagnostic; stored as the square root of the row
+        sum-of-squared X-residuals (so it is on the residual scale, not the
+        squared scale).
     hotellings_t2_ : pd.DataFrame of shape (n_samples, n_components)
         Cumulative Hotelling's T² statistic.
     explained_variance_ : np.ndarray of shape (n_components,)

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -183,7 +183,9 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
     predictions_ : pd.DataFrame of shape (n_samples, n_targets)
         Y predictions from the training data.
     spe_ : pd.DataFrame of shape (n_samples, n_components)
-        Squared Prediction Error (stored as sqrt of row sum-of-squares).
+        Per-row SPE diagnostic; stored as the square root of the row
+        sum-of-squared X-residuals (so it is on the residual scale, not the
+        squared scale).
     hotellings_t2_ : pd.DataFrame of shape (n_samples, n_components)
         Cumulative Hotelling's T² statistic.
     r2_per_component_ : pd.Series of length n_components

--- a/src/process_improve/multivariate/_preprocessing.py
+++ b/src/process_improve/multivariate/_preprocessing.py
@@ -151,7 +151,7 @@ def center(
 ) -> DataMatrix | tuple[DataMatrix, np.ndarray]:
     """
     Perform centering of data, using a function, `func` (default: np.mean).
-    The function, if supplied, but return a vector with as many columns as the matrix X.
+    The function, if supplied, must return a vector with as many columns as the matrix X.
 
     `axis` [optional; default=0] {integer or None}
 

--- a/src/process_improve/multivariate/_preprocessing.py
+++ b/src/process_improve/multivariate/_preprocessing.py
@@ -218,6 +218,16 @@ def scale(
     my_scale = np.mad
     X = scale(center(X), func=my_scale)
 
+    Returns
+    -------
+    scaled : DataMatrix
+        The scaled data, returned when ``extra_output=False`` (the default).
+    (scaled, scale_vector) : tuple[DataMatrix, np.ndarray]
+        When ``extra_output=True``, a tuple of the scaled data and the
+        per-column scaling vector (the reciprocal of `func` applied along
+        `axis`, with zero entries replaced by 1.0 to leave constant columns
+        unchanged) is returned instead.
+
     """
     if func is np.std and "ddof" not in kwargs:
         kwargs["ddof"] = ddof

--- a/src/process_improve/multivariate/_tpls.py
+++ b/src/process_improve/multivariate/_tpls.py
@@ -212,7 +212,7 @@ class TPLS(RegressorMixin, BaseEstimator):
     n_components : int
         A parameter used to specify the number of components.
 
-    d_matrix : dict[str, dict[str, pd.DataFrame]]
+    d_matrix : dict[str, pd.DataFrame]
         A dictionary containing the properties of each group of materials.
         Keys are group names; values are DataFrames with properties as columns and materials as rows.
         This "D" matrix is provided once at construction and reused for fitting, prediction and


### PR DESCRIPTION
Docstring-only updates (no behavioural changes to math) addressing inconsistencies found in an audit:

- **`src/process_improve/multivariate/_preprocessing.py:154`** — `center()` docstring contained the ungrammatical "The function, if supplied, but return a vector…"; changed `but` → `must`.
- **`src/process_improve/multivariate/_preprocessing.py:174`** — `scale()` returns `DataMatrix | tuple[DataMatrix, np.ndarray]` depending on `extra_output`, but the docstring had no `Returns` section. Added a NumPy-style Returns block describing both shapes.
- **`src/process_improve/multivariate/_tpls.py:215`** — TPLS class docstring declared `d_matrix : dict[str, dict[str, pd.DataFrame]]`, but the constructor only validates a flat `dict[str, pd.DataFrame]`. Corrected the docstring type to match the validation.
- **`src/process_improve/multivariate/_pca.py:250`** and **`src/process_improve/multivariate/_pls.py:186`** — `spe_` was documented as "Squared Prediction Error (stored as sqrt of row sum-of-squares)", which is self-contradictory. Rephrased identically in both files to make clear that the stored value is the square root of the row sum-of-squared X-residuals (i.e. on the residual scale, not the squared scale).
- **`src/process_improve/monitoring/control_charts.py:39`** — `ControlChart.__init__` documented variant values in mixed case (`'HW'`, `'CUSUM'`), but the code at lines 155 and 164 compares against `.strip().lower()` forms (`"hw"`, `"xbar.no.subgroup"`). Rewrote the documented variants in lowercase and added a note that the comparison is case-insensitive.

Version bumped to `1.41.1` in `pyproject.toml` and `CITATION.cff` (date `2026-06-19`), with a matching `CHANGELOG.md` entry under a new `## [1.41.1]` heading.

---
_Generated by [Claude Code](https://claude.ai/code/session_0172snbmLcjazVKew5zgJzKM)_