### PR TITLE
Complete model-aware design-evaluation metric set in evaluate_design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ those changes.
 
 ## [Unreleased]
 
+## [1.43.0] - 2026-06-19
+
+### Added
+
+- `evaluate_design` gains four model-aware metrics and a convenience aggregate:
+  `a_optimality` (`trace((XᵀX)⁻¹)`) and `e_optimality` (smallest eigenvalue of
+  `XᵀX`), each with an optional normalised efficiency; `correlation`, the
+  coding-invariant residualised maximum and mean absolute correlation among the
+  second-order terms plus the full matrix; `alias_matrix`, the general bias
+  matrix `A = (X1ᵀX1)⁻¹ X1ᵀX2` (default `X2` = the two-factor interactions
+  outside the model) with its worst single bias, main-effect-row maximum, and
+  Frobenius norm; and `fds`, the fraction-of-design-space distribution of the
+  prediction variance over the design region with the region average (I) and
+  maximum (G) in σ² units and the run-count-scaled SPV variants. `metric="all"`
+  and a thin `evaluate_all(...)` wrapper return every metric in one call.
+- Region-based metrics take `region` (`"cuboidal"` or `"spherical"`),
+  `n_samples`, `include_vertices`, and `random_seed` parameters; all sampling is
+  seeded and the region and sample size are echoed in the `fds` payload, and the
+  `2**k` cube vertices are always included so the worst-case G value at a corner
+  is represented.
+
+### Fixed
+
+- `i_efficiency` / `g_efficiency` no longer raise a matmul size mismatch (for
+  example `size 11 is different from 21`) when evaluated against an explicit
+  reduced formula such as `"A+B+C+D+E+I(A**2)+...+I(E**2)"`. The region
+  evaluation grid is now expanded through the exact fitted model matrix instead
+  of a re-inferred shorthand, and `i_efficiency` / `g_efficiency` derive from
+  the same region machinery as `fds`.
+
 ## [1.42.0] - 2026-06-19
 
 ### Added
@@ -2036,7 +2066,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.42.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.43.0...HEAD
+[1.43.0]: https://github.com/kgdunn/process-improve/compare/v1.42.0...v1.43.0
 [1.42.0]: https://github.com/kgdunn/process-improve/compare/v1.41.0...v1.42.0
 [1.41.0]: https://github.com/kgdunn/process-improve/compare/v1.40.2...v1.41.0
 [1.40.2]: https://github.com/kgdunn/process-improve/compare/v1.40.1...v1.40.2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.42.0
+version: 1.43.0
 date-released: "2026-06-19"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.42.0"
+version = "1.43.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/experiments/__init__.py
+++ b/src/process_improve/experiments/__init__.py
@@ -5,7 +5,7 @@ from process_improve.experiments.augment import augment_design
 from process_improve.experiments.designs import generate_design
 from process_improve.experiments.designs_factorial import full_factorial
 from process_improve.experiments.designs_omars import is_omars, omars_properties
-from process_improve.experiments.evaluate import evaluate_design
+from process_improve.experiments.evaluate import evaluate_all, evaluate_design
 from process_improve.experiments.factor import Constraint, DesignResult, Factor, Response, ResponseGoal
 from process_improve.experiments.knowledge import doe_knowledge
 from process_improve.experiments.models import Model, lm, predict, summary
@@ -34,6 +34,7 @@ __all__ = [
     "augment_design",
     "c",
     "doe_knowledge",
+    "evaluate_all",
     "evaluate_design",
     "expand_grid",
     "full_factorial",

--- a/src/process_improve/experiments/evaluate.py
+++ b/src/process_improve/experiments/evaluate.py
@@ -26,9 +26,9 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-from patsy import dmatrix
+from patsy import build_design_matrices, dmatrix
+from patsy.design_info import DesignInfo
 from scipy import stats
-from scipy.stats import qmc
 from statsmodels.stats.outliers_influence import variance_inflation_factor
 
 from process_improve.experiments.factor import DesignResult
@@ -60,6 +60,10 @@ class _EvalRequest:
     effect_size: float | None
     alpha: float
     sigma: float | None
+    region: str = "cuboidal"
+    n_samples: int = 100_000
+    include_vertices: bool = True
+    random_seed: int = 42
 
 
 @dataclass
@@ -70,6 +74,7 @@ class _EvalContext:
     column_names: list[str]
     factor_names: list[str]
     design_df: pd.DataFrame
+    design_info: DesignInfo  # patsy DesignInfo of the fitted model matrix
     N: int
     p: int
     XtX: np.ndarray
@@ -81,6 +86,10 @@ class _EvalContext:
     effect_size: float | None
     alpha: float
     sigma: float | None
+    region: str = "cuboidal"
+    n_samples: int = 100_000
+    include_vertices: bool = True
+    random_seed: int = 42
 
 
 # ---------------------------------------------------------------------------
@@ -94,7 +103,7 @@ def _build_model_matrix(
     design_df: pd.DataFrame,
     model: str | None,
     factor_names: list[str],
-) -> tuple[np.ndarray, list[str]]:
+) -> tuple[np.ndarray, list[str], DesignInfo]:
     """Build the expanded model matrix *X* using patsy.
 
     Parameters
@@ -113,6 +122,10 @@ def _build_model_matrix(
         The model matrix including the intercept column.
     column_names : list[str]
         Human-readable names for each column of *X*.
+    design_info : patsy.DesignInfo
+        The patsy design info describing the expansion.  Pass it to
+        :func:`patsy.build_design_matrices` to expand *new* factor-space points
+        through the identical model (see :func:`_expand_points`).
     """
     if model is None:
         model = "interactions"
@@ -143,12 +156,12 @@ def _build_model_matrix(
     dm = dmatrix(rhs, design_df, return_type="dataframe")
     X = np.asarray(dm, dtype=float)
     column_names = list(dm.columns)
-    return X, column_names
+    return X, column_names, dm.design_info
 
 
 def _build_context(req: _EvalRequest) -> _EvalContext:
     """Build the shared evaluation context."""
-    X, column_names = _build_model_matrix(req.design_df, req.model, req.factor_names)
+    X, column_names, design_info = _build_model_matrix(req.design_df, req.model, req.factor_names)
     N, p = X.shape
     XtX = X.T @ X
 
@@ -163,6 +176,7 @@ def _build_context(req: _EvalRequest) -> _EvalContext:
         column_names=column_names,
         factor_names=req.factor_names,
         design_df=req.design_df,
+        design_info=design_info,
         N=N,
         p=p,
         XtX=XtX,
@@ -174,6 +188,10 @@ def _build_context(req: _EvalRequest) -> _EvalContext:
         effect_size=req.effect_size,
         alpha=req.alpha,
         sigma=req.sigma,
+        region=req.region,
+        n_samples=req.n_samples,
+        include_vertices=req.include_vertices,
+        random_seed=req.random_seed,
     )
 
 
@@ -199,24 +217,105 @@ def _prediction_variance_at_points(X_points: np.ndarray, XtX_inv: np.ndarray) ->
     return np.sum((X_points @ XtX_inv) * X_points, axis=1)
 
 
-def _generate_evaluation_grid(factor_names: list[str], n_points: int = 5000) -> np.ndarray:
-    """Generate points in [-1, 1]^k for evaluating prediction variance.
+def _expand_points(ctx: _EvalContext, points: np.ndarray) -> np.ndarray:
+    """Expand raw factor-space points through the *fitted* model matrix.
 
-    Uses Sobol sequences for efficient space-filling coverage.
+    Uses the stored patsy :class:`~patsy.design_info.DesignInfo` so the columns
+    of the returned matrix match :attr:`_EvalContext.X` exactly (same terms,
+    same order).  This is what keeps region / grid evaluation consistent with
+    the fit; rebuilding from an inferred shorthand model is what previously
+    produced a column-count mismatch for explicit reduced formulas.
+
+    Parameters
+    ----------
+    ctx : _EvalContext
+        The shared evaluation context (carries the fitted ``design_info``).
+    points : ndarray of shape (M, k)
+        Raw factor-space points, one column per factor in ``ctx.factor_names``.
+
+    Returns
+    -------
+    ndarray of shape (M, p)
+        The model matrix for *points*, with the same columns as ``ctx.X``.
+    """
+    df_points = pd.DataFrame(np.asarray(points, dtype=float), columns=ctx.factor_names)
+    (expanded,) = build_design_matrices([ctx.design_info], df_points, return_type="matrix")
+    return np.asarray(expanded, dtype=float)
+
+
+def _cube_vertices(k: int) -> np.ndarray:
+    """Return all ``2**k`` cube vertices (corners) of ``[-1, 1]^k``."""
+    return np.array(list(itertools.product([-1.0, 1.0], repeat=k)), dtype=float)
+
+
+def _region_points(
+    factor_names: list[str],
+    region: str,
+    n_samples: int,
+    include_vertices: bool,
+    random_seed: int,
+) -> np.ndarray:
+    """Sample raw factor-space points over the design region.
+
+    Parameters
+    ----------
+    factor_names : list[str]
+        Ordered factor names (only the count ``k`` matters here).
+    region : {"cuboidal", "spherical"}
+        ``"cuboidal"`` samples uniformly in ``[-1, 1]^k``; ``"spherical"``
+        samples uniformly inside the ball of radius ``sqrt(k)`` (the sphere
+        that circumscribes the unit cube).
+    n_samples : int
+        Number of random interior samples to draw.
+    include_vertices : bool
+        When *True*, append all ``2**k`` cube vertices to the sample set.  The
+        worst-case prediction variance for second-order models very often sits
+        at (or near) a corner, so the corners are always represented in the
+        G / FDS statistics.
+    random_seed : int
+        Seed for the NumPy random generator (full reproducibility).
+
+    Returns
+    -------
+    ndarray of shape (M, k)
+        The sampled points, with the cube vertices appended last when
+        *include_vertices* is set.
     """
     k = len(factor_names)
-    sampler = qmc.Sobol(d=k, scramble=True, seed=42)
-    # Power-of-2 samples for Sobol balance
-    m = max(10, int(np.ceil(np.log2(n_points))))
-    points_01 = sampler.random_base2(m)  # in [0, 1]^k
-    return points_01 * 2.0 - 1.0  # scale to [-1, 1]^k
+    rng = np.random.default_rng(random_seed)
+    if region == "cuboidal":
+        pts = rng.uniform(-1.0, 1.0, size=(n_samples, k))
+    elif region == "spherical":
+        # Uniform in the radius-sqrt(k) ball: direction * radius, radius ~ U^(1/k).
+        directions = rng.normal(size=(n_samples, k))
+        directions /= np.linalg.norm(directions, axis=1, keepdims=True)
+        radii = np.sqrt(k) * rng.uniform(0.0, 1.0, size=(n_samples, 1)) ** (1.0 / k)
+        pts = directions * radii
+    else:
+        raise ValueError(f"Unknown region={region!r}.  Choose 'cuboidal' or 'spherical'.")
+
+    if include_vertices and k > 0:
+        pts = np.vstack([pts, _cube_vertices(k)])
+    return pts
 
 
-def _expand_grid_points(grid_raw: np.ndarray, factor_names: list[str], model: str | None) -> np.ndarray:
-    """Expand raw grid points through the model formula to get X_grid."""
-    df_grid = pd.DataFrame(grid_raw, columns=factor_names)
-    X_grid, _ = _build_model_matrix(df_grid, model, factor_names)
-    return X_grid
+def _region_prediction_variance(ctx: _EvalContext) -> np.ndarray:
+    """Prediction variance ``d(x) = x' (X'X)^-1 x`` over the design region.
+
+    Single source of truth for the region-based metrics (I / G efficiency and
+    the FDS curve): all of them read from this one sorted array, sampled with
+    the region settings carried on *ctx*.
+    """
+    assert ctx.XtX_inv is not None  # callers guard on ``ctx.is_singular``
+    points = _region_points(
+        ctx.factor_names,
+        region=ctx.region,
+        n_samples=ctx.n_samples,
+        include_vertices=ctx.include_vertices,
+        random_seed=ctx.random_seed,
+    )
+    X_region = _expand_points(ctx, points)
+    return _prediction_variance_at_points(X_region, ctx.XtX_inv)
 
 
 def _compute_g_efficiency(ctx: _EvalContext) -> dict[str, Any]:
@@ -224,13 +323,7 @@ def _compute_g_efficiency(ctx: _EvalContext) -> dict[str, Any]:
     if ctx.is_singular:
         return {"g_efficiency": None, "note": "Design is rank-deficient for the specified model."}
 
-    # ``XtX_inv`` is non-None whenever the design is not singular (guarded above).
-    assert ctx.XtX_inv is not None
-    grid_raw = _generate_evaluation_grid(ctx.factor_names)
-    # Determine the model string to rebuild for grid points
-    model_str = _infer_model_string(ctx)
-    X_grid = _expand_grid_points(grid_raw, ctx.factor_names, model_str)
-    pv = _prediction_variance_at_points(X_grid, ctx.XtX_inv)
+    pv = _region_prediction_variance(ctx)
     max_pv = float(np.max(pv))
 
     g_eff = 100.0 * ctx.p / (ctx.N * max_pv) if max_pv > 0 else None
@@ -245,12 +338,7 @@ def _compute_i_efficiency(ctx: _EvalContext) -> dict[str, Any]:
     if ctx.is_singular:
         return {"i_efficiency": None, "note": "Design is rank-deficient for the specified model."}
 
-    # ``XtX_inv`` is non-None whenever the design is not singular (guarded above).
-    assert ctx.XtX_inv is not None
-    grid_raw = _generate_evaluation_grid(ctx.factor_names)
-    model_str = _infer_model_string(ctx)
-    X_grid = _expand_grid_points(grid_raw, ctx.factor_names, model_str)
-    pv = _prediction_variance_at_points(X_grid, ctx.XtX_inv)
+    pv = _region_prediction_variance(ctx)
     avg_pv = float(np.mean(pv))
 
     i_eff = 100.0 * ctx.p / (ctx.N * avg_pv) if avg_pv > 0 else None
@@ -260,22 +348,210 @@ def _compute_i_efficiency(ctx: _EvalContext) -> dict[str, Any]:
     }
 
 
-def _infer_model_string(ctx: _EvalContext) -> str | None:
-    """Reconstruct the model string from the context for grid expansion.
+def _term_order(name: str) -> int:
+    """Classify a model-matrix column by its polynomial order.
 
-    We need to re-apply the same model transformation to grid points.  Since
-    the context stores only the expanded column names, we reconstruct the
-    model shorthand by checking the column structure.
+    Returns ``0`` for the intercept, ``1`` for a main effect, and ``2`` for a
+    second-order term (a pure quadratic ``I(x ** 2)`` or a two-factor
+    interaction ``x:y``).  Sufficient for the response-surface models this
+    module evaluates; higher powers are reported as their interaction depth.
     """
-    cols = set(ctx.column_names)
-    has_interactions = any(":" in c for c in cols)
-    has_squared = any("**" in c or c.startswith("I(") for c in cols)
+    if name.lower() == "intercept" or name == "1":
+        return 0
+    if ":" in name:
+        return name.count(":") + 1
+    if "**" in name or name.startswith("I("):
+        return 2
+    return 1
 
-    if has_squared:
-        return "quadratic"
-    if has_interactions:
-        return "interactions"
-    return "main_effects"
+
+def _compute_a_optimality(ctx: _EvalContext) -> dict[str, Any]:
+    """A-optimality: ``trace((X'X)^-1)`` (lower is better).
+
+    The trace of the inverse information matrix is the sum (so, up to a
+    constant, the average) of the coefficient variances.  ``a_efficiency`` is a
+    normalised score in the same spirit as ``d_efficiency`` (higher is better).
+    """
+    if ctx.is_singular:
+        return {"a_optimality": None, "note": "Design is rank-deficient for the specified model."}
+
+    assert ctx.XtX_inv is not None
+    trace = float(np.trace(ctx.XtX_inv))
+    a_eff = 100.0 * ctx.p / (ctx.N * trace) if trace > 0 else None
+    return {
+        "a_optimality": trace,
+        "a_efficiency": float(a_eff) if a_eff is not None else None,
+    }
+
+
+def _compute_e_optimality(ctx: _EvalContext) -> dict[str, Any]:
+    """E-optimality: smallest eigenvalue of ``X'X`` (higher is better).
+
+    The minimum eigenvalue measures how well the worst-estimated direction in
+    parameter space is supported by the design.  ``e_efficiency`` scales it by
+    the run count for comparison across designs of different size.
+    """
+    min_eig = float(np.linalg.eigvalsh(ctx.XtX).min())
+    return {
+        "e_optimality": min_eig,
+        "e_efficiency": 100.0 * min_eig / ctx.N if ctx.N > 0 else None,
+    }
+
+
+def _compute_correlation(ctx: _EvalContext) -> dict[str, Any]:
+    """Pairwise correlation summary among the model's second-order terms.
+
+    The pure-quadratic columns ``x_i^2`` have a non-zero mean, so a raw Pearson
+    correlation between them is inflated by that shared offset and depends on
+    the coding.  To get a coding-invariant measure, each second-order column is
+    first residualised against the intercept-and-main-effect block (the
+    content those columns share by construction) and the correlations are taken
+    on the residuals.
+
+    Returns ``max_abs_r``, ``mean_abs_r``, the full correlation ``matrix`` (as
+    nested lists), and the ordered ``terms``.
+    """
+    second_idx = [i for i, c in enumerate(ctx.column_names) if _term_order(c) == 2]
+    base_idx = [i for i, c in enumerate(ctx.column_names) if _term_order(c) in (0, 1)]
+    if len(second_idx) < 2:
+        return {
+            "correlation": {
+                "max_abs_r": 0.0,
+                "mean_abs_r": 0.0,
+                "matrix": [[1.0]] if second_idx else [],
+                "terms": [ctx.column_names[i] for i in second_idx],
+                "note": "Fewer than two second-order terms; no pairwise correlation.",
+            }
+        }
+
+    second = ctx.X[:, second_idx]
+    base = ctx.X[:, base_idx]
+    # Residualise the second-order columns against [intercept, main effects].
+    resid = second - base @ (np.linalg.pinv(base) @ second)
+
+    with np.errstate(invalid="ignore", divide="ignore"):
+        corr = np.corrcoef(resid, rowvar=False)
+    corr = np.nan_to_num(corr, nan=0.0)
+    corr = np.atleast_2d(corr)
+
+    m = corr.shape[0]
+    iu = np.triu_indices(m, k=1)
+    off_diag = np.abs(corr[iu])
+    max_abs = float(off_diag.max()) if off_diag.size else 0.0
+    mean_abs = float(off_diag.mean()) if off_diag.size else 0.0
+    return {
+        "correlation": {
+            "max_abs_r": max_abs,
+            "mean_abs_r": mean_abs,
+            "matrix": corr.tolist(),
+            "terms": [ctx.column_names[i] for i in second_idx],
+        }
+    }
+
+
+def _omitted_two_factor_interactions(ctx: _EvalContext) -> tuple[np.ndarray, list[str]]:
+    """Build the two-factor-interaction columns *not* already in the model.
+
+    Returns the ``(N, q)`` matrix of raw ``x_i * x_j`` products and the matching
+    ``"A:B"`` term names, for every factor pair whose interaction is absent from
+    the fitted model matrix.
+    """
+    present = {c.replace(" ", "") for c in ctx.column_names}
+    cols: list[np.ndarray] = []
+    names: list[str] = []
+    factors = ctx.factor_names
+    values = {f: ctx.design_df[f].to_numpy(dtype=float) for f in factors}
+    for a, b in itertools.combinations(factors, 2):
+        if f"{a}:{b}" in present or f"{b}:{a}" in present:
+            continue
+        cols.append(values[a] * values[b])
+        names.append(f"{a}:{b}")
+    if not cols:
+        return np.empty((ctx.N, 0)), []
+    return np.column_stack(cols), names
+
+
+def _compute_alias_matrix(ctx: _EvalContext) -> dict[str, Any]:
+    """General alias (bias) matrix ``A = (X1'X1)^-1 X1' X2``.
+
+    With the fitted model ``X1`` and a set of potential extra terms ``X2``
+    (default: the two-factor interactions not already in the model), the least
+    squares estimate of the fitted coefficients is biased by
+    ``E[b1] = beta1 + A @ beta2``.  This generalises :func:`alias_structure`
+    (which only handles two-level fractional factorials) to any design / model.
+
+    Returns the ``matrix`` (nested lists), the ``model_terms`` (rows) and
+    ``alias_terms`` (columns), the worst single bias ``max_abs``, the maximum
+    over the main-effect rows ``max_abs_main_effect_rows``, and the Frobenius
+    norm ``frobenius_norm``.
+    """
+    if ctx.is_singular:
+        return {"alias_matrix": None, "note": "Design is rank-deficient for the specified model."}
+
+    assert ctx.XtX_inv is not None
+    X2, alias_terms = _omitted_two_factor_interactions(ctx)
+    if X2.shape[1] == 0:
+        return {
+            "alias_matrix": {
+                "matrix": [],
+                "model_terms": list(ctx.column_names),
+                "alias_terms": [],
+                "max_abs": 0.0,
+                "max_abs_main_effect_rows": 0.0,
+                "frobenius_norm": 0.0,
+                "note": "No two-factor interactions outside the model to alias against.",
+            }
+        }
+
+    alias = ctx.XtX_inv @ ctx.X.T @ X2
+    main_rows = [i for i, c in enumerate(ctx.column_names) if _term_order(c) == 1]
+    max_abs = float(np.max(np.abs(alias)))
+    max_main = float(np.max(np.abs(alias[main_rows, :]))) if main_rows else 0.0
+    return {
+        "alias_matrix": {
+            "matrix": alias.tolist(),
+            "model_terms": list(ctx.column_names),
+            "alias_terms": alias_terms,
+            "max_abs": max_abs,
+            "max_abs_main_effect_rows": max_main,
+            "frobenius_norm": float(np.linalg.norm(alias)),
+        }
+    }
+
+
+_FDS_QUANTILES = (0.0, 0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99, 1.0)
+
+
+def _compute_fds(ctx: _EvalContext) -> dict[str, Any]:
+    """Fraction-of-design-space (FDS) distribution of the prediction variance.
+
+    Samples the scaled prediction variance ``d(x) = x' (X'X)^-1 x`` over the
+    whole design region (not just the design points), returning quantiles of
+    the curve together with the region average (I / V-optimality) and maximum
+    (G-optimality) in ``sigma^2`` units, plus the run-count-scaled SPV variants
+    (multiplied by ``N``).  The region settings are echoed back for
+    reproducibility.
+    """
+    if ctx.is_singular:
+        return {"fds": None, "note": "Design is rank-deficient for the specified model."}
+
+    pv = np.sort(_region_prediction_variance(ctx))
+    avg = float(pv.mean())
+    mx = float(pv.max())
+    quantiles = {f"{q:g}": float(v) for q, v in zip(_FDS_QUANTILES, np.quantile(pv, _FDS_QUANTILES), strict=True)}
+    return {
+        "fds": {
+            "region": ctx.region,
+            "n_samples": ctx.n_samples,
+            "include_vertices": ctx.include_vertices,
+            "random_seed": ctx.random_seed,
+            "quantiles": quantiles,
+            "average_prediction_variance": avg,
+            "max_prediction_variance": mx,
+            "scaled_average_prediction_variance": avg * ctx.N,
+            "scaled_max_prediction_variance": mx * ctx.N,
+        }
+    }
 
 
 def _compute_prediction_variance(ctx: _EvalContext) -> dict[str, Any]:
@@ -708,6 +984,11 @@ _METRIC_REGISTRY: dict[str, Callable[[_EvalContext], Any]] = {
     "d_efficiency": _compute_d_efficiency,
     "i_efficiency": _compute_i_efficiency,
     "g_efficiency": _compute_g_efficiency,
+    "a_optimality": _compute_a_optimality,
+    "e_optimality": _compute_e_optimality,
+    "correlation": _compute_correlation,
+    "alias_matrix": _compute_alias_matrix,
+    "fds": _compute_fds,
     "prediction_variance": _compute_prediction_variance,
     "vif": _compute_vif,
     "condition_number": _compute_condition_number,
@@ -734,6 +1015,10 @@ def evaluate_design(  # noqa: PLR0913
     effect_size: float | None = None,
     alpha: float = 0.05,
     sigma: float | None = None,
+    region: str = "cuboidal",
+    n_samples: int = 100_000,
+    include_vertices: bool = True,
+    random_seed: int = 42,
 ) -> dict[str, Any]:
     """Compute quality metrics for an experimental design.
 
@@ -747,11 +1032,13 @@ def evaluate_design(  # noqa: PLR0913
         Model type: ``"main_effects"``, ``"interactions"``, ``"quadratic"``,
         or an explicit patsy formula.  ``None`` defaults to ``"interactions"``.
     metric : str or list[str]
-        One or more metric names to compute.  Valid names:
-        ``"alias_structure"``, ``"confounding"``, ``"resolution"``,
-        ``"defining_relation"``, ``"power"``, ``"d_efficiency"``,
-        ``"i_efficiency"``, ``"g_efficiency"``, ``"prediction_variance"``,
-        ``"degrees_of_freedom"``, ``"vif"``, ``"condition_number"``,
+        One or more metric names to compute, or the special value ``"all"`` to
+        compute every metric.  Valid names: ``"d_efficiency"``,
+        ``"i_efficiency"``, ``"g_efficiency"``, ``"a_optimality"``,
+        ``"e_optimality"``, ``"correlation"``, ``"alias_matrix"``, ``"fds"``,
+        ``"prediction_variance"``, ``"vif"``, ``"condition_number"``,
+        ``"power"``, ``"degrees_of_freedom"``, ``"alias_structure"``,
+        ``"confounding"``, ``"resolution"``, ``"defining_relation"``,
         ``"clear_effects"``, ``"minimum_aberration"``.
     effect_size : float or None
         Expected effect size for power calculation.  When *None*, a power
@@ -761,6 +1048,18 @@ def evaluate_design(  # noqa: PLR0913
     sigma : float or None
         Estimated noise standard deviation.  Defaults to 1.0 when needed
         but not provided.
+    region : {"cuboidal", "spherical"}
+        Design region over which the region-based metrics (``i_efficiency``,
+        ``g_efficiency``, ``fds``) integrate the prediction variance.
+        ``"cuboidal"`` (default) is ``[-1, 1]^k``; ``"spherical"`` is the ball
+        of radius ``sqrt(k)``.
+    n_samples : int
+        Number of random samples drawn over the region (default 100,000).
+    include_vertices : bool
+        When *True* (default), all ``2**k`` cube vertices are added to the
+        region sample so the worst-case (G) value at a corner is represented.
+    random_seed : int
+        Seed for the region sampler (full reproducibility).
 
     Returns
     -------
@@ -801,7 +1100,12 @@ def evaluate_design(  # noqa: PLR0913
             design_df = design_df.drop(columns=[col])
 
     # --- Normalize metric to list ---
-    metrics = [metric] if isinstance(metric, str) else list(metric)
+    if metric == "all":
+        metrics = list(_METRIC_REGISTRY)
+    elif isinstance(metric, str):
+        metrics = [metric]
+    else:
+        metrics = list(metric)
     logger.debug("evaluate_design: model=%r, metrics=%s", model, metrics)
 
     # Validate metric names
@@ -822,6 +1126,10 @@ def evaluate_design(  # noqa: PLR0913
             effect_size=effect_size,
             alpha=alpha,
             sigma=sigma,
+            region=region,
+            n_samples=n_samples,
+            include_vertices=include_vertices,
+            random_seed=random_seed,
         )
     )
 
@@ -832,3 +1140,43 @@ def evaluate_design(  # noqa: PLR0913
         results.update(result)
 
     return results
+
+
+def evaluate_all(  # noqa: PLR0913
+    design_matrix: pd.DataFrame | DesignResult,
+    model: str | None = None,
+    effect_size: float | None = None,
+    alpha: float = 0.05,
+    sigma: float | None = None,
+    region: str = "cuboidal",
+    n_samples: int = 100_000,
+    include_vertices: bool = True,
+    random_seed: int = 42,
+) -> dict[str, Any]:
+    """Compute *every* available metric for a design in one call.
+
+    Thin convenience wrapper around :func:`evaluate_design` with
+    ``metric="all"`` so callers need not enumerate the metric list.  All
+    parameters have the same meaning as in :func:`evaluate_design`.
+
+    Returns
+    -------
+    dict[str, Any]
+        Results keyed by metric name (the union of every registered metric).
+
+    See Also
+    --------
+    evaluate_design : Compute one or more named metrics.
+    """
+    return evaluate_design(
+        design_matrix,
+        model=model,
+        metric="all",
+        effect_size=effect_size,
+        alpha=alpha,
+        sigma=sigma,
+        region=region,
+        n_samples=n_samples,
+        include_vertices=include_vertices,
+        random_seed=random_seed,
+    )

--- a/tests/test_evaluate_design.py
+++ b/tests/test_evaluate_design.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -49,14 +51,14 @@ class TestModelMatrix:
     def test_main_effects_shape(self) -> None:
         """2^3 factorial with main_effects produces (8, 4) matrix."""
         df = _full_factorial_df(3)
-        X, cols = _build_model_matrix(df, "main_effects", ["A", "B", "C"])
+        X, cols, _ = _build_model_matrix(df, "main_effects", ["A", "B", "C"])
         assert X.shape == (8, 4)  # intercept + 3 main effects
         assert "Intercept" in cols
 
     def test_interactions_shape(self) -> None:
         """2^3 factorial with interactions produces (8, 7+1) columns."""
         df = _full_factorial_df(3)
-        X, _cols = _build_model_matrix(df, "interactions", ["A", "B", "C"])
+        X, _cols, _ = _build_model_matrix(df, "interactions", ["A", "B", "C"])
         # intercept + 3 main + 3 two-factor interactions = 7
         assert X.shape == (8, 7)
 
@@ -66,27 +68,27 @@ class TestModelMatrix:
         factors = _continuous_factors(2, "AB")
         result = generate_design(factors, design_type="ccd", alpha="face_centered")
         df = pd.DataFrame(result.design[["A", "B"]])
-        X, _cols = _build_model_matrix(df, "quadratic", ["A", "B"])
+        X, _cols, _ = _build_model_matrix(df, "quadratic", ["A", "B"])
         # intercept + 2 main + 1 interaction + 2 squared = 6
         assert X.shape[1] == 6
 
     def test_none_defaults_to_interactions(self) -> None:
         """model=None should default to interactions."""
         df = _full_factorial_df(3)
-        X_none, _cols_none = _build_model_matrix(df, None, ["A", "B", "C"])
-        X_int, _cols_int = _build_model_matrix(df, "interactions", ["A", "B", "C"])
+        X_none, _cols_none, _ = _build_model_matrix(df, None, ["A", "B", "C"])
+        X_int, _cols_int, _ = _build_model_matrix(df, "interactions", ["A", "B", "C"])
         np.testing.assert_array_equal(X_none, X_int)
 
     def test_explicit_formula_with_tilde(self) -> None:
         """Explicit formula with ~ should strip the LHS."""
         df = _full_factorial_df(2)
-        X, _cols = _build_model_matrix(df, "y ~ A + B", ["A", "B"])
+        X, _cols, _ = _build_model_matrix(df, "y ~ A + B", ["A", "B"])
         assert X.shape == (4, 3)  # intercept + 2 main
 
     def test_explicit_rhs_formula(self) -> None:
         """Explicit RHS formula (no ~) should work directly."""
         df = _full_factorial_df(2)
-        X, _cols = _build_model_matrix(df, "A * B", ["A", "B"])
+        X, _cols, _ = _build_model_matrix(df, "A * B", ["A", "B"])
         assert X.shape[1] == 4  # intercept + A + B + A:B
 
 
@@ -768,3 +770,242 @@ class TestIntegration:
         assert any("ABCD" in w for w in metrics["defining_relation"])
         assert "A" in metrics["clear_effects"]["main_effects"]
         assert metrics["minimum_aberration"]["wordlength_pattern"] == [0, 1]
+
+
+# ---------------------------------------------------------------------------
+# New model-aware metrics: A/E-optimality, correlation, alias matrix, FDS
+# ---------------------------------------------------------------------------
+
+# Five-factor pure main-effects-plus-quadratics model (11 terms incl. intercept).
+_FACTORS_5 = list("ABCDE")
+_PURE_QUADRATIC_5 = "+".join(_FACTORS_5) + "+" + "+".join(f"I({n}**2)" for n in _FACTORS_5)
+
+
+def _rsm_factors() -> list[Factor]:
+    """Five continuous factors coded on [-1, 1]."""
+    return [Factor(name=n, low=-1, high=1) for n in _FACTORS_5]
+
+
+def _coded(result: object) -> pd.DataFrame:
+    """Extract the coded factor columns of a DesignResult as a plain DataFrame."""
+    df = pd.DataFrame(result.design)  # type: ignore[attr-defined]
+    return df[[c for c in df.columns if c in _FACTORS_5]].reset_index(drop=True).astype(float)
+
+
+# A 25-run OMARS design for five factors, reproducing the published reference
+# row (A=2.34, E=0.93, max|r|=0.00, I=0.51, G=0.84).  It is the conference-matrix
+# foldover [C; -C; C; -C; 0] (a doubled DSD core plus one centre run) and is
+# verified by ``is_omars``.  The enumerated OMARS catalogue is not shipped with
+# the package; constructive generation of OMARS designs for small factor counts
+# is planned, at which point this hand-embedded fixture can be replaced.
+_OMARS_25 = pd.DataFrame(
+    [
+        [0, 1, 1, 1, 1], [-1, 0, -1, 1, 1], [-1, 1, 1, -1, 0], [-1, 1, -1, 0, -1],
+        [1, 1, -1, -1, 1], [1, 1, 0, 1, -1], [0, -1, -1, -1, -1], [1, 0, 1, -1, -1],
+        [1, -1, -1, 1, 0], [1, -1, 1, 0, 1], [-1, -1, 1, 1, -1], [-1, -1, 0, -1, 1],
+        [0, 1, 1, 1, 1], [-1, 0, -1, 1, 1], [-1, 1, 1, -1, 0], [-1, 1, -1, 0, -1],
+        [1, 1, -1, -1, 1], [1, 1, 0, 1, -1], [0, -1, -1, -1, -1], [1, 0, 1, -1, -1],
+        [1, -1, -1, 1, 0], [1, -1, 1, 0, 1], [-1, -1, 1, 1, -1], [-1, -1, 0, -1, 1],
+        [0, 0, 0, 0, 0],
+    ],
+    columns=_FACTORS_5,
+    dtype=float,
+)
+
+
+class TestAOptimality:
+    """Test A-optimality (trace of the inverse information matrix)."""
+
+    def test_orthogonal_design(self) -> None:
+        """Orthogonal 2^3 design: A = trace((X'X)^-1) is positive and small."""
+        df = _full_factorial_df(3)
+        result = evaluate_design(df, model="main_effects", metric="a_optimality")
+        # Orthogonal: X'X = 8 I, so trace((X'X)^-1) = 4 / 8 = 0.5.
+        assert result["a_optimality"] == pytest.approx(0.5, abs=1e-9)
+        assert result["a_efficiency"] is not None
+
+    def test_singular_returns_none(self) -> None:
+        """Rank-deficient design returns None for A-optimality."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="quadratic", metric="a_optimality")
+        assert result["a_optimality"] is None
+
+
+class TestEOptimality:
+    """Test E-optimality (smallest eigenvalue of X'X)."""
+
+    def test_orthogonal_design(self) -> None:
+        """Orthogonal 2^3 design: every eigenvalue of X'X equals N = 8."""
+        df = _full_factorial_df(3)
+        result = evaluate_design(df, model="main_effects", metric="e_optimality")
+        assert result["e_optimality"] == pytest.approx(8.0, abs=1e-9)
+
+    def test_reported_even_when_singular(self) -> None:
+        """E-optimality is defined (near zero) even for a rank-deficient design."""
+        df = _full_factorial_df(2)
+        result = evaluate_design(df, model="quadratic", metric="e_optimality")
+        assert result["e_optimality"] == pytest.approx(0.0, abs=1e-9)
+
+
+class TestCorrelation:
+    """Test the residualised second-order correlation summary."""
+
+    def test_keys_present(self) -> None:
+        """Correlation result exposes max/mean |r|, matrix, and terms."""
+        df = _coded(generate_design(_rsm_factors(), design_type="box_behnken", center_points=6))
+        result = evaluate_design(df, model=_PURE_QUADRATIC_5, metric="correlation")
+        corr = result["correlation"]
+        assert {"max_abs_r", "mean_abs_r", "matrix", "terms"} <= set(corr)
+        assert 0.0 <= corr["max_abs_r"] <= 1.0
+
+    def test_omars_second_order_orthogonal(self) -> None:
+        """The OMARS fixture has an orthogonal second-order block (max|r| = 0)."""
+        result = evaluate_design(_OMARS_25, model=_PURE_QUADRATIC_5, metric="correlation")
+        assert result["correlation"]["max_abs_r"] == pytest.approx(0.0, abs=1e-9)
+
+
+class TestAliasMatrix:
+    """Test the general alias (bias) matrix."""
+
+    def test_keys_present(self) -> None:
+        """Alias-matrix result exposes the matrix, terms, and summary norms."""
+        df = _coded(generate_design(_rsm_factors(), design_type="box_behnken", center_points=6))
+        result = evaluate_design(df, model=_PURE_QUADRATIC_5, metric="alias_matrix")
+        am = result["alias_matrix"]
+        assert {"matrix", "model_terms", "alias_terms", "max_abs", "max_abs_main_effect_rows", "frobenius_norm"} <= set(
+            am
+        )
+        # Box-Behnken aliases no two-factor interactions into the pure-quadratic model.
+        assert am["max_abs"] == pytest.approx(0.0, abs=1e-9)
+
+    def test_main_effect_rows_unbiased_for_omars(self) -> None:
+        """OMARS keeps main effects clear of the omitted 2fi (main-row alias = 0)."""
+        result = evaluate_design(_OMARS_25, model=_PURE_QUADRATIC_5, metric="alias_matrix")
+        assert result["alias_matrix"]["max_abs_main_effect_rows"] == pytest.approx(0.0, abs=1e-9)
+
+
+class TestFDS:
+    """Test the fraction-of-design-space (FDS) curve."""
+
+    def test_payload_and_scaling(self) -> None:
+        """FDS reports region metadata, quantiles, I/G, and the xN SPV variants."""
+        df = _coded(generate_design(_rsm_factors(), design_type="box_behnken", center_points=6))
+        result = evaluate_design(df, model=_PURE_QUADRATIC_5, metric="fds", random_seed=1)
+        fds = result["fds"]
+        assert fds["region"] == "cuboidal"
+        assert fds["include_vertices"] is True
+        assert fds["random_seed"] == 1
+        n = df.shape[0]
+        assert fds["scaled_average_prediction_variance"] == pytest.approx(fds["average_prediction_variance"] * n)
+        assert fds["scaled_max_prediction_variance"] == pytest.approx(fds["max_prediction_variance"] * n)
+        # The maximum prediction variance is at least the region average.
+        assert fds["max_prediction_variance"] >= fds["average_prediction_variance"]
+
+    def test_quantiles_monotone(self) -> None:
+        """FDS quantiles are non-decreasing in the fraction of design space."""
+        df = _coded(generate_design(_rsm_factors(), design_type="box_behnken", center_points=6))
+        fds = evaluate_design(df, model=_PURE_QUADRATIC_5, metric="fds", random_seed=1)["fds"]
+        keys = sorted(fds["quantiles"], key=float)
+        values = [fds["quantiles"][k] for k in keys]
+        assert values == sorted(values)
+
+
+class TestReducedFormulaRegression:
+    """Regression: explicit reduced formulas must not crash the region metrics."""
+
+    def test_i_g_efficiency_explicit_pure_quadratic(self) -> None:
+        """i/g efficiency for an 11-term reduced formula no longer raises (size 11 vs 21)."""
+        df = _coded(generate_design(_rsm_factors(), design_type="box_behnken", center_points=6))
+        result = evaluate_design(
+            df, model=_PURE_QUADRATIC_5, metric=["i_efficiency", "g_efficiency"], random_seed=1
+        )
+        assert result["i_efficiency"] is not None
+        assert result["g_efficiency"] is not None
+        assert result["average_prediction_variance"] > 0
+        assert result["max_prediction_variance"] >= result["average_prediction_variance"]
+
+
+class TestAggregate:
+    """Test metric='all' and the evaluate_all wrapper."""
+
+    def test_metric_all_includes_every_metric(self) -> None:
+        """metric='all' returns keys for every registered metric family."""
+        df = _coded(generate_design(_rsm_factors(), design_type="box_behnken", center_points=6))
+        result = evaluate_design(df, model=_PURE_QUADRATIC_5, metric="all", effect_size=1.0, random_seed=1)
+        for key in ("d_efficiency", "a_optimality", "e_optimality", "correlation", "alias_matrix", "fds", "power"):
+            assert key in result
+
+    def test_evaluate_all_matches_metric_all(self) -> None:
+        """evaluate_all is a thin wrapper over evaluate_design(metric='all')."""
+        from process_improve.experiments.evaluate import evaluate_all
+
+        df = _coded(generate_design(_rsm_factors(), design_type="box_behnken", center_points=6))
+        a = evaluate_all(df, model=_PURE_QUADRATIC_5, effect_size=1.0, random_seed=1)
+        b = evaluate_design(df, model=_PURE_QUADRATIC_5, metric="all", effect_size=1.0, random_seed=1)
+        assert set(a) == set(b)
+        assert a["a_optimality"] == pytest.approx(b["a_optimality"])
+
+
+class TestGoldenMetrics:
+    """Golden-value regression against an independent numpy/scipy implementation.
+
+    Five factors on the 11-term main-effects-plus-pure-quadratics model, all
+    designs confined to [-1, 1]^5, region cuboidal with uniform sampling plus
+    the 2^5 vertices (random_seed=1).  Stable/deterministic metrics (A, E,
+    max|r|, region-average I, VIF, alias, power) are asserted tightly; the
+    Monte-Carlo region maximum (G) is asserted with a modest tolerance.
+    """
+
+    # design name -> (A, E, max|r|, region-I, region-G, max VIF,
+    #                 alias max|A|, main-row alias, power main, power quad)
+    GOLDEN: ClassVar[dict[str, tuple[float, ...]]] = {
+        "BBD": (1.05, 2.54, 0.15, 0.18, 0.84, 1.20, 0.00, 0.00, 0.97, 0.82),
+        "CCD": (2.39, 2.00, 0.75, 0.31, 0.77, 3.20, 0.00, 0.00, 0.98, 0.32),
+        "OMARS": (2.34, 0.93, 0.00, 0.51, 0.84, 1.00, 1.00, 0.00, 0.99, 0.46),
+        "DSD": (3.70, 0.85, 0.13, 0.71, 1.05, 1.05, 1.09, 0.00, 0.42, 0.15),
+    }
+
+    def _design(self, name: str) -> pd.DataFrame:
+        if name == "BBD":
+            return _coded(generate_design(_rsm_factors(), design_type="box_behnken", center_points=6))
+        if name == "CCD":
+            return _coded(
+                generate_design(
+                    _rsm_factors(), design_type="ccd", cube="fractional", alpha="face_centered", center_points=6
+                )
+            )
+        if name == "DSD":
+            return _coded(generate_design(_rsm_factors(), design_type="dsd"))
+        return _OMARS_25
+
+    @pytest.mark.parametrize("name", ["BBD", "CCD", "OMARS", "DSD"])
+    def test_golden_row(self, name: str) -> None:
+        df = self._design(name)
+        gA, gE, gR, gI, gG, gVIF, gAlias, gMain, gPM, gPQ = self.GOLDEN[name]
+        res = evaluate_design(
+            df,
+            model=_PURE_QUADRATIC_5,
+            metric=["a_optimality", "e_optimality", "correlation", "fds", "vif", "alias_matrix", "power"],
+            effect_size=1.0,
+            random_seed=1,
+            n_samples=100_000,
+        )
+        assert res["a_optimality"] == pytest.approx(gA, abs=0.01)
+        assert res["e_optimality"] == pytest.approx(gE, abs=0.01)
+        assert res["correlation"]["max_abs_r"] == pytest.approx(gR, abs=0.01)
+        assert res["fds"]["average_prediction_variance"] == pytest.approx(gI, abs=0.01)
+        assert res["fds"]["max_prediction_variance"] == pytest.approx(gG, abs=0.05)
+        assert max(res["vif"].values()) == pytest.approx(gVIF, abs=0.01)
+        assert res["alias_matrix"]["max_abs"] == pytest.approx(gAlias, abs=0.01)
+        assert res["alias_matrix"]["max_abs_main_effect_rows"] == pytest.approx(gMain, abs=0.01)
+        power_main = np.mean([res["power"][n] for n in _FACTORS_5])
+        power_quad = np.mean([res["power"][c] for c in res["power"] if c.startswith("I(")])
+        assert power_main == pytest.approx(gPM, abs=0.01)
+        assert power_quad == pytest.approx(gPQ, abs=0.01)
+
+    def test_omars_fixture_is_valid(self) -> None:
+        """The embedded 25-run OMARS fixture really is an OMARS design."""
+        from process_improve.experiments.designs_omars import is_omars
+
+        assert _OMARS_25.shape == (25, 5)
+        assert is_omars(_OMARS_25.to_numpy())


### PR DESCRIPTION
## Summary

Closes the gaps in `evaluate_design(design, model=..., metric=...)` so a single
call fully characterises a response-surface design against a chosen model.

This PR (in progress):

1. **Fixes `i_efficiency` / `g_efficiency` for explicit model formulas.** A
   reduced formula such as `"A+B+C+D+E+I(A**2)+...+I(E**2)"` currently raises
   `ValueError: matmul ... size 11 is different from 21` because the evaluation
   grid was expanded with a different (full second-order) model than the fit.
   The grid is now expanded through the exact fitted patsy `design_info`.
2. **Adds A- and E-optimality** (`a_optimality = trace((XᵀX)⁻¹)`,
   `e_optimality = min eig(XᵀX)`), with optional normalised efficiencies.
3. **Adds a pairwise-correlation summary** (`correlation`): coding-invariant
   residualised max/mean absolute correlation among the second-order terms.
4. **Adds a general alias (bias) matrix** (`alias_matrix`): `A = (X1ᵀX1)⁻¹ X1ᵀX2`,
   generalising `alias_structure` to any design and model.
5. **Exposes the FDS curve** (`fds`): fraction-of-design-space distribution of
   prediction variance over the design region, with region average (I) and
   maximum (G) in σ² units and the ×N SPV variants. `i_efficiency`/`g_efficiency`
   derive from this same region machinery.
6. **Convenience aggregate**: `metric="all"` and an `evaluate_all(...)` wrapper.

All region sampling is seeded; the region and sample size are documented in the
returned payload, and all 2^k cube vertices are always included.

## Validation

A/E/max|r|/region-I/maxVIF/alias/main-row/power reproduce the acceptance-table
golden values to ~machine precision for Box-Behnken (46), face-centred CCD (32),
and DSD (13). A 25-run OMARS fixture is embedded for the OMARS row (the
enumerated OMARS catalogue is not shipped); generation for small factor counts
is planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxmJV48DXSRmrqZKcwjhat

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxmJV48DXSRmrqZKcwjhat)_