### PR TITLE
Document the design-evaluation metrics and FDS curve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ those changes.
 
 ## [Unreleased]
 
+## [1.44.1] - 2026-06-20
+
+### Documentation
+
+- Added a "Evaluating Design Quality" user-guide page covering the
+  `evaluate_design` metrics (D/I/G efficiency, A/E-optimality, the term
+  correlation summary, the alias/bias matrix, prediction variance and the FDS
+  curve, power), the seeded region-sampling controls and their reproducibility,
+  and the tunable `fds_resolution` curve. Refreshed the `evaluate_design` entry
+  in the DOE tool reference with the full metric list, `metric="all"`, and the
+  region / FDS parameters.
+
 ## [1.44.0] - 2026-06-20
 
 ### Added
@@ -2100,7 +2112,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.44.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.44.1...HEAD
+[1.44.1]: https://github.com/kgdunn/process-improve/compare/v1.44.0...v1.44.1
 [1.44.0]: https://github.com/kgdunn/process-improve/compare/v1.43.0...v1.44.0
 [1.43.0]: https://github.com/kgdunn/process-improve/compare/v1.42.1...v1.43.0
 [1.42.1]: https://github.com/kgdunn/process-improve/compare/v1.42.0...v1.42.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.44.0
+version: 1.44.1
 date-released: "2026-06-20"
 keywords:
   - chemometrics

--- a/docs/doe/tools.md
+++ b/docs/doe/tools.md
@@ -54,12 +54,19 @@ Compute properties and quality metrics of an existing design.
 |---|---|---|
 | `design_matrix` | DataFrame | Design to evaluate |
 | `model` | str or None | `"main_effects"`, `"interactions"`, `"quadratic"`, or explicit formula |
-| `metric` | str or list | `"alias_structure"`, `"confounding"`, `"resolution"`, `"defining_relation"`, `"power"`, `"d_efficiency"`, `"i_efficiency"`, `"g_efficiency"`, `"prediction_variance"`, `"degrees_of_freedom"`, `"vif"`, `"condition_number"`, `"clear_effects"`, `"minimum_aberration"` |
+| `metric` | str or list | Any of `"d_efficiency"`, `"i_efficiency"`, `"g_efficiency"`, `"a_optimality"`, `"e_optimality"`, `"correlation"`, `"alias_matrix"`, `"fds"`, `"prediction_variance"`, `"vif"`, `"condition_number"`, `"power"`, `"degrees_of_freedom"`, `"alias_structure"`, `"confounding"`, `"resolution"`, `"defining_relation"`, `"clear_effects"`, `"minimum_aberration"`; or `"all"` to compute every metric |
 | `effect_size` | float or None | For power calculation |
 | `alpha` | float | Significance level (default 0.05) |
 | `sigma` | float or None | Estimated noise SD |
+| `region` | str | Region for the region-integrated metrics: `"cuboidal"` (default) or `"spherical"` |
+| `n_samples` | int | Monte-Carlo points over the region (default 100000) |
+| `include_vertices` | bool | Append the `2**k` cube corners to the region sample (default `True`) |
+| `random_seed` | int | Seed for the region sampler (default 42); fix it to reproduce the region maximum (G) |
+| `fds_resolution` | int or None | When set, the `fds` metric adds a dense `curve` sub-dict of that length; `None` (default) keeps the coarse 11-point quantile summary |
 
-**Outputs:** Requested metrics - alias chains, power curves, efficiency values, etc.
+**Outputs:** Requested metrics - efficiency and optimality values, the term-correlation summary, the alias (bias) matrix, the FDS curve, alias chains, power curves, etc.
+
+**Convenience:** `metric="all"` (or the `evaluate_all(...)` wrapper) returns every metric in one call.
 
 **Handles 7 questions as primary tool.** See [mapping](tool-question-mapping.md#evaluate_design).
 

--- a/docs/user_guide/design_evaluation.rst
+++ b/docs/user_guide/design_evaluation.rst
@@ -1,0 +1,216 @@
+Evaluating Design Quality
+=========================
+
+Once you have a candidate design, the next question is: *"How good is it for
+the model I intend to fit?"*  The :func:`~process_improve.experiments.evaluate_design`
+function answers this by computing a complete, model-aware set of quality
+metrics from the design matrix and a chosen model.  A single call can fully
+characterise a response-surface design: its efficiency, where it predicts well
+or badly, how its coefficients are correlated, and what bias it carries from
+terms left out of the model.
+
+Every metric is computed against the *model you specify*, not against the
+design in isolation.  A design that is excellent for a main-effects model can
+be poor for a full quadratic model, so the model always comes first.
+
+When to Use This Tool
+---------------------
+
+- **Comparing candidate designs** - score Box-Behnken, central composite,
+  definitive screening, OMARS, and optimal designs on the same footing before
+  committing runs.
+- **Checking a design against a reduced model** - verify that an explicit
+  formula (for example main effects plus pure quadratics) is estimable and
+  well-conditioned.
+- **Diagnosing where a design predicts poorly** - the fraction-of-design-space
+  (FDS) curve shows the spread of prediction variance across the whole region,
+  not just at the design points.
+- **Quantifying bias** - the alias matrix reports how much omitted two-factor
+  interactions would bias the fitted coefficients.
+
+Quick Start
+-----------
+
+.. code-block:: python
+
+   from process_improve.experiments import generate_design, evaluate_design, Factor
+
+   factors = [Factor(name=n, low=-1, high=1) for n in "ABCDE"]
+   design = generate_design(factors, design_type="box_behnken", center_points=6)
+
+   # A reduced model: main effects plus pure quadratics (no two-factor interactions).
+   model = "A+B+C+D+E+I(A**2)+I(B**2)+I(C**2)+I(D**2)+I(E**2)"
+
+   metrics = evaluate_design(
+       design,
+       model=model,
+       metric=["d_efficiency", "a_optimality", "e_optimality", "fds"],
+   )
+
+To compute every available metric in one call, pass ``metric="all"`` or use the
+:func:`~process_improve.experiments.evaluate_all` convenience wrapper:
+
+.. code-block:: python
+
+   from process_improve.experiments import evaluate_all
+
+   everything = evaluate_all(design, model=model)
+
+The Metrics
+-----------
+
+Optimality and efficiency
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These summarise the information matrix :math:`X^\top X` for the fitted model.
+
+- ``d_efficiency`` - :math:`100 \cdot \det(X^\top X)^{1/p} / N`; overall
+  information content (higher is better).
+- ``a_optimality`` - :math:`\operatorname{trace}((X^\top X)^{-1})`, the average
+  coefficient variance (**lower** is better).  Reported alongside an
+  ``a_efficiency`` score for parity with ``d_efficiency``.
+- ``e_optimality`` - the smallest eigenvalue of :math:`X^\top X`, the
+  worst-estimated direction in parameter space (**higher** is better).
+- ``vif`` - variance inflation factor per term; how much each coefficient
+  variance is inflated by non-orthogonality.
+- ``condition_number`` - conditioning of the model matrix.
+
+Term correlation
+~~~~~~~~~~~~~~~~~
+
+``correlation`` summarises the pairwise correlation among the *second-order*
+terms (pure quadratics and two-factor interactions).  Because the
+:math:`x_i^2` columns have a non-zero mean, a naive Pearson correlation is
+inflated by that shared offset and depends on the coding.  The metric instead
+residualises each second-order column against the intercept-and-main-effect
+block first, giving a coding-invariant measure.  It returns ``max_abs_r``,
+``mean_abs_r``, and the full ``matrix``.
+
+Alias (bias) matrix
+~~~~~~~~~~~~~~~~~~~~~
+
+``alias_matrix`` generalises the two-level alias structure to any design and
+model.  Given the fitted model :math:`X_1` and a set of potential extra terms
+:math:`X_2` (by default the two-factor interactions *not* already in the
+model), it computes
+
+.. math::
+
+   A = (X_1^\top X_1)^{-1} X_1^\top X_2,
+
+so the expected fitted coefficients are biased as
+:math:`\mathbb{E}[b_1] = \beta_1 + A\,\beta_2`.  The result reports the matrix,
+the worst single bias (``max_abs``), the maximum over the main-effect rows
+(``max_abs_main_effect_rows``), and the Frobenius norm.
+
+Prediction variance and the FDS curve
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``prediction_variance`` is the leverage :math:`d(x) = x^\top (X^\top X)^{-1} x`
+*at the design runs*.  ``fds`` instead samples :math:`d(x)` over the **whole
+design region**, giving the fraction-of-design-space distribution.  From the
+same region sample it reports:
+
+- ``average_prediction_variance`` - the region average (I / V-optimality),
+- ``max_prediction_variance`` - the region maximum (G-optimality), in
+  :math:`\sigma^2` units,
+- the run-count-scaled SPV variants (each multiplied by ``N``), and
+- a coarse 11-point ``quantiles`` summary.
+
+``i_efficiency`` and ``g_efficiency`` are derived from this same region
+machinery, so they are consistent with the ``fds`` payload.
+
+Power
+~~~~~
+
+``power`` reports the statistical power to detect each model term.  Pass
+``effect_size`` for a single power value per term, or omit it for a power curve
+over a range of effect sizes.
+
+Fractional-factorial structure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For two-level fractional factorials the tool also reports ``alias_structure``,
+``confounding``, ``resolution``, ``defining_relation``, ``clear_effects``, and
+``minimum_aberration`` from the generators.
+
+Region Sampling and Reproducibility
+-----------------------------------
+
+The region-integrated metrics (``i_efficiency``, ``g_efficiency``,
+``average_prediction_variance``, ``max_prediction_variance``, and ``fds``) are
+computed by Monte-Carlo sampling the design region.  The sampling is fully
+controllable and seeded:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 64
+
+   * - Parameter
+     - Default
+     - Meaning
+   * - ``region``
+     - ``"cuboidal"``
+     - ``"cuboidal"`` samples :math:`[-1, 1]^k`; ``"spherical"`` samples the
+       ball of radius :math:`\sqrt{k}`.
+   * - ``n_samples``
+     - ``100_000``
+     - Number of random points drawn over the region.
+   * - ``include_vertices``
+     - ``True``
+     - Always append the :math:`2^k` cube corners, where the worst-case
+       prediction variance usually sits.
+   * - ``random_seed``
+     - ``42``
+     - Seed for the region sampler; fixing it makes the maximum reproducible.
+
+The region **average** (I) is stable across seeds, but the region **maximum**
+(G) is sensitive to the sample: the worst point is often in the interior, so a
+denser sample finds higher worst-case values.  To tighten and reproduce the
+G estimate, raise ``n_samples`` and fix ``random_seed``:
+
+.. code-block:: python
+
+   metrics = evaluate_design(
+       design, model=model, metric="fds",
+       n_samples=120_000, random_seed=1,
+   )
+   metrics["fds"]["max_prediction_variance"]  # reproducible run to run
+
+The region, sample size, vertex flag, and seed actually used are echoed back in
+the ``fds`` payload.
+
+Tunable FDS Curve
+-----------------
+
+By default ``fds`` returns the coarse 11-point ``quantiles`` summary.  For a
+smooth plot, set ``fds_resolution`` to the number of points you want.  The
+payload then gains a ``curve`` sub-dict with ``fraction``,
+``prediction_variance``, and ``scaled_prediction_variance`` (the run-count
+scaled SPV) arrays of that length, evaluated on evenly spaced fractions in
+:math:`[0, 1]`.  The arrays are monotonically non-decreasing, and their
+endpoints equal the minimum and maximum prediction variance.
+
+.. code-block:: python
+
+   fds = evaluate_design(
+       design, model=model, metric="fds",
+       fds_resolution=200, random_seed=1,
+   )["fds"]
+
+   curve = fds["curve"]
+   curve["fraction"]              # 200 evenly spaced fractions in [0, 1]
+   curve["prediction_variance"]   # the FDS curve, sigma^2 units
+   curve["scaled_prediction_variance"]  # the same, scaled by N (SPV)
+
+Setting ``fds_resolution`` is fully backward compatible: when it is ``None``
+(the default) the output is unchanged and the coarse quantile summary is still
+present.
+
+See Also
+--------
+
+- :func:`~process_improve.experiments.evaluate_design` - full API reference.
+- :func:`~process_improve.experiments.evaluate_all` - compute every metric in
+  one call.
+- :doc:`doe_strategy` - choosing which design to generate in the first place.

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -8,3 +8,4 @@ User Guide
    cross_validation
    showcase
    doe_strategy
+   design_evaluation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.44.0"
+version = "1.44.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Documents the design-evaluation features added in #421 and #422.

- **New user-guide page** `docs/user_guide/design_evaluation.rst` ("Evaluating Design Quality"): explains every `evaluate_design` metric (D/I/G efficiency, A/E-optimality, the residualised term-`correlation` summary, the general `alias_matrix`, prediction variance and the `fds` curve, power, and the fractional-factorial structure metrics), with quick-start examples and a `See Also` section. Dedicated sections cover the seeded **region sampling** controls and their reproducibility (`region`, `n_samples`, `include_vertices`, `random_seed`), and the **tunable `fds_resolution`** curve.
- Wired into the user-guide toctree (`docs/user_guide/index.rst`).
- **Refreshed the DOE tool reference** (`docs/doe/tools.md`): the `evaluate_design` entry now lists the full current metric set, `metric="all"`, and the region / FDS parameters.

The API reference already auto-documents the module, so the new functions and parameters render from their docstrings.

## Verification

- Sphinx reference-resolution phase runs clean for the new page (no `reference target not found` / `undefined label` warnings); the build's remaining failures are pre-existing notebook execution needing `pandoc`/`plotly`, unrelated to this change.
- Docutils structural validation of the RST reports no problems (only the expected sphinx-role notes that sphinx resolves).

Patch version bump to 1.44.1 with CHANGELOG + CITATION.cff in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxmJV48DXSRmrqZKcwjhat

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxmJV48DXSRmrqZKcwjhat)_