### PR TITLE
Test analyze_omars() exact recovery on an orthogonal three-level design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ those changes.
 
 ## [Unreleased]
 
+## [1.45.1] - 2026-06-20
+
+### Added
+
+- Test coverage for `analyze_omars()` exact term recovery on a fully
+  orthogonal three-level design (zero second-order aliasing), complementing
+  the existing aliased-CCD tests.
+
 ## [1.45.0] - 2026-06-20
 
 ### Added
@@ -2125,7 +2133,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.45.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.45.1...HEAD
+[1.45.1]: https://github.com/kgdunn/process-improve/compare/v1.45.0...v1.45.1
 [1.45.0]: https://github.com/kgdunn/process-improve/compare/v1.44.1...v1.45.0
 [1.44.1]: https://github.com/kgdunn/process-improve/compare/v1.44.0...v1.44.1
 [1.44.0]: https://github.com/kgdunn/process-improve/compare/v1.43.0...v1.44.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.45.0
+version: 1.45.1
 date-released: "2026-06-20"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.45.0"
+version = "1.45.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/tests/test_omars.py
+++ b/tests/test_omars.py
@@ -38,6 +38,22 @@ def _response(design: pd.DataFrame, *, seed: int = 3, noise: float = 0.2) -> np.
     return 6 * x[:, 0] + 5 * x[:, 1] + 4 * (x[:, 0] * x[:, 1]) + 4 * (x[:, 0] ** 2) + noise_vec
 
 
+def _orthogonal_three_level() -> pd.DataFrame:
+    """Full 3-level factorial for three factors: 27 runs, levels in {-1, 0, 1}.
+
+    On the full factorial grid every second-order column (each quadratic and
+    each two-factor interaction) is mutually orthogonal: the off-diagonal of
+    the second-order Gram matrix is exactly zero.  This is the zero-aliasing
+    limit of the minimal aliasing that OMARS designs are built to achieve, so
+    it is the cleanest available stand-in for a true OMARS design until a
+    catalogued OMARS generator is available.  Because there is no aliasing,
+    the staged analysis can recover the *exact* set of active terms, with no
+    spurious ones.
+    """
+    grid = np.array(list(itertools.product([-1, 0, 1], repeat=3)), dtype=float)
+    return pd.DataFrame(grid, columns=list("ABC"))
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -106,6 +122,55 @@ def test_strong_heredity_gives_clean_recovery() -> None:
     assert result.active_interactions == ["A:B"]
     assert "A^2" in result.active_quadratics
     assert set(result.active_quadratics) <= {"A^2", "B^2"}
+
+
+# ---------------------------------------------------------------------------
+# Exact recovery on a fully orthogonal three-level design
+#
+# Unlike the CCD above (whose quadratics are aliased), this design has
+# mutually orthogonal second-order terms, so the staged analysis must recover
+# the active terms exactly, with no spurious extras.
+# ---------------------------------------------------------------------------
+
+
+def test_orthogonal_design_has_zero_second_order_aliasing() -> None:
+    from process_improve.experiments.omars import _full_second_order, _quadratic_columns
+
+    coded = _orthogonal_three_level().to_numpy()
+    second_order = _full_second_order(coded, _quadratic_columns(coded))
+    gram = second_order.T @ second_order
+    off_diagonal = np.abs(gram - np.diag(np.diag(gram)))
+    assert off_diagonal.max() == pytest.approx(0.0, abs=1e-9)
+
+
+def test_exact_recovery_on_orthogonal_design() -> None:
+    design = _orthogonal_three_level()
+    x = design.to_numpy()
+    rng = np.random.default_rng(0)
+    # Active: main effects A and B, the A:B interaction, and the A^2 quadratic.
+    y = 6 * x[:, 0] + 5 * x[:, 1] + 4 * (x[:, 0] * x[:, 1]) + 4 * (x[:, 0] ** 2) + rng.normal(0, 0.3, x.shape[0])
+
+    result = analyze_omars(design, y)
+
+    # With no aliasing, recovery is exact: precisely the true terms, nothing more.
+    assert result.active_main_effects == ["A", "B"]
+    assert result.active_interactions == ["A:B"]
+    assert result.active_quadratics == ["A^2"]
+
+
+def test_exact_recovery_of_pure_quadratic_without_parent_main_effect() -> None:
+    design = _orthogonal_three_level()
+    x = design.to_numpy()
+    rng = np.random.default_rng(1)
+    # Active: main effect A, and a pure C^2 curvature whose factor C has no
+    # linear main effect. Under no heredity the quadratic is still recovered.
+    y = 6 * x[:, 0] + 5 * (x[:, 2] ** 2) + rng.normal(0, 0.3, x.shape[0])
+
+    result = analyze_omars(design, y)
+
+    assert result.active_main_effects == ["A"]
+    assert result.active_interactions == []
+    assert result.active_quadratics == ["C^2"]
 
 
 def test_gate_stays_shut_without_curvature() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #416. The existing recovery tests for `analyze_omars()` run on a face-centered CCD, whose quadratic terms are aliased - so the staged search can flag a spurious second-order term or two (the test there asserts only subset membership). This adds a design with **zero second-order aliasing** so we can assert **exact** recovery.

## What's added

A full 3-level factorial fixture (`_orthogonal_three_level()`, 27 runs, levels `{-1, 0, 1}`). On the full factorial grid every quadratic and interaction column is mutually orthogonal - the off-diagonal of the second-order Gram matrix is exactly zero. That is the zero-aliasing limit of the *minimal* aliasing an OMARS design is built to achieve, and is the cleanest available stand-in for a true OMARS design until a catalogued OMARS generator exists.

Three new tests:

- `test_orthogonal_design_has_zero_second_order_aliasing` - asserts the Gram-matrix off-diagonal is zero, documenting why exact recovery is expected.
- `test_exact_recovery_on_orthogonal_design` - response with active `A`, `B`, `A:B`, `A^2`; the analysis recovers **exactly** those terms, no extras.
- `test_exact_recovery_of_pure_quadratic_without_parent_main_effect` - a pure `C^2` curvature whose factor has no linear main effect is still recovered under no heredity.

Test count 21 → 24, all passing; lint/format/mypy clean. Version bumped 1.45.0 → 1.45.1 (PATCH; test-only) with `CITATION.cff` and `CHANGELOG.md` synced.

## Note

When the OMARS design generator lands, the natural next step is to swap (or add) a catalogued OMARS design here so recovery is asserted against an economical minimally-aliased design rather than the zero-aliasing full factorial. The full factorial is the strict-correctness check; an OMARS design would exercise the minimal-aliasing regime the method is actually built for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NszK4uBNFPVfXqsK5aC2L9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NszK4uBNFPVfXqsK5aC2L9)_