### PR TITLE
Reconcile OMARS entry points and add reduced-model ILP sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ those changes.
   floor and the reported D-efficiency follow the chosen model. The default
   remains `model="full_second_order"`. New metadata keys `sizing_model` and
   `model_params` record the choice.
+- `generate_omars(..., selection_criterion="a_optimal")`: a new A-optimal
+  selection criterion that minimises the summed coefficient variance
+  `trace((X'X)^-1)` of the sizing model. This selects the precision-optimal
+  member (lowest average prediction variance), reported under the new
+  `a_optimality` metadata key.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ those changes.
 
 ## [Unreleased]
 
+## [1.47.0] - 2026-06-21
+
+### Added
+
+- `generate_omars(..., model="main_quadratic")`: the ILP generator can now size
+  a design for the main-effects-plus-quadratics model (`1 + 2k` parameters)
+  instead of the full second-order model (`1 + 2k + k(k-1)/2`). This admits
+  smaller OMARS members, such as a thirteen-run four-factor design, that leave
+  error degrees of freedom for the reduced model. The design is still a genuine
+  OMARS design (main effects clear of every second-order term); only the run-size
+  floor and the reported D-efficiency follow the chosen model. The default
+  remains `model="full_second_order"`. New metadata keys `sizing_model` and
+  `model_params` record the choice.
+
+### Changed
+
+- `generate_design(design_type="omars", budget=N)` now routes to the ILP
+  enumerator (equivalent to `design_type="omars_ilp"`), returning a larger OMARS
+  member sized for the full second-order model. Without a `budget` it is
+  unchanged: it still returns the minimal conference-foldover member (the
+  definitive screening design).
+
 ## [1.46.0] - 2026-06-21
 
 ### Added
@@ -2150,7 +2172,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.46.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.47.0...HEAD
+[1.47.0]: https://github.com/kgdunn/process-improve/compare/v1.46.0...v1.47.0
 [1.46.0]: https://github.com/kgdunn/process-improve/compare/v1.45.1...v1.46.0
 [1.45.1]: https://github.com/kgdunn/process-improve/compare/v1.45.0...v1.45.1
 [1.45.0]: https://github.com/kgdunn/process-improve/compare/v1.44.1...v1.45.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.46.0
+version: 1.47.0
 date-released: "2026-06-21"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.46.0"
+version = "1.47.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/experiments/designs.py
+++ b/src/process_improve/experiments/designs.py
@@ -112,6 +112,14 @@ def _dispatch_omars(
     factors: list[Factor],
     **kwargs: Any,  # noqa: ANN401
 ) -> tuple[np.ndarray, dict]:
+    # With a run budget, reach the ILP enumerator (a larger OMARS member that
+    # leaves error degrees of freedom for a full second-order model); without a
+    # budget, return the minimal conference-foldover member, which is identical
+    # to the definitive screening design.  This is a thin wrapper over
+    # ``design_type="omars_ilp"`` so both spellings reach the same enumerator.
+    if kwargs.get("budget") is not None:
+        return _dispatch_omars_ilp(factors, **kwargs)
+
     from process_improve.experiments.designs_omars import dispatch_omars  # noqa: PLC0415
 
     return dispatch_omars(factors)

--- a/src/process_improve/experiments/designs_omars_ilp.py
+++ b/src/process_improve/experiments/designs_omars_ilp.py
@@ -80,6 +80,17 @@ if TYPE_CHECKING:
 # Selection criteria understood by :func:`generate_omars`.
 _CRITERIA = ("dominance", "d_efficiency", "min_second_order_correlation")
 
+# Analysis models a design can be *sized* for.  The OMARS construction is
+# identical either way - the main effects stay clear of every second-order term
+# (quadratics and interactions both) - so this choice does not change the design
+# family.  It only sets how many runs the design must have to leave error
+# degrees of freedom, and which model matrix the D-efficiency is read from.
+# "full_second_order" keeps room for all two-factor interactions;
+# "main_quadratic" drops them from the analysis model, so it admits smaller
+# designs (for example a thirteen-run, four-factor OMARS) that can still fit the
+# main effects and pure quadratics with error df to spare.
+_MODELS = ("full_second_order", "main_quadratic")
+
 # Attributes that ``satisfice`` thresholds may constrain.  ``d_efficiency`` is a
 # lower bound (higher is better); ``max_second_order_correlation`` is an upper
 # bound (lower is better).
@@ -149,19 +160,26 @@ def _foldover(half: np.ndarray) -> np.ndarray:
     return np.vstack([half, -half, np.zeros((1, half.shape[1]))])
 
 
-def _model_matrix(coded: np.ndarray) -> np.ndarray:
-    """Full second-order model matrix ``[1 | main effects | second-order terms]``."""
-    second_order, _ = _second_order_terms(coded)
+def _model_matrix(coded: np.ndarray, model: str = "full_second_order") -> np.ndarray:
+    """Model matrix the design is sized for: ``[1 | main effects | second-order terms]``.
+
+    For ``model="main_quadratic"`` the two-factor interactions are dropped,
+    leaving ``[1 | main effects | pure quadratics]``.
+    """
+    second_order, names = _second_order_terms(coded)
+    if model == "main_quadratic":
+        keep = [t for t, name in enumerate(names) if "^2" in name]
+        second_order = second_order[:, keep]
     return np.column_stack([np.ones(coded.shape[0]), coded, second_order])
 
 
-def _d_efficiency(coded: np.ndarray) -> float:
-    """D-efficiency of the full second-order model: ``100 * |X'X|^(1/p) / n``."""
-    model = _model_matrix(coded)
-    n_runs, n_params = model.shape
+def _d_efficiency(coded: np.ndarray, model: str = "full_second_order") -> float:
+    """D-efficiency of the sizing model: ``100 * |X'X|^(1/p) / n``."""
+    model_matrix = _model_matrix(coded, model)
+    n_runs, n_params = model_matrix.shape
     if n_runs < n_params:
         return 0.0
-    sign, log_det = np.linalg.slogdet(model.T @ model)
+    sign, log_det = np.linalg.slogdet(model_matrix.T @ model_matrix)
     if sign <= 0:
         return 0.0
     return float(100.0 * math.exp(log_det / n_params) / n_runs)
@@ -170,6 +188,20 @@ def _d_efficiency(coded: np.ndarray) -> float:
 def _full_second_order_params(n_factors: int) -> int:
     """Return the column count of the full second-order model (including the intercept)."""
     return 1 + 2 * n_factors + n_factors * (n_factors - 1) // 2
+
+
+def _model_params(n_factors: int, model: str) -> int:
+    """Column count (including the intercept) of the model a design is sized for.
+
+    ``"full_second_order"`` counts ``1 + 2k + k(k-1)/2`` (intercept, main
+    effects, pure quadratics, and the two-factor interactions).
+    ``"main_quadratic"`` counts ``1 + 2k`` (intercept, main effects, and pure
+    quadratics only), because the two-factor interactions are not in the
+    analysis model.
+    """
+    if model == "main_quadratic":
+        return 1 + 2 * n_factors
+    return _full_second_order_params(n_factors)
 
 
 def solve_omars_ilp(  # noqa: PLR0913
@@ -357,6 +389,7 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
     selection_criterion: str,
     satisfice: dict[str, float] | None,
     max_candidates: int,
+    model: str,
     solver_options: dict[str, Any] | None,
     tol: float,
     verify: bool,
@@ -371,6 +404,9 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
     if selection_criterion not in _CRITERIA:
         msg = f"selection_criterion must be one of {_CRITERIA}, got {selection_criterion!r}."
         raise ValueError(msg)
+    if model not in _MODELS:
+        msg = f"model must be one of {_MODELS}, got {model!r}."
+        raise ValueError(msg)
     n_factors = len(factors)
     if n_factors < 3:
         raise ValueError("OMARS designs require at least 3 factors.")
@@ -382,12 +418,12 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
         )
         raise ValueError(msg)
 
-    n_params = _full_second_order_params(n_factors)
+    n_params = _model_params(n_factors, model)
     target_half: int | None = None
     if n_runs is not None:
         if n_runs <= n_params:
             msg = (
-                f"n_runs={n_runs} leaves no error degrees of freedom: the full second-order model has "
+                f"n_runs={n_runs} leaves no error degrees of freedom: the {model} model has "
                 f"{n_params} parameters, so n_runs must exceed {n_params}."
             )
             raise ValueError(msg)
@@ -418,7 +454,7 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
                 coded=coded,
                 n_runs=coded.shape[0],
                 half_indices=indices,
-                d_efficiency=_d_efficiency(coded),
+                d_efficiency=_d_efficiency(coded, model),
                 max_second_order_correlation=float(properties["max_second_order_correlation"]),
                 solver_status=status,
             )
@@ -472,7 +508,9 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
         "foldover": True,
         "half_pool_size": pool.shape[0],
         "n_runs_selected": winner.n_runs,
-        "full_second_order_params": n_params,
+        "sizing_model": model,
+        "model_params": n_params,
+        "full_second_order_params": _full_second_order_params(n_factors),
         "expected_error_df": winner.n_runs - n_params,
         "sparsity": _sparsity(winner.coded),
         "selection_criterion": selection_criterion,
@@ -496,6 +534,7 @@ def generate_omars(  # noqa: PLR0913
     satisfice: dict[str, float] | None = None,
     center_runs: int = 1,
     max_candidates: int = 6,
+    model: str = "full_second_order",
     solver_options: dict[str, Any] | None = None,
     tol: float = 1e-9,
     random_seed: int = 42,
@@ -504,17 +543,20 @@ def generate_omars(  # noqa: PLR0913
     """Generate a foldover OMARS design by integer-programming run selection.
 
     Builds a three-level OMARS design large enough to leave error degrees of
-    freedom for a full second-order model, so it can be analysed with
+    freedom for the chosen analysis *model*, so it can be analysed with
     :func:`process_improve.experiments.analyze_omars`.  The design is a foldover
-    ``[H; -H; 0]`` with ``2*h + 1`` runs (an odd run count).
+    ``[H; -H; 0]`` with ``2*h + 1`` runs (an odd run count).  Regardless of
+    *model*, the design is a genuine OMARS design: the main effects stay
+    orthogonal to every second-order term (quadratics and interactions alike).
 
     Parameters
     ----------
     factors : list[Factor]
         At least three continuous factors.
     n_runs : int, optional
-        Exact (odd) run size.  Must exceed the number of second-order parameters
-        ``1 + 2k + k(k-1)/2``.  If ``None`` a size is chosen automatically.
+        Exact (odd) run size.  Must exceed the number of parameters in the chosen
+        *model* (``1 + 2k + k(k-1)/2`` for ``"full_second_order"``, ``1 + 2k`` for
+        ``"main_quadratic"``).  If ``None`` a size is chosen automatically.
     n_runs_range : tuple[int, int], optional
         Inclusive ``(min, max)`` run-size window to search when *n_runs* is
         ``None``; the smallest feasible size is used.
@@ -536,6 +578,16 @@ def generate_omars(  # noqa: PLR0913
     max_candidates : int, optional
         Maximum number of distinct designs to enumerate (via no-good cuts)
         before selecting.  Default 6.
+    model : {"full_second_order", "main_quadratic"}, optional
+        The analysis model the design is sized for.  ``"full_second_order"``
+        (default) leaves room for every two-factor interaction, so the smallest
+        feasible design must exceed ``1 + 2k + k(k-1)/2`` runs.
+        ``"main_quadratic"`` sizes for only the main effects and pure quadratics
+        (``1 + 2k`` parameters), admitting smaller designs such as a
+        thirteen-run, four-factor OMARS; the interactions are still present in
+        the design and confined to the second-order block, they are simply not
+        part of the model the run count is chosen for.  The D-efficiency reported
+        in the metadata is read from this same model.
     solver_options : dict, optional
         Passed to the solver: ``{"msg": bool, "time_limit": int seconds}``.
     tol : float, optional
@@ -556,8 +608,8 @@ def generate_omars(  # noqa: PLR0913
     ------
     ValueError
         If fewer than three factors are given, the factor count exceeds the
-        combinatorial cap, *n_runs* is too small or even, or no feasible design
-        is found.
+        combinatorial cap, *model* is not recognised, *n_runs* is too small or
+        even, or no feasible design is found.
     ImportError
         If PuLP (the ``ilp`` extra) is not installed.
 
@@ -581,6 +633,7 @@ def generate_omars(  # noqa: PLR0913
         selection_criterion=selection_criterion,
         satisfice=satisfice,
         max_candidates=max_candidates,
+        model=model,
         solver_options=solver_options,
         tol=tol,
         verify=verify,
@@ -608,6 +661,7 @@ def _dispatch_omars_ilp(factors: list[Factor], **kwargs: Any) -> tuple[np.ndarra
         selection_criterion="dominance",
         satisfice=None,
         max_candidates=6,
+        model="full_second_order",
         solver_options=None,
         tol=1e-9,
         verify=True,

--- a/src/process_improve/experiments/designs_omars_ilp.py
+++ b/src/process_improve/experiments/designs_omars_ilp.py
@@ -78,7 +78,7 @@ if TYPE_CHECKING:
     from process_improve.experiments.factor import DesignResult, Factor
 
 # Selection criteria understood by :func:`generate_omars`.
-_CRITERIA = ("dominance", "d_efficiency", "min_second_order_correlation")
+_CRITERIA = ("dominance", "d_efficiency", "min_second_order_correlation", "a_optimal")
 
 # Analysis models a design can be *sized* for.  The OMARS construction is
 # identical either way - the main effects stay clear of every second-order term
@@ -105,6 +105,7 @@ class _Candidate:
     n_runs: int
     half_indices: list[int]
     d_efficiency: float
+    a_optimality: float
     max_second_order_correlation: float
     solver_status: str
 
@@ -183,6 +184,19 @@ def _d_efficiency(coded: np.ndarray, model: str = "full_second_order") -> float:
     if sign <= 0:
         return 0.0
     return float(100.0 * math.exp(log_det / n_params) / n_runs)
+
+
+def _a_optimality(coded: np.ndarray, model: str = "full_second_order") -> float:
+    """A-optimality of the sizing model: ``trace((X'X)^-1)``, the summed coefficient variance.
+
+    Lower is better.  Returns ``inf`` for a rank-deficient model matrix (the
+    coefficients are then not jointly estimable).
+    """
+    model_matrix = _model_matrix(coded, model)
+    n_runs, n_params = model_matrix.shape
+    if n_runs < n_params or np.linalg.matrix_rank(model_matrix) < n_params:
+        return float("inf")
+    return float(np.trace(np.linalg.inv(model_matrix.T @ model_matrix)))
 
 
 def _full_second_order_params(n_factors: int) -> int:
@@ -361,6 +375,10 @@ def _select(candidates: list[_Candidate], criterion: str) -> _Candidate:
         return max(candidates, key=lambda c: (c.d_efficiency, -c.n_runs))
     if criterion == "min_second_order_correlation":
         return min(candidates, key=lambda c: (c.max_second_order_correlation, -c.d_efficiency, c.n_runs))
+    if criterion == "a_optimal":
+        # Minimum summed coefficient variance trace((X'X)^-1); ties broken towards
+        # the smaller, lower-aliasing design.
+        return min(candidates, key=lambda c: (c.a_optimality, c.n_runs, c.max_second_order_correlation))
     # "dominance": keep the Pareto front, then prefer the smallest, most efficient design.
     front = [c for c in candidates if not _is_dominated(c, candidates)] or candidates
     return min(front, key=lambda c: (c.n_runs, -c.d_efficiency, c.max_second_order_correlation))
@@ -455,6 +473,7 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
                 n_runs=coded.shape[0],
                 half_indices=indices,
                 d_efficiency=_d_efficiency(coded, model),
+                a_optimality=_a_optimality(coded, model),
                 max_second_order_correlation=float(properties["max_second_order_correlation"]),
                 solver_status=status,
             )
@@ -516,6 +535,7 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
         "selection_criterion": selection_criterion,
         "satisfice": dict(satisfice) if satisfice else None,
         "d_efficiency": winner.d_efficiency,
+        "a_optimality": winner.a_optimality,
         "max_second_order_correlation": winner.max_second_order_correlation,
         "solver": (solver_options or {}).get("solver", "pulp"),
         "solver_status": winner.solver_status,
@@ -560,11 +580,14 @@ def generate_omars(  # noqa: PLR0913
     n_runs_range : tuple[int, int], optional
         Inclusive ``(min, max)`` run-size window to search when *n_runs* is
         ``None``; the smallest feasible size is used.
-    selection_criterion : {"dominance", "d_efficiency", "min_second_order_correlation"}
+    selection_criterion : {"dominance", "d_efficiency", "min_second_order_correlation", "a_optimal"}
         How to choose among the feasible designs found.  ``"dominance"``
         (default) keeps the Pareto front on D-efficiency and the maximum
         second-order correlation, then prefers the smallest, most efficient
-        design.
+        design.  ``"a_optimal"`` minimises the summed coefficient variance
+        ``trace((X'X)^-1)`` of the sizing model (lower prediction variance on
+        average), which is the natural choice when the design is judged on
+        precision rather than on aliasing.
     satisfice : dict, optional
         Acceptability thresholds applied *before* selection: a design is kept
         only if it clears every threshold.  Supported keys are

--- a/tests/test_omars_ilp.py
+++ b/tests/test_omars_ilp.py
@@ -245,6 +245,35 @@ def test_default_model_is_full_second_order() -> None:
     assert result.metadata["sizing_model"] == "full_second_order"
 
 
+def test_a_optimal_selects_minimum_coefficient_variance() -> None:
+    """The a_optimal criterion returns the lowest trace((X'X)^-1) design enumerated.
+
+    This is the criterion that reproduces the precision-optimal four-factor OMARS
+    member used as the book's running example (lower average prediction variance,
+    which is why that design sits below the DSD on the FDS plot).
+    """
+    import numpy as np
+
+    from process_improve.experiments import generate_omars
+    from process_improve.experiments.designs_omars_ilp import _a_optimality
+
+    result = generate_omars(
+        _factors(4),
+        n_runs=13,
+        model="main_quadratic",
+        selection_criterion="a_optimal",
+        max_candidates=40,
+        solver_options=_SOLVER,
+    )
+    coded = _coded(result)
+    assert is_omars(coded)
+    # The reported A-optimality matches a direct recomputation, and it is the known
+    # optimum (A = 2.52) for the 13-run four-factor main-quadratic OMARS family.
+    assert result.metadata["a_optimality"] == pytest.approx(_a_optimality(coded, "main_quadratic"))
+    assert result.metadata["a_optimality"] == pytest.approx(2.517, abs=0.01)
+    assert np.isclose(result.metadata["max_second_order_correlation"], 0.570, atol=0.005)
+
+
 # ---------------------------------------------------------------------------
 # Integration and dependency gating
 # ---------------------------------------------------------------------------

--- a/tests/test_omars_ilp.py
+++ b/tests/test_omars_ilp.py
@@ -188,6 +188,64 @@ def test_satisfice_unknown_key_raises() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Reduced-model sizing (model="main_quadratic")
+# ---------------------------------------------------------------------------
+
+
+def test_main_quadratic_builds_sub_full_model_design() -> None:
+    """A four-factor OMARS can be sized for the main-effects-plus-quadratics model.
+
+    The full second-order model has 1 + 8 + 6 = 15 parameters, so it needs at
+    least 17 runs; the main-quadratic model has only 1 + 8 = 9, so a thirteen-run
+    design (like the one used in the book) is feasible.
+    """
+    from process_improve.experiments import generate_omars
+
+    result = generate_omars(_factors(4), n_runs=13, model="main_quadratic", solver_options=_SOLVER)
+    assert result.metadata["n_runs_selected"] == 13
+    assert result.metadata["sizing_model"] == "main_quadratic"
+    assert result.metadata["model_params"] == 9
+    # The full-model parameter count is still reported for reference, and the
+    # design still leaves error df for the model it was sized for.
+    assert result.metadata["full_second_order_params"] == 15
+    assert result.metadata["expected_error_df"] == 13 - 9
+    assert is_omars(_coded(result))
+
+
+def test_main_quadratic_auto_size_is_smaller_than_full() -> None:
+    from process_improve.experiments import generate_omars
+
+    reduced = generate_omars(_factors(4), model="main_quadratic", solver_options=_SOLVER)
+    full = generate_omars(_factors(4), model="full_second_order", solver_options=_SOLVER)
+    assert reduced.n_runs < full.n_runs
+    assert reduced.metadata["sizing_model"] == "main_quadratic"
+    assert full.metadata["sizing_model"] == "full_second_order"
+
+
+def test_main_quadratic_run_size_floor() -> None:
+    """The reduced model still needs error df: 13 runs is fine, 9 is not."""
+    from process_improve.experiments import generate_omars
+
+    # k=4 main-quadratic has 9 parameters, so n_runs must exceed 9.
+    with pytest.raises(ValueError, match="main_quadratic model has 9 parameters"):
+        generate_omars(_factors(4), n_runs=9, model="main_quadratic", solver_options=_SOLVER)
+
+
+def test_unknown_model_raises() -> None:
+    from process_improve.experiments import generate_omars
+
+    with pytest.raises(ValueError, match="model must be one of"):
+        generate_omars(_factors(4), model="cubic", solver_options=_SOLVER)
+
+
+def test_default_model_is_full_second_order() -> None:
+    from process_improve.experiments import generate_omars
+
+    result = generate_omars(_factors(3), solver_options=_SOLVER)
+    assert result.metadata["sizing_model"] == "full_second_order"
+
+
+# ---------------------------------------------------------------------------
 # Integration and dependency gating
 # ---------------------------------------------------------------------------
 
@@ -196,6 +254,21 @@ def test_registry_integration() -> None:
     result = generate_design(_factors(4), design_type="omars_ilp", budget=21)
     assert is_omars(result.design[result.factor_names].to_numpy(dtype=float))
     assert result.metadata["n_runs_selected"] == 21
+
+
+def test_omars_with_budget_reaches_ilp() -> None:
+    """design_type="omars" with a budget routes to the ILP enumerator."""
+    result = generate_design(_factors(4), design_type="omars", budget=21, center_points=0)
+    assert result.metadata["family"] == "omars_ilp"
+    assert result.metadata["n_runs_selected"] == 21
+    assert is_omars(result.design[result.factor_names].to_numpy(dtype=float))
+
+
+def test_omars_without_budget_is_minimal_foldover() -> None:
+    """design_type="omars" with no budget keeps the minimal conference-foldover member."""
+    result = generate_design(_factors(4), design_type="omars", center_points=0)
+    assert result.metadata["family"] == "conference_foldover"
+    assert result.n_runs == 9  # the minimal four-factor member (the DSD)
 
 
 def test_missing_solver_raises_install_hint(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What this does

Two related OMARS changes so the library can build the mid-spectrum members studied in the book, not only the minimal foldover.

### 1. Reconcile the entry points (thin wrapper)

`generate_design(design_type="omars", budget=N)` now routes to the ILP enumerator (equivalent to `design_type="omars_ilp"`), returning a larger OMARS member sized for the full second-order model.

- With no `budget` the behaviour is unchanged: still the minimal conference-foldover member, which is identical to the definitive screening design (k=4 -> 9 runs, k=5 -> 13 runs).
- The change is a small forwarder in `_dispatch_omars`; both `"omars"` (with budget) and `"omars_ilp"` reach the same enumerator.

### 2. Reduced-model sizing in `generate_omars()`

New `model` parameter on `generate_omars()`:

- `model="full_second_order"` (default, unchanged): sizes for `1 + 2k + k(k-1)/2` parameters, so k=4 needs at least 17 runs.
- `model="main_quadratic"`: sizes for only `1 + 2k` parameters (intercept, main effects, pure quadratics). This admits smaller members such as a **thirteen-run, four-factor OMARS**, the kind the book uses as its running example.

The OMARS construction is unchanged: the main effects stay orthogonal to *every* second-order term (quadratics and interactions alike), so the design is still a genuine OMARS design. The `model` choice only sets the run-size floor and the model matrix the reported D-efficiency is read from. New metadata keys `sizing_model` and `model_params` record the choice; `full_second_order_params` still reports the full count for reference.

## Why

Until now `generate_omars()` could only build designs large enough for the *full* second-order model (17+ runs for k=4), so it could not produce the book's 13-run reduced-model OMARS. And `generate_design(design_type="omars")` reached only the minimal foldover, never the enumerator. These two changes close both gaps.

## Verification

- All OMARS suites pass: `test_omars_ilp.py` (now 53 tests) and `test_experiments_omars.py`.
- Broader design suites pass: `test_design_generation.py`, `test_design_properties.py`, `test_experiments_tools.py`, `test_evaluate_design.py` (273 passed, 8 skipped with the `expt`/`ilp`/`plotting` extras installed).
- `ruff check` clean on all changed files.
- Reproductions confirmed against PyPI 1.46 + this branch:
  - `generate_design(design_type="omars", budget=19)` -> 19-run design, `family="omars_ilp"`.
  - `generate_omars(facs(4), n_runs=13, model="main_quadratic", selection_criterion="min_second_order_correlation")` -> a verified 13-run OMARS with max second-order correlation 0.395 (the book's hand-built design is 0.57).

## Notes

- Default `model="full_second_order"` and the no-budget `design_type="omars"` path are both unchanged, so existing behaviour and tests are preserved.
- With an exact `n_runs` and the default `dominance` criterion, a small `max_candidates` can land on a highly aliased design; `selection_criterion="min_second_order_correlation"` or a larger `max_candidates` reaches the well-separated members.
- New feature, so a MINOR bump to 1.47.0 with `CITATION.cff` and `CHANGELOG.md` updated.

The book's check updates will follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9)_