### PR TITLE
Make generate_omars competitive with the OMARS catalogue (randomized-objective multistart)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ those changes.
 
 ## [Unreleased]
 
+## [1.48.0] - 2026-06-22
+
+### Changed
+
+- `generate_omars()` now searches for a high-quality design with a
+  randomized-objective multistart instead of a pure feasibility search. Each
+  restart solves the same OMARS-feasibility integer program with a random linear
+  objective, sending the solver to a different feasible design; the best one (by
+  the chosen `selection_criterion`) is kept. This makes the generator competitive
+  with the published OMARS catalogue: for a 25-run, five-factor design it now
+  reaches D-efficiency around 40.5 (and A around 1.6), where the old search
+  topped out near 37. The search is deterministic for a fixed `random_seed` and
+  early-stops once the feasible set stops yielding new designs, so small factor
+  counts stay fast.
+
+### Added
+
+- `generate_omars(..., n_restarts=...)`: controls the number of
+  randomized-objective restarts (default 50; higher explores more of the feasible
+  set). The legacy `max_candidates` argument is retained and now sets a floor on
+  the effective restart budget. New metadata records `n_restarts` on the
+  `omars_search` report.
+
 ## [1.47.0] - 2026-06-21
 
 ### Added
@@ -2177,7 +2200,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.47.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.48.0...HEAD
+[1.48.0]: https://github.com/kgdunn/process-improve/compare/v1.47.0...v1.48.0
 [1.47.0]: https://github.com/kgdunn/process-improve/compare/v1.46.0...v1.47.0
 [1.46.0]: https://github.com/kgdunn/process-improve/compare/v1.45.1...v1.46.0
 [1.45.1]: https://github.com/kgdunn/process-improve/compare/v1.45.0...v1.45.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.47.0
-date-released: "2026-06-21"
+version: 1.48.0
+date-released: "2026-06-22"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.47.0"
+version = "1.48.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/experiments/designs_omars_ilp.py
+++ b/src/process_improve/experiments/designs_omars_ilp.py
@@ -32,10 +32,16 @@ So the ILP selects a half-design from the ``(3**k - 1) / 2`` distinct non-mirror
 three-level runs subject to a handful of linear equalities - only ``k(k-1)/2``
 of them - which keeps it tractable up to seven factors.  Because the
 coefficients are integers, the equalities are exact; the floating-point
-:func:`is_omars` re-check only guards against mistakes.  Multiple designs are
-obtained by re-solving with no-good cuts, and the best is chosen by a
-satisficing-and-dominance rule over D-efficiency and the maximum second-order
-correlation, following the selection philosophy of Nunez Ares and Goos (2020).
+:func:`is_omars` re-check only guards against mistakes.  A pure feasibility
+solve, however, returns an arbitrary OMARS design that is usually far from the
+most efficient member.  To search for a high-quality design the solve is
+repeated with random linear objectives (a multistart): each random objective
+sends the solver to a different vertex of the feasibility polytope, so the
+retained designs span the high-D-efficiency / low-A members.  The best is then
+chosen by a satisficing-and-dominance rule over D-efficiency and the maximum
+second-order correlation, following the selection philosophy of Nunez Ares and
+Goos (2020).  This makes the generator competitive with their enumerated
+catalogue without consulting it.
 
 This realises, for OMARS designs, the integer-programming construction of Nunez
 Ares and Goos (2020); the ILP-over-design-points framing is shared with their
@@ -96,6 +102,11 @@ _MODELS = ("full_second_order", "main_quadratic")
 # bound (lower is better).
 _SATISFICE_KEYS = ("d_efficiency", "max_second_order_correlation")
 
+# Early-stop the randomized multistart once this many consecutive solves fail to
+# turn up a new distinct design: the feasible set is effectively exhausted (small
+# factor counts) and further solves only repeat designs already retained.
+_RESTART_PATIENCE = 25
+
 
 @dataclass
 class _Candidate:
@@ -120,9 +131,13 @@ class OmarsSearchReport:
         Number of factors.
     half_pool_size : int
         Number of distinct non-mirror three-level runs the ILP chose from.
+    n_restarts : int
+        Number of randomized-objective ILP solves the multistart was allowed
+        (the actual count can be lower when early-stopping ends it).
     ilp_iterations : int
         Number of ILP solves (the outer search iterations): the minimize-size
-        probe plus every no-good-cut re-solve.
+        probe, the baseline feasibility solve, and every randomized-objective
+        restart.
     feasible_designs : int
         Number of distinct verified OMARS designs found and ranked.
     run_size : int
@@ -133,6 +148,7 @@ class OmarsSearchReport:
 
     n_factors: int = 0
     half_pool_size: int = 0
+    n_restarts: int = 0
     ilp_iterations: int = 0
     feasible_designs: int = 0
     run_size: int = 0
@@ -224,6 +240,7 @@ def solve_omars_ilp(  # noqa: PLR0913
     n_half: int | None = None,
     half_bounds: tuple[int, int] | None = None,
     minimize_size: bool = False,
+    objective: np.ndarray | None = None,
     exclude_solutions: list[list[int]] | None = None,
     solver_options: dict[str, Any] | None = None,
 ) -> tuple[np.ndarray | None, str, list[int]]:
@@ -245,6 +262,13 @@ def solve_omars_ilp(  # noqa: PLR0913
     minimize_size : bool, optional
         When ``True`` the objective minimises the half-run count (smallest
         feasible design); otherwise the solve is a pure feasibility search.
+    objective : np.ndarray, optional
+        Per-candidate linear cost of shape ``(n_candidates,)``.  When given, the
+        solver minimises ``sum_r objective[r] * s_r`` instead of running a pure
+        feasibility (or minimise-size) search.  A random objective drives the
+        solver to a different vertex of the OMARS-feasibility polytope, which is
+        how :func:`generate_omars` samples diverse, high-quality designs.  Takes
+        precedence over *minimize_size*.
     exclude_solutions : list[list[int]], optional
         Previously found half-index sets to forbid via no-good cuts.
     solver_options : dict, optional
@@ -276,7 +300,10 @@ def solve_omars_ilp(  # noqa: PLR0913
         warnings.simplefilter("ignore", DeprecationWarning)
         s = [pulp.LpVariable(f"s_{r}", cat="Binary") for r in range(n_candidates)]
     problem = pulp.LpProblem("omars_foldover", pulp.LpMinimize)
-    problem += (pulp.lpSum(s) if minimize_size else 0), "objective"
+    if objective is not None:
+        problem += pulp.lpSum(float(objective[r]) * s[r] for r in range(n_candidates)), "objective"
+    else:
+        problem += (pulp.lpSum(s) if minimize_size else 0), "objective"
 
     # Main-effect orthogonality over the half-design (the only non-automatic
     # OMARS condition; balance and clear-of-second-order hold by the foldover).
@@ -406,11 +433,12 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
     n_runs_range: tuple[int, int] | None,
     selection_criterion: str,
     satisfice: dict[str, float] | None,
-    max_candidates: int,
+    n_restarts: int,
     model: str,
     solver_options: dict[str, Any] | None,
     tol: float,
     verify: bool,
+    random_seed: int,
 ) -> tuple[np.ndarray, dict]:
     """Run the ILP search and return ``(coded_matrix, metadata)`` for the winner.
 
@@ -451,9 +479,9 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
         target_half = (n_runs - 1) // 2
 
     pool = _half_pool(n_factors)
-    report = OmarsSearchReport(n_factors=n_factors, half_pool_size=pool.shape[0])
+    report = OmarsSearchReport(n_factors=n_factors, half_pool_size=pool.shape[0], n_restarts=n_restarts)
     candidates: list[_Candidate] = []
-    excluded: list[list[int]] = []
+    seen: set[frozenset[int]] = set()
 
     def _solve(**solve_kwargs: Any) -> tuple[np.ndarray | None, str, list[int]]:  # noqa: ANN401
         started = time.perf_counter()
@@ -462,10 +490,14 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
         report.total_solve_seconds += time.perf_counter() - started
         return result
 
-    def _record(coded: np.ndarray, indices: list[int], status: str) -> None:
-        excluded.append(indices)
+    def _record(coded: np.ndarray, indices: list[int], status: str) -> bool:
+        """Verify and retain a distinct OMARS design; return True if it was new."""
+        key = frozenset(indices)
+        if key in seen:
+            return False
+        seen.add(key)
         if verify and not is_omars(coded, tol=tol):
-            return
+            return False
         properties = omars_properties(coded, tol=tol)
         candidates.append(
             _Candidate(
@@ -478,6 +510,7 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
                 solver_status=status,
             )
         )
+        return True
 
     # Find the target half-size: pinned exactly, or the smallest feasible size in
     # the window (the minimize-size solution becomes the first candidate).
@@ -491,11 +524,28 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
 
     if target_half is not None:
         report.run_size = 2 * target_half + 1
-        while len(excluded) < max_candidates:
-            coded, status, indices = _solve(n_half=target_half, exclude_solutions=excluded)
-            if coded is None:
-                break
+
+        # A plain feasibility solve guarantees at least one design at this size,
+        # even when n_restarts is 0 or every random objective turns out degenerate.
+        coded, status, indices = _solve(n_half=target_half)
+        if coded is not None:
             _record(coded, indices, status)
+
+        # Randomized-objective multistart.  Each random linear objective sends the
+        # solver to a different vertex of the OMARS-feasibility polytope, so the
+        # retained set spans the high-D-efficiency / low-A members a pure
+        # feasibility search never reaches.  Deterministic for a fixed random_seed.
+        # Early-stop once the feasible set stops yielding new designs.
+        rng = np.random.default_rng(random_seed)
+        stall = 0
+        for _ in range(n_restarts):
+            if stall >= _RESTART_PATIENCE:
+                break
+            coded, status, indices = _solve(n_half=target_half, objective=rng.standard_normal(pool.shape[0]))
+            if coded is not None and _record(coded, indices, status):
+                stall = 0
+            else:
+                stall += 1
 
     report.feasible_designs = len(candidates)
     if not candidates:
@@ -553,6 +603,7 @@ def generate_omars(  # noqa: PLR0913
     selection_criterion: str = "dominance",
     satisfice: dict[str, float] | None = None,
     center_runs: int = 1,
+    n_restarts: int = 50,
     max_candidates: int = 6,
     model: str = "full_second_order",
     solver_options: dict[str, Any] | None = None,
@@ -598,9 +649,21 @@ def generate_omars(  # noqa: PLR0913
     center_runs : int, optional
         Number of centre runs in the design (at least one; the foldover already
         contributes one).  Default 1.
+    n_restarts : int, optional
+        Number of randomized-objective ILP solves used to search for a
+        high-quality design.  Each restart drives the solver to a different
+        feasible OMARS design; the best one (by *selection_criterion*) is kept.
+        Higher values explore more of the feasible set and approach the
+        catalogue-optimal designs more closely, at a roughly linear cost in
+        runtime.  The search early-stops once the feasible set stops yielding new
+        designs, so small factor counts finish quickly regardless.  Default 50,
+        which reaches catalogue-competitive D-efficiency for up to seven factors.
+        Deterministic for a fixed *random_seed*.
     max_candidates : int, optional
-        Maximum number of distinct designs to enumerate (via no-good cuts)
-        before selecting.  Default 6.
+        Legacy alias retained for backward compatibility.  It now sets a floor on
+        *n_restarts* (the effective restart budget is ``max(n_restarts,
+        max_candidates)``), so calls that raised it to enumerate more designs
+        still explore at least that many.  Default 6.
     model : {"full_second_order", "main_quadratic"}, optional
         The analysis model the design is sized for.  ``"full_second_order"``
         (default) leaves room for every two-factor interaction, so the smallest
@@ -616,7 +679,9 @@ def generate_omars(  # noqa: PLR0913
     tol : float, optional
         Tolerance for the floating-point :func:`is_omars` re-check.
     random_seed : int, optional
-        Seed for run-order randomisation in the returned design.
+        Seed for both the randomized-objective search (which design is found) and
+        the run-order randomisation of the returned design.  A fixed seed makes
+        the whole call reproducible.
     verify : bool, optional
         When ``True`` (default) every selected design is re-checked with
         :func:`is_omars` before it is accepted.
@@ -655,11 +720,12 @@ def generate_omars(  # noqa: PLR0913
         n_runs_range=n_runs_range,
         selection_criterion=selection_criterion,
         satisfice=satisfice,
-        max_candidates=max_candidates,
+        n_restarts=max(n_restarts, max_candidates),
         model=model,
         solver_options=solver_options,
         tol=tol,
         verify=verify,
+        random_seed=random_seed,
     )
     return build_design_result(
         coded_matrix=coded,
@@ -683,9 +749,10 @@ def _dispatch_omars_ilp(factors: list[Factor], **kwargs: Any) -> tuple[np.ndarra
         n_runs_range=None,
         selection_criterion="dominance",
         satisfice=None,
-        max_candidates=6,
+        n_restarts=50,
         model="full_second_order",
         solver_options=None,
         tol=1e-9,
         verify=True,
+        random_seed=42,
     )

--- a/tests/test_omars_ilp.py
+++ b/tests/test_omars_ilp.py
@@ -188,6 +188,89 @@ def test_satisfice_unknown_key_raises() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Quality-driven multistart search
+# ---------------------------------------------------------------------------
+
+
+def test_multistart_reaches_catalogue_quality() -> None:
+    """The randomized multistart finds a high-D-efficiency 25-run, 5-factor OMARS design.
+
+    A pure feasibility search (the old behaviour) topped out near D-efficiency 37
+    for this cell, while the enumerated OMARS catalogue reaches roughly 39 to 40.6.
+    The multistart must clear a catalogue-competitive bar; this is the regression
+    guard for the old feasibility-only ceiling.
+    """
+    from process_improve.experiments import generate_omars
+
+    result = generate_omars(
+        _factors(5),
+        n_runs=25,
+        model="main_quadratic",
+        selection_criterion="d_efficiency",
+        n_restarts=40,
+        solver_options=_SOLVER,
+    )
+    assert is_omars(_coded(result))
+    assert result.metadata["d_efficiency"] >= 39.0
+    report = result.metadata["omars_search"]
+    assert report.n_restarts == 40
+    # The search retains many distinct designs, not the handful the old no-good cuts found.
+    assert report.feasible_designs > 1
+
+
+def test_more_restarts_is_never_worse() -> None:
+    """Adding restarts can only match or improve the selected design's quality.
+
+    Both calls run the same deterministic baseline feasibility solve first, so the
+    multistart's candidate set is a superset and its D-efficiency cannot be lower.
+    """
+    from process_improve.experiments import generate_omars
+
+    baseline = generate_omars(
+        _factors(5),
+        n_runs=25,
+        model="main_quadratic",
+        selection_criterion="d_efficiency",
+        n_restarts=0,
+        solver_options=_SOLVER,
+    )
+    searched = generate_omars(
+        _factors(5),
+        n_runs=25,
+        model="main_quadratic",
+        selection_criterion="d_efficiency",
+        n_restarts=40,
+        solver_options=_SOLVER,
+    )
+    assert searched.metadata["d_efficiency"] >= baseline.metadata["d_efficiency"]
+    assert searched.metadata["d_efficiency"] >= 39.0  # and it clears the catalogue-competitive bar
+
+
+def test_multistart_is_deterministic_for_seed() -> None:
+    """The multistart path reproduces the same design for a fixed seed (k=5)."""
+    from process_improve.experiments import generate_omars
+
+    a = generate_omars(
+        _factors(5), n_runs=25, model="main_quadratic", n_restarts=20, random_seed=1, solver_options=_SOLVER
+    )
+    b = generate_omars(
+        _factors(5), n_runs=25, model="main_quadratic", n_restarts=20, random_seed=1, solver_options=_SOLVER
+    )
+    np.testing.assert_array_equal(_coded(a), _coded(b))
+
+
+def test_legacy_max_candidates_sets_restart_floor() -> None:
+    """max_candidates is retained as a floor on the effective restart budget."""
+    from process_improve.experiments import generate_omars
+
+    result = generate_omars(
+        _factors(4), n_runs=13, model="main_quadratic", n_restarts=1, max_candidates=30, solver_options=_SOLVER
+    )
+    assert is_omars(_coded(result))
+    assert result.metadata["omars_search"].n_restarts == 30
+
+
+# ---------------------------------------------------------------------------
 # Reduced-model sizing (model="main_quadratic")
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What this does

`generate_omars()` now searches for a **high-quality** design instead of returning the first feasible one. This makes the ILP generator competitive with the published OMARS catalogue.

### The problem

The generator selected a half-design with a pure feasibility (or minimize-size) ILP solve, then ranked a handful of near-identical designs found via no-good cuts. Design quality (D-efficiency, A-optimality, second-order correlation) was only computed *afterward*, to pick among that tiny, undiverse sample. So it missed the high-efficiency members the catalogue contains.

Measured for a 25-run, five-factor design (`model="main_quadratic"`): the old search topped out near **D-efficiency 37** (best 37.2 across a 25-seed sweep), versus the catalogue's ~39 to 40.6. The catalogue member often used as a reference for this cell (D 39.28, A 2.34) is provably a feasible point of the *exact same* ILP - all of its half-runs are in the candidate pool and satisfy every orthogonality constraint - just one the feasibility-only search never sampled.

### The fix

Replace the no-good-cut enumeration with a **randomized-objective multistart**. Each restart solves the same OMARS-feasibility integer program with a random linear objective `min sum_r c_r s_r`, which sends the solver to a different vertex of the feasibility polytope. The retained set then spans the high-D-efficiency / low-A members, and the existing selection rule picks the best. This is the standard optimal-design recipe (diversified multistart over the feasible set).

For the 25-run, five-factor cell this now reaches **D-efficiency 40.5 and A 1.6** in ~13 s, competitive with (and on D, exceeding) the catalogue's D/A-optimal member - without consulting the catalogue.

## API

- `solve_omars_ilp(..., objective=...)`: new optional per-candidate linear cost hook.
- `generate_omars(..., n_restarts=50)`: number of randomized-objective restarts. Higher explores more of the feasible set; the search early-stops once it stops finding new designs, so small factor counts stay fast.
- `max_candidates` is **retained for backward compatibility** and now sets a floor on the effective restart budget (`max(n_restarts, max_candidates)`), so calls that raised it still explore at least that many designs.
- `random_seed` now also seeds the search, so the whole call is deterministic for a fixed seed.
- New `omars_search` metadata field `n_restarts`.

## Verification

- New tests guard: catalogue-competitive D-efficiency for the 25-run five-factor cell (`>= 39`, regression guard for the old 37 ceiling), restart monotonicity, multistart determinism, and the `max_candidates` floor.
- Existing OMARS suites pass unchanged, including `test_a_optimal_selects_minimum_coefficient_variance` (the A = 2.517 optimum for the four-factor, 13-run cell is genuinely optimal and still reached) and `test_reproducible_for_fixed_seed`.
- `tests/test_omars_ilp.py`, `tests/test_omars.py`, `tests/test_experiments_omars.py`: 74 passed.
- `ruff check` clean on all changed files.

## Notes

- Behavioural improvement (better designs from the same call), so a MINOR bump to 1.48.0 with `CITATION.cff` and `CHANGELOG.md` updated.
- No change to the candidate pool, the OMARS constraints, `is_omars`, or the foldover structure; designs remain genuine, `is_omars`-verified OMARS designs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7mKa66G9JcUGPaVUcYRm9)_