### PR TITLE
Sensory: ignore-columns reshape option + end-to-end tutorial example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ those changes.
 
 ## [Unreleased]
 
+## [1.49.1] - 2026-06-29
+
+### Added
+
+- `reshape_to_long` (and the `sensory_reshape_to_long` tool) gain an optional
+  `ignore` list to drop nuisance columns before the melt, so wide exports that
+  carry extra non-schema columns reshape via "all remaining columns except
+  these".
+- A descriptive-panel tutorial worked example in the user guide, backed by an
+  end-to-end test (`tests/test_sensory_end_to_end.py`) on a synthetic panel:
+  reshape -> validate -> panel check / Mixed Assessor Model -> relate. The
+  example also demonstrates that genuine and spurious covariates both correlate
+  within a single dataset, so a within-sample correlation is not a transferable,
+  causal link.
+
 ## [1.49.0] - 2026-06-29
 
 ### Added
@@ -2241,7 +2256,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.49.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.49.1...HEAD
+[1.49.1]: https://github.com/kgdunn/process-improve/compare/v1.49.0...v1.49.1
 [1.49.0]: https://github.com/kgdunn/process-improve/compare/v1.48.0...v1.49.0
 [1.48.0]: https://github.com/kgdunn/process-improve/compare/v1.47.0...v1.48.0
 [1.47.0]: https://github.com/kgdunn/process-improve/compare/v1.46.0...v1.47.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ those changes.
   within a single dataset, so a within-sample correlation is not a transferable,
   causal link.
 
+### Fixed
+
+- The Mixed Assessor Model and `align_scores` used a NaN-propagating mean for an
+  attribute's grand mean, so any attribute with a missing cell was turned to
+  all-NaN by alignment and then silently dropped from the relate step. Use a
+  NaN-aware mean so attributes with missing cells are kept.
+
 ## [1.49.0] - 2026-06-29
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.49.0
+version: 1.49.1
 date-released: "2026-06-29"
 keywords:
   - chemometrics

--- a/docs/user_guide/sensory_panel.rst
+++ b/docs/user_guide/sensory_panel.rst
@@ -191,6 +191,88 @@ Rescaling does not remove genuine disagreement, so a panelist who truly ranks
 the products differently is better handled by dropping (``drop_panelists`` or
 ``correction="drop"``); align and drop can be combined.
 
+Worked example
+--------------
+
+This example runs the whole pipeline on a small synthetic panel. Ten assessors
+(J01-J10) scored twelve products (Product A-L) on nine attributes (Aroma
+intensity, Sweetness, Sourness, Bitterness, Firmness, Juiciness, Colour
+intensity, Aftertaste, Liking). The scores came out of the scoring software in
+the wide layout, with an extra ``site`` column we do not need and a few missing
+cells. We also have instrumental measurements per product, split on purpose
+into two kinds: genuine mechanistic correlates (``brix`` for sweetness,
+``titratable_acidity`` for sourness, ``polyphenols`` for bitterness,
+``volatile_oav`` for aroma) and spurious proxies or artifacts
+(``refractive_index`` and ``density`` ride on ``brix``;
+``total_dissolved_solids`` is an aggregate; ``price_tier`` tracks Liking only
+through the sample frame).
+
+Three assessors were constructed to misbehave: J07 scores at random, J03 rates
+everything high, and J09 uses only the middle of the scale.
+
+**Step 1, reshape.** The export is wide, so melt the attribute columns to the
+long schema and ignore ``site``. The round-trip check confirms the grand,
+per-attribute, and per-assessor means are unchanged.
+
+.. code-block:: python
+
+   from process_improve.sensory import (
+       reshape_to_long, validate_descriptive, panel_scorecard,
+       mixed_assessor_model, analyze_descriptive,
+   )
+
+   long_df, checks = reshape_to_long(
+       wide_table,
+       layout="wide_by_attribute",
+       mapping={"panelist_id": "Assessor", "product": "Product", "ignore": ["site"]},
+   )
+   assert checks["ok"]
+
+**Step 2, validate.**
+
+.. code-block:: python
+
+   validated = validate_descriptive(long_df, covariates, mode="observational")
+
+Any out-of-range or missing-cell issues are surfaced as warnings.
+
+**Step 3, check the panel.** The scorecard flags J07 (low agreement and
+discrimination). The Mixed Assessor Model reports each assessor's scaling
+coefficient ``beta``: about 1 for most, well below 1 for the compressor J09, and
+a large offset for the high rater J03. Once the random assessor is removed, the
+leftover assessor-by-product interaction is mostly scale usage, so the MAM
+product F-test exceeds the classical one (the disagreement error term shrinks).
+
+.. code-block:: python
+
+   card = panel_scorecard(long_df)
+   print(card.flagged)                       # ['J07']
+   mam = mixed_assessor_model(long_df)
+   print(mam.scaling.sort_values("beta").head())
+
+**Step 4, correct and relate.** Align all assessors onto a common scale (J03 is
+brought down, J09's range is stretched), then relate the attributes to the
+measurements.
+
+.. code-block:: python
+
+   result = analyze_descriptive(validated, correction="align")
+   import pandas as pd
+   assoc = pd.DataFrame(result.relate["associations"])
+   print(assoc[assoc["significant"]])
+
+The genuine correlates are significant (``brix`` with Sweetness,
+``titratable_acidity`` with Sourness, ``price_tier`` with Liking, each with a
+Benjamini-Hochberg q-value), but so are the spurious proxies (``refractive_index``
+and ``density`` with Sweetness), because within one dataset they all correlate.
+This is the trap to watch: a within-sample correlation is not a transferable,
+causal link. Telling a genuine correlate apart from a lazy proxy needs
+out-of-sample evidence (cross-validated Q-squared, a Van der Voet test, or a
+selectivity ratio), which is covered separately.
+
+The full runnable scenario is in the test suite
+(``tests/test_sensory_end_to_end.py``).
+
 Using the tools from an agent
 -----------------------------
 

--- a/docs/user_guide/sensory_panel.rst
+++ b/docs/user_guide/sensory_panel.rst
@@ -10,11 +10,16 @@ produced them?*
 The :mod:`process_improve.sensory` subpackage answers that with a small,
 generic pipeline. The data is described only as panelist, product, attribute,
 replicate, and score; nothing about the pipeline is specific to any particular
-kind of product. The flow has three steps:
+kind of product. The flow is:
 
+0. **reshape** a raw wide export into the long schema, if the data does not
+   already arrive in it;
 1. **validate** the panel data and a product-covariate table;
-2. **check the panel** and optionally drop anomalous panelists;
+2. **check the panel**, then either correct each panelist's scale use (the
+   Mixed Assessor Model) or drop anomalous panelists;
 3. **relate** each attribute back to the product.
+
+The worked example near the end runs all of these on a synthetic dataset.
 
 The data contract
 -----------------
@@ -237,8 +242,9 @@ per-attribute, and per-assessor means are unchanged.
 
 Any out-of-range or missing-cell issues are surfaced as warnings.
 
-**Step 3, check the panel.** The scorecard flags J07 (low agreement and
-discrimination). The Mixed Assessor Model reports each assessor's scaling
+**Step 3, check the panel.** The scorecard flags J07 (low agreement with the
+panel: its random scores do not track the consensus). The Mixed Assessor Model
+reports each assessor's scaling
 coefficient ``beta``: about 1 for most, well below 1 for the compressor J09, and
 a large offset for the high rater J03. Once the random assessor is removed, the
 leftover assessor-by-product interaction is mostly scale usage, so the MAM
@@ -265,12 +271,14 @@ measurements.
 The genuine correlates are significant (``brix`` with Sweetness,
 ``titratable_acidity`` with Sourness, ``price`` with Liking, each with a
 Benjamini-Hochberg q-value), but so are the spurious proxies (``refractive_index``
-and ``specific_gravity`` with Sweetness), because within one dataset they all
-correlate.
+and ``specific_gravity`` with Sweetness). Both of those ride on ``brix`` by
+construction (refractive index and specific gravity rise with dissolved sugar,
+not with perceived sweetness), so within this one dataset they track Sweetness
+just as strongly as ``brix`` itself.
 This is the trap to watch: a within-sample correlation is not a transferable,
-causal link. Telling a genuine correlate apart from a lazy proxy needs
-out-of-sample evidence (cross-validated Q-squared, a Van der Voet test, or a
-selectivity ratio), which is covered separately.
+causal link. Telling a genuine correlate apart from a proxy that merely rides
+on it needs out-of-sample evidence (cross-validated Q-squared, a Van der Voet
+test, or a selectivity ratio), which is covered separately.
 
 The full runnable scenario is in the test suite
 (``tests/test_sensory_end_to_end.py``).

--- a/docs/user_guide/sensory_panel.rst
+++ b/docs/user_guide/sensory_panel.rst
@@ -197,15 +197,16 @@ Worked example
 This example runs the whole pipeline on a small synthetic panel. Ten assessors
 (J01-J10) scored eighteen products (Product A-R) on nine attributes (Aroma
 intensity, Sweetness, Sourness, Bitterness, Firmness, Juiciness, Colour
-intensity, Aftertaste, Liking). The scores came out of the scoring software in
-the wide layout, with an extra ``site`` column we do not need and a few missing
-cells. We also have instrumental measurements per product, split on purpose
-into two kinds: genuine mechanistic correlates (``brix`` for sweetness,
-``titratable_acidity`` for sourness, ``polyphenols`` for bitterness,
-``volatile_oav`` for aroma) and spurious proxies or artifacts
-(``refractive_index`` and ``density`` ride on ``brix``;
-``total_dissolved_solids`` is an aggregate; ``price_tier`` tracks Liking only
-through the sample frame).
+intensity, Aftertaste, Liking), as integers on a 0-10 scale. The scores came out
+of the scoring software in the wide layout, with an extra ``site`` column we do
+not need and a few missing cells. We also have instrumental measurements per
+product, in realistic physical units, split on purpose into two kinds: genuine
+mechanistic correlates (``brix`` for sweetness, ``titratable_acidity`` for
+sourness, ``polyphenols`` for bitterness, ``aroma_oav`` for aroma, ``viscosity``
+for firmness) and spurious proxies or artifacts (``refractive_index`` and
+``specific_gravity`` ride on ``brix``; ``conductivity`` rides on the acid ions;
+``total_dissolved_solids`` is an aggregate; ``price`` tracks Liking only through
+the sample frame; ``serving_temperature`` is unrelated).
 
 Three assessors were constructed to misbehave: J07 scores at random, J03 rates
 everything high, and J09 uses only the middle of the scale.
@@ -262,9 +263,10 @@ measurements.
    print(assoc[assoc["significant"]])
 
 The genuine correlates are significant (``brix`` with Sweetness,
-``titratable_acidity`` with Sourness, ``price_tier`` with Liking, each with a
+``titratable_acidity`` with Sourness, ``price`` with Liking, each with a
 Benjamini-Hochberg q-value), but so are the spurious proxies (``refractive_index``
-and ``density`` with Sweetness), because within one dataset they all correlate.
+and ``specific_gravity`` with Sweetness), because within one dataset they all
+correlate.
 This is the trap to watch: a within-sample correlation is not a transferable,
 causal link. Telling a genuine correlate apart from a lazy proxy needs
 out-of-sample evidence (cross-validated Q-squared, a Van der Voet test, or a

--- a/docs/user_guide/sensory_panel.rst
+++ b/docs/user_guide/sensory_panel.rst
@@ -195,7 +195,7 @@ Worked example
 --------------
 
 This example runs the whole pipeline on a small synthetic panel. Ten assessors
-(J01-J10) scored twelve products (Product A-L) on nine attributes (Aroma
+(J01-J10) scored eighteen products (Product A-R) on nine attributes (Aroma
 intensity, Sweetness, Sourness, Bitterness, Firmness, Juiciness, Colour
 intensity, Aftertaste, Liking). The scores came out of the scoring software in
 the wide layout, with an extra ``site`` column we do not need and a few missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.49.0"
+version = "1.49.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/sensory/ingest.py
+++ b/src/process_improve/sensory/ingest.py
@@ -139,7 +139,7 @@ def reshape_to_long(  # noqa: C901, PLR0912, PLR0915
                 **({replicate_col: "replicate"} if replicate_col else {}),
             }
         ).copy()
-        long_df["score"] = pd.to_numeric(long_df["score"], errors="coerce")
+        long_df["score"] = pd.to_numeric(long_df["score"], errors="coerce").astype("float64")
         grand_before = float(np.nanmean(long_df["score"].to_numpy()))
         n_cells_before = int(long_df["score"].notna().sum())
         attr_mean_before = _series_mean_map(long_df, "attribute", "score")
@@ -171,7 +171,7 @@ def reshape_to_long(  # noqa: C901, PLR0912, PLR0915
 
         wide = data.copy()
         for col in value_cols:
-            wide[col] = pd.to_numeric(wide[col], errors="coerce")
+            wide[col] = pd.to_numeric(wide[col], errors="coerce").astype("float64")
         cell_block = wide[value_cols]
         grand_before = float(np.nanmean(cell_block.to_numpy()))
         n_cells_before = int(cell_block.notna().to_numpy().sum())
@@ -203,7 +203,7 @@ def reshape_to_long(  # noqa: C901, PLR0912, PLR0915
         long_df["replicate"] = 1
     for col in ("panelist_id", "product", "attribute"):
         long_df[col] = long_df[col].astype(str).str.strip()
-    long_df["score"] = pd.to_numeric(long_df["score"], errors="coerce")
+    long_df["score"] = pd.to_numeric(long_df["score"], errors="coerce").astype("float64")
 
     # --- Post-reshape marginal aggregates ------------------------------
     grand_after = float(np.nanmean(long_df["score"].to_numpy()))

--- a/src/process_improve/sensory/ingest.py
+++ b/src/process_improve/sensory/ingest.py
@@ -80,6 +80,9 @@ def reshape_to_long(  # noqa: C901, PLR0912, PLR0915
           column) and ``products`` (the list of product columns; if omitted,
           all non-id columns).
         * For ``long``: ``product``, ``attribute`` and ``score`` column names.
+        * ``ignore`` (optional): columns to drop before reshaping (nuisance
+          columns such as a site or batch code). When the attribute/product
+          list is omitted, "all remaining columns" excludes these.
 
     Returns
     -------
@@ -100,6 +103,12 @@ def reshape_to_long(  # noqa: C901, PLR0912, PLR0915
         raise ValueError(
             f"layout must be 'long', 'wide_by_attribute', or 'wide_by_product', got {layout!r}."
         )
+
+    # Drop any nuisance columns up front, so "all remaining columns" (when the
+    # attribute/product list is omitted) automatically excludes them.
+    ignore = mapping.get("ignore") or []
+    if ignore:
+        data = data.drop(columns=[c for c in ignore if c in data.columns])
 
     panelist_col = mapping.get("panelist_id")
     if not panelist_col:

--- a/src/process_improve/sensory/mam.py
+++ b/src/process_improve/sensory/mam.py
@@ -119,7 +119,7 @@ def mixed_assessor_model(panel: pd.DataFrame) -> MAMResult:
         matrix = _cell_means(panel, attribute)
         n_assessors, n_products = matrix.shape
         beta, means, _tau, ssq_tau = _assessor_scaling(matrix)
-        grand = float(matrix.to_numpy().mean())
+        grand = float(np.nanmean(matrix.to_numpy()))
 
         scaling_rows.extend(
             {
@@ -205,7 +205,7 @@ def align_scores(panel: pd.DataFrame, *, method: AlignMethod = "both", robust: b
     for attribute in panel["attribute"].unique():
         matrix = _cell_means(panel, attribute)
         beta, means, _tau, ssq_tau = _assessor_scaling(matrix)
-        grand = float(matrix.to_numpy().mean())
+        grand = float(np.nanmean(matrix.to_numpy()))
         if robust and ssq_tau > 0:
             consensus = matrix.mean(axis=0)
             centred_tau = (consensus - consensus.mean()).to_numpy()

--- a/src/process_improve/sensory/tools.py
+++ b/src/process_improve/sensory/tools.py
@@ -77,6 +77,13 @@ class _ReshapeInput(BaseModel):
         ),
     )
     score: str | None = Field(None, description="long: the column holding the score.")
+    ignore: list[str] | None = Field(
+        None,
+        description=(
+            "Optional nuisance columns to drop before reshaping (e.g. a site or batch code). When the "
+            "attribute / product list is omitted, all remaining columns excludes these."
+        ),
+    )
 
 
 @tool_spec(
@@ -103,6 +110,7 @@ def sensory_reshape_to_long(spec: _ReshapeInput) -> dict:
         "products": spec.products,
         "attribute": spec.attribute,
         "score": spec.score,
+        "ignore": spec.ignore,
     }
     try:
         long_df, checks = _reshape_to_long(pd.DataFrame(spec.data), layout=spec.layout, mapping=mapping)

--- a/src/process_improve/sensory/validation.py
+++ b/src/process_improve/sensory/validation.py
@@ -190,7 +190,7 @@ def validate_descriptive(  # noqa: PLR0912, PLR0913, PLR0915, C901
     for col in _LABEL_COLUMNS:
         df[col] = df[col].astype(str).str.strip()
     n_before = df["score"].notna().sum()
-    df["score"] = pd.to_numeric(df["score"], errors="coerce")
+    df["score"] = pd.to_numeric(df["score"], errors="coerce").astype("float64")
     n_unparsed = int(n_before - df["score"].notna().sum())
     if n_unparsed:
         warnings.append(f"{n_unparsed} score value(s) could not be parsed as numeric and became missing.")

--- a/tests/test_sensory_end_to_end.py
+++ b/tests/test_sensory_end_to_end.py
@@ -1,0 +1,172 @@
+"""End-to-end tutorial example for the descriptive-panel pipeline.
+
+A single synthetic scenario drives both this test and the documentation worked
+example, so the two stay in agreement. The data is entirely synthetic and
+generic: ten assessors score six products on nine attributes (wide layout, with
+a nuisance ``site`` column and a few missing cells), and a per-product table of
+instrumental covariates carries both genuine mechanistic correlates and
+spurious proxies/artifacts. Three assessors are planted to misbehave:
+
+* ``J07`` scores at random (disagrees with the panel),
+* ``J03`` rates everything high (a location shift),
+* ``J09`` uses only the middle of the scale (a compressed range).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from process_improve.sensory import (
+    DESCRIPTIVE_LONG_COLUMNS,
+    analyze_descriptive,
+    mixed_assessor_model,
+    panel_scorecard,
+    reshape_to_long,
+    validate_descriptive,
+)
+
+PRODUCTS = [f"Product {chr(ord('A') + i)}" for i in range(12)]
+ATTRIBUTES = [
+    "Aroma intensity",
+    "Sweetness",
+    "Sourness",
+    "Bitterness",
+    "Firmness",
+    "Juiciness",
+    "Colour intensity",
+    "Aftertaste",
+    "Liking",
+]
+ASSESSORS = [f"J{i:02d}" for i in range(1, 11)]
+
+
+def _zscore(x: np.ndarray) -> np.ndarray:
+    return (x - x.mean()) / x.std()
+
+
+def make_panel_and_covariates(seed: int = 0) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Return a wide panel table (with a nuisance ``site`` column) and covariates."""
+    rng = np.random.default_rng(seed)
+
+    # True per-product mean for each attribute (products genuinely differ).
+    latent = {attr: rng.uniform(3.0, 7.0, len(PRODUCTS)) for attr in ATTRIBUTES}
+    # Liking is driven by sweetness (up) and sourness (down), plus noise.
+    liking_signal = 0.8 * _zscore(latent["Sweetness"]) - 0.5 * _zscore(latent["Sourness"])
+    latent["Liking"] = np.clip(5.0 + liking_signal + rng.normal(0, 0.2, len(PRODUCTS)), 1.0, 9.0)
+
+    # Per-assessor baseline offset (normal assessors use the scale similarly).
+    offset = dict(zip(ASSESSORS, rng.normal(0, 0.3, len(ASSESSORS)), strict=True))
+
+    rows = []
+    for j in ASSESSORS:
+        for p_idx, product in enumerate(PRODUCTS):
+            row = {"Assessor": j, "Product": product, "site": "Site1" if p_idx % 2 == 0 else "Site2"}
+            for attr in ATTRIBUTES:
+                mean_pa = latent[attr][p_idx]
+                centre = latent[attr].mean()
+                if j == "J07":  # random: no relation to the products
+                    score = rng.normal(5.0, 1.5)
+                elif j == "J09":  # compressor: uses half the range
+                    score = centre + 0.5 * (mean_pa - centre) + offset[j] + rng.normal(0, 0.25)
+                elif j == "J03":  # shifted high
+                    score = mean_pa + 2.0 + rng.normal(0, 0.25)
+                else:  # normal assessor
+                    score = mean_pa + offset[j] + rng.normal(0, 0.25)
+                row[attr] = float(np.clip(score, 0.0, 10.0))
+            rows.append(row)
+    panel = pd.DataFrame(rows)
+
+    # A few missing cells, to exercise the balance handling.
+    for r, c in [(5, "Bitterness"), (17, "Aftertaste"), (40, "Firmness")]:
+        panel.loc[r, c] = np.nan
+
+    # Instrumental covariates per product: genuine mechanistic correlates ...
+    brix = latent["Sweetness"] + rng.normal(0, 0.08, len(PRODUCTS))
+    titratable_acidity = latent["Sourness"] + rng.normal(0, 0.08, len(PRODUCTS))
+    covariates = pd.DataFrame(
+        {
+            "product": PRODUCTS,
+            "brix": brix,  # -> Sweetness
+            "titratable_acidity": titratable_acidity,  # -> Sourness
+            "polyphenols": latent["Bitterness"] + rng.normal(0, 0.08, len(PRODUCTS)),  # -> Bitterness
+            "volatile_oav": latent["Aroma intensity"] + rng.normal(0, 0.08, len(PRODUCTS)),  # -> Aroma
+            # ... and spurious proxies / artifacts that correlate in-sample only.
+            "refractive_index": brix + rng.normal(0, 0.08, len(PRODUCTS)),  # rides on brix
+            "density": brix + rng.normal(0, 0.10, len(PRODUCTS)),  # rides on brix
+            "total_dissolved_solids": brix + titratable_acidity + rng.normal(0, 0.08, len(PRODUCTS)),  # aggregate
+            "price_tier": latent["Liking"] + rng.normal(0, 0.08, len(PRODUCTS)),  # artifact, tracks Liking
+        }
+    )
+    return panel, covariates
+
+
+def _assoc_row(assoc: pd.DataFrame, attribute: str, descriptor: str) -> pd.Series:
+    return assoc[(assoc["attribute"] == attribute) & (assoc["descriptor"] == descriptor)].iloc[0]
+
+
+def test_pipeline_end_to_end():
+    panel, covariates = make_panel_and_covariates()
+
+    # Step 1: reshape wide -> long, ignoring the nuisance 'site' column.
+    long_df, checks = reshape_to_long(
+        panel,
+        layout="wide_by_attribute",
+        mapping={"panelist_id": "Assessor", "product": "Product", "ignore": ["site"]},
+    )
+    assert checks["ok"]
+    assert list(long_df.columns) == list(DESCRIPTIVE_LONG_COLUMNS)
+    assert set(long_df["attribute"]) == set(ATTRIBUTES)
+    assert "site" not in long_df.columns
+
+    # Step 2: validate.
+    validated = validate_descriptive(long_df, covariates, mode="observational", score_min=0, score_max=10)
+    assert validated.ok
+
+    # Step 3: panel check - the random assessor is flagged.
+    card = panel_scorecard(long_df)
+    assert "J07" in card.flagged
+
+    # The Mixed Assessor Model recovers the planted scale usage on Sweetness.
+    mam = mixed_assessor_model(long_df)
+    sweet = mam.scaling[mam.scaling["attribute"] == "Sweetness"].set_index("panelist_id")
+    assert sweet.loc["J09", "beta"] < 0.7  # compressor
+    assert sweet.loc["J03", "offset"] == sweet["offset"].max()  # high rater
+    normal = sweet.drop(["J03", "J07", "J09"])
+    assert (normal["beta"].sub(1).abs() < 0.35).all()  # the rest track the panel
+
+    # Once the random assessor is removed, the leftover assessor-by-product
+    # interaction is mostly scale usage, so the MAM product F-test (which uses
+    # the genuine disagreement as the error) beats the classical one.
+    cleaned = long_df[long_df["panelist_id"] != "J07"]
+    mam_clean = mixed_assessor_model(cleaned)
+    ftest = mam_clean.ftests[mam_clean.ftests["attribute"] == "Sweetness"].iloc[0]
+    assert ftest["f_product_mam"] > ftest["f_product_classical"]
+
+    # Step 4: correct (align all assessors) and relate to the covariates.
+    result = analyze_descriptive(validated, correction="align")
+    assert result.correction == "align"
+    assoc = pd.DataFrame(result.relate["associations"])
+
+    # Genuine correlates are significant ...
+    assert _assoc_row(assoc, "Sweetness", "brix")["significant"]
+    assert _assoc_row(assoc, "Sourness", "titratable_acidity")["significant"]
+    assert _assoc_row(assoc, "Liking", "price_tier")["significant"]
+    # ... but so are the spurious proxies (the trap): they correlate in-sample.
+    assert _assoc_row(assoc, "Sweetness", "refractive_index")["significant"]
+    assert _assoc_row(assoc, "Sweetness", "density")["significant"]
+    # A descriptor with no causal path to an unrelated attribute stays non-significant.
+    assert not _assoc_row(assoc, "Sourness", "brix")["significant"]
+
+
+def test_means_only_table_is_refused():
+    # A product-by-attribute summary (no panelist column) cannot drive the MAM.
+    panel, _ = make_panel_and_covariates()
+    means_only = panel.drop(columns=["Assessor"]).groupby("Product", as_index=False)[ATTRIBUTES].mean()
+    with pytest.raises(ValueError, match="panelist"):
+        reshape_to_long(
+            means_only,
+            layout="wide_by_attribute",
+            mapping={"product": "Product", "ignore": ["site"]},
+        )

--- a/tests/test_sensory_end_to_end.py
+++ b/tests/test_sensory_end_to_end.py
@@ -27,7 +27,7 @@ from process_improve.sensory import (
     validate_descriptive,
 )
 
-PRODUCTS = [f"Product {chr(ord('A') + i)}" for i in range(12)]
+PRODUCTS = [f"Product {chr(ord('A') + i)}" for i in range(18)]
 ATTRIBUTES = [
     "Aroma intensity",
     "Sweetness",
@@ -158,6 +158,10 @@ def test_pipeline_end_to_end():
     assert _assoc_row(assoc, "Sweetness", "density")["significant"]
     # A descriptor with no causal path to an unrelated attribute stays non-significant.
     assert not _assoc_row(assoc, "Sourness", "brix")["significant"]
+    # Every attribute is related, including the ones with missing cells - a NaN
+    # cell must not silently drop an attribute (regression guard).
+    assert set(assoc["attribute"]) == set(ATTRIBUTES)
+    assert _assoc_row(assoc, "Bitterness", "polyphenols")["significant"]
 
 
 def test_means_only_table_is_refused():

--- a/tests/test_sensory_end_to_end.py
+++ b/tests/test_sensory_end_to_end.py
@@ -42,63 +42,97 @@ ATTRIBUTES = [
 ASSESSORS = [f"J{i:02d}" for i in range(1, 11)]
 
 
-def _zscore(x: np.ndarray) -> np.ndarray:
-    return (x - x.mean()) / x.std()
+def _sig(values: np.ndarray, figures: int = 4) -> np.ndarray:
+    """Round to a fixed number of significant figures (3-4, as a lab would report)."""
+    return np.array([float(f"{v:.{figures}g}") for v in np.asarray(values, dtype=float)])
+
+
+def _loguniform(u: np.ndarray, lo: float, hi: float) -> np.ndarray:
+    """Map u in [0, 1] onto [lo, hi] on a log scale (right-skewed, as in real product frames)."""
+    return np.exp(np.log(lo) + u * (np.log(hi) - np.log(lo)))
 
 
 def make_panel_and_covariates(seed: int = 0) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Return a wide panel table (with a nuisance ``site`` column) and covariates."""
+    """Return a wide panel table (integer scores, nuisance ``site`` column) and covariates.
+
+    Each product has a hidden intensity ``u`` in [0, 1] per mechanism; the
+    attribute means are linear in ``u`` while the instrumental covariates are
+    realistic physical quantities monotone in the same ``u`` (so genuine
+    covariates correlate with their attribute). The spurious covariates are
+    coupled to the mechanistic ones (e.g. refractive index ~ 1.333 + 0.00142 *
+    Brix), as they are physically, so they correlate in-sample without a direct
+    causal path to perception. Panel scores are integers on a 0-10 scale.
+    """
     rng = np.random.default_rng(seed)
+    n = len(PRODUCTS)
 
-    # True per-product mean for each attribute (products genuinely differ).
-    latent = {attr: rng.uniform(3.0, 7.0, len(PRODUCTS)) for attr in ATTRIBUTES}
-    # Liking is driven by sweetness (up) and sourness (down), plus noise.
-    liking_signal = 0.8 * _zscore(latent["Sweetness"]) - 0.5 * _zscore(latent["Sourness"])
-    latent["Liking"] = np.clip(5.0 + liking_signal + rng.normal(0, 0.2, len(PRODUCTS)), 1.0, 9.0)
+    # Hidden per-product intensity (one per mechanism) and the attribute means.
+    u = {key: rng.uniform(0.0, 1.0, n) for key in ATTRIBUTES}
+    liking_u = np.clip(0.7 * u["Sweetness"] + 0.3 * (1 - u["Sourness"]) + rng.normal(0, 0.05, n), 0, 1)
+    u["Liking"] = liking_u
+    attr_mean = {attr: 1.0 + 8.0 * u[attr] for attr in ATTRIBUTES}  # means on a 1-9 band
 
-    # Per-assessor baseline offset (normal assessors use the scale similarly).
-    offset = dict(zip(ASSESSORS, rng.normal(0, 0.3, len(ASSESSORS)), strict=True))
+    # Mechanistic covariates: realistic units / ranges, monotone in the same u.
+    brix = 0.5 + 64.5 * u["Sweetness"]  # deg Bx, 0.5-65
+    acidity = _loguniform(u["Sourness"], 0.3, 60.0)  # g/L, right-skewed
+    polyphenols = _loguniform(u["Bitterness"], 50.0, 4000.0)  # mg/L GAE
+    aroma_oav = _loguniform(u["Aroma intensity"], 1.0, 2000.0)  # OAV
+    viscosity = _loguniform(u["Firmness"], 1.0, 10000.0)  # mPa.s
+    # Spurious / proxy covariates, physically coupled to the mechanistic ones.
+    refractive_index = 1.333 + 0.00142 * brix + rng.normal(0, 0.0008, n)  # rides on Brix
+    specific_gravity = np.clip(0.998 + 0.0045 * brix + rng.normal(0, 0.004, n), 0.98, 1.35)  # rides on Brix
+    conductivity = np.clip(0.05 + 0.45 * acidity + rng.normal(0, 0.3, n), 0.05, 30.0)  # rides on acid ions
+    tds = np.clip(50 + 700 * brix + 200 * acidity + rng.normal(0, 200, n), 50, 50000)  # aggregate
+    price = _loguniform(liking_u, 0.30, 50.0)  # EUR/L, artifact tracking Liking
+    serving_temperature = rng.uniform(2.0, 70.0, n)  # measurement condition; unrelated
 
-    rows = []
-    for j in ASSESSORS:
-        for p_idx, product in enumerate(PRODUCTS):
-            row = {"Assessor": j, "Product": product, "site": "Site1" if p_idx % 2 == 0 else "Site2"}
-            for attr in ATTRIBUTES:
-                mean_pa = latent[attr][p_idx]
-                centre = latent[attr].mean()
-                if j == "J07":  # random: no relation to the products
-                    score = rng.normal(5.0, 1.5)
-                elif j == "J09":  # compressor: uses half the range
-                    score = centre + 0.5 * (mean_pa - centre) + offset[j] + rng.normal(0, 0.25)
-                elif j == "J03":  # shifted high
-                    score = mean_pa + 2.0 + rng.normal(0, 0.25)
-                else:  # normal assessor
-                    score = mean_pa + offset[j] + rng.normal(0, 0.25)
-                row[attr] = float(np.clip(score, 0.0, 10.0))
-            rows.append(row)
-    panel = pd.DataFrame(rows)
-
-    # A few missing cells, to exercise the balance handling.
-    for r, c in [(5, "Bitterness"), (17, "Aftertaste"), (40, "Firmness")]:
-        panel.loc[r, c] = np.nan
-
-    # Instrumental covariates per product: genuine mechanistic correlates ...
-    brix = latent["Sweetness"] + rng.normal(0, 0.08, len(PRODUCTS))
-    titratable_acidity = latent["Sourness"] + rng.normal(0, 0.08, len(PRODUCTS))
     covariates = pd.DataFrame(
         {
             "product": PRODUCTS,
-            "brix": brix,  # -> Sweetness
-            "titratable_acidity": titratable_acidity,  # -> Sourness
-            "polyphenols": latent["Bitterness"] + rng.normal(0, 0.08, len(PRODUCTS)),  # -> Bitterness
-            "volatile_oav": latent["Aroma intensity"] + rng.normal(0, 0.08, len(PRODUCTS)),  # -> Aroma
-            # ... and spurious proxies / artifacts that correlate in-sample only.
-            "refractive_index": brix + rng.normal(0, 0.08, len(PRODUCTS)),  # rides on brix
-            "density": brix + rng.normal(0, 0.10, len(PRODUCTS)),  # rides on brix
-            "total_dissolved_solids": brix + titratable_acidity + rng.normal(0, 0.08, len(PRODUCTS)),  # aggregate
-            "price_tier": latent["Liking"] + rng.normal(0, 0.08, len(PRODUCTS)),  # artifact, tracks Liking
+            "brix": _sig(brix),
+            "titratable_acidity": _sig(acidity),
+            "polyphenols": _sig(polyphenols),
+            "aroma_oav": _sig(aroma_oav),
+            "viscosity": _sig(viscosity),
+            "refractive_index": _sig(refractive_index),
+            "specific_gravity": _sig(specific_gravity),
+            "conductivity": _sig(conductivity),
+            "total_dissolved_solids": _sig(tds),
+            "price": _sig(price, 3),
+            "serving_temperature": _sig(serving_temperature, 3),
         }
     )
+
+    # Panel: integer 0-10 scores, with three planted atypical assessors.
+    offset = dict(zip(ASSESSORS, rng.normal(0, 0.3, len(ASSESSORS)), strict=True))
+    rows = []
+    for j in ASSESSORS:
+        for p_idx, product in enumerate(PRODUCTS):
+            row: dict[str, object] = {
+                "Assessor": j,
+                "Product": product,
+                "site": "Site1" if p_idx % 2 == 0 else "Site2",
+            }
+            for attr in ATTRIBUTES:
+                mean_pa = attr_mean[attr][p_idx]
+                centre = attr_mean[attr].mean()
+                if j == "J07":  # random: no relation to the products
+                    score = rng.normal(5.0, 1.5)
+                elif j == "J09":  # compressor: uses half the range
+                    score = centre + 0.5 * (mean_pa - centre) + offset[j] + rng.normal(0, 0.4)
+                elif j == "J03":  # shifted high
+                    score = mean_pa + 2.0 + rng.normal(0, 0.4)
+                else:  # normal assessor
+                    score = mean_pa + offset[j] + rng.normal(0, 0.4)
+                row[attr] = int(np.clip(round(score), 0, 10))
+            rows.append(row)
+    panel = pd.DataFrame(rows)
+    panel[ATTRIBUTES] = panel[ATTRIBUTES].astype("Int64")  # integer ratings (nullable for missing cells)
+
+    # A few missing cells, to exercise the balance and missing-data handling.
+    for r, c in [(5, "Bitterness"), (17, "Aftertaste"), (40, "Firmness")]:
+        panel.loc[r, c] = pd.NA
+
     return panel, covariates
 
 
@@ -152,10 +186,10 @@ def test_pipeline_end_to_end():
     # Genuine correlates are significant ...
     assert _assoc_row(assoc, "Sweetness", "brix")["significant"]
     assert _assoc_row(assoc, "Sourness", "titratable_acidity")["significant"]
-    assert _assoc_row(assoc, "Liking", "price_tier")["significant"]
+    assert _assoc_row(assoc, "Liking", "price")["significant"]
     # ... but so are the spurious proxies (the trap): they correlate in-sample.
     assert _assoc_row(assoc, "Sweetness", "refractive_index")["significant"]
-    assert _assoc_row(assoc, "Sweetness", "density")["significant"]
+    assert _assoc_row(assoc, "Sweetness", "specific_gravity")["significant"]
     # A descriptor with no causal path to an unrelated attribute stays non-significant.
     assert not _assoc_row(assoc, "Sourness", "brix")["significant"]
     # Every attribute is related, including the ones with missing cells - a NaN


### PR DESCRIPTION
## Summary

Incremental follow-up to the sensory subpackage. Two things:

- **`ignore` option on the reshape.** `reshape_to_long` (and the
  `sensory_reshape_to_long` tool) gain an optional `ignore` list, so wide
  exports that carry extra non-schema columns (e.g. a site or batch code) drop
  those before the melt; when the attribute / product list is omitted, "all
  remaining columns" excludes them. The round-trip invariant checks still apply
  to the kept columns.
- **A tutorial example** of the full pipeline: a documentation worked-example
  section plus a backing end-to-end test on a synthetic descriptive panel
  (reshape -> validate -> panel check / Mixed Assessor Model -> relate). The
  example also shows the covariate trap: genuine mechanistic measurements and
  spurious proxies/artifacts both correlate within one dataset, so the current
  relate step flags both; the narrative explains that within-sample correlation
  is not a transferable, causal link.

All data in the example is synthetic and generic.

## Test plan

- [x] `ignore` option lint/type clean and smoke-tested.
- [x] `tests/test_sensory_end_to_end.py` runs the full chain and asserts the
  planted behaviour: the random assessor is flagged; the scaling coefficients
  recover the shifted/compressed assessors; the MAM product F beats the
  classical one once the random assessor is removed; genuine and spurious
  covariate associations are both significant (the trap); a means-only table is
  refused.
- [x] `ruff` + `mypy` clean; sensory suite green (38 tests).

## Checklist

- [x] Version bumped in `pyproject.toml` (PATCH, 1.49.1)
- [x] Tests added
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)