### PR TITLE
Boost test coverage: enable pyoptex in CI and close measured gaps

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -16,6 +16,11 @@ show_missing = True
 # Do not show in the coverage report which files are fully covered
 skip_covered = True
 
+partial_branches =
+    # Availability guards whose false branch only fires in an environment
+    # without the optional dependency installed (CI installs everything).
+    pragma: no branch
+
 exclude_lines =
     # Don't complain if tests don't hit defensive assertion code:
     raise NotImplementedError

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ those changes.
 
 ## [Unreleased]
 
+## [1.51.1] - 2026-07-02
+
+### Added
+
+- The `pyoptex` coordinate-exchange optimal-design backend is now installed in
+  the development environment (dev dependency group) via uv
+  `override-dependencies` that relax pyoptex's plotly and numba pins, so the
+  D-, I-, and A-optimal and split-plot test paths run in CI instead of being
+  skipped. New direct tests cover the pyoptex adapter layer, and the fallback
+  and ImportError paths are now forced via monkeypatch so they are exercised
+  in every environment.
+- Expanded coverage tests for the DOE visualization plot builders, bivariate
+  elbow/peak detection, and control-chart edge paths; the coverage gate
+  (`--cov-fail-under`) was raised accordingly.
+
 ## [1.51.0] - 2026-06-30
 
 ### Added
@@ -2297,7 +2312,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.51.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.51.1...HEAD
+[1.51.1]: https://github.com/kgdunn/process-improve/compare/v1.51.0...v1.51.1
 [1.51.0]: https://github.com/kgdunn/process-improve/compare/v1.50.0...v1.51.0
 [1.50.0]: https://github.com/kgdunn/process-improve/compare/v1.49.1...v1.50.0
 [1.49.1]: https://github.com/kgdunn/process-improve/compare/v1.49.0...v1.49.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.51.0
-date-released: "2026-06-30"
+version: 1.51.1
+date-released: "2026-07-02"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/docs/doe/coverage.md
+++ b/docs/doe/coverage.md
@@ -26,8 +26,8 @@ Current implementation status across every agent-facing DoE tool.
 | Central Composite Design (face-centered, rotatable, inscribed, orthogonal) | `designs_response_surface.py::dispatch_ccd` via `pyDOE3.ccdesign`. | `TestCCD`, `TestCCDProperties`. |
 | Definitive Screening Design | `designs_response_surface.py::dispatch_dsd` - Paley conference-matrix construction (see caveat below). | `TestDSD`, `TestDSDProperties`. |
 | D-optimal | `designs_optimal.py::dispatch_d_optimal` - `pyoptex` coordinate exchange when available, otherwise point exchange on a 3-level candidate set. | `TestDOptimal`. |
-| I-optimal | `designs_optimal.py::dispatch_i_optimal` via `pyoptex`. | `TestIOptimal` (skipped without `pyoptex`). |
-| A-optimal | `designs_optimal.py::dispatch_a_optimal` via `pyoptex`. | `TestAOptimal` (skipped without `pyoptex`). |
+| I-optimal | `designs_optimal.py::dispatch_i_optimal` via `pyoptex`. | `TestIOptimal`, `test_designs_optimal_pyoptex.py` (run in CI; `pyoptex` is in the dev dependency group). |
+| A-optimal | `designs_optimal.py::dispatch_a_optimal` via `pyoptex`. | `TestAOptimal`, `test_designs_optimal_pyoptex.py` (run in CI; `pyoptex` is in the dev dependency group). |
 | Mixture (simplex-lattice, simplex-centroid) | `designs_mixture.py::dispatch_mixture` - auto-selects based on budget. | `TestMixture`. |
 | Taguchi orthogonal arrays | `designs_screening.py::dispatch_taguchi` via `pyDOE3.taguchi_design`. | `TestTaguchi`. |
 
@@ -57,6 +57,50 @@ All 14 metrics live in `experiments/evaluate.py` behind the `_METRIC_REGISTRY`:
 - **DSD conference matrix.** `_conference_matrix` in `designs_response_surface.py` uses Paley's construction when `m − 1` is an odd prime (covers `m ∈ {4, 6, 8, 12, 14, 18, 20, 24, 30, 32, 38, 42, 44, 48, 54, 60, 62, 68, 72, 74, 80, 84, 90, 98, …}`). For other *m* (including `m ∈ {10, 16, 22, 26, 28, 34, 36, 40, 46, 50, 52, 56, …}`) the function falls back to a cyclic approximation that does **not** satisfy `Cᵀ C = (m − 1) I`, and logs a warning. Main-effects orthogonality of the resulting DSD may be degraded in those sizes.
 - **Optimal designs without `pyoptex`.** D-optimal has a point-exchange fallback; I/A-optimal raise `ImportError` instead. Hard-to-change factors (split-plot structure) are currently ignored with a `logger.warning` when `pyoptex` is not available.
 - **Taguchi OA auto-selection** picks the smallest standard array that covers the requested factor count and level counts, but the underlying `pyDOE3.taguchi_design` requires the number of `levels_per_factor` entries to match the OA column count exactly, so requesting a Taguchi design with fewer factors than any available OA will fail. Users typically pick *k* to match one of the standard arrays (3, 4, 7, 11, 15, …).
+
+## Reliance on `pyoptex`
+
+`pyoptex` (github.com/mborn1/pyoptex) powers the high-quality optimal designs
+(D/I/A-optimal coordinate exchange and split-plot structures) in
+`designs_optimal.py`. For **end users** it is an optional, undeclared
+dependency: the core install never pulls it in, and the integration degrades
+cleanly when it is absent (D-optimal falls back to point exchange; I/A-optimal
+raise a clear `ImportError`; hard-to-change factors are ignored with a warning
+and a `hard_to_change_ignored` metadata flag). This keeps the coupling to a
+single, well-isolated adapter module.
+
+**How the gated tests get exercised.** In the uv-managed development
+environment, `pyoptex` IS installed: it sits in the `[dependency-groups].dev`
+list, and `[tool.uv] override-dependencies` relaxes its over-strict
+`plotly~=5.24` and `numba~=0.61` pins to this project's own floors. Every CI
+job runs `uv sync --dev --all-extras`, so the pyoptex-backed tests
+(`test_designs_optimal_pyoptex.py` and the gated classes in
+`test_design_generation.py`) run as blocking checks across the whole matrix.
+The no-pyoptex fallback and ImportError paths stay covered too: the tests in
+`test_designs_screening_optimal.py` force `_PYOPTEX_AVAILABLE = False` via
+monkeypatch instead of relying on the package being absent.
+
+**Why it is still not a published extra.** pip cannot apply uv overrides, so
+declaring `pyoptex` in the `expt`/`all` extras would make combinations like
+`[expt] + [plotting]` unresolvable for pip users. The upstream fix for the
+plotly pin (mborn1/pyoptex#49, `plotly>=5.24,<7`) is merged but not yet in a
+PyPI release; `numba~=0.61` is still pinned strictly even upstream. Until a
+release ships relaxed pins, end users who want I/A-optimal install `pyoptex`
+in a separate environment (`pip install pyoptex`).
+
+**Why not vendor it.** The slice used here (`doe/fixed_structure`) is
+Cython-compiled. Vendoring is permitted (`pyoptex` is BSD-3-Clause) but would
+add a C build toolchain to an otherwise pure-Python package and transfer the
+maintenance of numerically delicate optimizer code. The friction is a
+packaging release lag, not a code problem, so vendoring is the wrong trade.
+
+**Exit criterion.** Once `pyoptex` publishes a release with the relaxed pins,
+move it into the `expt`/`all` extras as a normal dependency and drop the
+`[tool.uv]` overrides (the numba override can only go once upstream relaxes
+`numba~=0.61`). If `pyoptex` instead goes unmaintained, the clean replacement
+is a minimal numpy coordinate-exchange for I/A-optimal (reusing the existing
+`point_exchange` pattern in `optimal.py`), not a transplant of the upstream
+Cython.
 
 ## No Silent Fallbacks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.51.0"
+version = "1.51.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,13 @@ dev = [
     "pandas-stubs>=2.3.3.260113",
     "plotly-stubs>=0.0.6",
     "pre-commit>=4.5.1",
+    # Coordinate-exchange optimal-design backend exercised by the pyoptex
+    # test paths in tests/test_design_generation.py and
+    # tests/test_designs_optimal_pyoptex.py. Dev-group only, NOT a published
+    # extra: pip cannot apply the [tool.uv] override-dependencies below, so
+    # advertising pyoptex in wheel metadata would make e.g. [expt]+[plotting]
+    # unresolvable for pip users until upstream ships relaxed pins.
+    "pyoptex>=1.2.1",
     "pytest>=9.0.2",
     "pytest-benchmark>=4.0.0",
     "pytest-cov>=7.0.0",
@@ -148,6 +155,18 @@ dev = [
     "ipykernel>=6.29",
     "tqdm-stubs>=0.2.1",
     "watchdog>=6.0.0",
+]
+
+[tool.uv]
+# pyoptex 1.2.1 (PyPI) pins plotly~=5.24 and numba~=0.61, which conflict with
+# the `plotting` (plotly>=6.5.2) and `fast` (numba>=0.63.1) extras. The plotly
+# relaxation is merged upstream (github.com/mborn1/pyoptex, plotly>=5.24,<7)
+# but not yet released; numba is still pinned strictly upstream. These
+# overrides match this project's own floors, so they change nothing else.
+# Drop the plotly override once a pyoptex release ships the relaxed pin.
+override-dependencies = [
+    "plotly>=6.5.2",
+    "numba>=0.63.1",
 ]
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -33,4 +33,4 @@ addopts = --new-first
     --cov-config=.coveragerc
     --no-cov-on-fail
     --cov-branch
-    --cov-fail-under 89
+    --cov-fail-under 92

--- a/src/process_improve/experiments/designs_optimal.py
+++ b/src/process_improve/experiments/designs_optimal.py
@@ -49,7 +49,7 @@ try:
     from pyoptex.utils.model import model2Y2X, partial_rsm_names
 
     _PYOPTEX_AVAILABLE = True
-except ImportError:
+except ImportError:  # pragma: no cover - exercised via env-without-pyoptex
     pass
 
 # ---------------------------------------------------------------------------
@@ -65,7 +65,7 @@ _PYOPTEX_MODEL_MAP = {
 
 #: Map our optimality-criterion strings to pyoptex metric constructors.
 _PYOPTEX_METRIC_MAP: dict = {}
-if _PYOPTEX_AVAILABLE:
+if _PYOPTEX_AVAILABLE:  # pragma: no branch - false only in env-without-pyoptex
     _PYOPTEX_METRIC_MAP = {
         "d_optimal": Dopt,
         "i_optimal": Iopt,

--- a/tests/test_bivariate.py
+++ b/tests/test_bivariate.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from process_improve.bivariate.methods import find_elbow_point
+from process_improve.bivariate.methods import find_elbow_point, find_line_intersection
 from process_improve.bivariate.tools import get_bivariate_tool_specs
 from process_improve.tool_safety import ToolInputInvalidError
 from process_improve.tool_spec import execute_tool_call
@@ -109,6 +109,36 @@ def test__corner_case() -> None:
         [np.nan] * 11,
     )
     assert found_elbow == -1
+
+
+def test__mismatched_lengths_raise() -> None:
+    """Vectors of different lengths raise a clear ValueError."""
+    with pytest.raises(ValueError, match="same length"):
+        find_elbow_point(np.arange(12.0), np.arange(11.0))
+
+
+def test__too_few_non_missing_values_raise() -> None:
+    """Ten or fewer non-missing pairs raise, even if the raw vectors are longer."""
+    x = np.arange(13.0)
+    y = 2.0 * x
+    y[[2, 5, 8]] = np.nan  # 10 non-missing pairs remain
+    with pytest.raises(ValueError, match="more than 10 values"):
+        find_elbow_point(x, y)
+
+
+def test_find_line_intersection_parallel_lines() -> None:
+    """Essentially parallel lines have no intersection: returns (nan, nan)."""
+    x, y = find_line_intersection(m1=2.0, b1=0.0, m2=2.0, b2=5.0)
+    assert np.isnan(x)
+    assert np.isnan(y)
+
+
+def test_find_line_intersection_known_point() -> None:
+    """Two crossing lines intersect where algebra says they should."""
+    # y = x and y = -x + 4 cross at (2, 2).
+    x, y = find_line_intersection(m1=1.0, b1=0.0, m2=-1.0, b2=4.0)
+    assert x == pytest.approx(2.0)
+    assert y == pytest.approx(2.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_designs_optimal_pyoptex.py
+++ b/tests/test_designs_optimal_pyoptex.py
@@ -1,0 +1,178 @@
+"""Tests for the pyoptex adapter layer in ``designs_optimal.py``.
+
+These exercise the coordinate-exchange backend directly: factor
+conversion (including the split-plot ``RandomEffect`` structure),
+``_run_pyoptex`` metadata, the three optimality criteria, and the
+run-order preservation branch in ``generate_design``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pyoptex")
+
+from process_improve.experiments.designs import generate_design
+from process_improve.experiments.designs_optimal import (
+    _convert_factors_to_pyoptex,
+    _PyoptexOptions,
+    _run_pyoptex,
+    dispatch_a_optimal,
+    dispatch_d_optimal,
+    dispatch_i_optimal,
+)
+from process_improve.experiments.factor import Factor
+
+
+def _continuous(n: int, names: str = "ABCDEF") -> list[Factor]:
+    return [Factor(name=names[i], low=0, high=10) for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# _convert_factors_to_pyoptex
+# ---------------------------------------------------------------------------
+
+
+class TestConvertFactors:
+    """Translation of our Factor objects into pyoptex Factor objects."""
+
+    def test_continuous_and_categorical_mapping(self) -> None:
+        factors = [
+            Factor(name="A", low=0, high=10),
+            Factor(name="B", type="categorical", levels=["lo", "mid", "hi"]),
+        ]
+        converted = _convert_factors_to_pyoptex(factors)
+        assert converted[0].name == "A"
+        assert converted[0].type == "continuous"
+        assert converted[0].re is None
+        assert converted[1].name == "B"
+        assert converted[1].type == "categorical"
+        assert list(converted[1].levels) == ["lo", "mid", "hi"]
+        assert converted[1].re is None
+
+    def test_hard_to_change_builds_random_effect(self) -> None:
+        """The htc factor gets a RandomEffect grouping runs into whole plots;
+        easy-to-change factors do not.
+        """
+        factors = _continuous(2)
+        converted = _convert_factors_to_pyoptex(factors, hard_to_change=["A"], n_runs=12)
+        re_a = converted[0].re
+        assert re_a is not None
+        assert converted[1].re is None
+        # 12 runs, default whole plots = max(4, 12 // 3) = 4, balanced blocks of 3.
+        np.testing.assert_array_equal(re_a.Z, np.repeat(np.arange(4), 3))
+        assert re_a.ratio == 0.5
+
+    def test_whole_plot_padding_when_runs_do_not_divide(self) -> None:
+        """When n_runs does not divide evenly, the last whole plot is padded."""
+        factors = _continuous(2)
+        converted = _convert_factors_to_pyoptex(
+            factors,
+            hard_to_change=["A"],
+            n_runs=10,
+            n_whole_plots=4,
+        )
+        np.testing.assert_array_equal(converted[0].re.Z, [0, 0, 1, 1, 2, 2, 3, 3, 3, 3])
+
+
+# ---------------------------------------------------------------------------
+# _run_pyoptex
+# ---------------------------------------------------------------------------
+
+
+class TestRunPyoptex:
+    """Direct coordinate-exchange runs with a single restart for speed."""
+
+    @pytest.mark.parametrize("model_type", ["main_effects", "quadratic"])
+    def test_model_types_round_trip(self, model_type: str) -> None:
+        design, meta = _run_pyoptex(
+            _continuous(2),
+            criterion="d_optimal",
+            budget=8,
+            options=_PyoptexOptions(model_type=model_type, n_tries=1),
+        )
+        assert design.shape == (8, 2)
+        assert meta["model_type"] == model_type
+        assert meta["backend"] == "pyoptex"
+
+    def test_unknown_model_type_falls_back_to_interactions(self) -> None:
+        """An unrecognized model_type maps to the 'tfi' pyoptex keyword."""
+        design, meta = _run_pyoptex(
+            _continuous(2),
+            criterion="d_optimal",
+            budget=8,
+            options=_PyoptexOptions(model_type="banana", n_tries=1),
+        )
+        assert design.shape == (8, 2)
+        assert meta["model_type"] == "banana"
+
+    @pytest.mark.parametrize("criterion", ["d_optimal", "i_optimal", "a_optimal"])
+    def test_all_criteria_report_metadata(self, criterion: str) -> None:
+        _design, meta = _run_pyoptex(
+            _continuous(2),
+            criterion=criterion,
+            budget=8,
+            options=_PyoptexOptions(n_tries=1),
+        )
+        assert meta["optimality_criterion"] == criterion
+        assert isinstance(meta["metric_value"], float)
+        assert meta["backend"] == "pyoptex"
+        assert "hard_to_change" not in meta
+
+    def test_hard_to_change_recorded_in_metadata(self) -> None:
+        _design, meta = _run_pyoptex(
+            _continuous(2),
+            criterion="d_optimal",
+            budget=8,
+            options=_PyoptexOptions(hard_to_change=["A"], n_tries=1),
+        )
+        assert meta["hard_to_change"] == ["A"]
+
+
+# ---------------------------------------------------------------------------
+# Dispatch defaults and mixed factor types
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchDefaults:
+    """Public dispatch functions with pyoptex available."""
+
+    def test_i_optimal_default_budget(self) -> None:
+        design, meta = dispatch_i_optimal(_continuous(3))
+        assert design.shape[0] == 7  # 2k + 1
+        assert meta["optimality_criterion"] == "i_optimal"
+
+    def test_a_optimal_default_budget(self) -> None:
+        design, meta = dispatch_a_optimal(_continuous(3))
+        assert design.shape[0] == 7  # 2k + 1
+        assert meta["optimality_criterion"] == "a_optimal"
+
+    def test_mixed_factor_types_smoke(self) -> None:
+        factors = [
+            Factor(name="A", low=0, high=10),
+            Factor(name="B", type="categorical", levels=["red", "green", "blue"]),
+        ]
+        design, meta = dispatch_d_optimal(factors, budget=9)
+        assert design.shape == (9, 2)
+        assert meta["backend"] == "pyoptex"
+
+
+# ---------------------------------------------------------------------------
+# generate_design integration: run order preserved for pyoptex backends
+# ---------------------------------------------------------------------------
+
+
+class TestRunOrderPreservation:
+    """pyoptex designs keep their optimized ordering (vital for split-plot)."""
+
+    def test_seed_does_not_randomize_pyoptex_design(self) -> None:
+        result = generate_design(
+            _continuous(2),
+            design_type="i_optimal",
+            budget=6,
+            random_seed=999,
+            center_points=0,
+        )
+        assert result.metadata.get("backend") == "pyoptex"
+        assert result.run_order == list(range(1, 7))

--- a/tests/test_designs_optimal_pyoptex.py
+++ b/tests/test_designs_optimal_pyoptex.py
@@ -64,6 +64,15 @@ class TestConvertFactors:
         np.testing.assert_array_equal(re_a.Z, np.repeat(np.arange(4), 3))
         assert re_a.ratio == 0.5
 
+    def test_multiple_hard_to_change_factors(self) -> None:
+        """Every hard-to-change factor shares the whole-plot RandomEffect."""
+        factors = _continuous(3)
+        converted = _convert_factors_to_pyoptex(factors, hard_to_change=["A", "B"], n_runs=12)
+        by_name = {f.name: f for f in converted}
+        assert by_name["A"].re is not None
+        assert by_name["B"].re is by_name["A"].re
+        assert by_name["C"].re is None
+
     def test_whole_plot_padding_when_runs_do_not_divide(self) -> None:
         """When n_runs does not divide evenly, the last whole plot is padded."""
         factors = _continuous(2)
@@ -147,6 +156,13 @@ class TestDispatchDefaults:
         design, meta = dispatch_a_optimal(_continuous(3))
         assert design.shape[0] == 7  # 2k + 1
         assert meta["optimality_criterion"] == "a_optimal"
+
+    def test_two_hard_to_change_factors_dispatch(self) -> None:
+        """Split-plot dispatch with two htc factors reports both in metadata."""
+        design, meta = dispatch_d_optimal(_continuous(3), budget=12, hard_to_change=["A", "B"])
+        assert design.shape[0] == 12
+        assert meta["hard_to_change"] == ["A", "B"]
+        assert meta["backend"] == "pyoptex"
 
     def test_mixed_factor_types_smoke(self) -> None:
         factors = [

--- a/tests/test_designs_screening_optimal.py
+++ b/tests/test_designs_screening_optimal.py
@@ -107,7 +107,8 @@ class TestDOptimalDispatch:
 
     def test_sec19_cap_rejects_large_candidate_set(self) -> None:
         """More factors than settings.max_factors_combinatorial is rejected
-        before the 3**k candidate set is allocated (SEC-19 / #268)."""
+        before the 3**k candidate set is allocated (SEC-19 / #268).
+        """
         with pytest.raises(ValueError, match="SEC-19 cap"):
             dispatch_d_optimal(_continuous(16), budget=40)
 

--- a/tests/test_designs_screening_optimal.py
+++ b/tests/test_designs_screening_optimal.py
@@ -135,6 +135,19 @@ class TestDOptimalDispatch:
         design, _meta = dispatch_d_optimal(_continuous(3), budget=2)
         assert design.shape[0] >= 4
 
+    def test_budget_capped_to_candidate_set(self) -> None:
+        """A budget above the 3**k candidate set is capped to its size."""
+        design, _meta = dispatch_d_optimal(_continuous(2), budget=50)
+        assert design.shape[1] == 2
+        assert design.shape[0] <= 9  # 3**2 candidate rows
+
+    @pytest.mark.parametrize("model_type", ["main_effects", "interactions", "quadratic"])
+    def test_model_type_accepted_on_fallback_path(self, model_type: str) -> None:
+        """model_type is accepted (though unused) by the point-exchange fallback."""
+        design, meta = dispatch_d_optimal(_continuous(3), budget=8, model_type=model_type)
+        assert design.shape[1] == 3
+        assert meta["backend"] == "point_exchange_fallback"
+
 
 @pytest.mark.usefixtures("no_pyoptex")
 class TestOptimalRequiresPyoptex:

--- a/tests/test_designs_screening_optimal.py
+++ b/tests/test_designs_screening_optimal.py
@@ -6,10 +6,9 @@ paths that the high-level ``generate_design`` API does not reach.
 
 from __future__ import annotations
 
-import importlib.util
-
 import pytest
 
+from process_improve.experiments import designs_optimal
 from process_improve.experiments.designs_optimal import (
     dispatch_a_optimal,
     dispatch_d_optimal,
@@ -21,9 +20,16 @@ from process_improve.experiments.designs_screening import (
 )
 from process_improve.experiments.factor import Factor
 
-_HAS_PYOPTEX = importlib.util.find_spec("pyoptex") is not None
 
-_skip_with_pyoptex = pytest.mark.skipif(_HAS_PYOPTEX, reason="behaviour differs when pyoptex installed")
+@pytest.fixture
+def no_pyoptex(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the no-pyoptex code paths regardless of installation.
+
+    The dispatch functions read the module-level ``_PYOPTEX_AVAILABLE`` flag
+    at call time, so patching the attribute is sufficient to exercise the
+    point-exchange fallback and the ImportError branches in any environment.
+    """
+    monkeypatch.setattr(designs_optimal, "_PYOPTEX_AVAILABLE", False)
 
 
 def _continuous(n: int) -> list[Factor]:
@@ -71,16 +77,16 @@ class TestTaguchiDispatch:
             dispatch_taguchi(factors)
 
 
+@pytest.mark.usefixtures("no_pyoptex")
 class TestDOptimalDispatch:
-    """D-optimal dispatch fallback paths (no pyoptex required)."""
+    """D-optimal dispatch fallback paths (pyoptex forced off)."""
 
-    @_skip_with_pyoptex
     def test_fallback_returns_design_and_metadata(self) -> None:
         design, meta = dispatch_d_optimal(_continuous(3), budget=8)
         assert design.shape[1] == 3
         assert meta["backend"] == "point_exchange_fallback"
+        assert isinstance(meta["d_optimality"], float)
 
-    @_skip_with_pyoptex
     def test_default_budget(self) -> None:
         design, _meta = dispatch_d_optimal(_continuous(2))
         assert design.shape[0] > 0
@@ -94,14 +100,24 @@ class TestDOptimalDispatch:
             dispatch_d_optimal(_continuous(2), budget=6, constraints=constraints)
         assert any("Constraint enforcement" in rec.message for rec in caplog.records)
 
-    @_skip_with_pyoptex
     def test_hard_to_change_without_pyoptex_warns(self, caplog: pytest.LogCaptureFixture) -> None:
         with caplog.at_level("WARNING"):
             dispatch_d_optimal(_continuous(2), budget=6, hard_to_change=["X1"])
         assert any("pyoptex is not installed" in rec.message for rec in caplog.records)
 
+    def test_sec19_cap_rejects_large_candidate_set(self) -> None:
+        """More factors than settings.max_factors_combinatorial is rejected
+        before the 3**k candidate set is allocated (SEC-19 / #268)."""
+        with pytest.raises(ValueError, match="SEC-19 cap"):
+            dispatch_d_optimal(_continuous(16), budget=40)
 
-@_skip_with_pyoptex
+    def test_budget_clamped_to_minimum_model_size(self) -> None:
+        """A budget below k + 1 is raised to k + 1 so the model is estimable."""
+        design, _meta = dispatch_d_optimal(_continuous(3), budget=2)
+        assert design.shape[0] >= 4
+
+
+@pytest.mark.usefixtures("no_pyoptex")
 class TestOptimalRequiresPyoptex:
     """I-optimal and A-optimal raise a clear error without pyoptex."""
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -193,6 +193,74 @@ def test_calculate_limits_rejects_unknown_kwargs() -> None:
     assert cc3.ld_2 == pytest.approx(0.7)
 
 
+def test_calculate_limits_rejects_non_positive_s() -> None:
+    """A zero or negative standard deviation is rejected up front."""
+    rng = np.random.default_rng(1)
+    y = 50.0 + rng.standard_normal(40)
+    cc = ControlChart()
+    with pytest.raises(ValueError, match="must be positive"):
+        cc.calculate_limits(y, s=-1.0)
+
+
+def test_unsupported_variant_cannot_estimate_limits() -> None:
+    """A variant with no fitting routine (e.g. cusum) leaves target/s unset and raises."""
+    rng = np.random.default_rng(2)
+    y = 50.0 + rng.standard_normal(100)
+    cc = ControlChart(variant="cusum")
+    with pytest.raises(ValueError, match="could not be estimated"):
+        cc.calculate_limits(y)
+
+
+def test_unknown_style_for_xbar_no_subgroup_raises() -> None:
+    """An unrecognized style leaves the xbar fit incomplete, which raises."""
+    rng = np.random.default_rng(3)
+    y = 50.0 + rng.standard_normal(40)
+    cc = ControlChart(style="banana", variant="xbar.no.subgroup")
+    with pytest.raises(ValueError, match="could not be estimated"):
+        cc.calculate_limits(y)
+
+
+def test_hw_zero_mad_but_nonconstant_warmup_falls_back_to_std() -> None:
+    """Symmetric warm-up residuals give MAD = 0 without being constant.
+
+    sigma_0 must then fall back to the regular standard deviation instead of
+    raising the constant-warm-up ValueError or poisoning the limits with 0.
+    """
+    rng = np.random.default_rng(4)
+    warm_up = [5.0] * 8 + [1.0, 9.0]  # median 5, residuals symmetric: MAD = 0
+    tail = (5.0 + rng.standard_normal(20)).tolist()
+    y = np.array(warm_up + tail)
+
+    cc = ControlChart()
+    cc.calculate_limits(y, target=5.0, ld_1=0.5, ld_2=0.8)
+
+    residuals = np.array(warm_up) - 5.0
+    expected_std = float(pd.Series(residuals).std())
+    assert cc.warm_up["sigma_0"] == pytest.approx(expected_std)
+    assert cc.s is not None
+    assert np.isfinite(cc.s)
+
+
+def test_rho_boundary_values() -> None:
+    """Bi-weight rho: zero at 0, capped at k beyond |x| > k, continuous at k."""
+    from process_improve.monitoring.control_charts import rho
+
+    assert rho(0.0) == pytest.approx(0.0)
+    assert rho(5.0) == pytest.approx(2.52)
+    assert rho(-5.0) == pytest.approx(2.52)
+    assert rho(2.52) == pytest.approx(2.52)
+
+
+def test_psi_boundary_values() -> None:
+    """Huber psi: identity inside |x| < k, clipped to k * sign(x) outside."""
+    from process_improve.monitoring.control_charts import psi
+
+    assert psi(1.5) == pytest.approx(1.5)
+    assert psi(3.0) == pytest.approx(2.0)
+    assert psi(-3.0) == pytest.approx(-2.0)
+    assert psi(2.0) == pytest.approx(2.0)
+
+
 def test_cpk_well_centered_process() -> None:
     """Cpk for a well-centered process with wide specs should be high."""
     rng = np.random.default_rng(42)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -8,11 +8,19 @@ entry point.
 from __future__ import annotations
 
 import json
+import math
 from typing import Any
 
 import pytest
 
 from process_improve.experiments.visualization import main_effects_plot, visualize_doe
+from process_improve.experiments.visualization.plots.optimization_plots import (
+    _composite_desirability,
+    _desirability_maximize,
+    _desirability_minimize,
+    _desirability_target,
+    _individual_desirability,
+)
 from process_improve.experiments.visualization.plots.registry import (
     create_plot,
     get_available_plot_types,
@@ -1077,3 +1085,836 @@ class TestToolSpecIntegration:
         })
         assert "error" not in result
         assert result["plot_type"] == "pareto"
+
+
+# ---------------------------------------------------------------------------
+# Desirability helper functions (optimization_plots.py)
+# ---------------------------------------------------------------------------
+
+
+class TestDesirabilityHelpers:
+    """Unit tests for the pure desirability functions in optimization_plots."""
+
+    def test_maximize_boundaries(self) -> None:
+        assert _desirability_maximize(0.0, low=1.0, high=2.0) == 0.0
+        assert _desirability_maximize(3.0, low=1.0, high=2.0) == 1.0
+        assert _desirability_maximize(1.5, low=1.0, high=2.0) == pytest.approx(0.5)
+
+    def test_minimize_boundaries(self) -> None:
+        assert _desirability_minimize(0.5, low=1.0, high=2.0) == 1.0
+        assert _desirability_minimize(2.5, low=1.0, high=2.0) == 0.0
+        assert _desirability_minimize(1.5, low=1.0, high=2.0) == pytest.approx(0.5)
+
+    def test_target_all_branches(self) -> None:
+        # Outside [low, high] on either side -> 0
+        assert _desirability_target(0.5, low=1.0, target=2.0, high=3.0) == 0.0
+        assert _desirability_target(3.5, low=1.0, target=2.0, high=3.0) == 0.0
+        # Below target: rising ramp
+        assert _desirability_target(1.5, low=1.0, target=2.0, high=3.0) == pytest.approx(0.5)
+        # Above target: falling ramp
+        assert _desirability_target(2.5, low=1.0, target=2.0, high=3.0) == pytest.approx(0.5)
+
+    def test_individual_desirability_goal_dispatch(self) -> None:
+        assert _individual_desirability(0.75, {"goal": "maximize", "low": 0.0, "high": 1.0}) == pytest.approx(0.75)
+        assert _individual_desirability(0.25, {"goal": "minimize", "low": 0.0, "high": 1.0}) == pytest.approx(0.75)
+        target_goal = {"goal": "target", "low": 0.0, "target": 0.5, "high": 1.0}
+        assert _individual_desirability(0.25, target_goal) == pytest.approx(0.5)
+        # Unknown goal type falls through to 0.0
+        assert _individual_desirability(0.5, {"goal": "unknown_goal"}) == 0.0
+
+    def test_composite_empty_list(self) -> None:
+        assert _composite_desirability([]) == 0.0
+
+    def test_composite_any_zero(self) -> None:
+        assert _composite_desirability([0.9, 0.0, 0.8]) == 0.0
+
+    def test_composite_importance_weighting(self) -> None:
+        """Importance weights should change the geometric mean."""
+        unweighted = _composite_desirability([0.25, 1.0])
+        weighted = _composite_desirability([0.25, 1.0], importances=[3.0, 1.0])
+        assert unweighted == pytest.approx(0.25**0.5)
+        assert weighted == pytest.approx(0.25**0.75)
+        assert weighted != pytest.approx(unweighted)
+
+
+# ---------------------------------------------------------------------------
+# Optimisation plot edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestDesirabilityContourEdgeCases:
+    def test_no_optimisation_data(self) -> None:
+        plot = create_plot("desirability_contour")
+        spec = plot.to_spec()
+        assert "no optimisation data" in spec.title.lower()
+
+    def test_empty_optimization_key_and_no_coefficients(self) -> None:
+        """An optimization dict without responses and no top-level coefficients."""
+        plot = create_plot("desirability_contour", analysis_results={"optimization": {}})
+        spec = plot.to_spec()
+        assert "no optimisation data" in spec.title.lower()
+
+    def test_single_factor(self, coefficients_2f: list) -> None:
+        plot = create_plot(
+            "desirability_contour",
+            analysis_results={"coefficients": coefficients_2f},
+            factors_to_plot=["A"],
+        )
+        spec = plot.to_spec()
+        assert "need at least 2" in spec.title.lower()
+
+
+class TestOverlayPlotEdgeCases:
+    def test_no_analysis_results(self) -> None:
+        plot = create_plot("overlay")
+        spec = plot.to_spec()
+        assert "no response data" in spec.title.lower()
+
+    def test_missing_optimization_key(self, coefficients_2f: list) -> None:
+        plot = create_plot("overlay", analysis_results={"coefficients": coefficients_2f})
+        spec = plot.to_spec()
+        assert "no response data" in spec.title.lower()
+
+    def test_single_factor(self, coefficients_2f: list) -> None:
+        plot = create_plot(
+            "overlay",
+            analysis_results={
+                "optimization": {"responses": [{"name": "Yield", "coefficients": coefficients_2f}]},
+            },
+            factors_to_plot=["A"],
+        )
+        spec = plot.to_spec()
+        assert "need at least 2" in spec.title.lower()
+
+    def test_response_with_empty_coefficients_skipped(self, coefficients_2f: list) -> None:
+        plot = create_plot(
+            "overlay",
+            analysis_results={
+                "optimization": {
+                    "responses": [
+                        {"name": "Yield", "coefficients": coefficients_2f},
+                        {"name": "NoModel", "coefficients": []},
+                    ],
+                },
+            },
+            factors_to_plot=["A", "B"],
+        )
+        spec = plot.to_spec()
+        # Only one contour layer: the empty-coefficient response is skipped
+        assert len(spec.panels[0].layers) == 1
+        assert spec.metadata["n_responses"] == 2
+
+    def test_constraint_labels_from_bounds(self, coefficients_2f: list) -> None:
+        """Responses carrying low/high bounds produce constraint annotations."""
+        plot = create_plot(
+            "overlay",
+            analysis_results={
+                "optimization": {
+                    "responses": [
+                        {"name": "Yield", "coefficients": coefficients_2f, "low": 30.0, "high": 50.0},
+                    ],
+                },
+            },
+            factors_to_plot=["A", "B"],
+        )
+        spec = plot.to_spec()
+        anns = spec.panels[0].annotations
+        assert len(anns) == 1
+        assert anns[0].label == "Yield: [30.00, 50.00]"
+
+
+class TestRidgeTracePlotEdgeCases:
+    def test_no_coefficients(self) -> None:
+        plot = create_plot("ridge_trace")
+        spec = plot.to_spec()
+        assert "no coefficients" in spec.title.lower()
+
+    def test_no_factors(self) -> None:
+        plot = create_plot(
+            "ridge_trace",
+            analysis_results={"coefficients": [{"term": "Intercept", "coefficient": 1.0}]},
+        )
+        spec = plot.to_spec()
+        assert "no factors" in spec.title.lower()
+
+    def test_singular_matrix_branch(self) -> None:
+        """The mu grid includes -10 exactly, making B + mu*I singular there.
+
+        With quadratic coefficients of 10.0 for both factors, the matrix
+        ``b_mat + (-10) * I`` is exactly zero, so ``np.linalg.solve`` raises
+        LinAlgError and the loop must continue to the next mu value.
+        """
+        coefficients = [
+            {"term": "A", "coefficient": 1.0},
+            {"term": "B", "coefficient": 1.0},
+            {"term": "I(A ** 2)", "coefficient": 10.0},
+            {"term": "I(B ** 2)", "coefficient": 10.0},
+        ]
+        plot = create_plot(
+            "ridge_trace",
+            analysis_results={"coefficients": coefficients},
+            factors_to_plot=["A", "B"],
+        )
+        spec = plot.to_spec()
+        assert spec.plot_type == "ridge_trace"
+        assert len(spec.panels) == 2
+        # All 30 radii still produce a response trace despite the singular mu
+        assert len(spec.panels[0].layers[0].data) == 30
+
+    def test_zero_linear_terms_keep_centre_solution(self) -> None:
+        """With b = 0 the solved x is the zero vector; factor traces stay at 0."""
+        coefficients = [
+            {"term": "Intercept", "coefficient": 5.0},
+            {"term": "I(A ** 2)", "coefficient": -2.0},
+            {"term": "I(B ** 2)", "coefficient": -3.0},
+        ]
+        plot = create_plot(
+            "ridge_trace",
+            analysis_results={"coefficients": coefficients},
+            factors_to_plot=["A", "B"],
+        )
+        spec = plot.to_spec()
+        factor_panel = spec.panels[1]
+        for layer in factor_panel.layers:
+            assert all(row["coded_level"] == 0.0 for row in layer.data)
+
+
+class TestSteepestAscentPathEdgeCases:
+    def test_no_coefficients(self) -> None:
+        plot = create_plot("steepest_ascent_path")
+        spec = plot.to_spec()
+        assert "no path data" in spec.title.lower()
+
+    def test_coefficients_without_factors(self, coefficients_2f: list) -> None:
+        """Coefficients present but no factor names derivable anywhere."""
+        plot = create_plot(
+            "steepest_ascent_path",
+            analysis_results={"coefficients": coefficients_2f},
+        )
+        spec = plot.to_spec()
+        assert "no path data" in spec.title.lower()
+
+    def test_all_zero_linear_coefficients(self) -> None:
+        coefficients = [
+            {"term": "Intercept", "coefficient": 40.0},
+            {"term": "A", "coefficient": 0.0},
+            {"term": "B", "coefficient": 0.0},
+        ]
+        plot = create_plot(
+            "steepest_ascent_path",
+            analysis_results={"coefficients": coefficients},
+            factors_to_plot=["A", "B"],
+        )
+        spec = plot.to_spec()
+        assert "no path data" in spec.title.lower()
+
+    def test_precomputed_path_with_empty_steps(self) -> None:
+        plot = create_plot(
+            "steepest_ascent_path",
+            analysis_results={"steepest_path": {"direction": "ascent", "steps": []}},
+        )
+        spec = plot.to_spec()
+        assert "no steps computed" in spec.title.lower()
+
+    def test_actual_response_overlay(self) -> None:
+        """Steps carrying actual_response add a scatter overlay of observations."""
+        path = {
+            "direction": "ascent",
+            "direction_vector": {"A": 1.0},
+            "step_size": 0.5,
+            "steps": [
+                {"step": 0, "coded": {"A": 0.0}, "predicted_response": 40.0, "actual_response": 39.5},
+                {"step": 1, "coded": {"A": 0.5}, "predicted_response": 43.0},
+                {"step": 2, "coded": {"A": 1.0}, "predicted_response": 46.0, "actual_response": 45.2},
+            ],
+        }
+        plot = create_plot(
+            "steepest_ascent_path",
+            analysis_results={"steepest_path": path},
+        )
+        spec = plot.to_spec()
+        resp_layers = spec.panels[0].layers
+        assert len(resp_layers) == 2
+        actual_layer = resp_layers[1]
+        assert actual_layer.name == "Actual"
+        # Only the two steps with actual_response contribute points
+        assert len(actual_layer.data) == 2
+        assert actual_layer.data[0]["actual"] == pytest.approx(39.5)
+
+
+# ---------------------------------------------------------------------------
+# Effect plot edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestMainEffectsPlotEdgeCases:
+    def test_infer_response_from_y_column(self, design_data_2f: list) -> None:
+        """Without response_column the 'y' column is used as the response."""
+        plot = create_plot("main_effects", design_data=design_data_2f)
+        spec = plot.to_spec()
+        assert spec.plot_type == "main_effects"
+        assert "Mean y" in spec.panels[0].y_title
+
+    def test_infer_response_falls_back_to_last_column(self) -> None:
+        data = [
+            {"A": -1, "B": -1, "conversion": 28},
+            {"A": 1, "B": -1, "conversion": 36},
+            {"A": -1, "B": 1, "conversion": 18},
+            {"A": 1, "B": 1, "conversion": 31},
+        ]
+        plot = create_plot("main_effects", design_data=data, factors_to_plot=["A", "B"])
+        spec = plot.to_spec()
+        assert "Mean conversion" in spec.panels[0].y_title
+
+    def test_response_column_not_in_data(self, design_data_2f: list) -> None:
+        plot = create_plot("main_effects", design_data=design_data_2f, response_column="missing")
+        spec = plot.to_spec()
+        assert "no response column" in spec.title.lower()
+
+    def test_unknown_factor_skipped(self, design_data_2f: list) -> None:
+        plot = create_plot(
+            "main_effects",
+            design_data=design_data_2f,
+            response_column="y",
+            factors_to_plot=["A", "Z"],
+        )
+        spec = plot.to_spec()
+        # Z is not a data column: only the A layer is produced
+        assert len(spec.panels[0].layers) == 1
+        assert spec.panels[0].layers[0].name == "A"
+
+    def test_intercept_only_formula_falls_back_to_columns(self, design_data_2f: list) -> None:
+        """A 'y ~ 1' formula yields no factor names; columns are used instead."""
+        plot = create_plot(
+            "main_effects",
+            design_data=design_data_2f,
+            response_column="y",
+            analysis_results={"model_summary": {"formula": "y ~ 1"}},
+        )
+        spec = plot.to_spec()
+        names = sorted(layer.name for layer in spec.panels[0].layers)
+        assert names == ["A", "B"]
+
+
+class TestInteractionPlotEdgeCases:
+    def test_no_data(self) -> None:
+        plot = create_plot("interaction")
+        spec = plot.to_spec()
+        assert "no data" in spec.title.lower()
+
+    def test_bad_response_column(self, design_data_2f: list) -> None:
+        plot = create_plot(
+            "interaction",
+            design_data=design_data_2f,
+            response_column="missing",
+            factors_to_plot=["A", "B"],
+        )
+        spec = plot.to_spec()
+        assert "no response column" in spec.title.lower()
+
+    def test_factors_not_in_data(self, design_data_2f: list) -> None:
+        plot = create_plot(
+            "interaction",
+            design_data=design_data_2f,
+            response_column="y",
+            factors_to_plot=["A", "Z"],
+        )
+        spec = plot.to_spec()
+        assert "not in data" in spec.title.lower()
+
+    def test_infer_response_from_y_column(self, design_data_2f: list) -> None:
+        plot = create_plot(
+            "interaction",
+            design_data=design_data_2f,
+            factors_to_plot=["A", "B"],
+        )
+        spec = plot.to_spec()
+        assert spec.plot_type == "interaction"
+        assert "Mean y" in spec.panels[0].y_title
+
+    def test_infer_response_falls_back_to_last_column(self) -> None:
+        data = [
+            {"A": -1, "B": -1, "conversion": 28},
+            {"A": 1, "B": -1, "conversion": 36},
+            {"A": -1, "B": 1, "conversion": 18},
+            {"A": 1, "B": 1, "conversion": 31},
+        ]
+        plot = create_plot("interaction", design_data=data, factors_to_plot=["A", "B"])
+        spec = plot.to_spec()
+        assert "Mean conversion" in spec.panels[0].y_title
+
+
+class TestPerturbationPlotEdgeCases:
+    def test_no_coefficients(self) -> None:
+        plot = create_plot("perturbation")
+        spec = plot.to_spec()
+        assert "no coefficients" in spec.title.lower()
+
+    def test_no_factors(self) -> None:
+        plot = create_plot(
+            "perturbation",
+            analysis_results={"coefficients": [{"term": "Intercept", "coefficient": 1.0}]},
+        )
+        spec = plot.to_spec()
+        assert "no factors" in spec.title.lower()
+
+    def test_quadratic_term_with_hold_values(self, quadratic_coefficients: list) -> None:
+        """Quadratic I(A ** 2) terms curve the sweep; other factors sit at hold values.
+
+        For factor A at the sweep endpoints, with B held at 0.5:
+        y(-1) = 80 - 5 - 3*0.5 - 4 + 1.5*(-1)*0.5 = 68.75
+        y(+1) = 80 + 5 - 3*0.5 - 4 + 1.5*(+1)*0.5 = 80.25
+        (the I(B ** 2) term contributes 0 because hold values are keyed by
+        factor name, not by transformed term name).
+        """
+        plot = create_plot(
+            "perturbation",
+            analysis_results={"coefficients": quadratic_coefficients},
+            factors_to_plot=["A", "B"],
+            hold_values={"B": 0.5},
+        )
+        spec = plot.to_spec()
+        layer_a = next(layer for layer in spec.panels[0].layers if layer.name == "A")
+        assert layer_a.data[0]["predicted"] == pytest.approx(68.75)
+        assert layer_a.data[-1]["predicted"] == pytest.approx(80.25)
+
+
+# ---------------------------------------------------------------------------
+# Significance plot edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestHalfNormalPlotEdgeCases:
+    def test_empty_effects(self) -> None:
+        plot = create_plot("half_normal", analysis_results={"effects": {}})
+        spec = plot.to_spec()
+        assert "no effects data" in spec.title.lower()
+
+    def test_single_effect(self) -> None:
+        plot = create_plot("half_normal", analysis_results={"effects": {"A": 5.0}})
+        spec = plot.to_spec()
+        assert spec.plot_type == "half_normal"
+        ref_layer = spec.panels[0].layers[1]
+        # Degenerate reference line from (0, 0) to (1, |effect|)
+        assert ref_layer.data[0] == {"quantile": 0, "abs_effect": 0}
+        assert ref_layer.data[1]["abs_effect"] == pytest.approx(5.0)
+
+    def test_all_but_one_significant(self, lenth_data: dict) -> None:
+        """With only one non-significant effect, the fallback line is used."""
+        lenth = dict(lenth_data)
+        lenth["effects"] = [{"term": "A", "effect": 8.0, "active_ME": True}]
+        plot = create_plot(
+            "half_normal",
+            analysis_results={"effects": {"A": 8.0, "B": -4.0}, "lenth_method": lenth},
+        )
+        spec = plot.to_spec()
+        ref_layer = spec.panels[0].layers[1]
+        # Fallback: line through origin up to the largest absolute effect
+        assert ref_layer.data[0]["abs_effect"] == 0
+        assert ref_layer.data[1]["abs_effect"] == pytest.approx(8.0)
+
+    def test_lenth_without_me_key(self) -> None:
+        """A lenth dict without ME produces no threshold annotation."""
+        plot = create_plot(
+            "half_normal",
+            analysis_results={
+                "effects": {"A": 8.0, "B": -4.0},
+                "lenth_method": {"effects": [{"term": "A", "effect": 8.0, "active_ME": True}]},
+            },
+        )
+        spec = plot.to_spec()
+        assert len(spec.panels[0].annotations) == 0
+
+
+class TestDanielPlotEdgeCases:
+    def test_empty_effects(self) -> None:
+        plot = create_plot("daniel", analysis_results={"effects": {}})
+        spec = plot.to_spec()
+        assert "no effects data" in spec.title.lower()
+
+    def test_single_effect(self) -> None:
+        plot = create_plot("daniel", analysis_results={"effects": {"A": 5.0}})
+        spec = plot.to_spec()
+        assert spec.plot_type == "daniel"
+        ref_layer = spec.panels[0].layers[1]
+        # Degenerate horizontal reference line at the single effect value
+        assert [row["quantile"] for row in ref_layer.data] == [-2, 2]
+        assert all(row["effect"] == pytest.approx(5.0) for row in ref_layer.data)
+
+
+class TestParetoPlotEdgeCases:
+    def test_lenth_with_only_me(self, two_factor_effects: dict) -> None:
+        plot = create_plot(
+            "pareto",
+            analysis_results={"effects": two_factor_effects, "lenth_method": {"ME": 3.0}},
+        )
+        spec = plot.to_spec()
+        assert len(spec.panels[0].annotations) == 1
+
+    def test_lenth_with_only_sme(self, two_factor_effects: dict) -> None:
+        plot = create_plot(
+            "pareto",
+            analysis_results={"effects": two_factor_effects, "lenth_method": {"SME": 5.0}},
+        )
+        spec = plot.to_spec()
+        anns = spec.panels[0].annotations
+        assert len(anns) == 1
+        assert "SME" in (anns[0].label or "")
+
+    def test_std_errors_with_no_matching_terms(self, two_factor_effects: dict) -> None:
+        """A std-error dict that matches no term yields no error bars."""
+        plot = create_plot(
+            "pareto",
+            analysis_results={
+                "effects": two_factor_effects,
+                "effect_std_errors": {"Z": 1.0},
+            },
+        )
+        spec = plot.to_spec()
+        assert "error_y" not in spec.panels[0].layers[0].style
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic plot edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticPlotEdgeCases:
+    @pytest.mark.parametrize("plot_type", [
+        "residuals_vs_fitted", "normal_probability", "residuals_vs_order",
+    ])
+    def test_empty_diagnostics_guard(self, plot_type: str) -> None:
+        plot = create_plot(plot_type, analysis_results={})
+        spec = plot.to_spec()
+        assert "no data" in spec.title.lower()
+
+
+class TestBoxCoxPlotEdgeCases:
+    def test_insufficient_values(self) -> None:
+        data = [{"y": 5.0}, {"y": 6.0}]
+        plot = create_plot("box_cox", design_data=data, response_column="y")
+        spec = plot.to_spec()
+        assert "insufficient data" in spec.title.lower()
+
+    def test_non_positive_response(self) -> None:
+        data = [{"y": 5.0}, {"y": 0.0}, {"y": 6.0}, {"y": 7.0}]
+        plot = create_plot("box_cox", design_data=data, response_column="y")
+        spec = plot.to_spec()
+        assert "requires all positive" in spec.title.lower()
+
+    def test_response_reconstructed_from_fitted_and_residuals(
+        self,
+        residual_diagnostics: dict,
+    ) -> None:
+        """Without design data the response is rebuilt as fitted + residuals."""
+        plot = create_plot(
+            "box_cox",
+            analysis_results={"residual_diagnostics": residual_diagnostics},
+        )
+        spec = plot.to_spec()
+        assert spec.plot_type == "box_cox"
+        assert "optimal_lambda" in spec.metadata
+
+    def test_response_column_missing_from_design_data(self) -> None:
+        """A response column absent from the design columns yields no values."""
+        data = [{"z": 5.0}, {"z": 6.0}, {"z": 7.0}]
+        plot = create_plot("box_cox", design_data=data, response_column="y")
+        spec = plot.to_spec()
+        assert "insufficient data" in spec.title.lower()
+
+    def test_mismatched_fitted_and_residual_lengths(self) -> None:
+        plot = create_plot(
+            "box_cox",
+            analysis_results={
+                "residual_diagnostics": {
+                    "fitted_values": [10.0, 11.0, 12.0],
+                    "residuals": [0.5, -0.5],
+                },
+            },
+        )
+        spec = plot.to_spec()
+        assert "insufficient data" in spec.title.lower()
+
+
+# ---------------------------------------------------------------------------
+# Surface plot edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestSurfacePlotEdgeCases:
+    def test_contour_no_coefficients(self) -> None:
+        plot = create_plot("contour")
+        spec = plot.to_spec()
+        assert "no coefficients" in spec.title.lower()
+
+    def test_contour_single_factor(self, coefficients_2f: list) -> None:
+        plot = create_plot(
+            "contour",
+            analysis_results={"coefficients": coefficients_2f},
+            factors_to_plot=["A"],
+        )
+        spec = plot.to_spec()
+        assert "need at least 2" in spec.title.lower()
+
+    def test_surface_3d_no_coefficients(self) -> None:
+        plot = create_plot("surface_3d")
+        spec = plot.to_spec()
+        assert "no coefficients" in spec.title.lower()
+
+    def test_surface_3d_single_factor(self, coefficients_2f: list) -> None:
+        plot = create_plot(
+            "surface_3d",
+            analysis_results={"coefficients": coefficients_2f},
+            factors_to_plot=["A"],
+        )
+        spec = plot.to_spec()
+        assert "need at least 2" in spec.title.lower()
+
+    def test_no_scatter_overlay_when_rows_lack_plotted_factors(
+        self,
+        coefficients_2f: list,
+    ) -> None:
+        """Design rows without the plotted factor columns produce no overlay."""
+        plot = create_plot(
+            "contour",
+            analysis_results={"coefficients": coefficients_2f},
+            design_data=[{"X": 1.0, "y": 2.0}],
+            response_column="y",
+            factors_to_plot=["A", "B"],
+        )
+        spec = plot.to_spec()
+        assert len(spec.panels[0].layers) == 1
+
+    def test_hover_with_non_numeric_values(self, coefficients_2f: list) -> None:
+        """Non-numeric factor and response values fall back to str() in hover."""
+        design_data = [
+            {"A": -1, "B": -1, "batch": "low", "y": "n/a"},
+            {"A": 1, "B": 1, "batch": "high", "y": "n/a"},
+        ]
+        plot = create_plot(
+            "contour",
+            analysis_results={"coefficients": coefficients_2f},
+            design_data=design_data,
+            response_column="y",
+            factors_to_plot=["A", "B"],
+        )
+        spec = plot.to_spec()
+        scatter = spec.panels[0].layers[1]
+        hover = scatter.data[0]["hover"]
+        assert "batch: low" in hover
+        assert "y: n/a" in hover
+
+    def test_overlay_without_response_column(self, coefficients_2f: list) -> None:
+        """Design points without a response column omit the response field."""
+        design_data = [{"A": -1, "B": -1}, {"A": 1, "B": 1}]
+        plot = create_plot(
+            "contour",
+            analysis_results={"coefficients": coefficients_2f},
+            design_data=design_data,
+            factors_to_plot=["A", "B"],
+        )
+        spec = plot.to_spec()
+        scatter = spec.panels[0].layers[1]
+        assert len(scatter.data) == 2
+        assert all("response" not in point for point in scatter.data)
+        assert "A" in scatter.data[0]["hover"]
+
+
+class TestPredictionVarianceEdgeCases:
+    def test_no_design_data(self) -> None:
+        plot = create_plot("prediction_variance")
+        spec = plot.to_spec()
+        assert "no design data" in spec.title.lower()
+
+    def test_single_factor(self, design_data_2f: list) -> None:
+        plot = create_plot(
+            "prediction_variance",
+            design_data=design_data_2f,
+            response_column="y",
+            factors_to_plot=["A"],
+        )
+        spec = plot.to_spec()
+        assert "need at least 2" in spec.title.lower()
+
+    def test_three_factor_design_with_hold_values(self, design_data_3f: list) -> None:
+        """The third (non-plotted) factor is held at its hold value.
+
+        Factors are derived from the data columns so that the model matrix
+        includes C, which is then pinned at 0.5 while A and B are swept.
+        """
+        plot = create_plot(
+            "prediction_variance",
+            design_data=design_data_3f,
+            response_column="y",
+            hold_values={"C": 0.5},
+        )
+        spec = plot.to_spec()
+        assert spec.plot_type == "prediction_variance"
+        z = spec.panels[0].layers[0].style["z_matrix"]
+        assert len(z) == 40
+        assert len(z[0]) == 40
+
+
+# ---------------------------------------------------------------------------
+# Design quality plot edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestFDSPlotEdgeCases:
+    def test_no_design_data(self) -> None:
+        plot = create_plot("fds_plot")
+        spec = plot.to_spec()
+        assert "no design data" in spec.title.lower()
+
+    def test_single_factor(self, design_data_2f: list) -> None:
+        plot = create_plot(
+            "fds_plot",
+            design_data=design_data_2f,
+            response_column="y",
+            factors_to_plot=["A"],
+        )
+        spec = plot.to_spec()
+        assert "need at least 2" in spec.title.lower()
+
+
+class TestPowerCurvePlotEdgeCases:
+    def test_no_design_information(self) -> None:
+        plot = create_plot("power_curve")
+        spec = plot.to_spec()
+        assert "no design information" in spec.title.lower()
+
+    def test_design_info_from_model_summary(self) -> None:
+        plot = create_plot(
+            "power_curve",
+            analysis_results={"model_summary": {"n_obs": 8, "n_params": 4}},
+        )
+        spec = plot.to_spec()
+        assert spec.plot_type == "power_curve"
+        assert spec.metadata["n_runs"] == 8
+        assert spec.metadata["n_terms"] == 4
+        assert spec.metadata["residual_df"] == 4
+
+    def test_model_summary_with_zero_counts(self) -> None:
+        plot = create_plot(
+            "power_curve",
+            analysis_results={"model_summary": {"n_obs": 0, "n_params": 0}},
+        )
+        spec = plot.to_spec()
+        assert "no design information" in spec.title.lower()
+
+
+# ---------------------------------------------------------------------------
+# Cube and square plot edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestCubePlotEdgeCases:
+    def test_no_data_source(self) -> None:
+        plot = create_plot("cube_plot", factors_to_plot=["A", "B", "C"])
+        spec = plot.to_spec()
+        assert "cannot compute vertex values" in spec.title.lower()
+
+    def test_raw_data_fallback_with_missing_vertex(self, design_data_3f: list) -> None:
+        """A vertex absent from the raw data gets a NaN value."""
+        # Drop the (-1, -1, -1) run: the first product([-1, 1], repeat=3) vertex
+        data = design_data_3f[1:]
+        plot = create_plot(
+            "cube_plot",
+            design_data=data,
+            response_column="y",
+            factors_to_plot=["A", "B", "C"],
+        )
+        spec = plot.to_spec()
+        vertices = spec.metadata["vertices"]
+        assert vertices[0]["levels"] == [-1, -1, -1]
+        assert math.isnan(vertices[0]["value"])
+        # The remaining vertices are still populated
+        assert all(not math.isnan(v["value"]) for v in vertices[1:])
+
+    def test_raw_data_missing_factor_column(self, design_data_2f: list) -> None:
+        """Design data lacking the C column cannot supply vertex values."""
+        plot = create_plot(
+            "cube_plot",
+            design_data=design_data_2f,
+            response_column="y",
+            factors_to_plot=["A", "B", "C"],
+        )
+        spec = plot.to_spec()
+        assert "cannot compute vertex values" in spec.title.lower()
+
+
+class TestSquarePlotEdgeCases:
+    def test_no_data_source(self) -> None:
+        plot = create_plot("square_plot", factors_to_plot=["A", "B"])
+        spec = plot.to_spec()
+        assert "cannot compute vertex values" in spec.title.lower()
+
+    def test_raw_data_fallback_with_missing_vertex(self, design_data_2f: list) -> None:
+        """A vertex absent from the raw data gets a NaN value."""
+        data = [r for r in design_data_2f if not (r["A"] == -1 and r["B"] == -1)]
+        plot = create_plot(
+            "square_plot",
+            design_data=data,
+            response_column="y",
+            factors_to_plot=["A", "B"],
+        )
+        spec = plot.to_spec()
+        vertices = spec.metadata["vertices"]
+        assert vertices[0]["levels"] == [-1, -1]
+        assert math.isnan(vertices[0]["value"])
+        assert all(not math.isnan(v["value"]) for v in vertices[1:])
+
+    def test_raw_data_missing_factor_column(self) -> None:
+        """Design data lacking the B column cannot supply vertex values."""
+        data = [{"A": -1, "y": 10.0}, {"A": 1, "y": 12.0}]
+        plot = create_plot(
+            "square_plot",
+            design_data=data,
+            response_column="y",
+            factors_to_plot=["A", "B"],
+        )
+        spec = plot.to_spec()
+        assert "cannot compute vertex values" in spec.title.lower()
+
+
+# ---------------------------------------------------------------------------
+# Registry factor-name inference edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestFactorNameInference:
+    def test_formula_without_design_data_uses_blocklist(self) -> None:
+        """With no design data the static reserved-word blocklist applies."""
+        plot = create_plot(
+            "pareto",
+            analysis_results={
+                "effects": {"A": 1.0, "B": -2.0},
+                "model_summary": {"formula": "y ~ A + np.power(B, 2) + I(A ** 2)"},
+            },
+        )
+        names = plot._get_factor_names()
+        assert "A" in names
+        assert "B" in names
+        for noise in ("np", "power", "I"):
+            assert noise not in names
+
+    def test_design_data_with_only_response_column(self) -> None:
+        plot = create_plot(
+            "pareto",
+            analysis_results={"effects": {}},
+            design_data=[{"y": 1.0}],
+            response_column="y",
+        )
+        assert plot._get_factor_names() == []
+
+    def test_formula_without_tilde_falls_back_to_design_data(self) -> None:
+        plot = create_plot(
+            "pareto",
+            analysis_results={
+                "effects": {"A": 1.0},
+                "model_summary": {"formula": "not-a-formula"},
+            },
+            design_data=[{"A": -1, "y": 0.0}],
+            response_column="y",
+        )
+        assert plot._get_factor_names() == ["A"]


### PR DESCRIPTION
## Summary

- Enable the pyoptex optimal-design backend in the dev/CI environment: `pyoptex>=1.2.1` added to the dev dependency group, with `[tool.uv] override-dependencies = ["plotly>=6.5.2", "numba>=0.63.1"]` to relax pyoptex's over-strict pins. The plotly relaxation is already merged upstream (mborn1/pyoptex#49) but not yet released on PyPI; the numba pin is still strict upstream. The overrides match this project's own floors, so nothing else changes. pyoptex stays out of the published extras because pip cannot apply uv overrides, so wheel metadata advertising it would make `[expt]+[plotting]` unresolvable for pip users.
- The 8 previously always-skipped pyoptex tests (D/I/A-optimal, split-plot) now run as blocking checks, and a new `tests/test_designs_optimal_pyoptex.py` covers the adapter layer directly (factor conversion, RandomEffect whole-plot grouping/padding, multiple hard-to-change factors, model types, all three criteria, run-order preservation). `designs_optimal.py`: 47% to 100% branch coverage. The fallback and ImportError paths in `test_designs_screening_optimal.py` are forced via a `no_pyoptex` monkeypatch fixture instead of skip-when-installed markers, so both branches run in every environment; new tests cover the SEC-19 candidate-set cap, budget clamp/cap, and fallback model_type passthrough.
- Closed the other measured coverage gaps: 78 new tests for the DOE visualization plot builders (plots package 86% to 99%), plus edge-path tests for `bivariate/_elbow_peak.py` (100%) and `monitoring/control_charts.py` (100%). Full-suite coverage rose to 93.8%, and the `--cov-fail-under` gate is raised 89 to 92.
- **Merged with main (v1.52.1)** and re-versioned to **1.52.2**; integrated main's #446/#447 changes (mixed-level models, install-hint messages, `constraints_enforced` / `hard_to_change_ignored` metadata) into the reworked tests. Full suite on the merged tree: 1981 passed, 2 pre-existing skips.
- **Supersedes and closes #415**: its unique test cases and its "Reliance on pyoptex" docs section (rewritten for the override-based setup) were ported here; its non-blocking git-main CI job is no longer needed since pyoptex now runs blocking in the main matrix.

Note for the maintainer: this session does not commit `uv.lock` per repo policy; please refresh the lock manually after merge (`uv lock`). CI relocks on the fly in the interim. Once upstream ships a pyoptex release with the relaxed plotly pin, the plotly override can be dropped; the numba override stays until `numba~=0.61` is relaxed upstream too.

## Test plan

- [x] `uv sync --dev --all-extras` resolves with pyoptex 1.2.1, plotly 6.8.0, numba 0.66.0 via the uv overrides
- [x] pyoptex-gated tests run (not skipped) and pass: 8 pre-existing + 16 new adapter tests
- [x] Fallback and ImportError branches covered via monkeypatched `_PYOPTEX_AVAILABLE`
- [x] Full suite on the merged tree: 1981 passed, 2 pre-existing skips, 93.8% total branch coverage (92 gate)
- [x] `ruff check .` and `mypy src/process_improve` clean locally
- [ ] CI green across the OS/Python matrix (first run is the real installability test for pyoptex's kaleido chain on Windows/macOS)

## Checklist

- [x] Version bumped in `pyproject.toml` (PATCH: 1.52.1 -> 1.52.2 after merging main, CITATION.cff synced)
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KfWQwqC9Fm3K4eqQ5fzGt