### PR TITLE
Fix docstring drift surfaced by audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,40 @@ those changes.
 
 ## [Unreleased]
 
+## [1.51.1] - 2026-07-03
+
+### Fixed
+
+- Docstring drift surfaced by an audit pass, across multiple modules
+  (docstring-only changes; no runtime behaviour changes):
+  - `MBPCA` class docstring in `_mbpca.py`: remove the phantom `super_vip_`
+    entry from the fitted-attributes list (only `block_vip_` is set).
+  - `TPLS` class docstring `Example` in `_tpls.py`: wrap the `all_data`
+    dict in `DataFrameDict(all_data)` before calling `estimator.fit(...)`,
+    matching the runtime type check.
+  - `TPLS.diagnose` docstring `Example` in `_tpls.py`: swap the illustrative
+    `estimator.predict(new_data)` call to `estimator.diagnose(new_data)`
+    since `predict` is deprecated.
+  - `TPLS.help()` text in `_tpls.py`: point users at
+    `tpls.diagnose(X_new)` (not the deprecated `predict`) and correct the
+    `spe_limit` call shape to `.spe_limit["Y"][group]()` to match the
+    nested dict-of-dicts populated by `fit()`.
+  - `variance_decomposition` docstring in `univariate/metrics.py`: the
+    example was still calling `within_between_standard_deviation(...)`; update
+    to the current name.
+  - `ttest_paired_from_df` docstring in `univariate/metrics.py`: the
+    Output bullets (6-9) said "B minus A"; the implementation computes
+    `A - B`, so the bullets now say "A minus B" to match.
+  - `robust_regression` returns block in `regression/_robust_regression.py`:
+    drop the `t_value` entry - `out["t_value"]` is only ever initialised
+    to `np.nan`.
+  - `analyze_experiment` Parameters block in `experiments/analysis.py`:
+    remove the `coding` parameter documentation (the parameter is present
+    in the signature but never referenced in the body).
+  - `PLS.cross_validate` docstring in `multivariate/_pls.py`: add the
+    previously-undocumented `sample_weight` parameter (threaded into every
+    sub-fit).
+
 ## [1.51.0] - 2026-06-30
 
 ### Added
@@ -2297,7 +2331,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.51.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.51.1...HEAD
+[1.51.1]: https://github.com/kgdunn/process-improve/compare/v1.51.0...v1.51.1
 [1.51.0]: https://github.com/kgdunn/process-improve/compare/v1.50.0...v1.51.0
 [1.50.0]: https://github.com/kgdunn/process-improve/compare/v1.49.1...v1.50.0
 [1.49.1]: https://github.com/kgdunn/process-improve/compare/v1.49.0...v1.49.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.51.0
-date-released: "2026-06-30"
+version: 1.51.1
+date-released: "2026-07-03"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.51.0"
+version = "1.51.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/experiments/analysis.py
+++ b/src/process_improve/experiments/analysis.py
@@ -173,8 +173,6 @@ def analyze_experiment(  # noqa: PLR0912, PLR0913, PLR0915, C901
         Default 0.05.
     transform : str or None
         ``"log"``, ``"sqrt"``, ``"inverse"``, ``"box_cox"``, or ``None``.
-    coding : str
-        ``"coded"`` or ``"actual"``.
     new_points : DataFrame or None
         For prediction or confirmation testing.
     observed_at_new : list[float] or None

--- a/src/process_improve/multivariate/_mbpca.py
+++ b/src/process_improve/multivariate/_mbpca.py
@@ -84,7 +84,7 @@ class MBPCA(_HotellingsT2LimitMixin, TransformerMixin, BaseEstimator):
     block_scores_, block_loadings_                    dict[str, DataFrame]
     r2_x_per_block_cumulative_, r2_x_per_block_per_component_
     r2_x_per_variable_                                dict[str, DataFrame]
-    block_vip_, super_vip_
+    block_vip_
     block_spe_, block_hotellings_t2_, super_hotellings_t2_
     explained_variance_, scaling_factor_for_super_scores_
     fitting_info_, has_missing_data_, algorithm_

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -1797,6 +1797,10 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             Random seed for reproducibility (K-fold shuffle and bootstrap).
         show_progress : bool, default True
             Whether to display a ``tqdm`` progress bar.
+        sample_weight : np.ndarray of shape (n_samples,), optional
+            Per-sample non-negative weights. Threaded into every sub-fit so
+            each resample's PLS uses the same weighting scheme as the parent
+            model. Default ``None`` (all samples weighted equally).
 
         Returns
         -------

--- a/src/process_improve/multivariate/_tpls.py
+++ b/src/process_improve/multivariate/_tpls.py
@@ -270,7 +270,7 @@ class TPLS(RegressorMixin, BaseEstimator):
     >>> quality_indicators = {"Quality":    pd.DataFrame(rng.standard_normal((n_formulas, n_outputs)))}
     >>> all_data = {"Z": process_conditions, "F": formulas, "Y": quality_indicators}
     >>> estimator = TPLS(n_components=4, d_matrix=properties)
-    >>> estimator.fit(all_data)
+    >>> estimator.fit(DataFrameDict(all_data))
     """
 
     # This is a dictionary allowing to define the type of parameters.
@@ -555,7 +555,7 @@ class TPLS(RegressorMixin, BaseEstimator):
 
         # Testing/inference phase:
         new_data = {"Z": ..., "F": ...}  # you need at least the F block for a new prediction. "Z" is optional.
-        predictions = estimator.predict(new_data)
+        predictions = estimator.diagnose(new_data)
 
         Parameters
         ----------
@@ -834,7 +834,7 @@ class TPLS(RegressorMixin, BaseEstimator):
         ----------
         Build model:                tpls = TPLS(n_components=2, d_matrix=d_matrix).fit(X)
         Get model's predictions:    tpls.hat            <-- the hat-matrix, i.e., the predictions
-        Predict on new data:        tpls.predict(X_new)
+        Predict on new data:        tpls.diagnose(X_new)
         See model summary:          tpls.display_results()
         This help page:             tpls.help()
 
@@ -847,7 +847,7 @@ class TPLS(RegressorMixin, BaseEstimator):
 
 
         .hotellings_t2_limit()      Returns the Hotelling's T2 limit for the model              [float]
-        .spe_limit[block]()         Return the SPE limit for the block; e.g. .spe_limit["Y"]() [float]
+        .spe_limit[block][group]()  Return the SPE limit for a group in a block; e.g. .spe_limit["Y"][group]() [float]
 
         .vip()                      Variable importance (VIP) for the D- and F-blocks          [dict]
 

--- a/src/process_improve/regression/_robust_regression.py
+++ b/src/process_improve/regression/_robust_regression.py
@@ -130,7 +130,6 @@ def robust_regression(  # noqa: PLR0913, PLR0915
         k:                        the number of model parameters (2 if fit_intercept else 1)
         fitted_values:            the N predicted values, one per row in y
         residuals:                the N residuals
-        t_value:                  the t-values for the standard errors
         conf_intervals:           K rows x 2 columns (lower, upper) confidence intervals
         conf_interval_intercept:  (lower, upper) confidence interval for the intercept
         pi_range:                 prediction intervals above and below, over the range of data

--- a/src/process_improve/univariate/metrics.py
+++ b/src/process_improve/univariate/metrics.py
@@ -393,10 +393,10 @@ def ttest_paired_from_df(
     4. Group B mean
     5. Differences mean: average difference between the groups (not the same as the difference
        of the averages from items 3 and 4 above)
-    6. z-value for the difference between group "B" minus group "A"
+    6. z-value for the difference between group "A" minus group "B"
     7. p-value for this z-value
-    8. Confidence interval low value for difference between group "B" minus group "A"
-    9. Confidence interval high value for difference between group "B" minus group "A"
+    8. Confidence interval low value for difference between group "A" minus group "B"
+    9. Confidence interval high value for difference between group "A" minus group "B"
 
     """
     data_subset = df[[grouper_column, values_column]].copy()
@@ -1128,7 +1128,7 @@ def variance_decomposition(df: pd.DataFrame, measured: str, repeat: str) -> dict
     1     102       1
     2      94       2
     3      95       2
-    >>> output = within_between_standard_deviation(df, measured="Result", repeat="Repeat")
+    >>> output = variance_decomposition(df, measured="Result", repeat="Repeat")
     {'total_ms':       16.666667,
      'total_dof':      3,
      'within_ms':      0.5,


### PR DESCRIPTION
## Summary

Docstring/comment-only changes across multiple modules; no runtime behaviour changes, no signature changes.

| # | File | Fix |
|---|------|-----|
| 1 | `src/process_improve/multivariate/_mbpca.py` | `MBPCA` class docstring: drop phantom `super_vip_` entry from the fitted-attributes list; `fit()` only populates `block_vip_`. |
| 2 | `src/process_improve/multivariate/_tpls.py` | `TPLS` class docstring example: wrap `all_data` dict in `DataFrameDict(all_data)` before `estimator.fit(...)` since `TPLS.fit()` raises `TypeError` on a bare dict. |
| 3 | `src/process_improve/univariate/metrics.py` | `variance_decomposition` docstring: example now calls the current name `variance_decomposition(...)` instead of the pre-rename `within_between_standard_deviation(...)`. |
| 4 | `src/process_improve/multivariate/_tpls.py` (~line 837) | `TPLS.help()` text: point at `tpls.diagnose(X_new)` instead of the deprecated `tpls.predict(X_new)`. |
| 5 | `src/process_improve/multivariate/_tpls.py` (~line 850) | `TPLS.help()` text: correct SPE-limit call shape from `.spe_limit["Y"]()` to `.spe_limit["Y"][group]()` to match the nested dict-of-dicts populated in `fit()`. |
| 6 | `src/process_improve/multivariate/_tpls.py` (~line 558) | `TPLS.diagnose` docstring example: replace `estimator.predict(new_data)` with `estimator.diagnose(new_data)`. |
| 7 | `src/process_improve/regression/_robust_regression.py` (~line 133) | `robust_regression` Returns: drop the `t_value` entry; `out["t_value"]` is only ever initialised to `np.nan`. |
| 8 | `src/process_improve/experiments/analysis.py` (~line 176) | `analyze_experiment` Parameters block: remove the `coding` parameter entry (declared in the signature but never referenced in the body). Signature untouched. |
| 9 | `src/process_improve/multivariate/_pls.py` (~line 1799) | `PLS.cross_validate` Parameters block: add previously-undocumented `sample_weight` parameter, matching the style of the other parameters. |
| 10 | `src/process_improve/univariate/metrics.py` (~line 396-399) | `ttest_paired_from_df` Output bullets 6-9: prose said "B minus A" but the code computes `A - B` (`differences = sample_A - sample_B.to_numpy()`); prose now reads "A minus B" to match. |

Version bumped to `1.51.1` (PATCH; docstrings/comments only). `CITATION.cff` synced (`version: 1.51.1`, `date-released: "2026-07-03"`). `CHANGELOG.md` gains a `## [1.51.1] - 2026-07-03` section under `## [Unreleased]`, and the link-reference footer is updated.

## Test plan

- [x] `uv run ruff check src/ tests/` passes.
- [x] `uv run ruff format --check` on the touched files shows only pre-existing drift (unchanged from `main`); no new format issues introduced.
- [x] No signature or function-body changes; behaviour is identical.
- [ ] `uv.lock` is intentionally not touched (Claude Code session rule).

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2gv3MsNTLFo6jEugpnfL2)_