### PR TITLE
Export OLS and fit_robust_lm from process_improve.regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ those changes.
 
 ## [Unreleased]
 
+## [1.51.1] - 2026-07-03
+
+### Added
+
+- `OLS` and `fit_robust_lm` are now importable from
+  `process_improve.regression` directly (previously only from
+  `process_improve.regression.methods`), matching the package-level
+  exports of the other regression helpers. Used by the least squares
+  chapter of the PID book.
+
 ## [1.51.0] - 2026-06-30
 
 ### Added
@@ -2297,7 +2307,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.51.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.51.1...HEAD
+[1.51.1]: https://github.com/kgdunn/process-improve/compare/v1.51.0...v1.51.1
 [1.51.0]: https://github.com/kgdunn/process-improve/compare/v1.50.0...v1.51.0
 [1.50.0]: https://github.com/kgdunn/process-improve/compare/v1.49.1...v1.50.0
 [1.49.1]: https://github.com/kgdunn/process-improve/compare/v1.49.0...v1.49.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.51.0
-date-released: "2026-06-30"
+version: 1.51.1
+date-released: "2026-07-03"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.51.0"
+version = "1.51.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/regression/__init__.py
+++ b/src/process_improve/regression/__init__.py
@@ -1,12 +1,16 @@
 """Robust regression methods."""
 
 from process_improve.regression.methods import (
+    OLS,
+    fit_robust_lm,
     multiple_linear_regression,
     repeated_median_slope,
     robust_regression,
 )
 
 __all__ = [
+    "OLS",
+    "fit_robust_lm",
     "multiple_linear_regression",
     "repeated_median_slope",
     "robust_regression",


### PR DESCRIPTION
`OLS` and `fit_robust_lm` were listed in `process_improve.regression.methods.__all__` but not re-exported by the package `__init__`, so `from process_improve.regression import OLS` raised `ImportError` while `robust_regression`, `repeated_median_slope` and `multiple_linear_regression` imported fine.

The least squares chapter of the PID book (kgdunn/pid-book#185) is switching its learner-facing code blocks from `sklearn.linear_model.LinearRegression` to `OLS`, which makes the package-level import the natural spelling for readers.

- `src/process_improve/regression/__init__.py`: add `OLS` and `fit_robust_lm` to the imports and `__all__` (no behaviour change; pure re-export).
- Version bumped 1.51.0 -> 1.51.1 (patch), `CITATION.cff` synced to the same version and today's date, changelog entry added under a new 1.51.1 heading with the compare links updated.

Verified locally: `from process_improve.regression import OLS, fit_robust_lm` succeeds; the pid-book code blocks using it run end-to-end. Test suite left to CI (pytest not available in this sandbox); the change is a pure re-export so no test changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCJ1WYunYpnLKgKi7bhEMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCJ1WYunYpnLKgKi7bhEMT)_