### PR TITLE
Fix PLS(scale=True) to actually scale the X and Y blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ those changes.
 
 ## [Unreleased]
 
+## [1.51.3] - 2026-07-08
+
+### Fixed
+
+- `PLS(scale=True)` now actually mean-centers and unit-variance-scales the
+  X **and** Y blocks before fitting, matching its docstring and
+  `sklearn.cross_decomposition.PLSRegression`. The `scale` flag was
+  previously inert (stored but never used), so `fit()` ran NIPALS on the
+  raw data. A caller who relied on `scale=True` and did not pre-scale got a
+  silently degraded fit whenever the Y columns had unequal variances,
+  because the high-variance columns dominated the latent extraction.
+  Predictions, `predictions_` and `beta_coefficients_` are returned on the
+  original data scale. `scale=False` is unchanged and remains the correct
+  setting when scaling externally (e.g. with `MCUVScaler`); a weighted fit
+  scales on the positive-weight rows only, so a zero weight stays
+  equivalent to dropping that row.
+
 ## [1.51.2] - 2026-07-05
 
 ### Added
@@ -2341,7 +2358,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.51.2...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.51.3...HEAD
+[1.51.3]: https://github.com/kgdunn/process-improve/compare/v1.51.2...v1.51.3
 [1.51.2]: https://github.com/kgdunn/process-improve/compare/v1.51.1...v1.51.2
 [1.51.1]: https://github.com/kgdunn/process-improve/compare/v1.51.0...v1.51.1
 [1.51.0]: https://github.com/kgdunn/process-improve/compare/v1.50.0...v1.51.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.51.2
-date-released: "2026-07-05"
+version: 1.51.3
+date-released: "2026-07-08"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.51.2"
+version = "1.51.3"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -152,9 +152,16 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
     n_components : int
         Number of latent components to extract.
     scale : bool, default=True
-        Whether to scale X and Y to unit variance (sklearn internal scaling).
-        When using ``MCUVScaler`` externally, set ``scale=False`` to avoid
-        double scaling.
+        Mean-center and unit-variance-scale both the X and Y blocks internally
+        before fitting (``ddof=1``, done with :class:`MCUVScaler`). This mirrors
+        :class:`sklearn.cross_decomposition.PLSRegression`, whose ``scale=True``
+        default also scales X and Y; the parameter exists so ``PLS`` is a
+        drop-in for the sklearn estimator. Predictions, ``predictions_`` and
+        ``beta_coefficients_`` are returned on the original (un-scaled) data
+        scale. When you scale externally (e.g. with ``MCUVScaler``), set
+        ``scale=False`` to avoid the (idempotent) double scaling. Note: the
+        cross-validation helpers (:meth:`select_n_components`) always re-fit an
+        :class:`MCUVScaler` inside each training fold regardless of this flag.
     max_iter : int, default=1000
         Maximum number of iterations for the NIPALS algorithm.
     tol : float, default=sqrt(machine epsilon)
@@ -247,6 +254,11 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         missing_data_settings: dict | None = None,
     ):
         self.n_components: int = n_components
+        # ``scale`` (like ``copy``) mirrors sklearn PLSRegression's constructor
+        # signature for drop-in API compatibility. Unlike ``copy`` it is wired
+        # up: when True, fit() centers and unit-variance-scales X and Y via
+        # MCUVScaler (see fit()). It must be stored verbatim here and read only
+        # in fit(), per the sklearn __init__ convention.
         self.scale = scale
         self.max_iter = max_iter
         self.tol = tol
@@ -626,6 +638,29 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         assert isinstance(X, pd.DataFrame)
         assert isinstance(Y, pd.DataFrame)
 
+        # Honour ``scale`` (see __init__): center + unit-variance-scale X and Y
+        # with the library's MCUVScaler, matching sklearn PLSRegression's
+        # ``scale=True`` default. The NIPALS core and every fitted attribute run
+        # in this scaled space; the user-facing predictions_ / beta_coefficients_
+        # / predict() outputs below are mapped back to the original data scale.
+        # On already-scaled input (center ~ 0, scale ~ 1) this is a no-op, so
+        # callers who pre-scale (scale=False) or pass MCUVScaler output are
+        # unaffected. MCUVScaler is NaN-aware and leaves constant columns at 1.
+        self._x_scaler: MCUVScaler | None = None
+        self._y_scaler: MCUVScaler | None = None
+        if self.scale:
+            # Fit the scalers on the rows that actually enter the fit. With
+            # sample_weight, zero-weight rows are excluded from NIPALS (via the
+            # sqrt(w) rescale), so they must not influence the center/scale
+            # either - otherwise a zero-weight row would stop being equivalent to
+            # a dropped row. All rows are then transformed with those statistics.
+            x_fit_rows = X if sample_weight is None else X[sample_weight > 0]
+            y_fit_rows = Y if sample_weight is None else Y[sample_weight > 0]
+            self._x_scaler = MCUVScaler().fit(x_fit_rows)
+            self._y_scaler = MCUVScaler().fit(y_fit_rows)
+            X = self._x_scaler.transform(X)
+            Y = self._y_scaler.transform(Y)
+
         # Check if number of components is supported against maximum requested
         min_dim = min(N, K)
         A = min_dim if self.n_components is None else int(self.n_components)
@@ -662,8 +697,16 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         direct_weights = self._x_weights @ safe_inverse(
             self._x_loadings.T @ self._x_weights, what="(x_loadings' @ x_weights)"
         )
-        # beta = RC' [KxM]: direct link from k-th X variable to m-th Y variable
+        # beta = RC' [KxM]: direct link from k-th X variable to m-th Y variable.
+        # NIPALS ran in the (optionally) scaled space, so this beta maps scaled X
+        # to scaled Y. Rescale to the original data units so it stays the
+        # documented raw-X -> raw-Y relationship (and matches sklearn's coef_):
+        # beta_orig[k, m] = beta_scaled[k, m] * y_scale[m] / x_scale[k].
         beta_coefficients = direct_weights @ self.y_loadings_.T
+        if self._x_scaler is not None and self._y_scaler is not None:
+            x_scale = self._x_scaler.scale_.to_numpy()[:, np.newaxis]
+            y_scale = self._y_scaler.scale_.to_numpy()[np.newaxis, :]
+            beta_coefficients = beta_coefficients * (y_scale / x_scale)
 
         component_names = list(range(1, A + 1))
         # ENG-18: scores_ / x_weights_ / x_loadings_ / spe_ are stored as private
@@ -675,7 +718,11 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         self.y_scores_ = pd.DataFrame(self.y_scores_, index=Y.index, columns=component_names)
         self.y_weights_ = pd.DataFrame(self.y_weights_, index=Y.columns, columns=component_names)
         self.y_loadings_ = pd.DataFrame(self.y_loadings_, index=Y.columns, columns=component_names)
-        self.predictions_ = pd.DataFrame(self._scores @ self.y_loadings_.values.T, index=Y.index, columns=Y.columns)
+        predictions = pd.DataFrame(self._scores @ self.y_loadings_.values.T, index=Y.index, columns=Y.columns)
+        if self._y_scaler is not None:
+            # NIPALS predictions are in scaled-Y space; report on the original scale.
+            predictions = self._y_scaler.inverse_transform(predictions)
+        self.predictions_ = predictions
         self.direct_weights_ = pd.DataFrame(direct_weights, index=X.columns, columns=component_names)
         self.beta_coefficients_ = pd.DataFrame(beta_coefficients, index=X.columns, columns=Y.columns)
         # ``max(1, N-1)`` -- see SEC-21 (#270) sub-item 6.
@@ -789,6 +836,9 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         if sample_index is None:
             sample_index = pd.RangeIndex(X_arr.shape[0])  # type: ignore[assignment]
         X_df = pd.DataFrame(X_arr, index=sample_index, columns=feature_columns)
+        if self._x_scaler is not None:
+            # Project in the same (scaled) space the model was fit in.
+            X_df = self._x_scaler.transform(X_df)
         return X_df @ self.direct_weights_
 
     def fit_transform(self, X: DataMatrix, Y: DataMatrix | None = None) -> pd.DataFrame:
@@ -905,6 +955,10 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         if sample_index is None:
             sample_index = pd.RangeIndex(X_arr.shape[0])  # type: ignore[assignment]
         X = pd.DataFrame(X_arr, index=sample_index, columns=feature_columns)
+        if self._x_scaler is not None:
+            # Move X into the scaled space so scores, T², SPE and y_hat are all
+            # computed consistently with how the model was fit.
+            X = self._x_scaler.transform(X)
 
         scores = X @ self.direct_weights_
 
@@ -917,8 +971,10 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         residuals = X - X_hat
         spe_values = pd.Series(np.sqrt(np.power(residuals, 2).sum(axis=1)), index=X.index, name="SPE")
 
-        # Y predictions
+        # Y predictions (computed in scaled-Y space; mapped back to original units)
         y_hat = scores @ self.y_loadings_.T
+        if self._y_scaler is not None:
+            y_hat = self._y_scaler.inverse_transform(y_hat)
 
         return Bunch(scores=scores, hotellings_t2=t2, spe=spe_values, y_hat=y_hat)
 

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -1891,9 +1891,13 @@ def test_pls_scale_true_scales_x_and_y_blocks() -> None:
     assert model.predict(X).values == pytest.approx(ref.predict(X.values), rel=1e-3, abs=1e-3)
 
     # scale=False stays a pass-through: feeding pre-scaled data is not re-scaled.
+    # predict() exercises the diagnose() pass-through; transform() the other one.
     passthrough = PLS(n_components=n_comp, scale=False).fit(x_scaler.transform(X), y_scaler.transform(Y))
     assert passthrough.predict(x_scaler.transform(X)).values == pytest.approx(
         manual.predict(x_scaler.transform(X)).values, abs=1e-12
+    )
+    assert passthrough.transform(x_scaler.transform(X)).values == pytest.approx(
+        manual.transform(x_scaler.transform(X)).values, abs=1e-12
     )
 
 

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -1842,6 +1842,61 @@ def test_pls_in_pipeline_and_clone_matches_plsregression() -> None:
     )
 
 
+def test_pls_scale_true_scales_x_and_y_blocks() -> None:
+    """PLS(scale=True) mean-centers and unit-variance-scales both X and Y.
+
+    Regression guard for the ``scale`` flag, which was previously inert (X and Y
+    were fed to NIPALS unscaled). On a multi-target Y whose columns have very
+    different variances, an estimator that fails to scale Y lets the
+    high-variance columns dominate the latent extraction and fits poorly. The
+    fixed ``scale=True`` must:
+
+    (a) reproduce the manual ``MCUVScaler`` + ``scale=False`` path exactly (same
+        NIPALS, scaling only relocated), with predictions on the original scale;
+    (b) match ``sklearn.cross_decomposition.PLSRegression(scale=True)``; and
+    (c) leave the fit genuinely good (R2 was ~0.1x when Y went unscaled).
+    """
+    rng = np.random.default_rng(7)
+    n, n_comp = 60, 4
+    X = pd.DataFrame(rng.normal(size=(n, 5)), columns=[f"x{i}" for i in range(5)])
+    beta = rng.normal(size=(5, 4))
+    core = X.values @ beta
+    # Deliberately heterogeneous Y-column variances and non-zero offsets.
+    Y = pd.DataFrame(
+        core * np.array([0.05, 1.0, 5.0, 20.0])
+        + np.array([10.0, -3.0, 100.0, 0.2])
+        + rng.normal(0, 0.02, (n, 4)),
+        columns=[f"y{i}" for i in range(4)],
+    )
+
+    model = PLS(n_components=n_comp, scale=True).fit(X, Y)
+
+    # (a) Exact equivalence to explicit external scaling, inverse-transformed.
+    x_scaler = MCUVScaler().fit(X)
+    y_scaler = MCUVScaler().fit(Y)
+    manual = PLS(n_components=n_comp, scale=False).fit(x_scaler.transform(X), y_scaler.transform(Y))
+    manual_pred = y_scaler.inverse_transform(manual.predict(x_scaler.transform(X)))
+    assert model.predict(X).values == pytest.approx(manual_pred.values, abs=1e-9)
+    assert model.predictions_.values == pytest.approx(manual_pred.values, abs=1e-9)
+    # transform() reproduces the fitted scores (projection uses the same scaling).
+    assert model.transform(X).values == pytest.approx(model.scores_.values, abs=1e-9)
+
+    # (c) The fit is genuinely good; the inert flag scored ~0.1 here.
+    r2 = r2_score(Y, model.predict(X), multioutput="variance_weighted")
+    assert r2 > 0.99
+
+    # (b) Parity with sklearn PLSRegression(scale=True) on the raw data. Its
+    # coef_ is (n_targets, n_features); ours is (n_features, n_targets).
+    ref = PLSRegression(n_components=n_comp, scale=True).fit(X.values, Y.values)
+    assert model.predict(X).values == pytest.approx(ref.predict(X.values), rel=1e-3, abs=1e-3)
+
+    # scale=False stays a pass-through: feeding pre-scaled data is not re-scaled.
+    passthrough = PLS(n_components=n_comp, scale=False).fit(x_scaler.transform(X), y_scaler.transform(Y))
+    assert passthrough.predict(x_scaler.transform(X)).values == pytest.approx(
+        manual.predict(x_scaler.transform(X)).values, abs=1e-12
+    )
+
+
 @pytest.fixture
 def fixture_pls_ldpe_example() -> dict[str, pd.DataFrame | np.ndarray | float | int]:
     """


### PR DESCRIPTION
## Summary

- `PLS`'s `scale` constructor flag mirrors `sklearn.cross_decomposition.PLSRegression`'s signature (for drop-in API compatibility) but was **inert**: `self.scale` was stored and never read, so `fit()` ran NIPALS on the raw X and Y. A caller who trusted `scale=True`, or ported code from `PLSRegression` (whose `scale=True` default does scale), and did not pre-scale got a silently degraded fit whenever the Y columns had unequal variances, since the high-variance columns then dominate the latent extraction.
- Wire `scale` up: `scale=True` now mean-centers and unit-variance-scales **both** blocks via the existing `MCUVScaler`, keeps NIPALS in that space, and maps `predictions_`, `predict()` / `diagnose()` `y_hat`, and `beta_coefficients_` back to the original data scale (so `beta_coefficients_` matches sklearn's `coef_`). `scale=False` is unchanged and remains the correct setting when scaling externally.
- A weighted fit (`sample_weight`) scales on the positive-weight rows only, so a zero weight stays equivalent to dropping that row.
- Documented on the parameter and at the fit-time scaling block *why* the flag exists (sklearn-signature parity) and what it now does, so it is not mistaken for dead code again.

Behaviour only changes on the previously-broken unscaled-input path: on already-scaled input `MCUVScaler` yields center ~ 0 / scale ~ 1, so the added transforms are ~identity and existing pre-scaled workflows are unaffected.

## Test plan

- [x] New test `test_pls_scale_true_scales_x_and_y_blocks`: on a multi-target Y with deliberately heterogeneous column variances, `scale=True` (a) reproduces the manual `MCUVScaler` + `scale=False` path to 1e-9, (b) matches `PLSRegression(scale=True)` predictions, and (c) yields R2 > 0.99 (was ~0.1 under the inert flag). Also checks `scale=False` stays a pass-through.
- [x] Full multivariate suite plus the at-risk paths (`test_sklearn_compat`, `test_multivariate_sample_weight`, feature-names, introspection, robustness, nipals-seed): **225 passed, 1 skipped**. No test edits were needed; the weight-aware scaling preserves the zero-weight-equals-dropped-row property.
- [x] `ruff check src/process_improve/multivariate/_pls.py` passes.

## Checklist

- [x] Version bumped in `pyproject.toml` (PATCH: 1.51.2 -> 1.51.3)
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated (and `CITATION.cff` synced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj)_