### PR TITLE
Report PLS.rmse_ (and prediction_interval) on the original Y scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ those changes.
 
 ## [Unreleased]
 
+## [1.51.4] - 2026-07-09
+
+### Fixed
+
+- `PLS.rmse_` is now reported on the original (un-scaled) Y scale when
+  `scale=True`, consistent with `predictions_` and `beta_coefficients_`.
+  Previously it was left in the internally standardized space, so a
+  `scale=True` fit on unscaled data returned an RMSE in units of a Y
+  standard deviation rather than the original response units. As a direct
+  consequence `PLS.prediction_interval()` (which uses `rmse_` as its
+  residual error term when no cross-validation result is supplied) now
+  produces intervals on the correct scale; previously its two branches
+  disagreed, since the cross-validated branch was already on the original
+  scale. Fits with `scale=False` (data scaled externally) are unaffected.
+
 ## [1.51.3] - 2026-07-08
 
 ### Fixed
@@ -2358,7 +2373,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.51.3...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.51.4...HEAD
+[1.51.4]: https://github.com/kgdunn/process-improve/compare/v1.51.3...v1.51.4
 [1.51.3]: https://github.com/kgdunn/process-improve/compare/v1.51.2...v1.51.3
 [1.51.2]: https://github.com/kgdunn/process-improve/compare/v1.51.1...v1.51.2
 [1.51.1]: https://github.com/kgdunn/process-improve/compare/v1.51.0...v1.51.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.51.3
-date-released: "2026-07-08"
+version: 1.51.4
+date-released: "2026-07-09"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.51.3"
+version = "1.51.4"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -210,7 +210,9 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
     r2y_per_variable_ : pd.DataFrame of shape (n_targets, n_components)
         Per-variable R² for Y after each component.
     rmse_ : pd.DataFrame of shape (n_targets, n_components)
-        Root mean squared error of Y predictions per component.
+        Root mean squared error of Y predictions per component, on the original
+        (un-scaled) Y scale, consistent with ``predictions_`` and
+        ``prediction_interval``.
     explained_variance_ : np.ndarray of shape (n_components,)
         Variance explained by each component in X.
     scaling_factor_for_scores_ : pd.Series of length n_components
@@ -796,8 +798,16 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             self.r2y_per_variable_.iloc[:, a] = np.where(
                 prior_SSY_col > 0, col_SSY / np.where(prior_SSY_col > 0, prior_SSY_col, 1.0), np.nan
             )
+            # rmse_ is reported on the ORIGINAL Y scale. NIPALS runs in the
+            # (optionally) scaled space, so rescale each target's RMSE by its Y
+            # standard deviation when scale=True. This keeps rmse_ consistent
+            # with predictions_ / diagnose().y_hat (also original-scale) and with
+            # prediction_interval(), which uses rmse_ as the residual error term.
             residuals_y = Yd.to_numpy() - y_hat.to_numpy()
-            self.rmse_.iloc[:, a] = np.sqrt(np.mean(residuals_y**2, axis=0))
+            rmse_a = np.sqrt(np.mean(residuals_y**2, axis=0))
+            if self._y_scaler is not None:
+                rmse_a = rmse_a * self._y_scaler.scale_.to_numpy()
+            self.rmse_.iloc[:, a] = rmse_a
 
         return self
 

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -1901,6 +1901,44 @@ def test_pls_scale_true_scales_x_and_y_blocks() -> None:
     )
 
 
+def test_pls_rmse_and_interval_on_original_scale() -> None:
+    """rmse_ and a no-cv prediction_interval are on the ORIGINAL Y scale under scale=True.
+
+    Regression guard: internal scaling (scale=True) runs NIPALS in standardized
+    space, but rmse_ must be rescaled to original Y units so it stays consistent
+    with predictions_ / diagnose().y_hat, and with prediction_interval(), which
+    uses rmse_ as its residual error term. A multi-target Y with very different
+    column magnitudes makes the scale error obvious.
+    """
+    rng = np.random.default_rng(3)
+    n = 60
+    X = pd.DataFrame(rng.normal(size=(n, 5)), columns=[f"x{i}" for i in range(5)])
+    beta = rng.normal(size=(5, 3))
+    Y = pd.DataFrame(
+        X.values @ beta * np.array([0.1, 3.0, 40.0]) + np.array([5.0, -2.0, 100.0])
+        + rng.normal(0, 0.05, (n, 3)),
+        columns=["ya", "yb", "yc"],
+    )
+    model = PLS(n_components=5, scale=True).fit(X, Y)
+
+    # rmse_ at the last component equals the original-unit RMSE of predict().
+    y_hat = model.predict(X)
+    rmse_original = np.sqrt(((Y.values - y_hat.values) ** 2).mean(axis=0))
+    assert model.rmse_.iloc[:, -1].to_numpy() == pytest.approx(rmse_original, rel=1e-6, abs=1e-9)
+    # ... and is NOT the standardized-unit RMSE (the pre-fix value), which would
+    # differ by roughly the per-column Y standard deviation.
+    rmse_scaled = rmse_original / Y.std(ddof=1).to_numpy()
+    assert not np.allclose(model.rmse_.iloc[:, -1].to_numpy(), rmse_scaled, rtol=1e-2)
+
+    # The no-cv prediction interval uses original-unit rmse_, so its half-width
+    # is on the Y scale (here ~ the 0.05 noise), not shrunk by standardization.
+    pi = model.prediction_interval(X.iloc[:5], conf_level=0.95)
+    half_width = (pi.upper.to_numpy() - pi.lower.to_numpy()) / 2.0
+    assert np.all(half_width > 0)
+    # per-target half-width is close to t*sqrt(1+leverage)*rmse_ (original units)
+    assert half_width.mean() == pytest.approx(0.1, abs=0.06)
+
+
 @pytest.fixture
 def fixture_pls_ldpe_example() -> dict[str, pd.DataFrame | np.ndarray | float | int]:
     """


### PR DESCRIPTION
## Summary

- Follow-up correctness fix to the `PLS(scale=True)` scaling work (v1.51.3). When `scale=True`, `fit()` runs NIPALS in the internally standardized space and maps `predictions_` / `beta_coefficients_` / `diagnose().y_hat` back to original units. **`rmse_` was left in the standardized space**, so a `scale=True` fit on unscaled data returned an RMSE in units of a Y standard deviation, inconsistent with `predictions_`.
- **`prediction_interval()` inherited the inconsistency**: with no cross-validation result it uses `rmse_` as the residual error term, so its no-cv branch produced wrong-scale intervals, while its `cv_result` branch (already on the original scale) did not; the two branches disagreed.
- Fix: rescale each target's per-component RMSE by its Y standard deviation when `scale=True` (guarded on the fitted Y scaler). `scale=False` fits, where the caller scales externally, are byte-for-byte unchanged.

## Test plan

- [x] New `test_pls_rmse_and_interval_on_original_scale`: on a `scale=True` fit of a multi-target Y with very different column magnitudes, `rmse_` (last component) equals the original-unit RMSE of `predict()`, is *not* the standardized-unit value, and a no-cv `prediction_interval` half-width is on the Y scale.
- [x] Full multivariate suite plus `test_multivariate_sample_weight` and `test_sklearn_compat`: **190 passed, 1 skipped**. No existing test changed behavior (they fit pre-scaled data / `scale=False`, so `rmse_` is unaffected).
- [x] `ruff check src/process_improve/multivariate/_pls.py` passes.

## Checklist

- [x] Version bumped in `pyproject.toml` (PATCH: 1.51.3 -> 1.51.4)
- [x] Tests added
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated (and `CITATION.cff` synced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj)_