### PR TITLE
DOE consistency: drop RunOrder/Block, allow categorical contrasts, flag unenforced options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ those changes.
 
 ## [Unreleased]
 
+## [1.51.5] - 2026-07-09
+
+### Fixed
+
+- `analyze_experiment` no longer treats the design-bookkeeping columns
+  `RunOrder` and `Block` as model factors when a full design frame is
+  passed with the response joined; they are dropped, matching
+  `evaluate_design`, so the two consumers agree on what counts as a factor.
+
+### Added
+
+- The formula validator now allows patsy categorical-contrast helpers
+  (`C`, `Treatment`, `Sum`, `Diff`, `Helmert`, `Poly`), so a caller can
+  specify explicit contrasts for a categorical factor, e.g.
+  `analyze_experiment(..., model="y ~ C(catalyst, Sum) + temp")`. Their
+  arguments are restricted to column names, contrast helpers, and literals;
+  arbitrary calls remain rejected.
+- The optimal-design dispatchers record `constraints_enforced=False` in the
+  returned metadata when constraints are supplied (enforcement is not yet
+  implemented), and `hard_to_change_ignored` when a split-plot request is
+  dropped because `pyoptex` is not installed, so these degradations are
+  detectable on the result rather than only in a log line.
+
 ## [1.51.4] - 2026-07-09
 
 ### Fixed
@@ -2373,7 +2396,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.51.4...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.51.5...HEAD
+[1.51.5]: https://github.com/kgdunn/process-improve/compare/v1.51.4...v1.51.5
 [1.51.4]: https://github.com/kgdunn/process-improve/compare/v1.51.3...v1.51.4
 [1.51.3]: https://github.com/kgdunn/process-improve/compare/v1.51.2...v1.51.3
 [1.51.2]: https://github.com/kgdunn/process-improve/compare/v1.51.1...v1.51.2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.51.4
+version: 1.51.5
 date-released: "2026-07-09"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.51.4"
+version = "1.51.5"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/experiments/_lm.py
+++ b/src/process_improve/experiments/_lm.py
@@ -43,6 +43,14 @@ _IDENTIFIER_RE = re.compile(r"^[A-Za-z_]\w*$")
 # data column: ``I(...)`` (identity / "as-is") and ``Q(...)`` (quote a name).
 _TRANSFORM_FUNCS = frozenset({"I", "Q"})
 
+# Patsy categorical-contrast helpers. These are pure (they only re-code a
+# categorical column into contrast columns), so they are safe to allow inside a
+# formula. ``C(col)`` and ``C(col, Sum)`` / ``Treatment`` / ``Poly`` etc. let a
+# caller specify explicit contrasts for a categorical factor. Their arguments
+# are restricted (see ``_check_categorical_arg``) to data columns, other
+# contrast helpers, and literals; never arbitrary calls.
+_CATEGORICAL_FUNCS = frozenset({"C", "Treatment", "Sum", "Diff", "Helmert", "Poly"})
+
 # Curated allowlist of numpy callables permitted inside a formula when
 # ``allow_numpy=True``. These are pure, element-wise math transforms. We do NOT
 # allow arbitrary ``np.<anything>`` because numpy also exposes dangerous I/O such
@@ -237,11 +245,18 @@ def _check_formula_node(node: ast.AST, allowed: set[str], *, allow_numpy: bool) 
 
 
 def _check_formula_call(node: ast.Call, allowed: set[str], *, allow_numpy: bool) -> None:
-    """Validate a call node: only ``I()``/``Q()`` or an allowlisted ``np.<func>``."""
+    """Validate a call node: ``I()``/``Q()``, a categorical contrast, or ``np.<func>``."""
+    func = node.func
+
+    # Categorical-contrast helpers (C, Treatment, Sum, ...) have their own arg
+    # rules (bare contrast names, literals, keyword reference levels).
+    if isinstance(func, ast.Name) and func.id in _CATEGORICAL_FUNCS:
+        _check_categorical_call(node, allowed, allow_numpy=allow_numpy)
+        return
+
     if node.keywords:
         raise UnsafeFormulaError("keyword arguments are not allowed in a formula call.")
 
-    func = node.func
     if isinstance(func, ast.Name) and func.id in _TRANSFORM_FUNCS:
         pass
     elif allow_numpy and isinstance(func, ast.Attribute):
@@ -253,12 +268,62 @@ def _check_formula_call(node: ast.Call, allowed: set[str], *, allow_numpy: bool)
                 f"numpy function 'np.{func.attr}' is not in the allowed set {sorted(_NUMPY_ALLOWED_FUNCS)}."
             )
     else:
-        raise UnsafeFormulaError("only I()/Q() (and, when enabled, np.<func>()) calls are allowed in a formula.")
+        raise UnsafeFormulaError(
+            "only I()/Q(), categorical contrasts C()/Treatment()/Sum()/Diff()/Helmert()/Poly() "
+            "(and, when enabled, np.<func>()) calls are allowed in a formula."
+        )
 
     for arg in node.args:
         if isinstance(arg, ast.Starred):
             raise UnsafeFormulaError("starred arguments are not allowed in a formula call.")
         _check_formula_node(arg, allowed, allow_numpy=allow_numpy)
+
+
+def _check_categorical_call(node: ast.Call, allowed: set[str], *, allow_numpy: bool) -> None:
+    """Validate a categorical-contrast call: ``C()``/``Treatment()``/``Sum()``/..."""
+    for arg in node.args:
+        if isinstance(arg, ast.Starred):
+            raise UnsafeFormulaError("starred arguments are not allowed in a formula call.")
+        _check_categorical_arg(arg, allowed, allow_numpy=allow_numpy)
+    for kw in node.keywords:
+        if kw.arg is None:
+            raise UnsafeFormulaError("**kwargs are not allowed in a formula call.")
+        _check_literal_or_container(kw.value)
+
+
+def _check_categorical_arg(node: ast.AST, allowed: set[str], *, allow_numpy: bool) -> None:
+    """Validate one argument of a categorical-contrast call (``C``/``Treatment``/...).
+
+    Permitted: a data-column name, a bare contrast helper name (``Sum``), a
+    nested contrast call (``Treatment(reference="A")``), or a literal / list of
+    literals (reference levels, polynomial degree).
+    """
+    # A bare contrast-helper name used as the contrast argument, e.g. C(f, Sum).
+    if isinstance(node, ast.Name) and node.id in _CATEGORICAL_FUNCS:
+        return
+    # A nested contrast call, e.g. C(f, Treatment(reference="A")).
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in _CATEGORICAL_FUNCS:
+        _check_formula_call(node, allowed, allow_numpy=allow_numpy)
+        return
+    # A literal reference level / degree, or a list/tuple of them.
+    if isinstance(node, (ast.Constant, ast.List, ast.Tuple)):
+        _check_literal_or_container(node)
+        return
+    # Otherwise it must be an ordinary allowed node (a data column, I()/Q(), ...).
+    _check_formula_node(node, allowed, allow_numpy=allow_numpy)
+
+
+def _check_literal_or_container(node: ast.AST) -> None:
+    """Allow only string / numeric literals, or lists / tuples of them."""
+    if isinstance(node, (ast.List, ast.Tuple)):
+        for element in node.elts:
+            _check_literal_or_container(element)
+        return
+    if isinstance(node, ast.Constant):
+        value = node.value
+        if not isinstance(value, bool) and isinstance(value, (str, int, float)):
+            return
+    raise UnsafeFormulaError("categorical-contrast arguments must be column names, contrast helpers, or literals.")
 
 
 def forg(x: float, prec: int = 3) -> str:

--- a/src/process_improve/experiments/analysis.py
+++ b/src/process_improve/experiments/analysis.py
@@ -225,8 +225,13 @@ def analyze_experiment(  # noqa: PLR0912, PLR0913, PLR0915, C901
     if response_col not in df.columns:
         raise ValueError(f"Response column '{response_col}' not found in data.")
 
-    # Factor columns = everything except the response
-    factor_cols = [c for c in df.columns if c != response_col]
+    # Factor columns = everything except the response and the design-bookkeeping
+    # columns. A DesignResult carries "RunOrder" (and optionally "Block"); if a
+    # caller passes the whole design frame with the response joined, these must
+    # not become model terms. This mirrors evaluate_design's filtering so the two
+    # public consumers agree on what counts as a factor.
+    _NON_FACTOR_COLS = {response_col, "RunOrder", "Block"}
+    factor_cols = [c for c in df.columns if c not in _NON_FACTOR_COLS]
     for col in factor_cols:
         validate_identifier_is_safe(col)
 

--- a/src/process_improve/experiments/designs_optimal.py
+++ b/src/process_improve/experiments/designs_optimal.py
@@ -303,19 +303,31 @@ def dispatch_d_optimal(
         )
 
     if _PYOPTEX_AVAILABLE:
-        return _run_pyoptex(
+        matrix, meta = _run_pyoptex(
             factors,
             criterion="d_optimal",
             budget=budget,
             options=_PyoptexOptions(model_type=model_type, hard_to_change=hard_to_change),
         )
+        # Record that constraints were not enforced so the DesignResult carries
+        # the fact programmatically, not only as an easy-to-miss log line.
+        if constraints:
+            meta["constraints_enforced"] = False
+        return matrix, meta
 
     if hard_to_change:
         logger.warning(
             "pyoptex is not installed - hard_to_change factors will be ignored. "
             "Install with: pip install pyoptex"
         )
-    return _run_point_exchange_fallback(factors, budget)
+    matrix, meta = _run_point_exchange_fallback(factors, budget)
+    if constraints:
+        meta["constraints_enforced"] = False
+    if hard_to_change:
+        # The randomized fallback cannot honour the split-plot request; surface
+        # it on the result rather than only in the log.
+        meta["hard_to_change_ignored"] = list(hard_to_change)
+    return matrix, meta
 
 
 def dispatch_i_optimal(
@@ -361,12 +373,15 @@ def dispatch_i_optimal(
     if budget is None:
         budget = 2 * k + 1
 
-    return _run_pyoptex(
+    matrix, meta = _run_pyoptex(
         factors,
         criterion="i_optimal",
         budget=budget,
         options=_PyoptexOptions(model_type=model_type, hard_to_change=hard_to_change),
     )
+    if constraints:
+        meta["constraints_enforced"] = False
+    return matrix, meta
 
 
 def dispatch_a_optimal(
@@ -412,9 +427,12 @@ def dispatch_a_optimal(
     if budget is None:
         budget = 2 * k + 1
 
-    return _run_pyoptex(
+    matrix, meta = _run_pyoptex(
         factors,
         criterion="a_optimal",
         budget=budget,
         options=_PyoptexOptions(model_type=model_type, hard_to_change=hard_to_change),
     )
+    if constraints:
+        meta["constraints_enforced"] = False
+    return matrix, meta

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -575,4 +575,6 @@ def test_analyze_experiment_ignores_runorder_and_block_columns() -> None:
     assert not any("RunOrder" in t for t in terms)
     assert not any("Block" in t for t in terms)
     # The real factors and their interaction are still present.
-    assert "A" in terms and "B" in terms and "A:B" in terms
+    assert "A" in terms
+    assert "B" in terms
+    assert "A:B" in terms

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -553,3 +553,26 @@ class TestSeparateResponses:
         y = pd.DataFrame({"y": [28, 36, 18, 31]})
         result = analyze_experiment(df, responses=y, analysis_type="coefficients")
         assert "coefficients" in result
+
+
+def test_analyze_experiment_ignores_runorder_and_block_columns() -> None:
+    """RunOrder / Block bookkeeping columns must not become model factors.
+
+    A DesignResult frame carries a "RunOrder" (and optionally "Block") column;
+    when the whole frame is passed with the response joined, these must be
+    dropped, matching evaluate_design's filtering, rather than fitted as terms.
+    """
+    df = pd.DataFrame({
+        "RunOrder": [1, 2, 3, 4, 5, 6, 7, 8],
+        "Block": [1, 1, 1, 1, 2, 2, 2, 2],
+        "A": [-1, 1, -1, 1, -1, 1, -1, 1],
+        "B": [-1, -1, 1, 1, -1, -1, 1, 1],
+        "y": [10, 14, 8, 12, 11, 15, 9, 13],
+    })
+    res = analyze_experiment(df, response_column="y", model="interactions",
+                             analysis_type=["coefficients"])
+    terms = [c["term"] for c in res["coefficients"]]
+    assert not any("RunOrder" in t for t in terms)
+    assert not any("Block" in t for t in terms)
+    # The real factors and their interaction are still present.
+    assert "A" in terms and "B" in terms and "A:B" in terms

--- a/tests/test_designs_screening_optimal.py
+++ b/tests/test_designs_screening_optimal.py
@@ -94,6 +94,25 @@ class TestDOptimalDispatch:
             dispatch_d_optimal(_continuous(2), budget=6, constraints=constraints)
         assert any("Constraint enforcement" in rec.message for rec in caplog.records)
 
+    def test_constraints_recorded_as_not_enforced_in_meta(self) -> None:
+        """Passing constraints records constraints_enforced=False on the result meta.
+
+        Enforcement is not implemented, so the flag lets a caller detect that the
+        returned design does not honour the constraints, rather than relying only
+        on an easy-to-miss log line.
+        """
+        from process_improve.experiments.factor import Constraint
+
+        constraints = [Constraint(expression="X1 + X2 <= 10")]
+        _design, meta = dispatch_d_optimal(_continuous(2), budget=6, constraints=constraints)
+        assert meta.get("constraints_enforced") is False
+
+    @_skip_with_pyoptex
+    def test_hard_to_change_ignored_flag_without_pyoptex(self) -> None:
+        """Without pyoptex the split-plot request is dropped and recorded on the meta."""
+        _design, meta = dispatch_d_optimal(_continuous(2), budget=6, hard_to_change=["X1"])
+        assert meta.get("hard_to_change_ignored") == ["X1"]
+
     @_skip_with_pyoptex
     def test_hard_to_change_without_pyoptex_warns(self, caplog: pytest.LogCaptureFixture) -> None:
         with caplog.at_level("WARNING"):

--- a/tests/test_experiments_models_formula.py
+++ b/tests/test_experiments_models_formula.py
@@ -179,10 +179,10 @@ class TestCategoricalContrasts:
     @pytest.mark.parametrize(
         "formula",
         [
-            'y ~ C(A, os.system)',       # contrast arg is not a helper/literal/column
-            'y ~ C(A, evil())',          # nested non-contrast call
-            'y ~ Contrast(A)',           # not an allowlisted contrast helper
-            'y ~ C(A, __import__)',      # dunder name as contrast
+            "y ~ C(A, os.system)",  # contrast arg is not a helper/literal/column
+            "y ~ C(A, evil())",  # nested non-contrast call
+            "y ~ Contrast(A)",  # not an allowlisted contrast helper
+            "y ~ C(A, __import__)",  # dunder name as contrast
         ],
     )
     def test_unsafe_categorical_calls_rejected(self, formula: str) -> None:

--- a/tests/test_experiments_models_formula.py
+++ b/tests/test_experiments_models_formula.py
@@ -156,3 +156,35 @@ class TestValidateIdentifierIsSafe:
     def test_non_string_rejected(self) -> None:
         with pytest.raises(UnsafeFormulaError, match="must be a string"):
             validate_identifier_is_safe(123)  # type: ignore[arg-type]
+
+
+class TestCategoricalContrasts:
+    """Patsy categorical-contrast helpers (C, Treatment, Sum, ...) are allowed."""
+
+    @pytest.mark.parametrize(
+        "formula",
+        [
+            "y ~ C(A)",
+            "y ~ C(A, Sum)",
+            "y ~ C(A, Treatment)",
+            "y ~ C(A, Treatment(reference=0))",
+            "y ~ C(A, Diff) + C(B, Helmert)",
+            "y ~ B + C(A) + C(A):B",
+            "y ~ C(A, Poly)",
+        ],
+    )
+    def test_categorical_contrasts_allowed(self, formula: str) -> None:
+        validate_formula_is_safe(formula, _COLUMNS, allow_transforms=True)
+
+    @pytest.mark.parametrize(
+        "formula",
+        [
+            'y ~ C(A, os.system)',       # contrast arg is not a helper/literal/column
+            'y ~ C(A, evil())',          # nested non-contrast call
+            'y ~ Contrast(A)',           # not an allowlisted contrast helper
+            'y ~ C(A, __import__)',      # dunder name as contrast
+        ],
+    )
+    def test_unsafe_categorical_calls_rejected(self, formula: str) -> None:
+        with pytest.raises(UnsafeFormulaError):
+            validate_formula_is_safe(formula, _COLUMNS, allow_transforms=True, allow_numpy=True)


### PR DESCRIPTION
## Summary

Four small, independent consistency fixes to the designed-experiments module (surfaced while driving a mixed-level design end-to-end).

- **`analyze_experiment` no longer fits `RunOrder` / `Block` as factors.** A `DesignResult` frame carries a `RunOrder` (and optional `Block`) column; passing the whole frame with the response joined previously added them as phantom model terms. They are now dropped, matching `evaluate_design` (`evaluate.py:1122`), so the two public consumers agree on what counts as a factor.
- **The formula validator now allows patsy categorical-contrast helpers** (`C`, `Treatment`, `Sum`, `Diff`, `Helmert`, `Poly`). You can now write `analyze_experiment(..., model="y ~ C(catalyst, Sum) + temp")` to specify explicit contrasts for a categorical factor. Contrast-call arguments are restricted to column names, contrast helpers, and literals; arbitrary calls (`os.system`, `__import__`, `evil()`, `C(f, os.system)`, `np.load`) remain rejected, so the SEC-01 allowlist is intact.
- **Unenforced options are now recorded on the result metadata.** The optimal dispatchers set `constraints_enforced=False` when constraints are supplied (enforcement is not yet implemented) and `hard_to_change_ignored=[...]` when a split-plot request is dropped because `pyoptex` is absent, so these documented degradations are detectable programmatically, not only via a log line. The existing warnings are unchanged.

Note: this PR is stacked on #444 (`claude/pls-rmse-original-units`); its base will retarget to `main` when that merges.

## Test plan

- [x] New tests: `TestCategoricalContrasts` (contrasts accepted, injections rejected); `test_analyze_experiment_ignores_runorder_and_block_columns`; `test_constraints_recorded_as_not_enforced_in_meta`; `test_hard_to_change_ignored_flag_without_pyoptex`.
- [x] Explicit experiments/analysis/formula/security suites: **246 passed, 6 skipped**. Existing constraint/`hard_to_change` warning tests unchanged (the warn contract is preserved).
- [x] `ruff check` and `mypy` clean on the three changed source files.

## Checklist

- [x] Version bumped in `pyproject.toml` (1.51.4 -> 1.51.5)
- [x] Tests added
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated (and `CITATION.cff` synced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj)_