### PR TITLE
Make mixed-level (categorical + continuous) optimal designs first-class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ those changes.
 
 ## [Unreleased]
 
+## [1.52.0] - 2026-07-09
+
+### Added
+
+- Mixed-level optimal designs (one or more categorical factors alongside
+  continuous ones) are now first-class through the public API:
+  - `generate_design(..., design_type="i_optimal"/"d_optimal"/"a_optimal")`
+    now accepts and forwards `model_type` (previously unreachable through the
+    unified entry point), and returns a usable `DesignResult` when a
+    categorical factor is present. The categorical factor is carried as its
+    labels in both the coded and actual designs, instead of raising in the
+    coded-to-actual conversion.
+  - `model_type="quadratic"` with a categorical factor now builds a partial
+    response-surface model (pure quadratics on the continuous factors only;
+    the categorical enters as a main effect plus its interactions), rather
+    than requesting an undefined categorical square and failing with a rank
+    collinearity error.
+  - `evaluate_design` returns finite quality metrics (D/I/G-efficiency,
+    condition number, degrees of freedom, prediction variance, FDS) for a
+    design with a categorical factor. The categorical is contrast-coded by
+    patsy and prediction-variance integration samples each categorical over
+    its levels; only continuous factors receive a squared term.
+
+### Changed
+
+- `generate_omars` now raises a clear `ValueError` naming the offending
+  factor(s) when a categorical factor is supplied (OMARS requires continuous
+  factors), instead of failing later with a `TypeError`.
+
 ## [1.51.5] - 2026-07-09
 
 ### Fixed
@@ -2396,7 +2425,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.51.5...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.52.0...HEAD
+[1.52.0]: https://github.com/kgdunn/process-improve/compare/v1.51.5...v1.52.0
 [1.51.5]: https://github.com/kgdunn/process-improve/compare/v1.51.4...v1.51.5
 [1.51.4]: https://github.com/kgdunn/process-improve/compare/v1.51.3...v1.51.4
 [1.51.3]: https://github.com/kgdunn/process-improve/compare/v1.51.2...v1.51.3

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.51.5
+version: 1.52.0
 date-released: "2026-07-09"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.51.5"
+version = "1.52.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/experiments/designs.py
+++ b/src/process_improve/experiments/designs.py
@@ -290,6 +290,7 @@ def generate_design(  # noqa: PLR0913
     cube: str = "full",
     constraints: list[Constraint] | None = None,
     hard_to_change: list[str] | None = None,
+    model_type: str = "interactions",
     random_seed: int = 42,
 ) -> DesignResult:
     """Generate an experimental design matrix.
@@ -337,6 +338,14 @@ def generate_design(  # noqa: PLR0913
         Constraints on the factor space.
     hard_to_change : list[str] or None
         Names of hard-to-change factors (triggers split-plot structure).
+    model_type : str
+        Model the optimal designs (``"d_optimal"``, ``"i_optimal"``,
+        ``"a_optimal"``) are built for: ``"main_effects"``, ``"interactions"``
+        (default), or ``"quadratic"``.  With a categorical factor present,
+        ``"quadratic"`` builds a partial response-surface model (quadratics on
+        the continuous factors only; the categorical enters as a main effect
+        plus its interactions), since a categorical factor has no square.
+        Ignored by the classical (non-optimal) design families.
     random_seed : int
         Seed for reproducible randomization (default 42).
 
@@ -386,6 +395,7 @@ def generate_design(  # noqa: PLR0913
         "cube": cube,
         "hard_to_change": hard_to_change,
         "constraints": constraints,
+        "model_type": model_type,
     }
 
     coded_matrix, meta = dispatch_fn(factors, **dispatch_kwargs)

--- a/src/process_improve/experiments/designs_omars_ilp.py
+++ b/src/process_improve/experiments/designs_omars_ilp.py
@@ -710,6 +710,16 @@ def generate_omars(  # noqa: PLR0913
     True
     """
     from process_improve.experiments.designs_utils import build_design_result  # noqa: PLC0415
+    from process_improve.experiments.factor import FactorType  # noqa: PLC0415
+
+    categorical = [f.name for f in factors if f.type == FactorType.categorical]
+    if categorical:
+        raise ValueError(
+            "OMARS designs require continuous factors; got categorical factor(s): "
+            f"{categorical}. OMARS is built from three-level quantitative contrasts. "
+            "For a mixed-level study use an optimal design (generate_design(..., "
+            "design_type='i_optimal'))."
+        )
 
     if center_runs < 1:
         raise ValueError("center_runs must be at least 1.")

--- a/src/process_improve/experiments/designs_optimal.py
+++ b/src/process_improve/experiments/designs_optimal.py
@@ -182,9 +182,22 @@ def _run_pyoptex(
         n_runs=budget,
     )
 
-    # Build model matrix
+    # Build the model per factor. A categorical factor has no pure-quadratic
+    # term (its square is undefined and, once indicator-coded, idempotent), so a
+    # "quadratic" request becomes a partial response-surface model: quadratics on
+    # the continuous factors, main-effect-plus-interactions on the categorical
+    # ones. This is the standard second-order-with-categorical model and avoids
+    # the rank collinearity a uniform x**2 would create.
+    from process_improve.experiments.factor import FactorType  # noqa: PLC0415
+
     rsm_key = _PYOPTEX_MODEL_MAP.get(model_type, "tfi")
-    model_spec = partial_rsm_names({f.name: rsm_key for f in factors})
+
+    def _factor_rsm_key(factor: Factor) -> str:
+        if rsm_key == "quad" and factor.type == FactorType.categorical:
+            return "tfi"
+        return rsm_key
+
+    model_spec = partial_rsm_names({f.name: _factor_rsm_key(f) for f in factors})
     y2x = model2Y2X(model_spec, pyoptex_factors)
 
     # Select metric

--- a/src/process_improve/experiments/designs_utils.py
+++ b/src/process_improve/experiments/designs_utils.py
@@ -39,16 +39,27 @@ def matrix_to_columns(
     list[Column]
         One ``Column`` per factor, with ``pi_*`` metadata set from the ``Factor``.
     """
+    from process_improve.experiments.factor import FactorType  # noqa: PLC0415
+
     columns: list[Column] = []
     for i, factor in enumerate(factors):
-        col = c(
-            matrix[:, i].tolist(),
-            name=factor.name,
-            lo=factor.low,
-            hi=factor.high,
-            units=factor.units,
-            coded=not is_actual,
-        )
+        values = matrix[:, i].tolist()
+        if factor.type == FactorType.categorical:
+            # A categorical factor carries labels, not coded numbers. Build it
+            # from its levels and mark it not-coded so the coded<->actual affine
+            # map (which assumes a numeric low/high range) is skipped and the
+            # labels pass straight through to both the coded and actual designs.
+            col = c(values, name=factor.name, levels=factor.levels, units=factor.units)
+            col.pi_is_coded = False
+        else:
+            col = c(
+                matrix[:, i].tolist(),
+                name=factor.name,
+                lo=factor.low,
+                hi=factor.high,
+                units=factor.units,
+                coded=not is_actual,
+            )
         columns.append(col)
     return columns
 

--- a/src/process_improve/experiments/evaluate.py
+++ b/src/process_improve/experiments/evaluate.py
@@ -136,6 +136,14 @@ def _build_model_matrix(
     for name in factor_names:
         validate_identifier_is_safe(name)
 
+    # A categorical factor is carried as a non-numeric (label) column; patsy
+    # contrast-codes it automatically, so it must NOT be manually expanded into
+    # dummy columns by the caller (that is what creates singular within-factor
+    # cross terms). Only quantitative factors get a pure-quadratic term - a
+    # categorical has no square - so "quadratic" becomes a partial response
+    # surface model when a categorical factor is present.
+    numeric_factors = [f for f in factor_names if pd.api.types.is_numeric_dtype(design_df[f])]
+
     # Map shorthand names to patsy right-hand-side formulas
     joined = " + ".join(factor_names)
     if model == "main_effects":
@@ -143,8 +151,8 @@ def _build_model_matrix(
     elif model == "interactions":
         rhs = f"({joined}) ** 2"
     elif model == "quadratic":
-        squared = " + ".join(f"I({f} ** 2)" for f in factor_names)
-        rhs = f"({joined}) ** 2 + {squared}"
+        squared = " + ".join(f"I({f} ** 2)" for f in numeric_factors)
+        rhs = f"({joined}) ** 2 + {squared}" if squared else f"({joined}) ** 2"
     elif "~" in model:
         # Explicit formula with response side - strip LHS
         rhs = model.split("~", 1)[1].strip()
@@ -310,15 +318,56 @@ def _region_prediction_variance(ctx: _EvalContext) -> np.ndarray:
     the region settings carried on *ctx*.
     """
     assert ctx.XtX_inv is not None  # callers guard on ``ctx.is_singular``
-    points = _region_points(
-        ctx.factor_names,
-        region=ctx.region,
-        n_samples=ctx.n_samples,
-        include_vertices=ctx.include_vertices,
-        random_seed=ctx.random_seed,
-    )
-    X_region = _expand_points(ctx, points)
-    return _prediction_variance_at_points(X_region, ctx.XtX_inv)
+
+    # Categorical factors are label columns; they cannot be sampled on the
+    # numeric [-1, 1] region. When any is present, sample each categorical
+    # uniformly over its observed levels and each quantitative factor over the
+    # region, then expand through the fitted model. All-continuous designs keep
+    # the original fast path unchanged.
+    cat_levels = {
+        f: ctx.design_df[f].unique()
+        for f in ctx.factor_names
+        if not pd.api.types.is_numeric_dtype(ctx.design_df[f])
+    }
+    if not cat_levels:
+        points = _region_points(
+            ctx.factor_names,
+            region=ctx.region,
+            n_samples=ctx.n_samples,
+            include_vertices=ctx.include_vertices,
+            random_seed=ctx.random_seed,
+        )
+        X_region = _expand_points(ctx, points)
+        return _prediction_variance_at_points(X_region, ctx.XtX_inv)
+
+    rng = np.random.default_rng(ctx.random_seed)
+    data: dict[str, np.ndarray] = {}
+    for f in ctx.factor_names:
+        if f in cat_levels:
+            data[f] = rng.choice(cat_levels[f], size=ctx.n_samples)
+        else:
+            data[f] = rng.uniform(-1.0, 1.0, size=ctx.n_samples)
+    df_points = pd.DataFrame(data)
+
+    # Represent the region corners (where the worst-case prediction variance for
+    # a second-order model usually sits) by crossing the quantitative-factor cube
+    # vertices with a random categorical level.
+    if ctx.include_vertices:
+        cont_names = [f for f in ctx.factor_names if f not in cat_levels]
+        if cont_names:
+            corners = _cube_vertices(len(cont_names))
+            corner: dict[str, np.ndarray] = {}
+            col = 0
+            for f in ctx.factor_names:
+                if f in cat_levels:
+                    corner[f] = rng.choice(cat_levels[f], size=corners.shape[0])
+                else:
+                    corner[f] = corners[:, col]
+                    col += 1
+            df_points = pd.concat([df_points, pd.DataFrame(corner)], ignore_index=True)
+
+    (expanded,) = build_design_matrices([ctx.design_info], df_points, return_type="matrix")
+    return _prediction_variance_at_points(np.asarray(expanded, dtype=float), ctx.XtX_inv)
 
 
 def _compute_g_efficiency(ctx: _EvalContext) -> dict[str, Any]:
@@ -659,9 +708,14 @@ def _compute_degrees_of_freedom(ctx: _EvalContext) -> dict[str, Any]:
     df_residual = ctx.N - ctx.p
     df_total = ctx.N - 1
 
-    # Detect replicates by counting distinct rows
-    design_rounded = np.round(ctx.design_df[ctx.factor_names].values, decimals=10)
-    n_distinct = len(set(map(tuple, design_rounded)))
+    # Detect replicates by counting distinct factor-setting rows. Round the
+    # quantitative columns to absorb floating-point noise; categorical (label)
+    # columns are compared as-is (they cannot be rounded).
+    design_sub = ctx.design_df[ctx.factor_names].copy()
+    numeric_cols = [c for c in ctx.factor_names if pd.api.types.is_numeric_dtype(design_sub[c])]
+    if numeric_cols:
+        design_sub[numeric_cols] = design_sub[numeric_cols].round(10)
+    n_distinct = len(design_sub.drop_duplicates())
     has_replicates = n_distinct < ctx.N
 
     result: dict[str, Any] = {

--- a/tests/test_evaluate_design.py
+++ b/tests/test_evaluate_design.py
@@ -1128,3 +1128,72 @@ class TestFDSResolution:
         second = evaluate_design(bbd, model=_PURE_QUADRATIC_5, metric="fds", n_samples=120_000, random_seed=1)
         assert first["fds"]["max_prediction_variance"] == second["fds"]["max_prediction_variance"]
         assert first["fds"]["max_prediction_variance"] == pytest.approx(0.84, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Mixed-level (categorical + continuous) factor support
+# ---------------------------------------------------------------------------
+import importlib.util  # noqa: E402
+
+_HAS_PYOPTEX = importlib.util.find_spec("pyoptex") is not None
+_needs_pyoptex = pytest.mark.skipif(not _HAS_PYOPTEX, reason="optimal designs require pyoptex")
+
+
+def test_build_model_matrix_mixed_quadratic_is_partial_rsm() -> None:
+    """A quadratic model with a categorical factor squares only the numeric factors.
+
+    The categorical column stays a label column that patsy contrast-codes; it is
+    never manually dummy-expanded (which would create singular cross terms) and
+    never squared (a category has no square).
+    """
+    df = pd.DataFrame({
+        "cat": ["A", "B", "C", "A", "B", "C"],
+        "x1": [-1.0, 0.0, 1.0, 1.0, -1.0, 0.0],
+        "x2": [1.0, -1.0, 0.0, 0.0, 1.0, -1.0],
+    })
+    _X, names, _info = _build_model_matrix(df, "quadratic", ["cat", "x1", "x2"])
+    flat = [n.replace(" ", "") for n in names]
+    # No square of the categorical factor.
+    assert not any("I(cat**2)" in n for n in flat)
+    # Categorical contrasts and continuous squares are present.
+    assert any(n.startswith("cat[") for n in flat)
+    assert "I(x1**2)" in flat
+    assert "I(x2**2)" in flat
+
+
+@_needs_pyoptex
+def test_generate_and_evaluate_mixed_level_design() -> None:
+    """End-to-end: generate an optimal mixed-level design and evaluate it.
+
+    generate_design must return a usable DesignResult with the categorical
+    factor as labels, and evaluate_design must return finite quality metrics
+    (D/I/G efficiency, condition number, degrees of freedom, FDS) rather than
+    None / inf as it did when the categorical was dummy-expanded.
+    """
+    np.random.seed(42)  # noqa: NPY002  # pyoptex coordinate exchange reads the global RNG
+    factors = [
+        Factor(name="catalyst", type="categorical", levels=["A", "B", "C", "D"]),
+        Factor(name="temp", type="continuous", low=50, high=90),
+        Factor(name="conc", type="continuous", low=0.1, high=0.5),
+        Factor(name="rate", type="continuous", low=1, high=9),
+    ]
+    res = generate_design(factors, design_type="i_optimal", budget=44, model_type="quadratic")
+    # The categorical is carried as labels in both the coded and actual designs.
+    assert set(res.design["catalyst"].unique()) <= {"A", "B", "C", "D"}
+    assert set(res.design_actual["catalyst"].unique()) <= {"A", "B", "C", "D"}
+
+    design = res.design.drop(columns=["RunOrder"])
+    metrics = evaluate_design(
+        design,
+        model="quadratic",
+        metric=["d_efficiency", "i_efficiency", "g_efficiency", "condition_number",
+                "degrees_of_freedom", "fds"],
+    )
+    assert metrics["d_efficiency"] is not None
+    assert metrics["d_efficiency"] > 0
+    assert metrics["i_efficiency"] is not None
+    assert metrics["g_efficiency"] is not None
+    assert np.isfinite(metrics["condition_number"])
+    assert metrics["degrees_of_freedom"]["model"] > 0
+    assert metrics["fds"] is not None
+    assert metrics["fds"]["average_prediction_variance"] > 0

--- a/tests/test_omars_ilp.py
+++ b/tests/test_omars_ilp.py
@@ -402,3 +402,21 @@ def test_search_report_records_diagnostics() -> None:
     assert report.ilp_iterations >= 1
     assert report.feasible_designs >= 1
     assert report.total_solve_seconds >= 0.0
+
+
+def test_generate_omars_rejects_categorical_factor() -> None:
+    """A categorical factor gets a clear error, not a downstream TypeError.
+
+    OMARS is built from three-level quantitative contrasts, so a categorical
+    factor is out of scope; the message names the offending factor and points to
+    the optimal-design path for mixed-level studies.
+    """
+    from process_improve.experiments import generate_omars
+
+    factors = [
+        Factor(name="supplier", type="categorical", levels=["A", "B", "C"]),
+        Factor(name="temp", low=-1, high=1),
+        Factor(name="time", low=-1, high=1),
+    ]
+    with pytest.raises(ValueError, match="OMARS designs require continuous factors"):
+        generate_omars(factors, solver_options=_SOLVER)


### PR DESCRIPTION
## Summary

Generating and evaluating an optimal design with a categorical factor alongside continuous ones previously required dropping to `pyoptex` and `patsy` by hand (the coded-to-actual conversion crashed, `model_type="quadratic"` hit a rank collinearity, `evaluate_design` returned `None`/`inf`, and `generate_omars` raised a bare `TypeError`). This wires the whole path through the public API.

- **`generate_design` forwards `model_type`** to `dispatch_{d,i,a}_optimal` (it was accepted there but never placed in the dispatch kwargs, so it was unreachable through the unified entry point), and **returns a usable `DesignResult` for a categorical factor**: the categorical is realized as its labels in both `design` and `design_actual`, instead of raising `np.diff`/`np.mean` on a `None` range in the coded-to-actual affine map (`structures.py`).
- **The optimal model is built per factor.** `model_type="quadratic"` with a categorical present becomes a *partial* response-surface model: pure quadratics on the continuous factors only, the categorical entering as a main effect plus its interactions. A categorical has no square (`d**2 == d` once indicator-coded), which is what previously made the coordinate exchange unable to find a full-rank design.
- **`evaluate_design` returns finite metrics for a categorical design.** The model matrix contrast-codes the categorical (no caller-side dummy expansion, so no singular within-factor cross terms), only continuous factors are squared, prediction-variance / FDS integration samples each categorical uniformly over its levels, and replicate detection compares label columns as-is.
- **`generate_omars` raises a clear `ValueError`** naming the offending categorical factor(s) and pointing to the optimal-design path, instead of a downstream `None + None` `TypeError`.

End-to-end, a six-level categorical + four continuous factors now runs `generate_design(..., "i_optimal", model_type="quadratic")` -> `evaluate_design(..., model="quadratic", metric=[...,"fds"])` -> `analyze_experiment(..., model="y ~ C(cat, Sum) + ...")` with no direct `pyoptex`/`patsy` in user code.

Stacked on #445 (`claude/doe-consistency-fixes`); base retargets to `main` when that merges.

## Test plan

- [x] New tests: `test_build_model_matrix_mixed_quadratic_is_partial_rsm` (no `I(cat**2)`, contrasts + continuous squares present); `test_generate_and_evaluate_mixed_level_design` (finite D/I/G, condition number, df, FDS; pyoptex-gated); `test_generate_omars_rejects_categorical_factor`.
- [x] Experiments suite (evaluate / design-generation / optimal / OMARS / analysis / formula / tools): **400 passed, 6 skipped**, no regressions.
- [x] `ruff check` and `mypy` clean on the five changed source files.

## Checklist

- [x] Version bumped in `pyproject.toml` (MINOR: 1.51.5 -> 1.52.0)
- [x] Tests added
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated (and `CITATION.cff` synced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj)_