### PR TITLE
Alias optimality metrics and clarify the pyoptex install path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ those changes.
 
 ## [Unreleased]
 
+## [1.52.1] - 2026-07-09
+
+### Added
+
+- `pyoptex` is now a declared optional-dependency extra
+  (`pip install 'process-improve[pyoptex]'`, also included in `[all]`). It
+  powers the coordinate-exchange I-/A-optimal and `hard_to_change` split-plot
+  designs in `experiments.designs_optimal`; D-optimal still works without it
+  via the built-in point-exchange fallback. The "not installed" errors and the
+  fallback warning now name the extra instead of a bare `pip install pyoptex`.
+- `evaluate_design` accepts the opposite suffix as an alias for the
+  optimality-criterion metrics (for example `"d_optimality"` for
+  `"d_efficiency"`, or `"a_efficiency"` for `"a_optimality"`), resolving to the
+  canonical metric so either spelling works. The result is still keyed under
+  the canonical name.
+
 ## [1.52.0] - 2026-07-09
 
 ### Added
@@ -2425,7 +2441,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.52.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.52.1...HEAD
+[1.52.1]: https://github.com/kgdunn/process-improve/compare/v1.52.0...v1.52.1
 [1.52.0]: https://github.com/kgdunn/process-improve/compare/v1.51.5...v1.52.0
 [1.51.5]: https://github.com/kgdunn/process-improve/compare/v1.51.4...v1.51.5
 [1.51.4]: https://github.com/kgdunn/process-improve/compare/v1.51.3...v1.51.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,20 @@ those changes.
 
 ### Added
 
-- `pyoptex` is now a declared optional-dependency extra
-  (`pip install 'process-improve[pyoptex]'`, also included in `[all]`). It
-  powers the coordinate-exchange I-/A-optimal and `hard_to_change` split-plot
-  designs in `experiments.designs_optimal`; D-optimal still works without it
-  via the built-in point-exchange fallback. The "not installed" errors and the
-  fallback warning now name the extra instead of a bare `pip install pyoptex`.
 - `evaluate_design` accepts the opposite suffix as an alias for the
   optimality-criterion metrics (for example `"d_optimality"` for
   `"d_efficiency"`, or `"a_efficiency"` for `"a_optimality"`), resolving to the
   canonical metric so either spelling works. The result is still keyed under
   the canonical name.
+
+### Changed
+
+- The "pyoptex is not installed" errors (I-/A-optimal) and the D-optimal
+  fallback warning now explain that pyoptex must be installed separately and
+  why it is not bundled as an extra: its latest release pins `plotly<6`, which
+  conflicts with this project's `plotly>=6.5.2`, so the two cannot share an
+  environment. D-optimal still works without pyoptex via the built-in
+  point-exchange fallback.
 
 ## [1.52.0] - 2026-07-09
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.52.0
+version: 1.52.1
 date-released: "2026-07-09"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.52.0"
+version = "1.52.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"
@@ -80,6 +80,12 @@ fast = ["numba>=0.63.1"]
 # CBC solver in its wheels, so no system package is required.
 ilp = ["pulp>=2.8"]
 
+# Coordinate-exchange optimal designs (I-/A-optimal, split-plot / hard-to-change
+# structures) in ``experiments.designs_optimal``. Without pyoptex, D-optimal
+# still works via the built-in point-exchange fallback, but I-/A-optimal and
+# hard_to_change split-plot designs are unavailable.
+pyoptex = ["pyoptex>=1.2.1"]
+
 # Meta extra: reproduces the pre-ENG-13 install closure.
 all = [
     "matplotlib>=3.10.8",
@@ -89,6 +95,7 @@ all = [
     "plotly>=6.5.2",
     "pulp>=2.8",
     "pyDOE3>=1.0",
+    "pyoptex>=1.2.1",
     "ridgeplot>=0.5.0",
     "scikit-image>=0.25.2",
     "seaborn>=0.13.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,11 +80,14 @@ fast = ["numba>=0.63.1"]
 # CBC solver in its wheels, so no system package is required.
 ilp = ["pulp>=2.8"]
 
-# Coordinate-exchange optimal designs (I-/A-optimal, split-plot / hard-to-change
-# structures) in ``experiments.designs_optimal``. Without pyoptex, D-optimal
-# still works via the built-in point-exchange fallback, but I-/A-optimal and
-# hard_to_change split-plot designs are unavailable.
-pyoptex = ["pyoptex>=1.2.1"]
+# NOTE: ``pyoptex`` (coordinate-exchange I-/A-optimal and split-plot designs in
+# ``experiments.designs_optimal``) is intentionally *not* a declared extra. Its
+# latest release (1.2.1) pins ``plotly~=5.24`` (i.e. < 6), which conflicts with
+# this project's ``plotly>=6.5.2`` floor in the ``plotting``/``all`` extras. A
+# single environment cannot satisfy both, so declaring a ``pyoptex`` extra would
+# make ``uv sync --all-extras`` (used by CI) unresolvable. Install pyoptex
+# separately in its own environment; without it, D-optimal still works via the
+# built-in point-exchange fallback.
 
 # Meta extra: reproduces the pre-ENG-13 install closure.
 all = [
@@ -95,7 +98,6 @@ all = [
     "plotly>=6.5.2",
     "pulp>=2.8",
     "pyDOE3>=1.0",
-    "pyoptex>=1.2.1",
     "ridgeplot>=0.5.0",
     "scikit-image>=0.25.2",
     "seaborn>=0.13.2",

--- a/src/process_improve/_extras.py
+++ b/src/process_improve/_extras.py
@@ -10,6 +10,7 @@ optional dependencies behind extras::
     pip install 'process-improve[mcp]'         # mcp
     pip install 'process-improve[fast]'        # numba (JIT)
     pip install 'process-improve[ilp]'         # pulp (OMARS design generator)
+    pip install 'process-improve[pyoptex]'     # pyoptex (I-/A-optimal, split-plot designs)
     pip install 'process-improve[all]'         # everything above
 
 Modules that need an optional dependency import it inside a

--- a/src/process_improve/_extras.py
+++ b/src/process_improve/_extras.py
@@ -10,7 +10,6 @@ optional dependencies behind extras::
     pip install 'process-improve[mcp]'         # mcp
     pip install 'process-improve[fast]'        # numba (JIT)
     pip install 'process-improve[ilp]'         # pulp (OMARS design generator)
-    pip install 'process-improve[pyoptex]'     # pyoptex (I-/A-optimal, split-plot designs)
     pip install 'process-improve[all]'         # everything above
 
 Modules that need an optional dependency import it inside a

--- a/src/process_improve/experiments/designs_optimal.py
+++ b/src/process_improve/experiments/designs_optimal.py
@@ -5,9 +5,11 @@
 Uses ``pyoptex`` (coordinate exchange) when available for high-quality
 optimal designs with support for split-plot structures.  Falls back to the
 built-in ``point_exchange()`` in ``optimal.py`` for D-optimal when
-``pyoptex`` is not installed.  Install the optional dependency with
-``pip install 'process-improve[pyoptex]'``; without it, I-/A-optimal and
-``hard_to_change`` split-plot requests are unavailable.
+``pyoptex`` is not installed.  ``pyoptex`` is not a process-improve extra
+because it pins ``plotly~=5.24`` (< 6), which conflicts with this project's
+``plotly>=6.5.2``; install it separately (``pip install pyoptex``) in its own
+environment. Without it, I-/A-optimal and ``hard_to_change`` split-plot
+requests are unavailable.
 """
 
 from __future__ import annotations
@@ -25,7 +27,6 @@ except ImportError:  # pragma: no cover - exercised via env-without-pyDOE3
     from process_improve._extras import _MissingExtra
     fullfact = _MissingExtra("pyDOE3", "expt")  # type: ignore[assignment]
 
-from process_improve._extras import require_extra
 from process_improve.experiments.optimal import point_exchange
 
 if TYPE_CHECKING:
@@ -54,6 +55,17 @@ try:
     _PYOPTEX_AVAILABLE = True
 except ImportError:
     pass
+
+#: Remediation hint shown when pyoptex is required but not installed. pyoptex is
+#: deliberately not a process-improve extra: its latest release pins
+#: ``plotly~=5.24`` (< 6), which conflicts with this project's ``plotly>=6.5.2``
+#: floor, so the two cannot share an environment. Install it separately.
+_PYOPTEX_INSTALL_HINT = (
+    "Install it separately with `pip install pyoptex` (note: pyoptex pins "
+    "plotly<6, which conflicts with this project's plotly>=6.5.2, so it cannot "
+    "be co-installed with the 'plotting'/'all' extras; use a separate "
+    "environment)."
+)
 
 # ---------------------------------------------------------------------------
 # pyoptex adapter layer
@@ -333,8 +345,8 @@ def dispatch_d_optimal(
 
     if hard_to_change:
         logger.warning(
-            "pyoptex is not installed - hard_to_change factors will be ignored. "
-            "Install it with: pip install 'process-improve[pyoptex]'"
+            "pyoptex is not installed - hard_to_change factors will be ignored. %s",
+            _PYOPTEX_INSTALL_HINT,
         )
     matrix, meta = _run_point_exchange_fallback(factors, budget)
     if constraints:
@@ -380,7 +392,7 @@ def dispatch_i_optimal(
         If pyoptex is not installed.
     """
     if not _PYOPTEX_AVAILABLE:
-        raise require_extra("pyoptex", "pyoptex")
+        raise ImportError(f"I-optimal design generation requires pyoptex. {_PYOPTEX_INSTALL_HINT}")
 
     k = len(factors)
     if budget is None:
@@ -431,7 +443,7 @@ def dispatch_a_optimal(
         If pyoptex is not installed.
     """
     if not _PYOPTEX_AVAILABLE:
-        raise require_extra("pyoptex", "pyoptex")
+        raise ImportError(f"A-optimal design generation requires pyoptex. {_PYOPTEX_INSTALL_HINT}")
 
     k = len(factors)
     if budget is None:

--- a/src/process_improve/experiments/designs_optimal.py
+++ b/src/process_improve/experiments/designs_optimal.py
@@ -5,7 +5,9 @@
 Uses ``pyoptex`` (coordinate exchange) when available for high-quality
 optimal designs with support for split-plot structures.  Falls back to the
 built-in ``point_exchange()`` in ``optimal.py`` for D-optimal when
-``pyoptex`` is not installed.
+``pyoptex`` is not installed.  Install the optional dependency with
+``pip install 'process-improve[pyoptex]'``; without it, I-/A-optimal and
+``hard_to_change`` split-plot requests are unavailable.
 """
 
 from __future__ import annotations
@@ -23,6 +25,7 @@ except ImportError:  # pragma: no cover - exercised via env-without-pyDOE3
     from process_improve._extras import _MissingExtra
     fullfact = _MissingExtra("pyDOE3", "expt")  # type: ignore[assignment]
 
+from process_improve._extras import require_extra
 from process_improve.experiments.optimal import point_exchange
 
 if TYPE_CHECKING:
@@ -331,7 +334,7 @@ def dispatch_d_optimal(
     if hard_to_change:
         logger.warning(
             "pyoptex is not installed - hard_to_change factors will be ignored. "
-            "Install with: pip install pyoptex"
+            "Install it with: pip install 'process-improve[pyoptex]'"
         )
     matrix, meta = _run_point_exchange_fallback(factors, budget)
     if constraints:
@@ -377,10 +380,7 @@ def dispatch_i_optimal(
         If pyoptex is not installed.
     """
     if not _PYOPTEX_AVAILABLE:
-        raise ImportError(
-            "I-optimal design generation requires pyoptex. "
-            "Install with: pip install pyoptex"
-        )
+        raise require_extra("pyoptex", "pyoptex")
 
     k = len(factors)
     if budget is None:
@@ -431,10 +431,7 @@ def dispatch_a_optimal(
         If pyoptex is not installed.
     """
     if not _PYOPTEX_AVAILABLE:
-        raise ImportError(
-            "A-optimal design generation requires pyoptex. "
-            "Install with: pip install pyoptex"
-        )
+        raise require_extra("pyoptex", "pyoptex")
 
     k = len(factors)
     if budget is None:

--- a/src/process_improve/experiments/evaluate.py
+++ b/src/process_improve/experiments/evaluate.py
@@ -1076,6 +1076,22 @@ _METRIC_REGISTRY: dict[str, Callable[[_EvalContext], Any]] = {
     "minimum_aberration": _compute_minimum_aberration,
 }
 
+#: Accepted spelling variants for the optimality-criterion metrics. The registry
+#: historically mixed suffixes (``d_efficiency`` / ``i_efficiency`` /
+#: ``g_efficiency`` versus ``a_optimality`` / ``e_optimality``), so callers who
+#: reach for the "other" suffix (a natural guess, e.g. ``d_optimality``) hit an
+#: "unknown metric" error. Each alias resolves to its canonical registry key
+#: *before* validation, so both spellings work and the returned dict still keys
+#: the result under the canonical name. Aliases are deliberately kept out of
+#: ``_METRIC_REGISTRY`` so ``metric="all"`` does not compute anything twice.
+_METRIC_ALIASES: dict[str, str] = {
+    "d_optimality": "d_efficiency",
+    "i_optimality": "i_efficiency",
+    "g_optimality": "g_efficiency",
+    "a_efficiency": "a_optimality",
+    "e_efficiency": "e_optimality",
+}
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -1114,7 +1130,10 @@ def evaluate_design(  # noqa: PLR0913
         ``"prediction_variance"``, ``"vif"``, ``"condition_number"``,
         ``"power"``, ``"degrees_of_freedom"``, ``"alias_structure"``,
         ``"confounding"``, ``"resolution"``, ``"defining_relation"``,
-        ``"clear_effects"``, ``"minimum_aberration"``.
+        ``"clear_effects"``, ``"minimum_aberration"``. The optimality-criterion
+        metrics also accept the opposite suffix as an alias (e.g.
+        ``"d_optimality"`` for ``"d_efficiency"``, ``"a_efficiency"`` for
+        ``"a_optimality"``); the result is keyed under the canonical name.
     effect_size : float or None
         Expected effect size for power calculation.  When *None*, a power
         curve over a range of effect sizes is returned instead.
@@ -1188,6 +1207,8 @@ def evaluate_design(  # noqa: PLR0913
         metrics = [metric]
     else:
         metrics = list(metric)
+    # Resolve accepted spelling variants to their canonical registry keys.
+    metrics = [_METRIC_ALIASES.get(m, m) for m in metrics]
     logger.debug("evaluate_design: model=%r, metrics=%s", model, metrics)
 
     # Validate metric names

--- a/tests/test_designs_screening_optimal.py
+++ b/tests/test_designs_screening_optimal.py
@@ -133,24 +133,27 @@ class TestOptimalRequiresPyoptex:
             dispatch_a_optimal(_continuous(3), budget=8)
 
 
-class TestOptimalMissingExtraMessage:
-    """The not-installed error points at the ``[pyoptex]`` extra.
+class TestOptimalMissingPyoptexMessage:
+    """The not-installed error explains how to install pyoptex and why it is not
+    a declared extra (its plotly<6 pin conflicts with the project's plotly>=6.5.2).
 
     Forcing the availability flag off lets this run regardless of whether
     pyoptex is present in the test environment, so the remediation message is
     always covered.
     """
 
-    def test_i_optimal_error_names_the_extra(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_i_optimal_error_explains_install(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from process_improve.experiments import designs_optimal
 
         monkeypatch.setattr(designs_optimal, "_PYOPTEX_AVAILABLE", False)
-        with pytest.raises(ImportError, match=r"process-improve\[pyoptex\]"):
+        with pytest.raises(ImportError, match=r"pip install pyoptex") as info:
             dispatch_i_optimal(_continuous(3), budget=8)
+        assert "plotly" in str(info.value)
 
-    def test_a_optimal_error_names_the_extra(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_a_optimal_error_explains_install(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from process_improve.experiments import designs_optimal
 
         monkeypatch.setattr(designs_optimal, "_PYOPTEX_AVAILABLE", False)
-        with pytest.raises(ImportError, match=r"process-improve\[pyoptex\]"):
+        with pytest.raises(ImportError, match=r"pip install pyoptex") as info:
             dispatch_a_optimal(_continuous(3), budget=8)
+        assert "plotly" in str(info.value)

--- a/tests/test_designs_screening_optimal.py
+++ b/tests/test_designs_screening_optimal.py
@@ -131,3 +131,26 @@ class TestOptimalRequiresPyoptex:
     def test_a_optimal_raises_import_error(self) -> None:
         with pytest.raises(ImportError, match="pyoptex"):
             dispatch_a_optimal(_continuous(3), budget=8)
+
+
+class TestOptimalMissingExtraMessage:
+    """The not-installed error points at the ``[pyoptex]`` extra.
+
+    Forcing the availability flag off lets this run regardless of whether
+    pyoptex is present in the test environment, so the remediation message is
+    always covered.
+    """
+
+    def test_i_optimal_error_names_the_extra(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from process_improve.experiments import designs_optimal
+
+        monkeypatch.setattr(designs_optimal, "_PYOPTEX_AVAILABLE", False)
+        with pytest.raises(ImportError, match=r"process-improve\[pyoptex\]"):
+            dispatch_i_optimal(_continuous(3), budget=8)
+
+    def test_a_optimal_error_names_the_extra(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from process_improve.experiments import designs_optimal
+
+        monkeypatch.setattr(designs_optimal, "_PYOPTEX_AVAILABLE", False)
+        with pytest.raises(ImportError, match=r"process-improve\[pyoptex\]"):
+            dispatch_a_optimal(_continuous(3), budget=8)

--- a/tests/test_evaluate_design.py
+++ b/tests/test_evaluate_design.py
@@ -639,6 +639,28 @@ class TestDispatcher:
         with pytest.raises(ValueError, match="Unknown metric"):
             evaluate_design(df, model="main_effects", metric="nonexistent")
 
+    def test_optimality_suffix_aliases_resolve(self) -> None:
+        """The opposite suffix is accepted and keyed under the canonical name."""
+        df = _full_factorial_df(3)
+        # d_optimality -> d_efficiency (an _efficiency metric requested by _optimality)
+        via_alias = evaluate_design(df, model="main_effects", metric="d_optimality")
+        via_canon = evaluate_design(df, model="main_effects", metric="d_efficiency")
+        assert "d_efficiency" in via_alias
+        assert "d_optimality" not in via_alias
+        assert via_alias["d_efficiency"] == via_canon["d_efficiency"]
+        # a_efficiency -> a_optimality. Requesting the _efficiency spelling is now
+        # valid (previously an unknown-metric error); a_optimality's own output
+        # already carries both a_optimality and a_efficiency keys.
+        via_alias_a = evaluate_design(df, model="main_effects", metric="a_efficiency")
+        assert "a_optimality" in via_alias_a
+
+    def test_metric_alias_in_list(self) -> None:
+        """Aliases resolve inside a metric list alongside canonical names."""
+        df = _full_factorial_df(3)
+        result = evaluate_design(df, model="main_effects", metric=["d_optimality", "vif"])
+        assert "d_efficiency" in result
+        assert "vif" in result
+
     def test_accepts_design_result(self) -> None:
         """evaluate_design accepts a DesignResult object."""
         factors = _continuous_factors(2, "AB")


### PR DESCRIPTION
## Summary

- Add symmetric spelling aliases for the optimality-criterion metrics in `evaluate_design`. The registry historically mixed suffixes (`d_efficiency`/`i_efficiency`/`g_efficiency` vs `a_optimality`/`e_optimality`), so a natural guess such as `d_optimality` raised an unknown-metric error. Each alias (`d_optimality`→`d_efficiency`, `i_optimality`→`i_efficiency`, `g_optimality`→`g_efficiency`, `a_efficiency`→`a_optimality`, `e_efficiency`→`e_optimality`) resolves to its canonical key before validation, so either spelling works; the result is still keyed under the canonical name. Aliases stay out of the metric registry so `metric="all"` computes each metric once.
- Make the `pyoptex`-required messages honest and actionable. The I-/A-optimal "not installed" `ImportError`s and the D-optimal fallback warning now explain that `pyoptex` must be installed separately, in its own environment, and why. D-optimal still works without `pyoptex` via the built-in point-exchange fallback.
- Bump `1.52.0` → `1.52.1` (PATCH), with `CITATION.cff` and `CHANGELOG.md` kept in sync.

### Why `pyoptex` is not a declared extra

The original intent was to add a `pyoptex` optional-dependency extra so I-/A-optimal and split-plot designs had a clean install path. That is not currently viable: `pyoptex` 1.2.1 (its latest release) pins `plotly~=5.24` (i.e. `< 6`), which conflicts with this project's `plotly>=6.5.2` floor in the `plotting`/`all` extras. Because CI runs `uv sync --dev --all-extras` (activating every extra at once), declaring a `pyoptex` extra made the whole install unresolvable and turned every job red. The conflict is inherent, not a lockfile artifact, so this PR documents the constraint in `pyproject.toml` and in the runtime messages instead of shipping an extra that cannot be installed alongside plotting. (Relaxing the `plotly>=6.5.2` floor would be the alternative, but that is a deliberate project pin and out of scope here.)

This PR is stacked on `claude/mixed-level-doe`; it targets that branch and will retarget to `main` automatically once the base merges.

## Test plan

- [x] `pytest tests/test_evaluate_design.py tests/test_designs_screening_optimal.py tests/test_design_generation.py tests/test_extras.py -o "addopts="` passes
- [x] New tests: metric-alias resolution (canonical key, alias inside a list) in `test_evaluate_design.py`; monkeypatched "pyoptex not installed" errors for I-/A-optimal name the separate-install path and the plotly caveat in `test_designs_screening_optimal.py`
- [x] `ruff check .` and `mypy src/process_improve` pass
- [x] `pyproject.toml` parses and resolves without the unsatisfiable `pyoptex` pin; version reads `1.52.1`

## Checklist

- [x] Version bumped in `pyproject.toml` (PATCH)
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj