### PR TITLE
Maintenance WP2: test Python 3.10 on Windows/macOS, dedupe CI job setup into a composite action

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,0 +1,21 @@
+name: Set up project environment
+description: >-
+  Install uv, pin the requested Python version, and sync the project's dev
+  environment with all extras. Shared by the CI jobs in run-tests.yml and
+  docs.yml so the setup sequence is defined once.
+
+inputs:
+  python-version:
+    description: Python version to install and pin for uv
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install uv and set the python version
+      uses: astral-sh/setup-uv@v7
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Install the project (editable, dev deps, all extras)
+      run: uv sync --dev --all-extras
+      shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,12 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
+      - name: Set up project environment
+        uses: ./.github/actions/setup-env
         with:
           python-version: "3.11"
-      - name: Install dependencies
-        run: uv sync --dev --all-extras
       - name: Install pandoc (required by nbsphinx)
         run: sudo apt-get update && sudo apt-get install -y pandoc
       - name: Configure GitHub Pages

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,12 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
-    - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v7
+    - name: Set up project environment
+      uses: ./.github/actions/setup-env
       with:
         python-version: "3.13"
-    - name: Install the project (editable)
-      run: uv sync --dev --all-extras
     - name: Lint with ruff
       run: uv run ruff check .
 
@@ -45,12 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
-    - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v7
+    - name: Set up project environment
+      uses: ./.github/actions/setup-env
       with:
         python-version: "3.13"
-    - name: Install the project (editable)
-      run: uv sync --dev --all-extras
     - name: Type-check with mypy
       run: uv run mypy src/process_improve
 
@@ -58,14 +54,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       # Adjust for min and max supported Python versions
-        python-version: ["3.13"]
+        # The min (3.10) and max (3.13) supported Python versions run on all
+        # three operating systems; the versions in between run on ubuntu only.
+        # This keeps 8 jobs instead of the full 12-job product while still
+        # validating both Python extremes off Linux.
+        python-version: ["3.10", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
         experimental: [false]
         include:
-          - python-version: "3.10"
-            os: ubuntu-latest
-            experimental: false
           - python-version: "3.11"
             os: ubuntu-latest
             experimental: false
@@ -91,8 +87,8 @@ jobs:
     - uses: actions/checkout@v7
       with:
         fetch-depth: 0
-    - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v7
+    - name: Set up project environment
+      uses: ./.github/actions/setup-env
       with:
         python-version: ${{ matrix.python-version }}
     # Test building & distribution
@@ -100,9 +96,6 @@ jobs:
       run: uv build
     - name: Check if the built package can be installed and imported
       run: uv run --isolated --with . --no-project -- python -c "import process_improve"
-    # Editable install for testing
-    - name: Install the project (editable)
-      run: uv sync --dev --all-extras
     # This is where the actual unit and integration tests start
     - name: Test with pytest
       run: uv run pytest --cov-report=xml
@@ -122,12 +115,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
-    - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v7
+    - name: Set up project environment
+      uses: ./.github/actions/setup-env
       with:
         python-version: "3.13"
-    - name: Install the project (editable)
-      run: uv sync --dev --all-extras
     - name: Test with pytest under python -O
       # Strip the default --cov / --pdb / -n auto / --exitfirst options;
       # for -O detection we want the full failure surface, not the first one.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.52.3
-date-released: "2026-07-10"
+version: 1.52.4
+date-released: "2026-07-11"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.52.3"
+version = "1.52.4"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? One to three bullet points. -->

Implements work package 2 of the 2026-07-10 maintenance review (#449). Independent of WP1 (#451); whichever merges second may need a trivial version-line rebase.

- The test matrix now runs the minimum (3.10) and maximum (3.13) supported Pythons on all of ubuntu/windows/macos, with 3.11/3.12 staying ubuntu-only: 8 jobs instead of the previous 6, closing the gap where `requires-python >= 3.10` was never validated off Linux.
- The copy-pasted install-uv + `uv sync --dev --all-extras` sequence (five copies across `run-tests.yml` and `docs.yml`) now lives once in `.github/actions/setup-env`. Behavior-preserving: same setup-uv version and sync flags; codecov still uploads exactly once (ubuntu + 3.13); the free-threaded exclusion note (issue #43) is preserved.

## Test plan

<!-- How was this change verified? -->

- [x] Workflow and action YAML parse cleanly
- [ ] All 8 matrix legs plus lint, typecheck, test-under-dash-O, and docs jobs green on this PR
- [ ] CI logs confirm the composite action ran in every job and codecov uploaded once

## Checklist

- [x] Version bumped in `pyproject.toml` (PATCH for fixes/docs/config, MINOR for new features): 1.52.4, `CITATION.cff` synced
- [ ] Tests added or updated where relevant (n/a: workflow-only change)
- [x] `ruff check .` passes (no Python files touched)
- [ ] `CHANGELOG.md` updated (deliberately skipped: owner opted for no changelog entry for this internal-only batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CynhA39u8mQeFWR3Ccf2UJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CynhA39u8mQeFWR3Ccf2UJ)_