### PR TITLE
Maintenance WP3: add API reference pages for sensory, simulation, and the tooling layer

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.52.3
-date-released: "2026-07-10"
+version: 1.52.5
+date-released: "2026-07-11"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -11,4 +11,7 @@ API Reference
    regression
    batch
    bivariate
+   sensory
+   simulation
    visualization
+   tooling

--- a/docs/api/sensory.rst
+++ b/docs/api/sensory.rst
@@ -1,0 +1,37 @@
+Sensory Panel Analysis
+======================
+
+Descriptive panel-data analysis: validate a panel dataset, check panelist
+performance, and relate sensory attributes to instrumental or design
+variables. See the :doc:`user guide </user_guide/sensory_panel>` for a
+worked walkthrough.
+
+.. automodule:: process_improve.sensory.ingest
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: process_improve.sensory.validation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: process_improve.sensory.panel
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: process_improve.sensory.mam
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: process_improve.sensory.analysis
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: process_improve.sensory.recipes
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/sensory.rst
+++ b/docs/api/sensory.rst
@@ -8,30 +8,24 @@ worked walkthrough.
 
 .. automodule:: process_improve.sensory.ingest
    :members:
-   :undoc-members:
    :show-inheritance:
 
 .. automodule:: process_improve.sensory.validation
    :members:
-   :undoc-members:
    :show-inheritance:
 
 .. automodule:: process_improve.sensory.panel
    :members:
-   :undoc-members:
    :show-inheritance:
 
 .. automodule:: process_improve.sensory.mam
    :members:
-   :undoc-members:
    :show-inheritance:
 
 .. automodule:: process_improve.sensory.analysis
    :members:
-   :undoc-members:
    :show-inheritance:
 
 .. automodule:: process_improve.sensory.recipes
    :members:
-   :undoc-members:
    :show-inheritance:

--- a/docs/api/simulation.rst
+++ b/docs/api/simulation.rst
@@ -1,0 +1,16 @@
+Process Simulation
+==================
+
+Fake-data / process-simulator subpackage: generate synthetic process data
+with controllable structure (drift, faults, correlation) for examples,
+teaching, and tests.
+
+.. automodule:: process_improve.simulation.model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: process_improve.simulation.context
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/simulation.rst
+++ b/docs/api/simulation.rst
@@ -7,10 +7,8 @@ teaching, and tests.
 
 .. automodule:: process_improve.simulation.model
    :members:
-   :undoc-members:
    :show-inheritance:
 
 .. automodule:: process_improve.simulation.context
    :members:
-   :undoc-members:
    :show-inheritance:

--- a/docs/api/tooling.rst
+++ b/docs/api/tooling.rst
@@ -1,0 +1,32 @@
+Recipes and Tool Infrastructure
+===============================
+
+The analysis-recipe framework and the tool-call layer that exposes
+``process_improve`` functionality to LLM agents (Anthropic tool use and the
+MCP server). The narrative description of this layer lives in
+:doc:`/architecture`.
+
+.. automodule:: process_improve.recipes
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: process_improve.tool_spec
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: process_improve.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: process_improve.tool_safety
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: process_improve.mcp_server
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/tooling.rst
+++ b/docs/api/tooling.rst
@@ -8,25 +8,20 @@ MCP server). The narrative description of this layer lives in
 
 .. automodule:: process_improve.recipes
    :members:
-   :undoc-members:
    :show-inheritance:
 
 .. automodule:: process_improve.tool_spec
    :members:
-   :undoc-members:
    :show-inheritance:
 
 .. automodule:: process_improve.config
    :members:
-   :undoc-members:
    :show-inheritance:
 
 .. automodule:: process_improve.tool_safety
    :members:
-   :undoc-members:
    :show-inheritance:
 
 .. automodule:: process_improve.mcp_server
    :members:
-   :undoc-members:
    :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,11 @@ autodoc_default_options = {
     "members": True,
     "show-inheritance": True,
 }
+# The mcp package's pydantic models fail schema generation under autodoc's
+# reload-based importer (fine on a direct import), which breaks documenting
+# process_improve.mcp_server. Mock it: the api/tooling page then documents
+# mcp_server's own docstrings without importing the real FastMCP.
+autodoc_mock_imports = ["mcp"]
 
 # -- Intersphinx mapping ----------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.52.3"
+version = "1.52.5"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? One to three bullet points. -->

Implements work package 3 of the 2026-07-10 maintenance review (#450). Independent of WP1 (#451) and WP2 (#452); the last of the three to merge may need a trivial version-line rebase.

- Adds `docs/api/sensory.rst`, `docs/api/simulation.rst`, and `docs/api/tooling.rst` (recipes, tool_spec, config, tool_safety, mcp_server), wired into the API toctree. These modules previously had no reference documentation at all; the per-package `tools.py` MCP wrappers stay out, matching the existing pages.
- Uses `:members:` without `:undoc-members:` on the new pages: the sensory/tooling result classes document their fields in napoleon Attributes sections, and `:undoc-members:` duplicated those objects, failing the strict `-W` build with 35 warnings.
- Also carries the macOS CBC-solver skip for `test_more_restarts_is_never_worse` (cherry-picked to every open branch) so the flaky Rosetta-emulated solver does not fail this PR's test matrix.

## Test plan

<!-- How was this change verified? -->

- [x] `sphinx-build docs docs/_build/html -b html -W` passes locally (zero warnings; notebooks executed)
- [x] New pages render with populated member listings (sensory: 40 objects, simulation: 9, tooling: 61)
- [x] All 13 newly documented modules import cleanly for autodoc (including `mcp_server` with the `mcp` extra installed)
- [ ] Docs workflow green on this PR

## Checklist

- [x] Version bumped in `pyproject.toml` (PATCH for fixes/docs/config, MINOR for new features): 1.52.5, `CITATION.cff` synced
- [ ] Tests added or updated where relevant (n/a: docs-only, plus one test-skip marker)
- [x] `ruff check .` passes
- [ ] `CHANGELOG.md` updated (deliberately skipped: owner opted for no changelog entry for this internal-only batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CynhA39u8mQeFWR3Ccf2UJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CynhA39u8mQeFWR3Ccf2UJ)_