### PR TITLE
Fix PLS.diagnose().spe returning 0 for named-column X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ those changes.
 
 ## [Unreleased]
 
+## [1.52.4] - 2026-07-11
+
+### Fixed
+
+- `PLS.diagnose(X).spe` returned 0 for every row when `X` had named (string)
+  feature columns. The X reconstruction was built as `scores @ self._x_loadings.T`
+  on the scores DataFrame, which relabelled the result columns `0..K-1`; the
+  subsequent `X - X_hat` subtraction then aligned by label to all-NaN and every
+  SPE collapsed to 0. Integer-labelled columns hid the bug. The reconstruction is
+  now done in NumPy so the feature columns stay aligned. Scores, T2, and y_hat
+  were unaffected.
+
 ## [1.52.2] - 2026-07-09
 
 ### Added
@@ -2461,7 +2473,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.52.2...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.52.4...HEAD
+[1.52.4]: https://github.com/kgdunn/process-improve/compare/v1.52.3...v1.52.4
 [1.52.2]: https://github.com/kgdunn/process-improve/compare/v1.52.1...v1.52.2
 [1.52.1]: https://github.com/kgdunn/process-improve/compare/v1.52.0...v1.52.1
 [1.52.0]: https://github.com/kgdunn/process-improve/compare/v1.51.5...v1.52.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.52.3
-date-released: "2026-07-10"
+version: 1.52.4
+date-released: "2026-07-11"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.52.3"
+version = "1.52.4"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -976,9 +976,12 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         t2_values = np.sum(np.power((scores / self.scaling_factor_for_scores_.to_numpy()), 2), axis=1)
         t2 = pd.Series(t2_values, index=X.index, name="Hotelling's T²")
 
-        # SPE: residual after X reconstruction
-        X_hat = scores @ self._x_loadings.T
-        residuals = X - X_hat
+        # SPE: residual after reconstructing X from its scores. Reconstruct in NumPy so the
+        # feature columns stay aligned with X: a DataFrame ``scores @ self._x_loadings.T`` product
+        # relabels the columns 0..K-1, which then misaligns the ``X - X_hat`` subtraction to all-NaN
+        # and collapses every SPE to 0.
+        x_hat = scores.to_numpy() @ self._x_loadings.T
+        residuals = X.to_numpy() - x_hat
         spe_values = pd.Series(np.sqrt(np.power(residuals, 2).sum(axis=1)), index=X.index, name="SPE")
 
         # Y predictions (computed in scaled-Y space; mapped back to original units)

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -3906,6 +3906,26 @@ def test_pca_diagnose_new_data() -> None:
     assert (result.spe >= 0).all()
 
 
+def test_pls_diagnose_spe_matches_fitted_with_named_columns() -> None:
+    """PLS.diagnose(X).spe must equal the fitted spe_ (last component) when X has named columns.
+
+    Regression test: the reconstruction was built as ``scores @ self._x_loadings.T`` on the scores
+    DataFrame, which relabelled the result columns 0..K-1. With string feature names the following
+    ``X - X_hat`` subtraction then misaligned to all-NaN and every SPE collapsed to 0. Integer
+    column labels hid the bug because the relabelled columns happened to line up.
+    """
+    rng = np.random.default_rng(0)
+    n_rows, n_cols = 40, 6
+    x_data = pd.DataFrame(rng.standard_normal((n_rows, n_cols)), columns=[f"feat_{i}" for i in range(n_cols)])
+    y_data = pd.DataFrame({"y": x_data.to_numpy() @ rng.standard_normal(n_cols) + 0.1 * rng.standard_normal(n_rows)})
+    model = PLS(n_components=3, scale=True).fit(x_data, y_data)
+
+    diag = model.diagnose(x_data)
+    fitted_spe = model.spe_.iloc[:, -1].to_numpy()
+    assert diag.spe.to_numpy() == pytest.approx(fitted_spe, abs=1e-9)
+    assert float(diag.spe.to_numpy().max()) > 0.0  # the bug collapsed every SPE to exactly 0
+
+
 def test_pca_diagnose_numpy_input() -> None:
     """PCA.diagnose() should accept numpy arrays as well as DataFrames."""
     rng = np.random.default_rng(42)


### PR DESCRIPTION
## Summary

- `PLS.diagnose(X).spe` returned **0 for every row** whenever `X` had named (string) feature columns. The X reconstruction was built as `scores @ self._x_loadings.T` on the scores **DataFrame**, which relabels the result columns `0..K-1`; the following `X - X_hat` subtraction then aligns by label to all-NaN, and the NaN-skipping `sum` collapses every SPE to 0. Integer-labelled columns (e.g. from a plain numpy array, as in the existing SIMCA test) hid the bug because the relabelled columns happened to line up.
- The reconstruction is now done in NumPy (`scores.to_numpy() @ self._x_loadings.T`, subtracted from `X.to_numpy()`), so the feature columns stay aligned. `scores`, `hotellings_t2`, and `y_hat` were already correct and are unchanged.
- Surfaced while using `diagnose()` for SPE/T2 diagnostics on a model whose X carried patsy term names.

## Test plan

- [x] New regression test `test_pls_diagnose_spe_matches_fitted_with_named_columns` fits `PLS(scale=True)` on named-column data and asserts `diagnose(X).spe` matches the fitted `spe_` (last component) and is non-zero. It fails before the fix (all-zero SPE) and passes after.
- [x] Existing diagnose/SPE/SIMCA tests still pass (`pytest -k "diagnose or spe or simca"`, 15 passed).
- [x] `ruff check` passes on the changed files.
- Verified directly: `diagnose(X_train).spe` now matches `spe_` to machine precision; PCA and the `tools.py` reconstructions were already NumPy-based and unaffected.

## Checklist

- [x] Version bumped in `pyproject.toml` (1.52.3 → 1.52.4, PATCH)
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated (and `CITATION.cff` kept in sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj)_