### PR TITLE
Add fixed_runs (design augmentation) to generate_design for optimal families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ those changes.
 
 ## [Unreleased]
 
+## [1.53.0] - 2026-07-11
+
+### Added
+
+- `generate_design(..., fixed_runs=<DataFrame>)` for the optimal design families
+  (`d_optimal`, `i_optimal`, `a_optimal`): hold a set of runs fixed and let the
+  pyoptex coordinate exchange fill the rest (design augmentation), forwarding to
+  pyoptex's `create_parameters(prior=...)`. The fixed runs occupy the first rows
+  of the result and `budget` counts them; a common use is seeding a centre point.
+  Works with split-plot (`hard_to_change`) designs. Continuous columns are given
+  in coded `[-1, 1]` units and categorical columns as level labels, matching the
+  returned design; inputs are validated (columns present, known levels, in-range,
+  and `budget > len(fixed_runs)`), and `fixed_runs` for a non-optimal `design_type`
+  or without pyoptex raises a clear error.
+
 ## [1.52.4] - 2026-07-11
 
 ### Fixed
@@ -2473,7 +2488,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.52.4...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.53.0...HEAD
+[1.53.0]: https://github.com/kgdunn/process-improve/compare/v1.52.4...v1.53.0
 [1.52.4]: https://github.com/kgdunn/process-improve/compare/v1.52.3...v1.52.4
 [1.52.2]: https://github.com/kgdunn/process-improve/compare/v1.52.1...v1.52.2
 [1.52.1]: https://github.com/kgdunn/process-improve/compare/v1.52.0...v1.52.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.52.4
+version: 1.53.0
 date-released: "2026-07-11"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.52.4"
+version = "1.53.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/experiments/designs.py
+++ b/src/process_improve/experiments/designs.py
@@ -26,6 +26,7 @@ from collections.abc import Callable
 from typing import Any
 
 import numpy as np
+import pandas as pd
 
 try:
     from pyDOE3 import ff2n
@@ -146,6 +147,7 @@ def _dispatch_d_optimal(
         hard_to_change=kwargs.get("hard_to_change"),
         constraints=kwargs.get("constraints"),
         model_type=kwargs.get("model_type", "interactions"),
+        fixed_runs=kwargs.get("fixed_runs"),
     )
 
 
@@ -161,6 +163,7 @@ def _dispatch_i_optimal(
         hard_to_change=kwargs.get("hard_to_change"),
         constraints=kwargs.get("constraints"),
         model_type=kwargs.get("model_type", "interactions"),
+        fixed_runs=kwargs.get("fixed_runs"),
     )
 
 
@@ -176,6 +179,7 @@ def _dispatch_a_optimal(
         hard_to_change=kwargs.get("hard_to_change"),
         constraints=kwargs.get("constraints"),
         model_type=kwargs.get("model_type", "interactions"),
+        fixed_runs=kwargs.get("fixed_runs"),
     )
 
 
@@ -291,6 +295,7 @@ def generate_design(  # noqa: PLR0913
     constraints: list[Constraint] | None = None,
     hard_to_change: list[str] | None = None,
     model_type: str = "interactions",
+    fixed_runs: pd.DataFrame | None = None,
     random_seed: int = 42,
 ) -> DesignResult:
     """Generate an experimental design matrix.
@@ -346,6 +351,14 @@ def generate_design(  # noqa: PLR0913
         the continuous factors only; the categorical enters as a main effect
         plus its interactions), since a categorical factor has no square.
         Ignored by the classical (non-optimal) design families.
+    fixed_runs : pandas.DataFrame or None
+        Runs to hold fixed while the optimizer fills the rest (design augmentation), for the
+        optimal families only (``"d_optimal"``, ``"i_optimal"``, ``"a_optimal"``, which use
+        pyoptex). One row per fixed run, one column per factor, in the same coding as the returned
+        design: continuous factors in coded ``[-1, 1]`` units, categorical factors as level labels.
+        The fixed runs occupy the first rows of the result and ``budget`` counts them, so
+        ``budget`` must exceed ``len(fixed_runs)``. A common use is to seed a centre point. Raises
+        ``ValueError`` if given for a non-optimal ``design_type``.
     random_seed : int
         Seed for reproducible randomization (default 42).
 
@@ -382,6 +395,12 @@ def generate_design(  # noqa: PLR0913
     if design_type not in _DESIGN_REGISTRY:
         raise ValueError(f"Unknown design_type={design_type!r}.  Choose from: {', '.join(sorted(_DESIGN_REGISTRY))}.")
 
+    if fixed_runs is not None and design_type not in {"d_optimal", "i_optimal", "a_optimal"}:
+        raise ValueError(
+            f"fixed_runs (design augmentation) is only supported for the optimal design families "
+            f"(d_optimal, i_optimal, a_optimal); got design_type={design_type!r}."
+        )
+
     # --- Dispatch ----------------------------------------------------------
     dispatch_fn = _DESIGN_REGISTRY[design_type]
 
@@ -396,6 +415,7 @@ def generate_design(  # noqa: PLR0913
         "hard_to_change": hard_to_change,
         "constraints": constraints,
         "model_type": model_type,
+        "fixed_runs": fixed_runs,
     }
 
     coded_matrix, meta = dispatch_fn(factors, **dispatch_kwargs)

--- a/src/process_improve/experiments/designs_optimal.py
+++ b/src/process_improve/experiments/designs_optimal.py
@@ -158,6 +158,69 @@ class _PyoptexOptions:
     model_type: str = "interactions"
     hard_to_change: list[str] | None = None
     n_tries: int = 10
+    fixed_runs: pd.DataFrame | None = None
+
+
+def _prepare_prior_runs(fixed_runs: pd.DataFrame, factors: list[Factor], budget: int) -> pd.DataFrame:
+    """Validate and format fixed runs for pyoptex's ``prior=`` augmentation.
+
+    ``fixed_runs`` holds runs to keep fixed while the coordinate exchange fills the remaining
+    ``budget - len(fixed_runs)`` runs. It must be in the same coding as the returned design:
+    continuous factors in coded ``[-1, 1]`` units, categorical factors as level labels. Columns
+    other than the factor names are ignored, and the input is not mutated.
+
+    Parameters
+    ----------
+    fixed_runs : pandas.DataFrame
+        One row per fixed run, one column per factor.
+    factors : list[Factor]
+        The design factors.
+    budget : int
+        Total number of runs (fixed plus optimized).
+
+    Returns
+    -------
+    pandas.DataFrame
+        A copy holding only the factor columns, in factor order, ready to pass to pyoptex.
+    """
+    from process_improve.experiments.factor import FactorType  # noqa: PLC0415
+
+    if not isinstance(fixed_runs, pd.DataFrame):
+        raise TypeError("fixed_runs must be a pandas DataFrame with one column per factor.")
+    names = [f.name for f in factors]
+    missing = [n for n in names if n not in fixed_runs.columns]
+    if missing:
+        raise ValueError(f"fixed_runs is missing columns for factors: {missing}.")
+    n_fixed = len(fixed_runs)
+    if n_fixed == 0:
+        raise ValueError("fixed_runs is empty; omit it instead of passing an empty frame.")
+    if n_fixed >= budget:
+        raise ValueError(
+            f"fixed_runs has {n_fixed} runs but budget is {budget}; budget must exceed the number "
+            f"of fixed runs so at least one run is optimized."
+        )
+    prior = fixed_runs.loc[:, names].reset_index(drop=True).copy()
+    for f in factors:
+        col = prior[f.name]
+        if f.type == FactorType.categorical:
+            levels = list(f.levels or [])
+            unknown = sorted(set(col.astype(str)) - {str(lv) for lv in levels})
+            if unknown:
+                raise ValueError(
+                    f"fixed_runs has unknown levels for categorical factor {f.name!r}: {unknown}. "
+                    f"Valid levels: {levels}."
+                )
+        else:
+            vals = pd.to_numeric(col, errors="coerce")
+            if vals.isna().any():
+                raise ValueError(f"fixed_runs has non-numeric values for continuous factor {f.name!r}.")
+            if (vals.abs() > 1.0 + 1e-9).any():
+                raise ValueError(
+                    f"fixed_runs values for continuous factor {f.name!r} must be in coded [-1, 1], "
+                    f"the same coding as the returned design."
+                )
+            prior[f.name] = vals.astype(float)
+    return prior
 
 
 def _run_pyoptex(
@@ -219,8 +282,12 @@ def _run_pyoptex(
     metric_cls = _PYOPTEX_METRIC_MAP[criterion]
     metric = metric_cls()
 
+    prior = None
+    if opts.fixed_runs is not None:
+        prior = _prepare_prior_runs(opts.fixed_runs, factors, budget)
+
     fn = default_fn(pyoptex_factors, metric, y2x)
-    params = create_parameters(pyoptex_factors, fn, nruns=budget)
+    params = create_parameters(pyoptex_factors, fn, nruns=budget, prior=prior)
     design_df, state = create_fixed_structure_design(params, n_tries=n_tries)
 
     meta = {
@@ -231,6 +298,8 @@ def _run_pyoptex(
     }
     if hard_to_change:
         meta["hard_to_change"] = hard_to_change
+    if prior is not None:
+        meta["n_fixed_runs"] = len(prior)
 
     return design_df.values, meta
 
@@ -289,12 +358,13 @@ def _run_point_exchange_fallback(
 # ---------------------------------------------------------------------------
 
 
-def dispatch_d_optimal(
+def dispatch_d_optimal(  # noqa: PLR0913
     factors: list[Factor],
     budget: int | None = None,
     hard_to_change: list[str] | None = None,
     constraints: list[Constraint] | None = None,
     model_type: str = "interactions",
+    fixed_runs: pd.DataFrame | None = None,
 ) -> tuple[np.ndarray, dict]:
     """Generate a D-optimal design.
 
@@ -323,6 +393,9 @@ def dispatch_d_optimal(
     if budget is None:
         budget = 2 * k + 1
 
+    if fixed_runs is not None and not _PYOPTEX_AVAILABLE:
+        raise ImportError(f"fixed_runs (design augmentation) requires pyoptex. {_PYOPTEX_INSTALL_HINT}")
+
     if constraints:
         logger.warning(
             "Constraint enforcement in optimal designs is experimental. "
@@ -335,7 +408,7 @@ def dispatch_d_optimal(
             factors,
             criterion="d_optimal",
             budget=budget,
-            options=_PyoptexOptions(model_type=model_type, hard_to_change=hard_to_change),
+            options=_PyoptexOptions(model_type=model_type, hard_to_change=hard_to_change, fixed_runs=fixed_runs),
         )
         # Record that constraints were not enforced so the DesignResult carries
         # the fact programmatically, not only as an easy-to-miss log line.
@@ -358,12 +431,13 @@ def dispatch_d_optimal(
     return matrix, meta
 
 
-def dispatch_i_optimal(
+def dispatch_i_optimal(  # noqa: PLR0913
     factors: list[Factor],
     budget: int | None = None,
     hard_to_change: list[str] | None = None,
     constraints: list[Constraint] | None = None,
     model_type: str = "interactions",
+    fixed_runs: pd.DataFrame | None = None,
 ) -> tuple[np.ndarray, dict]:
     """Generate an I-optimal design (minimizes average prediction variance).
 
@@ -402,19 +476,20 @@ def dispatch_i_optimal(
         factors,
         criterion="i_optimal",
         budget=budget,
-        options=_PyoptexOptions(model_type=model_type, hard_to_change=hard_to_change),
+        options=_PyoptexOptions(model_type=model_type, hard_to_change=hard_to_change, fixed_runs=fixed_runs),
     )
     if constraints:
         meta["constraints_enforced"] = False
     return matrix, meta
 
 
-def dispatch_a_optimal(
+def dispatch_a_optimal(  # noqa: PLR0913
     factors: list[Factor],
     budget: int | None = None,
     hard_to_change: list[str] | None = None,
     constraints: list[Constraint] | None = None,
     model_type: str = "interactions",
+    fixed_runs: pd.DataFrame | None = None,
 ) -> tuple[np.ndarray, dict]:
     """Generate an A-optimal design (minimizes trace of variance matrix).
 
@@ -453,7 +528,7 @@ def dispatch_a_optimal(
         factors,
         criterion="a_optimal",
         budget=budget,
-        options=_PyoptexOptions(model_type=model_type, hard_to_change=hard_to_change),
+        options=_PyoptexOptions(model_type=model_type, hard_to_change=hard_to_change, fixed_runs=fixed_runs),
     )
     if constraints:
         meta["constraints_enforced"] = False

--- a/tests/test_designs_optimal_pyoptex.py
+++ b/tests/test_designs_optimal_pyoptex.py
@@ -257,3 +257,37 @@ class TestFixedRuns:
         centre = pd.DataFrame([{"cat": "A", "x1": 0.0, "x2": 0.0}])
         with pytest.raises(ValueError, match="budget must exceed"):
             generate_design(_mixed_factors(), design_type="i_optimal", budget=1, fixed_runs=centre)
+
+    def test_fixed_runs_must_be_a_dataframe(self) -> None:
+        with pytest.raises(TypeError, match="must be a pandas DataFrame"):
+            generate_design(_mixed_factors(), design_type="i_optimal", budget=14,
+                            fixed_runs=[{"cat": "A", "x1": 0.0, "x2": 0.0}])  # type: ignore[arg-type]
+
+    def test_fixed_runs_empty_frame_rejected(self) -> None:
+        empty = pd.DataFrame({"cat": [], "x1": [], "x2": []})
+        with pytest.raises(ValueError, match="empty"):
+            generate_design(_mixed_factors(), design_type="i_optimal", budget=14, fixed_runs=empty)
+
+    def test_fixed_runs_non_numeric_continuous_rejected(self) -> None:
+        bad = pd.DataFrame([{"cat": "A", "x1": "middle", "x2": 0.0}])
+        with pytest.raises(ValueError, match="non-numeric"):
+            generate_design(_mixed_factors(), design_type="i_optimal", budget=14, fixed_runs=bad)
+
+    def test_two_fixed_runs_both_appear_first(self) -> None:
+        seed = pd.DataFrame([{"cat": "A", "x1": 0.0, "x2": 0.0},
+                             {"cat": "B", "x1": 1.0, "x2": -1.0}])
+        np.random.seed(3)  # noqa: NPY002
+        result = generate_design(_mixed_factors(), design_type="i_optimal", budget=14, fixed_runs=seed)
+        assert result.metadata.get("n_fixed_runs") == 2
+        head = result.design.iloc[:2]
+        assert list(head["cat"]) == ["A", "B"]
+        assert float(head.iloc[1]["x1"]) == pytest.approx(1.0)
+        assert float(head.iloc[1]["x2"]) == pytest.approx(-1.0)
+
+    def test_fixed_runs_requires_pyoptex(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from process_improve.experiments import designs_optimal
+
+        monkeypatch.setattr(designs_optimal, "_PYOPTEX_AVAILABLE", False)
+        centre = pd.DataFrame([{"cat": "A", "x1": 0.0, "x2": 0.0}])
+        with pytest.raises(ImportError, match="requires pyoptex"):
+            designs_optimal.dispatch_d_optimal(_mixed_factors(), budget=14, fixed_runs=centre)

--- a/tests/test_designs_optimal_pyoptex.py
+++ b/tests/test_designs_optimal_pyoptex.py
@@ -9,6 +9,7 @@ run-order preservation branch in ``generate_design``.
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
 import pytest
 
 pytest.importorskip("pyoptex")
@@ -192,3 +193,67 @@ class TestRunOrderPreservation:
         )
         assert result.metadata.get("backend") == "pyoptex"
         assert result.run_order == list(range(1, 7))
+
+
+# ---------------------------------------------------------------------------
+# fixed_runs: seed the coordinate exchange with runs held fixed (pyoptex prior)
+# ---------------------------------------------------------------------------
+
+
+def _mixed_factors() -> list[Factor]:
+    return [Factor(name="cat", type="categorical", levels=["A", "B", "C"]),
+            Factor(name="x1", low=0, high=10),
+            Factor(name="x2", low=0, high=10)]
+
+
+class TestFixedRuns:
+    """Design augmentation: hold given runs fixed and optimize the rest."""
+
+    def test_fixed_centre_point_appears_first_and_budget_counts_it(self) -> None:
+
+        centre = pd.DataFrame([{"cat": "A", "x1": 0.0, "x2": 0.0}])
+        np.random.seed(1)  # noqa: NPY002 (pyoptex reads the legacy global RNG)
+        result = generate_design(_mixed_factors(), design_type="i_optimal", budget=14,
+                                 model_type="interactions", fixed_runs=centre)
+        design = result.design
+        assert len(design) == 14
+        assert result.metadata.get("n_fixed_runs") == 1
+        row0 = design.iloc[0]
+        assert row0["cat"] == "A"
+        assert abs(float(row0["x1"])) < 1e-9
+        assert abs(float(row0["x2"])) < 1e-9
+
+    def test_fixed_runs_supported_with_split_plot(self) -> None:
+
+        centre = pd.DataFrame([{"cat": "A", "x1": 0.0, "x2": 0.0}])
+        np.random.seed(2)  # noqa: NPY002
+        result = generate_design(_mixed_factors(), design_type="i_optimal", budget=14,
+                                 hard_to_change=["x1"], fixed_runs=centre)
+        assert len(result.design) == 14
+        assert result.metadata.get("n_fixed_runs") == 1
+
+    def test_fixed_runs_rejected_for_non_optimal_design(self) -> None:
+
+        centre = pd.DataFrame([{"cat": "A", "x1": 0.0, "x2": 0.0}])
+        with pytest.raises(ValueError, match="only supported for the optimal"):
+            generate_design(_mixed_factors(), design_type="full_factorial", fixed_runs=centre)
+
+    @pytest.mark.parametrize(
+        ("frame", "match"),
+        [
+            ([{"cat": "A", "x1": 0.0}], "missing columns"),
+            ([{"cat": "Z", "x1": 0.0, "x2": 0.0}], "unknown levels"),
+            ([{"cat": "A", "x1": 2.0, "x2": 0.0}], "coded"),
+        ],
+    )
+    def test_fixed_runs_input_validation(self, frame: list, match: str) -> None:
+
+        with pytest.raises(ValueError, match=match):
+            generate_design(_mixed_factors(), design_type="i_optimal", budget=14,
+                            fixed_runs=pd.DataFrame(frame))
+
+    def test_fixed_runs_must_leave_room_to_optimize(self) -> None:
+
+        centre = pd.DataFrame([{"cat": "A", "x1": 0.0, "x2": 0.0}])
+        with pytest.raises(ValueError, match="budget must exceed"):
+            generate_design(_mixed_factors(), design_type="i_optimal", budget=1, fixed_runs=centre)


### PR DESCRIPTION
## Summary

- `generate_design(..., fixed_runs=<DataFrame>)` lets you **hold a set of runs fixed** while the pyoptex coordinate exchange optimizes the rest (design augmentation). It forwards to pyoptex's `create_parameters(prior=...)`, which our optimal path previously never used.
- Supported for the optimal families (`d_optimal`, `i_optimal`, `a_optimal`), **including split-plot** (`hard_to_change`). The fixed runs occupy the first rows of the result and `budget` counts them (so `budget > len(fixed_runs)`). A common use is seeding a centre point into an I-optimal design.
- `fixed_runs` is given in the **same coding as the returned design**: continuous factors in coded `[-1, 1]` units, categorical factors as level labels. The input is validated (all factor columns present, known categorical levels, continuous in range, room to optimize) and not mutated. Passing `fixed_runs` for a non-optimal `design_type`, or when pyoptex is not installed, raises a clear error.

Motivated by a case study that wanted a centre point seeded into an otherwise I-optimal split-plot design; pyoptex supports it natively via `prior=`, this wires it through the public entry point.

## Test plan

- [x] New `TestFixedRuns` suite in `tests/test_designs_optimal_pyoptex.py`: the seeded centre point appears as the first run and `budget` is honored; split-plot + `fixed_runs` works; and the validation paths (non-optimal design, `budget <= len(fixed_runs)`, missing column, unknown level, out-of-coded-range) all raise. 7 tests pass.
- [x] `tests/test_designs_optimal_pyoptex.py` and `tests/test_design_generation.py` still pass (116 total).
- [x] `ruff check` and `mypy src/process_improve/experiments/{designs,designs_optimal}.py` pass.

## Checklist

- [x] Version bumped in `pyproject.toml` (1.52.3 → 1.53.0, MINOR: new feature)
- [x] Tests added
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated (and `CITATION.cff` kept in sync)

Note: independent of the small `diagnose().spe` bugfix in #454; if that merges first, this branch needs only a version-line/CHANGELOG rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvUM1DPgi2S3JFLjRJTJWj)_