### PR TITLE
Fix bugs in sensory descriptive-data validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ those changes.
 
 ## [Unreleased]
 
+## [1.54.0] - 2026-07-13
+
+### Changed
+
+- `sensory.validate_descriptive` no longer blocks on an unbalanced panel or on
+  panel products that are missing from the covariate table. Descriptive panels
+  are incomplete by design, and the observational relate aggregates to product
+  means, so imbalance is now surfaced as a warning instead of a blocking error.
+  Panel products with no covariate row are dropped with a warning and the relate
+  runs on the matched intersection; only a total mismatch (no products in common)
+  is still a blocking error.
+
+### Fixed
+
+- The product/covariate join now matches the covariate identifier column
+  case- and whitespace-insensitively, so a covariate table whose column is not
+  exactly lowercase `product` aligns instead of silently falling back to the row
+  index (which previously reported every product as missing). Duplicate product
+  rows in the covariate table are collapsed to their numeric mean so the join key
+  stays unique.
+
 ## [1.53.0] - 2026-07-11
 
 ### Added
@@ -2488,7 +2509,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.53.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.54.0...HEAD
+[1.54.0]: https://github.com/kgdunn/process-improve/compare/v1.53.0...v1.54.0
 [1.53.0]: https://github.com/kgdunn/process-improve/compare/v1.52.4...v1.53.0
 [1.52.4]: https://github.com/kgdunn/process-improve/compare/v1.52.3...v1.52.4
 [1.52.2]: https://github.com/kgdunn/process-improve/compare/v1.52.1...v1.52.2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.53.0
-date-released: "2026-07-11"
+version: 1.54.0
+date-released: "2026-07-13"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.53.0"
+version = "1.54.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/sensory/validation.py
+++ b/src/process_improve/sensory/validation.py
@@ -104,19 +104,33 @@ def _content_hash(panel: pd.DataFrame, covariates: pd.DataFrame, mode: str) -> s
     return hasher.hexdigest()
 
 
-def _normalise_covariates(covariates: pd.DataFrame) -> pd.DataFrame:
-    """Return the covariate table indexed by ``product``.
+def _normalise_covariates(covariates: pd.DataFrame) -> tuple[pd.DataFrame, list[str]]:
+    """Return the covariate table indexed by ``product``, plus any warnings.
 
-    Accepts either a ``product`` column or a frame already indexed by product.
+    The product column is matched case- and whitespace-insensitively (``Product``,
+    ``PRODUCT ``, ... all resolve), so a covariate file that does not label the column
+    exactly ``product`` still aligns instead of silently falling back to the integer
+    index. Duplicate product rows are collapsed to their numeric mean, so the index is
+    unique for the downstream label-based join.
     """
     cov = covariates.copy()
-    if "product" in cov.columns:
-        cov["product"] = cov["product"].astype(str).str.strip()
-        cov = cov.set_index("product")
+    warnings: list[str] = []
+    product_col = next((c for c in cov.columns if str(c).strip().lower() == "product"), None)
+    if product_col is not None:
+        cov[product_col] = cov[product_col].astype(str).str.strip()
+        cov = cov.set_index(product_col)
+        cov.index.name = "product"
     else:
         cov.index = cov.index.astype(str).str.strip()
         cov.index.name = "product"
-    return cov
+    if cov.index.has_duplicates:
+        dupes = sorted({str(x) for x in cov.index[cov.index.duplicated()]})
+        cov = cov.groupby(level=0).mean(numeric_only=True)
+        warnings.append(
+            f"Covariate table had duplicate rows for product(s) {dupes}; each was collapsed to its "
+            f"numeric mean."
+        )
+    return cov, warnings
 
 
 def validate_descriptive(  # noqa: PLR0912, PLR0913, PLR0915, C901
@@ -150,7 +164,10 @@ def validate_descriptive(  # noqa: PLR0912, PLR0913, PLR0915, C901
         are reported as a warning.
     balance_warn, balance_error : float
         Missing-cell fractions (of the full panelist x product x attribute x
-        replicate grid) above which a warning or a blocking error is raised.
+        replicate grid) above which an unbalanced-panel warning is raised.
+        Imbalance is reported but never blocks the observational relate, which
+        aggregates to product means; ``balance_error`` only controls the wording
+        (badly-unbalanced vs unbalanced).
 
     Returns
     -------
@@ -217,7 +234,37 @@ def validate_descriptive(  # noqa: PLR0912, PLR0913, PLR0915, C901
                 f"[{score_min}, {score_max}]."
             )
 
+    # --- Covariate table + product reconciliation ---------------------
+    # Normalise first so the balance audit and stats reflect the products the
+    # relate will actually run on. The relate aggregates to product means and
+    # looks covariates up by product label, so a panel product with no covariate
+    # row cannot be related; drop those (warning) and relate on the intersection.
+    # It is a blocking error only when nothing lines up at all.
+    cov, cov_warnings = _normalise_covariates(covariates)
+    warnings.extend(cov_warnings)
+    panel_products = set(df["product"].unique())
+    cov_products = set(cov.index)
+    absent = sorted(panel_products - cov_products)
+    if absent:
+        matched = panel_products & cov_products
+        if not matched:
+            errors.append(
+                "No panel product has a matching row in the covariate table. Panel products: "
+                f"{sorted(panel_products)}; covariate products: {sorted(cov_products)}."
+            )
+        else:
+            warnings.append(
+                f"{len(absent)} panel product(s) have no row in the covariate table and were "
+                f"dropped from the relate: {absent}. Relating on the {len(matched)} matched "
+                f"product(s)."
+            )
+            df = df[df["product"].isin(matched)].reset_index(drop=True)
+
     # --- Balance audit -------------------------------------------------
+    # Reported on the retained (matched) panel. Real descriptive panels are
+    # incomplete by design (not every panelist rates every product), and the
+    # relate uses product means, so imbalance is surfaced as a warning rather
+    # than blocking the analysis.
     n_panelist = df["panelist_id"].nunique()
     n_product = df["product"].nunique()
     n_attribute = df["attribute"].nunique()
@@ -228,24 +275,16 @@ def validate_descriptive(  # noqa: PLR0912, PLR0913, PLR0915, C901
     ).shape[0]
     missing_fraction = 0.0 if expected == 0 else 1.0 - present / expected
     if missing_fraction > balance_error:
-        errors.append(
+        warnings.append(
             f"Panel is badly unbalanced: {missing_fraction:.1%} of the full "
-            f"panelist x product x attribute x replicate grid is missing "
-            f"(error threshold {balance_error:.0%})."
+            f"panelist x product x attribute x replicate grid is missing. The relate uses product "
+            f"means, so this does not block it, but the per-product means rest on fewer scores."
         )
     elif missing_fraction > balance_warn:
         warnings.append(
             f"Panel is unbalanced: {missing_fraction:.1%} of the full grid is "
             f"missing (warning threshold {balance_warn:.0%})."
         )
-
-    # --- Covariate table ----------------------------------------------
-    cov = _normalise_covariates(covariates)
-    panel_products = set(df["product"].unique())
-    cov_products = set(cov.index)
-    absent = sorted(panel_products - cov_products)
-    if absent:
-        errors.append(f"These products have no row in the covariate table: {absent}.")
 
     # Observational mode only for now (designed mode is rejected above).
     non_numeric = [c for c in cov.columns if not pd.api.types.is_numeric_dtype(cov[c])]

--- a/tests/test_sensory.py
+++ b/tests/test_sensory.py
@@ -101,10 +101,47 @@ def test_validate_missing_column_is_error():
     assert result.normalized_df is None
 
 
-def test_validate_missing_product_in_covariates_is_error():
+def test_validate_missing_product_in_covariates_drops_and_warns():
+    # A panel product with no covariate row cannot be related (the relate looks
+    # covariates up by product), so it is dropped with a warning and the relate
+    # proceeds on the matched intersection, rather than blocking.
     result = validate_descriptive(_panel(), _obs(drop_last=True), mode="observational")
+    assert result.ok
+    assert result.errors == []
+    assert any("no row in the covariate table" in w and "dropped" in w for w in result.warnings)
+    # The unmatched product is gone from the normalised panel.
+    assert PRODUCTS[-1] not in set(result.normalized_df["product"])
+    assert result.stats["n_products"] == len(PRODUCTS) - 1
+
+
+def test_validate_no_products_match_is_error():
+    # When nothing lines up at all, that is a genuine blocking error.
+    obs = _obs()
+    obs["product"] = [f"other-{p}" for p in obs["product"]]
+    result = validate_descriptive(_panel(), obs, mode="observational")
     assert not result.ok
-    assert any("no row in the covariate table" in e for e in result.errors)
+    assert any("No panel product has a matching row" in e for e in result.errors)
+
+
+def test_validate_capitalised_product_column_still_aligns():
+    # A covariate table whose identifier column is not exactly lowercase
+    # "product" (e.g. "Product") must still align, not fall back to the index.
+    obs = _obs().rename(columns={"product": "Product"})
+    result = validate_descriptive(_panel(), obs, mode="observational")
+    assert result.ok, result.errors
+    assert result.covariates.index.name == "product"
+    assert set(result.covariates.index) == set(PRODUCTS)
+
+
+def test_validate_duplicate_covariate_rows_collapse_with_warning():
+    obs = _obs()
+    dup = pd.concat([obs, obs.iloc[[0]].assign(sodium=obs.iloc[0]["sodium"] + 0.4)], ignore_index=True)
+    result = validate_descriptive(_panel(), dup, mode="observational")
+    assert result.ok, result.errors
+    assert any("duplicate rows" in w for w in result.warnings)
+    # Index is unique after collapsing; the duplicated product keeps one (mean) row.
+    assert result.covariates.index.is_unique
+    assert result.covariates.loc[PRODUCTS[0], "sodium"] == pytest.approx(obs.iloc[0]["sodium"] + 0.2)
 
 
 def test_validate_out_of_range_score_warns():
@@ -115,14 +152,15 @@ def test_validate_out_of_range_score_warns():
     assert any("outside the expected range" in w for w in result.warnings)
 
 
-def test_validate_unbalanced_panel_errors():
-    # Punch random holes across the grid (every panelist/product/attribute is
-    # still present, so the full grid stays the same size) to exceed the 20%
-    # missing-cell error threshold.
+def test_validate_unbalanced_panel_warns_but_does_not_block():
+    # Punch random holes across the grid to exceed the 20% missing-cell
+    # threshold. Because the relate aggregates to product means, imbalance is
+    # surfaced as a warning and does not block the analysis.
     panel = _panel().sample(frac=0.7, random_state=0).reset_index(drop=True)
     result = validate_descriptive(panel, _obs(), mode="observational")
-    assert not result.ok
-    assert any("unbalanced" in e for e in result.errors)
+    assert result.ok
+    assert not any("unbalanced" in e for e in result.errors)
+    assert any("unbalanced" in w for w in result.warnings)
 
 
 def test_validate_bad_mode_raises():


### PR DESCRIPTION
## Summary
- Bug fixes in the `sensory` descriptive-data validation so it handles real-world inputs: tolerate incomplete panels and partial covariate coverage (warn instead of error), match the covariate product column case-insensitively, and collapse duplicate covariate rows.

## Test plan
- [x] `uv run pytest tests/test_sensory.py tests/test_sensory_end_to_end.py --no-cov`

## Checklist
- [x] Version bumped in `pyproject.toml` (MINOR)
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated
