### PR TITLE
Update README + docs landing for recent releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ those changes.
 
 ## [Unreleased]
 
+## [1.55.1] - 2026-07-21
+
+### Documentation
+
+- Marketing refresh of the front-facing docs to catch up with the recent
+  releases. The README gains a "What's new" section and runnable quick-start
+  snippets for on-line monitoring with `AdaptivePCA` and for OMARS / D-optimal
+  designs; the feature list and capability table now cover adaptive/on-line
+  monitoring and the OMARS / optimal-design engine. The scikit-learn section is
+  reframed as complementary ("Works alongside scikit-learn") rather than
+  adversarial, and the inactive `factori.al` references are removed. The Sphinx
+  landing page and quickstart guide are updated to mirror the new highlights.
+
 ## [1.55.0] - 2026-07-19
 
 ### Added
@@ -2536,7 +2549,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.55.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.55.1...HEAD
+[1.55.1]: https://github.com/kgdunn/process-improve/compare/v1.55.0...v1.55.1
 [1.55.0]: https://github.com/kgdunn/process-improve/compare/v1.54.0...v1.55.0
 [1.54.0]: https://github.com/kgdunn/process-improve/compare/v1.53.0...v1.54.0
 [1.53.0]: https://github.com/kgdunn/process-improve/compare/v1.52.4...v1.53.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,14 @@ those changes.
 
 ### Documentation
 
-- Marketing refresh of the front-facing docs to catch up with the recent
+- Documentation update of the front-facing docs to catch up with the recent
   releases. The README gains a "What's new" section and runnable quick-start
   snippets for on-line monitoring with `AdaptivePCA` and for OMARS / D-optimal
   designs; the feature list and capability table now cover adaptive/on-line
   monitoring and the OMARS / optimal-design engine. The scikit-learn section is
   reframed as complementary ("Works alongside scikit-learn") rather than
-  adversarial, and the inactive `factori.al` references are removed. The Sphinx
-  landing page and quickstart guide are updated to mirror the new highlights.
+  adversarial, and the `factori.al` references are removed. The Sphinx landing
+  page and quickstart guide are updated to mirror the new highlights.
 
 ## [1.55.0] - 2026-07-19
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.55.0
-date-released: "2026-07-19"
+version: 1.55.1
+date-released: "2026-07-21"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/README.md
+++ b/README.md
@@ -70,13 +70,6 @@ practitioners actually use on real plant and lab data:
 Outputs are `pandas`-native: scores, loadings, and predictions keep your row
 and column labels.
 
-> **Scale:** the estimators are *in-memory* - they assume the (scaled) data
-> matrix fits in RAM, plus a couple of working copies during `fit`. A float64
-> matrix needs about `rows x cols x 8 bytes` (e.g. 10M x 200 is ~16 GB). For
-> the practical limits and guidance on larger-than-RAM data, see
-> [Scaling and memory](https://kgdunn.github.io/process-improve/scaling.html)
-> ([source](docs/scaling.rst)).
-
 It is the companion package to the online textbook
 [Process Improvement using Data](https://learnche.org/pid).
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ sure am I?*
 
 ## What's new
 
-The last few releases turned `process-improve` from a batch-modelling toolkit
-into an end-to-end one. Highlights (full history in [CHANGELOG.md](CHANGELOG.md)):
+The last few releases extend `process-improve` from offline model-building into
+end-to-end, on-line workflows. Highlights (full history in [CHANGELOG.md](CHANGELOG.md)):
 
 - **Models that keep up with a drifting process.** `AdaptivePCA` and
   `AdaptivePLS` (v1.55) are recursive estimators for on-line monitoring and soft
-  sensing: seed them from a batch fit, then stream one observation at a time.
+  sensing: seed them from an initial fit, then stream one observation at a time.
   They track the operating point, re-learn the correlation structure, and tell
   you - in units of components - exactly how far the process has drifted from
   where it was trained.
@@ -218,9 +218,10 @@ print(evaluate_design(d_opt, metric="all"))   # D/I/G-efficiency, aliasing, pred
 
 ### On-line monitoring with Adaptive PCA
 
-Batch models go stale the moment the process drifts. `AdaptivePCA` seeds itself
-from a batch fit, then keeps learning as data streams in - flagging faults and
-reporting exactly how far the process has moved from where it was trained:
+A static model goes stale the moment the process drifts. `AdaptivePCA` seeds
+itself from an initial fit, then keeps learning as data streams in - flagging
+faults and reporting exactly how far the process has moved from where it was
+trained:
 
 ```python
 from process_improve.multivariate import AdaptivePCA

--- a/README.md
+++ b/README.md
@@ -225,8 +225,7 @@ reporting exactly how far the process has moved from where it was trained:
 ```python
 from process_improve.multivariate import AdaptivePCA
 
-# Seed on a block of known-good ("common cause") data. Pass RAW data:
-# the adaptive model mean-centres and scales internally.
+# Seed on a block of known-good ("common cause") data
 monitor = AdaptivePCA(n_components=3).fit(X_reference)
 
 # Feed live observations one row at a time

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Multivariate analysis, designed experiments, and process monitoring for Python.**
 Built for the chemometrics, manufacturing, and pharma workflows where you need to
-know not just *what fits*, but *is this batch normal, which variable moved, and how
-sure am I?*
+know not just *what fits*, but *is this observation normal, which variable moved,
+and how sure am I?*
 
 [![PyPI version](https://img.shields.io/pypi/v/process-improve.svg)](https://pypi.org/project/process-improve/)
 [![Python versions](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fkgdunn%2Fprocess-improve%2Fmain%2Fpyproject.toml&label=python)](https://pypi.org/project/process-improve/)
@@ -27,7 +27,7 @@ end-to-end, on-line workflows. Highlights (full history in [CHANGELOG.md](CHANGE
 
 - **Models that keep up with a drifting process.** `AdaptivePCA` and
   `AdaptivePLS` (v1.55) are recursive estimators for on-line monitoring and soft
-  sensing: seed them from an initial fit, then stream one observation at a time.
+  sensing: start from an initial fit, then stream one observation at a time.
   They track the operating point, re-learn the correlation structure, and tell
   you - in units of components - exactly how far the process has drifted from
   where it was trained.
@@ -218,10 +218,9 @@ print(evaluate_design(d_opt, metric="all"))   # D/I/G-efficiency, aliasing, pred
 
 ### On-line monitoring with Adaptive PCA
 
-A static model goes stale the moment the process drifts. `AdaptivePCA` seeds
-itself from an initial fit, then keeps learning as data streams in - flagging
-faults and reporting exactly how far the process has moved from where it was
-trained:
+A static model goes stale the moment the process drifts. `AdaptivePCA` starts
+from an initial fit, then keeps learning as data streams in - flagging faults and
+reporting exactly how far the process has moved from where it was trained:
 
 ```python
 from process_improve.multivariate import AdaptivePCA

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # process-improve
 
 **Multivariate analysis, designed experiments, and process monitoring for Python.**
-Built for chemometrics, manufacturing, and pharma data - the methods that scikit-learn skips.
+Built for the chemometrics, manufacturing, and pharma workflows where you need to
+know not just *what fits*, but *is this batch normal, which variable moved, and how
+sure am I?*
 
 [![PyPI version](https://img.shields.io/pypi/v/process-improve.svg)](https://pypi.org/project/process-improve/)
 [![Python versions](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fkgdunn%2Fprocess-improve%2Fmain%2Fpyproject.toml&label=python)](https://pypi.org/project/process-improve/)
@@ -18,6 +20,27 @@ Built for chemometrics, manufacturing, and pharma data - the methods that scikit
 > ([source](docs/architecture.rst)) is the map of the codebase - package layout, the estimator
 > stack, and the MCP tool layer.
 
+## What's new
+
+The last few releases turned `process-improve` from a batch-modelling toolkit
+into an end-to-end one. Highlights (full history in [CHANGELOG.md](CHANGELOG.md)):
+
+- **Models that keep up with a drifting process.** `AdaptivePCA` and
+  `AdaptivePLS` (v1.55) are recursive estimators for on-line monitoring and soft
+  sensing: seed them from a batch fit, then stream one observation at a time.
+  They track the operating point, re-learn the correlation structure, and tell
+  you - in units of components - exactly how far the process has drifted from
+  where it was trained.
+- **A DOE engine that goes past textbook designs.** OMARS (orthogonal minimally
+  aliased response surfaces), D-/I-/A-optimal designs, fractional-cube CCDs,
+  design augmentation (`fixed_runs=`), and an `evaluate_design` suite that scores
+  any design on D/I/G-efficiency, aliasing, and prediction variance.
+- **Sensory & descriptive panel analysis** (`process_improve.sensory`): validate
+  a panel, flag inconsistent assessors with the Mixed Assessor Model, and relate
+  attributes to product covariates - with an honest genuine-vs-proxy separation.
+- **Robust regression** (`process_improve.regression`): repeated-median and
+  Theil-Sen estimators for data with outliers, plus `OLS` and `fit_robust_lm`.
+
 ## What it does
 
 `process-improve` provides production-grade implementations of the methods
@@ -28,12 +51,20 @@ practitioners actually use on real plant and lab data:
 - **PLS** regression with a fully sklearn-compatible API, VIP scores, and
   cross-validated diagnostics
 - **TPLS** - PLS for *T-shaped (multi-block) data structures*
+- **Adaptive PCA / PLS** - recursive, self-updating models for on-line process
+  monitoring and soft sensing; they follow a drifting process one observation at
+  a time and report how far it has moved
 - **Outlier detection** combining Hotelling's T² and SPE with an ESD-based test
 - **Designed experiments** - full-factorial, fractional-factorial, and
-  response-surface designs, plus a multi-stage DOE strategy recommender
+  response-surface designs; OMARS and D-/I-/A-optimal designs; a design-quality
+  scorer (`evaluate_design`); and a multi-stage DOE strategy recommender
 - **Process monitoring** - Shewhart, CUSUM, and Holt-Winters control charts
 - **Batch data analysis** - alignment, feature extraction, and multivariate
   batch monitoring (MBPCA / MBPLS)
+- **Sensory & descriptive panel analysis** - panel validation, the Mixed Assessor
+  Model, and attribute-to-product relations with a genuine-vs-proxy separation
+- **Robust regression** - repeated-median and Theil-Sen estimators for data with
+  outliers
 - **Interactive Plotly diagnostics** bound directly to every fitted model
 
 Outputs are `pandas`-native: scores, loadings, and predictions keep your row
@@ -47,26 +78,27 @@ and column labels.
 > ([source](docs/scaling.rst)).
 
 It is the companion package to the online textbook
-[Process Improvement using Data](https://learnche.org/pid), and powers the
-statistical engine behind [factori.al](https://factori.al).
+[Process Improvement using Data](https://learnche.org/pid).
 
-## Why not scikit-learn?
+## Works alongside scikit-learn
 
-scikit-learn answers *"what fits the data?"* - `process-improve` answers
-*"is this batch normal, which variable went off, and how confident am I in the
-prediction?"* The two libraries are designed to be used together;
-`process-improve` follows sklearn conventions (`fit`, `predict`, `score`, the
-`_` suffix on fitted attributes) and drops into existing pipelines.
+`process-improve` is designed to sit *next to* scikit-learn, not replace it. It
+follows the same conventions (`fit`, `predict`, `score`, the `_` suffix on fitted
+attributes), so its estimators drop straight into `Pipeline`, `GridSearchCV`, and
+`cross_val_score`. What it adds is the process-analytics layer on top: the
+diagnostics that tell you whether a new batch is normal, which variable moved, and
+how confident the prediction is.
 
-| Capability                                       | scikit-learn | process-improve |
-| ------------------------------------------------ | :----------: | :-------------: |
-| PCA, PLS with sklearn-style API                  |       ✓      |        ✓        |
-| Missing-data fitting (NIPALS / TSR)              |       -      |        ✓        |
-| Hotelling's T² + SPE outlier limits              |       -      |        ✓        |
-| Variable-level score contributions               |       -      |        ✓        |
-| Cross-validated coefficient confidence intervals |       -      |        ✓        |
-| Multi-block models (TPLS)                         |       -      |        ✓        |
-| Designed experiments (DoE)                        |       -      |        ✓        |
+| Capability                                        | scikit-learn | process-improve |
+| ------------------------------------------------- | :----------: | :-------------: |
+| PCA, PLS with sklearn-style API                   |       ✓      |        ✓        |
+| Missing-data fitting (NIPALS / TSR)               |       -      |        ✓        |
+| Hotelling's T² + SPE outlier limits               |       -      |        ✓        |
+| Variable-level score contributions                |       -      |        ✓        |
+| Cross-validated coefficient confidence intervals  |       -      |        ✓        |
+| Multi-block models (TPLS)                          |       -      |        ✓        |
+| On-line / adaptive monitoring (recursive PCA/PLS) |       -      |        ✓        |
+| Designed experiments, incl. OMARS & optimal       |       -      |        ✓        |
 | Control charts (Shewhart / CUSUM / Holt-Winters)  |       -      |        ✓        |
 | Batch process monitoring (MBPCA / MBPLS)          |       -      |        ✓        |
 | Plotly diagnostics built in                       |       -      |        ✓        |
@@ -170,6 +202,55 @@ for s in strategy["stages"]:
     print(s["stage_number"], s["design_type"], s["estimated_runs"])
 ```
 
+### One-shot optimal & OMARS designs
+
+Ask for a ready-to-run design table and score it, in two lines:
+
+```python
+from process_improve.experiments import Factor, generate_design, evaluate_design
+
+factors = [
+    Factor(name="A", low=-1, high=1),
+    Factor(name="B", low=-1, high=1),
+    Factor(name="C", low=-1, high=1),
+]
+
+# An OMARS design: main effects clear of every second-order term
+design = generate_design(factors, design_type="omars")
+
+# Or a run-budgeted D-optimal design, then grade its quality
+d_opt = generate_design(factors, design_type="d_optimal", budget=14)
+print(evaluate_design(d_opt, metric="all"))   # D/I/G-efficiency, aliasing, prediction variance
+```
+
+### On-line monitoring with Adaptive PCA
+
+Batch models go stale the moment the process drifts. `AdaptivePCA` seeds itself
+from a batch fit, then keeps learning as data streams in - flagging faults and
+reporting exactly how far the process has moved from where it was trained:
+
+```python
+from process_improve.multivariate import AdaptivePCA
+
+# Seed on a block of known-good ("common cause") data. Pass RAW data:
+# the adaptive model mean-centres and scales internally.
+monitor = AdaptivePCA(n_components=3).fit(X_reference)
+
+# Feed live observations one row at a time
+for _, row in X_stream.iterrows():
+    result = monitor.update(row.to_numpy())
+    if not result.in_control:
+        print(f"Out-of-control point: SPE={result.spe:.2f}, T²={result.hotellings_t2:.2f}")
+
+# How far has the model drifted from its training subspace? (in units of components)
+print(monitor.distance_.tail())
+print(monitor.center_shift_.tail())   # operating-point migration, in training-SD units
+```
+
+`AdaptivePLS` does the same for regression and soft sensing, and handles
+infrequently-sampled responses: the X-space model adapts every step while the
+regression part waits for the next lab result.
+
 Longer, fully-worked versions of each example live in the
 [Quickstart guide](https://kgdunn.github.io/process-improve/quickstart.html)
 and the [`examples/`](examples/) folder.
@@ -193,7 +274,6 @@ preserved through `fit` and `transform`.
 - **Applied DoE tutorial (8 modules):**
   <https://kgdunn.github.io/process-improve/applied_doe/index.html>
 - **Companion textbook:** [Process Improvement using Data](https://learnche.org/pid)
-- **Hosted experiment-design tool:** [factori.al](https://factori.al)
 - **Local docs build:** `cd docs && make html`
 
 ## Citing process-improve

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ It is the companion package to the online textbook
 follows the same conventions (`fit`, `predict`, `score`, the `_` suffix on fitted
 attributes), so its estimators drop straight into `Pipeline`, `GridSearchCV`, and
 `cross_val_score`. What it adds is the process-analytics layer on top: the
-diagnostics that tell you whether a new batch is normal, which variable moved, and
+diagnostics that tell you whether a new observation is normal, which variable moved, and
 how confident the prediction is.
 
 | Capability                                        | scikit-learn | process-improve |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@ Process Improvement using Data
 ==============================
 
 A Python package for multivariate data analysis, designed experiments, and process
-monitoring. It covers batch modelling (PCA, PLS, TPLS) and *on-line*, self-updating
+monitoring. It covers offline model-building (PCA, PLS, TPLS) and *on-line*, self-updating
 monitoring (adaptive PCA / PLS), a designed-experiments engine that reaches past the
 textbook catalogue (OMARS and D-/I-/A-optimal designs, with a design-quality scorer),
 control charts, batch-process analysis, and descriptive sensory-panel analysis.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,11 @@ Process Improvement using Data
 ==============================
 
 A Python package for multivariate data analysis, designed experiments, and process
-monitoring. Companion to the online textbook
+monitoring. It covers batch modelling (PCA, PLS, TPLS) and *on-line*, self-updating
+monitoring (adaptive PCA / PLS), a designed-experiments engine that reaches past the
+textbook catalogue (OMARS and D-/I-/A-optimal designs, with a design-quality scorer),
+control charts, batch-process analysis, and descriptive sensory-panel analysis.
+Companion to the online textbook
 `Process Improvement using Data <https://learnche.org/pid>`_.
 
 .. toctree::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -83,9 +83,9 @@ On-line Monitoring (Adaptive PCA / PLS)
 ---------------------------------------
 
 A static model goes stale as soon as the process drifts. ``AdaptivePCA`` and
-``AdaptivePLS`` seed themselves from an initial fit, then keep learning as data
-streams in, one observation at a time. Pass **raw** data: the adaptive model
-mean-centres and scales internally.
+``AdaptivePLS`` start from an initial fit, then keep learning as data streams in,
+one observation at a time. Pass **raw** data: the adaptive model mean-centres and
+scales internally.
 
 .. code-block:: python
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -82,8 +82,8 @@ Use cross-validation to select the number of PCA components:
 On-line Monitoring (Adaptive PCA / PLS)
 ---------------------------------------
 
-Batch models go stale as soon as the process drifts. ``AdaptivePCA`` and
-``AdaptivePLS`` seed themselves from a batch fit, then keep learning as data
+A static model goes stale as soon as the process drifts. ``AdaptivePCA`` and
+``AdaptivePLS`` seed themselves from an initial fit, then keep learning as data
 streams in, one observation at a time. Pass **raw** data: the adaptive model
 mean-centres and scales internally.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -79,6 +79,58 @@ Use cross-validation to select the number of PCA components:
    print(f"Recommended: {result.n_components} components")
    print(f"PRESS ratios: {result.press_ratio}")
 
+On-line Monitoring (Adaptive PCA / PLS)
+---------------------------------------
+
+Batch models go stale as soon as the process drifts. ``AdaptivePCA`` and
+``AdaptivePLS`` seed themselves from a batch fit, then keep learning as data
+streams in, one observation at a time. Pass **raw** data: the adaptive model
+mean-centres and scales internally.
+
+.. code-block:: python
+
+   from process_improve.multivariate import AdaptivePCA
+
+   # Seed on a block of known-good ("common cause") data
+   monitor = AdaptivePCA(n_components=3).fit(X_reference)
+
+   # Feed live observations one row at a time
+   for _, row in X_stream.iterrows():
+       result = monitor.update(row.to_numpy())
+       if not result.in_control:
+           print(f"Out of control: SPE={result.spe:.2f}, T2={result.hotellings_t2:.2f}")
+
+   # Drift diagnostics accumulated over the stream
+   monitor.distance_       # subspace drift, in units of components
+   monitor.center_shift_   # operating-point migration, in training-SD units
+
+``AdaptivePLS`` does the same for regression and soft sensing, and supports
+infrequently-sampled responses: the X-space model adapts every step while the
+regression part waits for the next response.
+
+Optimal & OMARS Designs
+-----------------------
+
+Beyond the textbook designs, ask for an OMARS (orthogonal minimally aliased
+response surface) or an optimal design, then grade its quality:
+
+.. code-block:: python
+
+   from process_improve.experiments import Factor, generate_design, evaluate_design
+
+   factors = [
+       Factor(name="A", low=-1, high=1),
+       Factor(name="B", low=-1, high=1),
+       Factor(name="C", low=-1, high=1),
+   ]
+
+   # OMARS: main effects clear of every second-order term
+   design = generate_design(factors, design_type="omars")
+
+   # A run-budgeted D-optimal design, scored on every quality metric
+   d_opt = generate_design(factors, design_type="d_optimal", budget=14)
+   metrics = evaluate_design(d_opt, metric="all")  # D/I/G-efficiency, aliasing, ...
+
 DOE Strategy Example
 --------------------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -84,8 +84,7 @@ On-line Monitoring (Adaptive PCA / PLS)
 
 A static model goes stale as soon as the process drifts. ``AdaptivePCA`` and
 ``AdaptivePLS`` start from an initial fit, then keep learning as data streams in,
-one observation at a time. Pass **raw** data: the adaptive model mean-centres and
-scales internally.
+one observation at a time.
 
 .. code-block:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.55.0"
+version = "1.55.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Update the front-facing docs so they catch up with the last few weeks of releases (through v1.55.0) and read in a way that makes a prospective user want to try the package right away.

- **README**: new "What's new" section; expanded feature list and comparison table (adaptive/on-line monitoring, OMARS & optimal DOE); new runnable quick-start snippets for `AdaptivePCA` on-line monitoring and for OMARS / D-optimal designs.
- **Softened the scikit-learn framing** from an adversarial "Why not scikit-learn?" to a complementary "Works alongside scikit-learn", per maintainer preference.
- **Removed the `factori.al` references.**
- **Dropped the in-memory/scaling caveat callout** from the README front page.
- **Wording**: reserve "batch" for the batch-process data sense used elsewhere in the repo; the adaptive-model context now uses "static"/"initial"/"offline" instead.
- **Docs landing/quickstart** updated to mirror the new highlights.
- Version bumped to `1.55.1` with a matching `CITATION.cff` update and a `CHANGELOG.md` Documentation entry.

## Test plan

- [x] New README/quickstart snippets were executed against the real API: `AdaptivePCA().fit().update()`, `AdaptivePLS().fit()`, `generate_design(..., design_type="omars"/"d_optimal")`, and `evaluate_design(..., metric="all")` all run.
- [x] No em-dashes introduced in the edited docs.
- [x] `pyproject.toml` and `CITATION.cff` report the same version.

## Checklist

- [x] Version bumped in `pyproject.toml` (PATCH for docs)
- [ ] Tests added or updated where relevant (docs-only change; not applicable)
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X762hoccCvqtJuDgwUf6BH