### PR TITLE
Advertise model inversion in the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ those changes.
 
 ## [Unreleased]
 
+## [1.62.2] - 2026-07-29
+
+### Changed
+
+- README: model inversion is now advertised alongside the other headline
+  capabilities, with a runnable `PLS.invert()` / `OPLS` quick-start example on
+  the cheddar-cheese data and links to the user-guide page and book chapter.
+
 ## [1.62.1] - 2026-07-28
 
 ### Added
@@ -2779,7 +2787,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.62.1...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.62.2...HEAD
+[1.62.2]: https://github.com/kgdunn/process-improve/compare/v1.62.1...v1.62.2
 [1.62.1]: https://github.com/kgdunn/process-improve/compare/v1.62.0...v1.62.1
 [1.62.0]: https://github.com/kgdunn/process-improve/compare/v1.61.0...v1.62.0
 [1.61.0]: https://github.com/kgdunn/process-improve/compare/v1.60.0...v1.61.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.62.1
-date-released: "2026-07-28"
+version: 1.62.2
+date-released: "2026-07-29"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ and how sure am I?*
 The last few releases extend `process-improve` from offline model-building into
 end-to-end, on-line workflows. Highlights (full history in [CHANGELOG.md](CHANGELOG.md)):
 
+- **Run a model backwards, to design rather than predict.** `PLS.invert()`
+  (v1.61) fixes the quality you want and solves for the inputs that reach it.
+  The answer is rarely one recipe: it is a whole *null space* of them, which you
+  can walk to trade one input against another while the prediction holds still.
+  The new `OPLS` estimator reaches the same set of designs by separating that
+  freedom during fitting, which for a single response is provably the same
+  subspace ([García-Carrión et al., 2025](https://doi.org/10.1002/cem.70057)).
+  Written up with a worked example in the
+  [user guide](https://kgdunn.github.io/process-improve/user_guide/model_inversion.html)
+  and, at length, in [the book](https://learnche.org/pid/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space).
 - **Models that keep up with a drifting process.** `AdaptivePCA` and
   `AdaptivePLS` (v1.55) are recursive estimators for on-line monitoring and soft
   sensing: start from an initial fit, then stream one observation at a time.
@@ -51,6 +61,9 @@ practitioners actually use on real plant and lab data:
 - **PLS** regression with a fully sklearn-compatible API, VIP scores, and
   cross-validated diagnostics
 - **TPLS** - PLS for *T-shaped (multi-block) data structures*
+- **Model inversion** - `PLS.invert()` and `OPLS` solve for the inputs that
+  reach a target quality, return the null space of equally valid designs, and
+  report how far each design sits from the data that support it
 - **Adaptive PCA / PLS** - recursive, self-updating models for on-line process
   monitoring and soft sensing; they follow a drifting process one observation at
   a time and report how far it has moved
@@ -90,6 +103,7 @@ how confident the prediction is.
 | Variable-level score contributions                |       -      |        ✓        |
 | Cross-validated coefficient confidence intervals  |       -      |        ✓        |
 | Multi-block models (TPLS)                          |       -      |        ✓        |
+| Model inversion: design inputs for a target        |       -      |        ✓        |
 | On-line / adaptive monitoring (recursive PCA/PLS) |       -      |        ✓        |
 | Designed experiments, incl. OMARS & optimal       |       -      |        ✓        |
 | Control charts (Shewhart / CUSUM / Holt-Winters)  |       -      |        ✓        |
@@ -173,6 +187,36 @@ print(cv.beta_ci_lower, cv.beta_ci_upper)   # 95% CI for each beta
 print(cv.significant)                       # betas significantly != 0
 print(cv.q_squared)                         # cross-validated R² (Q²)
 ```
+
+### Model inversion - design the inputs for a quality you choose
+
+```python
+from process_improve.multivariate.methods import PLS, OPLS
+
+# X: acetic acid, H2S and lactic acid in 26 cheddar cheeses; y: their taste score
+pls = PLS(n_components=2).fit(X, y)
+
+design = pls.invert(y_desired=20.9)
+print(design.x_new.round(2).to_list())   # [5.52, 5.56, 1.4], in the original units
+print(design.hotellings_t2.round(2))     # 0.06: well inside the calibration data
+print(design.null_space_dimension)       # 1: a line of designs, not a single recipe
+
+# Walk that line. The recipe changes; the predicted taste does not.
+for step in (-1.0, 0.0, 1.0):
+    print(pls.invert(20.9, null_space_coordinates=[step]).x_new.round(2).to_list())
+# [4.95, 6.1, 1.33]
+# [5.52, 5.56, 1.4]
+# [6.09, 5.02, 1.46]
+
+# O-PLS separates that freedom while fitting, so inversion becomes one division.
+opls = OPLS(n_orthogonal_components=1).fit(X, y)
+print(opls.invert(y_desired=20.9).x_new.round(2).to_list())   # [5.46, 5.62, 1.39]
+```
+
+Both routes describe the same set of designs, and differ only in which point on
+it they report. The freedom is what you spend on cost, supply, or a regulatory
+window; the `hotellings_t2` is what tells you when a design has walked past the
+evidence.
 
 ### DOE - multi-stage experimental strategy
 
@@ -265,6 +309,10 @@ preserved through `fit` and `transform`.
 - **API reference & user guide:** <https://kgdunn.github.io/process-improve/>
 - **Applied DoE tutorial (8 modules):**
   <https://kgdunn.github.io/process-improve/applied_doe/index.html>
+- **Model inversion, end to end:** the
+  [user-guide page](https://kgdunn.github.io/process-improve/user_guide/model_inversion.html),
+  and the book chapter it is drawn from,
+  [Using a PLS model backwards](https://learnche.org/pid/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space)
 - **Companion textbook:** [Process Improvement using Data](https://learnche.org/pid)
 - **Local docs build:** `cd docs && make html`
 

--- a/README.md
+++ b/README.md
@@ -25,29 +25,24 @@ and how sure am I?*
 The last few releases extend `process-improve` from offline model-building into
 end-to-end, on-line workflows. Highlights (full history in [CHANGELOG.md](CHANGELOG.md)):
 
-- **Run a model backwards, to design rather than predict.** `PLS.invert()`
-  (v1.61) fixes the quality you want and solves for the inputs that reach it.
-  The answer is rarely one recipe: it is a whole *null space* of them, which you
-  can walk to trade one input against another while the prediction holds still.
-  The new `OPLS` estimator reaches the same set of designs by separating that
-  freedom during fitting, which for a single response is provably the same
-  subspace ([García-Carrión et al., 2025](https://doi.org/10.1002/cem.70057)).
-  Written up with a worked example in the
+- **Design, rather than predict.** `PLS.invert()` (v1.61) solves for the inputs
+  that reach a target quality, and returns the *null space* of equally valid
+  recipes. `OPLS` reaches the same designs by separating that freedom while
+  fitting. See the
   [user guide](https://kgdunn.github.io/process-improve/user_guide/model_inversion.html)
-  and, at length, in [the book](https://learnche.org/pid/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space).
+  or the longer
+  [book chapter](https://learnche.org/pid/latent-variable-modelling/projection-to-latent-structures/pls-model-inversion-and-the-orthogonal-space).
 - **Models that keep up with a drifting process.** `AdaptivePCA` and
-  `AdaptivePLS` (v1.55) are recursive estimators for on-line monitoring and soft
-  sensing: start from an initial fit, then stream one observation at a time.
-  They track the operating point, re-learn the correlation structure, and tell
-  you - in units of components - exactly how far the process has drifted from
-  where it was trained.
-- **A DOE engine that goes past textbook designs.** OMARS (orthogonal minimally
-  aliased response surfaces), D-/I-/A-optimal designs, fractional-cube CCDs,
-  design augmentation (`fixed_runs=`), and an `evaluate_design` suite that scores
-  any design on D/I/G-efficiency, aliasing, and prediction variance.
+  `AdaptivePLS` (v1.55) fit once, then stream one observation at a time,
+  re-learning the correlation structure and reporting how far the process has
+  drifted, in units of components.
+- **A DOE engine that goes past textbook designs.** OMARS designs, D-/I-/A-optimal
+  designs, fractional-cube CCDs, design augmentation (`fixed_runs=`), and an
+  `evaluate_design` suite scoring any design on efficiency, aliasing, and
+  prediction variance.
 - **Sensory & descriptive panel analysis** (`process_improve.sensory`): validate
   a panel, flag inconsistent assessors with the Mixed Assessor Model, and relate
-  attributes to product covariates - with an honest genuine-vs-proxy separation.
+  attributes to product covariates.
 - **Robust regression** (`process_improve.regression`): repeated-median and
   Theil-Sen estimators for data with outliers, plus `OLS` and `fit_robust_lm`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.62.1"
+version = "1.62.2"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
`PLS.invert()` and `OPLS` shipped in 1.61, and the user-guide page in 1.62.1, but someone landing on the repository page had no way to find out either existed. This puts the capability where readers look.

## What changed

- **"What's new"**: a new leading bullet on running a model backwards, the null space of equally valid designs, and the `OPLS` route to the same subspace, citing García-Carrión et al. (2025) and linking both the user-guide page and the book chapter.
- **"What it does"**: a model-inversion entry beside PCA / PLS / TPLS.
- **scikit-learn comparison table**: a "Model inversion: design inputs for a target" row.
- **Quick start**: a new section between PLS and DOE, showing `invert()`, the null-space dimension, walking the null space, and the `OPLS` equivalent. Every printed value in that block was run against the packaged cheddar-cheese data and pasted from the actual output.
- **Documentation & learning resources**: a link to the user-guide page and the book chapter.

## Version

PATCH bump to 1.62.2, `CITATION.cff` kept in sync (version and `date-released`), and a `### Changed` entry under a new `1.62.2` heading with the link-reference footer updated. Tell me if you would rather this sat under `Unreleased` without a bump; the repository convention reads as bump-on-every-PR, so I followed that.

No source, test, or configuration changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsTypY4FcRbrXRxorb9raz)_