### PR TITLE
Docstring/code consistency audit for computational modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ those changes.
 
 ## [Unreleased]
 
+## [1.62.3] - 2026-07-31
+
+### Fixed
+
+- Docstrings: `PCA.select_n_components` now documents the
+  `return_consensus` parameter (previously present in the signature but
+  missing from the Parameters section) and the four extra Bunch keys it
+  attaches (`minka_n_components`, `parallel_analysis_n_components`,
+  `consensus`, `consensus_counts`).
+- Docstring: `PLS.select_n_components` `selection_mode` bullet in the
+  Returns section had a truncated sentence ("or `None` when
+  `selection_distribution` is."); completed to "... is `None`.".
+
 ## [1.62.2] - 2026-07-29
 
 ### Changed
@@ -2787,7 +2800,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.62.2...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.62.3...HEAD
+[1.62.3]: https://github.com/kgdunn/process-improve/compare/v1.62.2...v1.62.3
 [1.62.2]: https://github.com/kgdunn/process-improve/compare/v1.62.1...v1.62.2
 [1.62.1]: https://github.com/kgdunn/process-improve/compare/v1.62.0...v1.62.1
 [1.62.0]: https://github.com/kgdunn/process-improve/compare/v1.61.0...v1.62.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.62.2
-date-released: "2026-07-29"
+version: 1.62.3
+date-released: "2026-07-31"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.62.2"
+version = "1.62.3"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -1074,6 +1074,14 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             emits a :class:`DeprecationWarning`; the value is ignored. Use
             ``selection_rule="q2_increment"`` (and tune ``min_q2_increase``)
             for a comparable parsimony preference.
+        return_consensus : bool, default False
+            When ``True``, also run :meth:`minka_mle` and
+            :meth:`parallel_analysis` on ``X`` and attach their
+            recommendations to the returned Bunch alongside the ekf choice
+            (see the ``minka_n_components`` /
+            ``parallel_analysis_n_components`` / ``consensus`` /
+            ``consensus_counts`` fields below). Off by default because the
+            two extra estimates require their own eigendecomposition.
         **pca_kwargs
             Additional keyword arguments passed to the ``PCA()`` constructor
             under ``cv_scheme="row_wise"`` (e.g. ``algorithm="nipals"``).
@@ -1107,6 +1115,18 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
               (preserved for back-compat).
             - ``cv_scheme`` - the scheme used (``"ekf"`` or ``"row_wise"``).
             - ``selection_rule`` - the rule used to pick ``n_components``.
+
+            When ``return_consensus=True`` the Bunch also carries four
+            extra keys sourced from the cheap cross-checks:
+
+            - ``minka_n_components`` - :meth:`minka_mle` estimate (int).
+            - ``parallel_analysis_n_components`` -
+              :meth:`parallel_analysis` estimate (int).
+            - ``consensus`` - ``"agree"`` when the three recommendations
+              lie within one component of one another, ``"disagree"``
+              otherwise.
+            - ``consensus_counts`` - the three recommendations as a
+              ``(ekf, minka, parallel_analysis)`` tuple.
 
         References
         ----------

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -1308,7 +1308,7 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
               distribution signals a confident recommendation; a flat or
               multi-modal one flags it for review.
             - ``selection_mode`` - the most-voted component count, or
-              ``None`` when ``selection_distribution`` is.
+              ``None`` when ``selection_distribution`` is ``None``.
             - ``selection_is_stable`` - ``True`` iff the modal vote share
               meets ``stability_threshold``; ``None`` when no distribution
               was computed.


### PR DESCRIPTION
## Summary

Audit of user-facing computational functions across `multivariate/`,
`experiments/`, `monitoring/`, `regression/`, `univariate/`, and
`batch/` for docstring/code inconsistencies. Two real docstring bugs
found and fixed; no code behaviour changes.

- **`PCA.select_n_components`** (`src/process_improve/multivariate/_pca.py`):
  the `return_consensus` keyword argument was in the signature but
  missing from the Parameters section, and the four extra Bunch keys
  it attaches (`minka_n_components`, `parallel_analysis_n_components`,
  `consensus`, `consensus_counts`) were not listed in Returns. Both now
  documented.

- **`PLS.select_n_components`** (`src/process_improve/multivariate/_pls.py`):
  the `selection_mode` bullet in the Returns section had a truncated
  sentence: "or `None` when `selection_distribution` is." Completed to
  "... is `None`."

Version bumped to `1.62.3` (PATCH: docstring-only fix); `CITATION.cff`
and `CHANGELOG.md` updated to match.

### Flagged for human review, not changed

- `analyze_experiment` (`src/process_improve/experiments/analysis.py:149`)
  has a `coding: str = "coded"` parameter in its signature that is
  neither used in the function body nor documented in the docstring.
  Left alone since the fix is a code change, not a docstring change.
  Either the parameter should be dropped or the intended behaviour
  wired up and documented.

## Test plan

- [ ] `uv run ruff check .` passes
- [ ] `uv run pytest` still passes (docstring-only changes)

## Checklist

- [x] Version bumped in `pyproject.toml` (PATCH for docstring fixes)
- [ ] Tests added or updated where relevant (n/a - docstring-only)
- [ ] `ruff check .` passes
- [x] `CHANGELOG.md` updated