### PR TITLE
feat(experiments): expose trade_off_table as an MCP tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ those changes.
 
 ## [Unreleased]
 
+## [1.64.0] - 2026-08-08
+
+### Added
+
+- `trade_off_table` is now an agent-callable MCP tool
+  (`experiments/_tools/trade_off_table.py`). It returns the two-level
+  factorial trade-off grid: one cell per (run budget, factor count), each
+  carrying the design label, its resolution and the generators that build
+  it. Cells where the budget exceeds the full factorial report replication
+  rather than an error, and impossible combinations come back blank with the
+  reason attached. The run and factor axes are caller-supplied, bounded at
+  128 runs and 12 factors so the minimum-aberration search behind each cell
+  stays interactive.
+
 ## [1.63.0] - 2026-08-08
 
 ### Added
@@ -2872,7 +2886,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.63.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.64.0...HEAD
+[1.64.0]: https://github.com/kgdunn/process-improve/compare/v1.63.0...v1.64.0
 [1.63.0]: https://github.com/kgdunn/process-improve/compare/v1.62.3...v1.63.0
 [1.62.3]: https://github.com/kgdunn/process-improve/compare/v1.62.2...v1.62.3
 [1.62.2]: https://github.com/kgdunn/process-improve/compare/v1.62.1...v1.62.2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.63.0
+version: 1.64.0
 date-released: "2026-08-08"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.63.0"
+version = "1.64.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/experiments/_tools/trade_off_table.py
+++ b/src/process_improve/experiments/_tools/trade_off_table.py
@@ -1,0 +1,131 @@
+# (c) Kevin Dunn, 2010-2026. MIT License.
+"""MCP tool wrapper: ``trade_off_table`` (ENG-02)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from process_improve.experiments._tools import _TOOL_EXPECTED_EXCEPTIONS, _register, logger
+from process_improve.tool_spec import clean, tool_spec
+
+# Beyond this the exhaustive minimum-aberration search behind each cell stops
+# being interactive, so the tool refuses the request at the schema layer.
+_MAX_RUNS = 128
+_MAX_FACTORS = 12
+
+
+class TradeOffTableInput(BaseModel):
+    """Input contract for ``trade_off_table``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    runs: list[int] = Field(
+        default=[4, 8, 16, 32, 64],
+        description=("Run budgets, one per row of the table. Each must be a power of two (4, 8, 16, 32, 64, 128)."),
+        min_length=1,
+        max_length=8,
+    )
+    factors: list[int] = Field(
+        default=[3, 4, 5, 6, 7, 8, 9],
+        description="Factor counts, one per column of the table. Each between 2 and 12.",
+        min_length=1,
+        max_length=11,
+    )
+
+
+@tool_spec(
+    name="trade_off_table",
+    description=(
+        "Build the two-level factorial trade-off table: for each combination of run budget "
+        "and number of factors, the design that fits and what it costs in aliasing. "
+        "Each cell reports the design label (e.g. '2^(7-4) III'), its resolution, and the "
+        "generators that build it; cells where the budget exceeds the full factorial report "
+        "replication instead ('2^3 (twice)'), and impossible combinations are blank. "
+        "Use this tool when the user is choosing how many experiments to run, asks how many "
+        "factors they can screen on a given budget, or asks what they give up by running "
+        "fewer experiments. For the full alias chains of one specific design, use "
+        "evaluate_design or generate_design instead."
+    ),
+    input_model=TradeOffTableInput,
+    examples="""
+    # "I can afford 16 runs. How many factors can I screen, and what do I lose?"
+        -> ``trade_off_table(runs=[16], factors=[4, 5, 6, 7, 8, 9])``
+
+    # "Show me the standard runs-against-factors trade-off table."
+        -> ``trade_off_table()``
+
+    # "Is it worth doubling from 8 to 16 runs for my 6 factors?"
+        -> ``trade_off_table(runs=[8, 16], factors=[6])``
+    """,
+    category="experiments",
+)
+def trade_off_table_tool(spec: TradeOffTableInput) -> dict[str, Any]:
+    """Return the runs-against-factors trade-off table, with per-cell detail."""
+    try:
+        from process_improve.experiments.tradeoff import tradeoff  # noqa: PLC0415
+
+        for n_runs in spec.runs:
+            if n_runs < 2 or n_runs > _MAX_RUNS or (n_runs & (n_runs - 1)) != 0:
+                raise ValueError(f"Each run budget must be a power of 2 between 2 and {_MAX_RUNS}; got {n_runs}.")
+        for n_factors in spec.factors:
+            if not (2 <= n_factors <= _MAX_FACTORS):
+                raise ValueError(f"Each factor count must be between 2 and {_MAX_FACTORS}; got {n_factors}.")
+
+        table: dict[str, dict[str, str]] = {}
+        cells: list[dict[str, Any]] = []
+        for n_runs in spec.runs:
+            row: dict[str, str] = {}
+            for n_factors in spec.factors:
+                try:
+                    result = tradeoff(runs=n_runs, factors=n_factors, display=False)
+                except ValueError as exc:
+                    # No such design: too many factors for the budget. The cell
+                    # is blank in the table, and the reason is kept in `cells`.
+                    row[str(n_factors)] = ""
+                    cells.append(
+                        {
+                            "runs": n_runs,
+                            "factors": n_factors,
+                            "label": "",
+                            "exists": False,
+                            "reason": str(exc),
+                        }
+                    )
+                    continue
+                row[str(n_factors)] = result.label
+                cells.append(
+                    {
+                        "runs": n_runs,
+                        "factors": n_factors,
+                        "label": result.label,
+                        "exists": True,
+                        "resolution": result.resolution,
+                        "roman": result.roman,
+                        "n_generators": result.n_generators,
+                        "generators": result.generators,
+                        "replicates": result.replicates,
+                    }
+                )
+            table[str(n_runs)] = row
+
+        return clean(
+            {
+                "table": table,
+                "cells": cells,
+                "reading_guide": (
+                    "Rows are run budgets, columns are factor counts. Going down a column costs "
+                    "more experiments but buys resolution; going across a row studies more factors "
+                    "for the same money, at the cost of heavier aliasing. Resolution III aliases "
+                    "main effects with two-factor interactions; resolution IV keeps main effects "
+                    "clear of them; resolution V separates two-factor interactions from each other."
+                ),
+            }
+        )
+    except _TOOL_EXPECTED_EXCEPTIONS as e:
+        logger.exception("Tool trade_off_table failed")
+        return {"error": str(e)}
+
+
+_register("trade_off_table")

--- a/src/process_improve/experiments/tools.py
+++ b/src/process_improve/experiments/tools.py
@@ -34,6 +34,7 @@ from process_improve.experiments._tools.augment_design import augment_design_too
 from process_improve.experiments._tools.visualize_doe import visualize_doe_tool
 from process_improve.experiments._tools.doe_knowledge import doe_knowledge_tool
 from process_improve.experiments._tools.recommend_strategy import recommend_strategy_tool
+from process_improve.experiments._tools.trade_off_table import trade_off_table_tool
 
 __all__ = [
     "analyze_experiment_tool",
@@ -46,6 +47,7 @@ __all__ = [
     "get_experiments_tool_specs",
     "optimize_responses_tool",
     "recommend_strategy_tool",
+    "trade_off_table_tool",
     "visualize_doe_tool",
 ]
 

--- a/tests/test_experiments_tools.py
+++ b/tests/test_experiments_tools.py
@@ -8,6 +8,7 @@ end (success path) and, where cheap, also exercises its except-branch.
 
 from __future__ import annotations
 
+import json
 import pathlib
 
 import pandas as pd
@@ -16,6 +17,7 @@ import pytest
 # execute_tool_call calls discover_tools(), which imports
 # process_improve.experiments.tools and triggers all @tool_spec
 # registrations - no explicit import is needed here.
+from process_improve.tool_safety import ToolInputInvalidError
 from process_improve.tool_spec import execute_tool_call
 
 # ---------------------------------------------------------------------------
@@ -544,3 +546,68 @@ class TestRecommendStrategy:
             {"factors": [{"name": "broken"}]},
         )
         assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# trade_off_table
+# ---------------------------------------------------------------------------
+
+
+class TestTradeOffTable:
+    def test_default_table_matches_the_course_notes(self) -> None:
+        """The default grid is the trade-off table from the course notes."""
+        result = execute_tool_call("trade_off_table", {})
+        assert "error" not in result
+        assert result["table"]["8"]["7"] == "2^(7-4) III"
+        assert result["table"]["16"]["5"] == "2^(5-1) V"
+        assert result["table"]["16"]["3"] == "2^3 (twice)"
+
+    def test_cells_carry_the_generators(self) -> None:
+        """Each existing cell reports how the design is built."""
+        result = execute_tool_call("trade_off_table", {"runs": [8], "factors": [5]})
+        (cell,) = result["cells"]
+        assert cell["exists"] is True
+        assert cell["generators"] == ["D=AB", "E=AC"]
+        assert cell["roman"] == "III"
+        assert cell["n_generators"] == 2
+
+    def test_impossible_cell_is_blank_with_a_reason(self) -> None:
+        """8 runs cannot hold 9 factors; the cell is blank and says why."""
+        result = execute_tool_call("trade_off_table", {"runs": [8], "factors": [9]})
+        assert result["table"]["8"]["9"] == ""
+        (cell,) = result["cells"]
+        assert cell["exists"] is False
+        assert "cannot accommodate" in cell["reason"]
+
+    def test_over_budget_cell_reports_replication(self) -> None:
+        """A budget larger than the full factorial is replication, not an error."""
+        result = execute_tool_call("trade_off_table", {"runs": [32], "factors": [3]})
+        (cell,) = result["cells"]
+        assert cell["label"] == "2^3 (4 times)"
+        assert cell["replicates"] == 4
+        assert cell["resolution"] is None
+
+    def test_output_is_json_serialisable(self) -> None:
+        """Tool output crosses the MCP boundary, so it must serialise."""
+        result = execute_tool_call("trade_off_table", {"runs": [8, 16], "factors": [4, 5]})
+        assert json.loads(json.dumps(result)) == result
+
+    def test_non_power_of_two_runs_returns_error(self) -> None:
+        result = execute_tool_call("trade_off_table", {"runs": [7], "factors": [5]})
+        assert "power of 2" in result["error"]
+
+    def test_out_of_range_factors_returns_error(self) -> None:
+        result = execute_tool_call("trade_off_table", {"runs": [8], "factors": [99]})
+        assert "between 2 and 12" in result["error"]
+
+    def test_unknown_key_is_rejected_by_the_schema(self) -> None:
+        """``extra="forbid"`` closes the kwarg-injection vector (SEC-15)."""
+        with pytest.raises(ToolInputInvalidError):
+            execute_tool_call("trade_off_table", {"runs": [8], "bogus": 1})
+
+    def test_registered_in_the_experiments_tool_specs(self) -> None:
+        from process_improve.experiments.tools import get_experiments_tool_specs
+
+        specs = {s["name"]: s for s in get_experiments_tool_specs()}
+        assert "trade_off_table" in specs
+        assert specs["trade_off_table"]["input_schema"]["additionalProperties"] is False


### PR DESCRIPTION
## Summary

- Follow-up to #486: registers `trade_off_table` as an agent-callable tool, in `experiments/_tools/trade_off_table.py`. Follows the ENG-02 one-module-per-tool layout and the ENG-04 / ENG-10 pydantic input contract (`ConfigDict(extra="forbid")`, parsed model as the single positional argument).
- Only the trade-off table is exposed. The simulators (`popcorn`, `grocery`, `manufacture`) and the dataset loaders are deliberately left off the tool surface.

The tool returns the two-level factorial grid: one cell per (run budget, factor count), each carrying the design label, its resolution and the generators that build it. Two cases an agent needs to explain rather than just report:

- **Budget exceeds the full factorial** - the cell reports replication (`2^3 (4 times)`, `replicates: 4`) instead of erroring.
- **No such design** - the cell is blank in `table`, and the matching entry in `cells` carries `exists: false` plus the reason ("8 runs cannot accommodate 9 factors: only 7 factors fit into 8 runs").

Run and factor axes are caller-supplied, bounded at 128 runs and 12 factors so the minimum-aberration search behind each cell stays interactive. Output is `clean()`ed and JSON round-trips.

## Test plan

- [x] 9 new tests in `tests/test_experiments_tools.py`, all driven end to end through `execute_tool_call`: default grid against the course-notes table, per-cell generators, the blank-cell and replication cases, JSON serialisability, both validation errors, schema rejection of unknown keys (SEC-15), and registry membership.
- [x] `_tools/trade_off_table.py` is fully covered.
- [x] Full suite green locally: 2264 passed, 4 skipped, 94.03% coverage.
- [x] `ruff check .` and `mypy src/process_improve` clean.

## Checklist

- [x] Version bumped in `pyproject.toml` (1.63.0 -> 1.64.0, MINOR: new tool), with `CITATION.cff` kept in sync
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzfBSecQWwr9AhCN5MqTe1)_