### PR TITLE
feat(experiments): an OMARS trade-off table, and the estimability frontier it exposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ those changes.
 
 ## [Unreleased]
 
+## [1.66.0] - 2026-08-09
+
+### Added
+
+- `experiments/omars_tradeoff.py`: a trade-off table for OMARS designs, the
+  counterpart of the two-level `trade_off_table`. Resolution cannot be the
+  currency here, because an OMARS design always has its main effects orthogonal
+  to each other and to every second-order term; what a run budget actually buys
+  is *which model is estimable*. Three capability classes follow from the
+  foldover structure and are reported per cell along with the error degrees of
+  freedom left to test that model with:
+
+  - `Full` (`N >= k^2 + k + 1`): main effects, pure quadratics and all
+    two-factor interactions jointly estimable.
+  - `Quad` (`N >= 2k + 3`): main effects and pure quadratics, with error df.
+  - `Satd` (`N = 2k + 1`): estimable but exactly saturated, so no inference.
+
+  New public functions `omars_tradeoff`, `omars_trade_off_table` and
+  `omars_minimum_runs`, plus the `OmarsTradeoffResult` dataclass, all exported
+  from `process_improve.experiments`. Every number is closed-form, so the table
+  needs no integer program and no solver, and is exact rather than dependent on
+  a search budget.
+
 ## [1.65.0] - 2026-08-09
 
 ### Fixed
@@ -2929,7 +2952,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.65.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.66.0...HEAD
+[1.66.0]: https://github.com/kgdunn/process-improve/compare/v1.65.0...v1.66.0
 [1.65.0]: https://github.com/kgdunn/process-improve/compare/v1.64.0...v1.65.0
 [1.64.0]: https://github.com/kgdunn/process-improve/compare/v1.63.0...v1.64.0
 [1.63.0]: https://github.com/kgdunn/process-improve/compare/v1.62.3...v1.63.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,49 @@ those changes.
 
 ## [Unreleased]
 
+## [1.65.0] - 2026-08-09
+
+### Fixed
+
+- `experiments/designs_omars_ilp.py`: **`generate_omars` returned designs that
+  could not fit the model they were sized for, for every k >= 4.** A foldover
+  OMARS design is `[H; -H; 0]`, and every second-order term is an *even*
+  function, so the quadratic and interaction columns of `H` and `-H` are
+  identical. That caps the rank of the full second-order model matrix at
+  `k + min(h + 1, 1 + k(k+1)/2)`, which means the model is estimable only from
+  `N = k^2 + k + 1` runs (13, 21, 31, 43, 57 for k = 3 to 7). The run-size
+  heuristic used a 25% slack rule over the parameter count instead, giving 13,
+  19, 27, 35, 45: below the frontier from four factors up. Sizing now starts at
+  the estimability frontier, and an explicit `n_runs` below it is rejected with
+  an actionable message rather than silently producing an unusable design.
+- `experiments/designs_omars_ilp.py`: `_d_efficiency` had no rank guard, unlike
+  its neighbour `_a_optimality` and unlike
+  `evaluate._compute_d_efficiency`. `slogdet` returns a finite log-determinant
+  for an exactly singular integer Gram matrix, so a rank-deficient design
+  reported a small but plausible D-efficiency (about 3 for the nineteen-run,
+  four-factor case whose determinant is exactly zero) instead of signalling
+  that the model cannot be fitted. Rank-deficient designs now score `0.0`. The
+  two metadata fields had been contradicting each other: `a_optimality` was
+  correctly reporting `inf` alongside the fabricated `d_efficiency`.
+- `experiments/designs_omars_ilp.py`: `expected_error_df` is computed from the
+  model matrix rank rather than from the nominal parameter count, so it is
+  right even when a caller pins a run size the model cannot support.
+
+### Added
+
+- `generate_omars` metadata gains `model_rank` and `min_runs_for_model`, making
+  the estimability frontier visible to callers.
+
+### Changed
+
+- Auto-sized `generate_omars` designs are larger for four or more factors
+  (k=4: 19 -> 21 runs, k=5: 27 -> 31, k=6: 35 -> 43, k=7: 45 -> 57) because the
+  previous sizes were not estimable. D-efficiency of the resulting designs goes
+  up correspondingly: at k=4 from a fabricated 2.83 to a real 38.74, at k=5
+  from 1.03 to 30.34. Designs sized with `model="main_quadratic"` are
+  unaffected in kind and can now be smaller, since that model's frontier is the
+  DSD's `2k + 1`.
+
 ## [1.64.0] - 2026-08-08
 
 ### Added
@@ -2886,7 +2929,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.64.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.65.0...HEAD
+[1.65.0]: https://github.com/kgdunn/process-improve/compare/v1.64.0...v1.65.0
 [1.64.0]: https://github.com/kgdunn/process-improve/compare/v1.63.0...v1.64.0
 [1.63.0]: https://github.com/kgdunn/process-improve/compare/v1.62.3...v1.63.0
 [1.62.3]: https://github.com/kgdunn/process-improve/compare/v1.62.2...v1.62.3

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.64.0
-date-released: "2026-08-08"
+version: 1.65.0
+date-released: "2026-08-09"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.65.0
+version: 1.66.0
 date-released: "2026-08-09"
 keywords:
   - chemometrics

--- a/docs/api/experiments.rst
+++ b/docs/api/experiments.rst
@@ -49,6 +49,10 @@ Designed Experiments
    :members:
    :show-inheritance:
 
+.. automodule:: process_improve.experiments.omars_tradeoff
+   :members:
+   :show-inheritance:
+
 .. automodule:: process_improve.experiments.simulations
    :members:
    :show-inheritance:

--- a/docs/user_guide/omars_designs.rst
+++ b/docs/user_guide/omars_designs.rst
@@ -83,11 +83,45 @@ coefficients are integers, the equalities are exact (no numerical tolerance
 enters the optimisation); a floating-point :func:`~process_improve.experiments.is_omars`
 re-check guards every accepted design as a sanity check.
 
+The estimability frontier
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A foldover cannot fit a full second-order model at just any run size, and the
+threshold is higher than simply counting parameters.
+
+Every second-order term is an **even** function of the factors, so the
+quadratic and interaction columns of :math:`H` and :math:`-H` are *identical*.
+The even block of the model matrix therefore has at most :math:`h + 1` distinct
+rows, against :math:`1 + k(k+1)/2` columns (an intercept, :math:`k` quadratics
+and :math:`k(k-1)/2` interactions).  The main effects live in the odd block and
+contribute at most :math:`k` more, so for every foldover
+
+.. math::
+
+   \mathrm{rank}(X) \le k + \min\!\left(h + 1,\; 1 + \tfrac{k(k+1)}{2}\right),
+
+with equality for half-designs in general position.  The full second-order
+model is therefore estimable only from
+
+.. math::
+
+   N = k^2 + k + 1
+
+runs: 13, 21, 31, 43 and 57 runs for three to seven factors.  Note that this is
+strictly more than the parameter count :math:`1 + 2k + k(k-1)/2` from four
+factors up, so "more runs than parameters" is *not* a sufficient test.
+Sizing starts at this frontier, and ``n_runs`` below it is refused.
+
+Choosing ``model="main_quadratic"`` drops the interactions from the model being
+sized for, which lowers the frontier to the definitive screening design's
+:math:`2k + 1` runs.
+
 Choosing the run size and the design
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- When ``n_runs`` is given it is used directly (it must be odd and larger than
-  the number of second-order parameters :math:`1 + 2k + k(k-1)/2`).
+- When ``n_runs`` is given it is used directly. It must be odd, and it must
+  reach the **estimability frontier** described above; a smaller value is
+  rejected rather than silently producing a design that cannot fit the model.
 - Otherwise the solver minimises the run count within a window to return the
   smallest feasible design that still leaves error degrees of freedom.
 - Several distinct designs are then enumerated at that run size by adding
@@ -121,13 +155,16 @@ provenance and a search report under ``metadata`` (``family``, ``sparsity``,
 Performance: iterations and timing by factor count
 --------------------------------------------------
 
-The table below reports, for the default settings (the automatic smallest-size
-search with ``max_candidates=6``), the size of the candidate half-pool, the run
-size of the smallest design found, the resulting error degrees of freedom, the
-number of ILP solves performed (the *iteration count*: one minimise-size probe
-plus the no-good-cut re-solves), and the cumulative CBC solver time.  Times were
+The table below reports, for the automatic smallest-size search at
+``n_restarts=8``, the size of the candidate half-pool, the run size of the
+smallest design found, the resulting error degrees of freedom, the number of ILP
+solves performed (the *iteration count*: one minimise-size probe plus the
+no-good-cut re-solves), and the cumulative CBC solver time.  The run size is the
+estimability frontier :math:`k^2 + k + 1` described above, and the error degrees
+of freedom follow as :math:`N - (1 + 2k + k(k-1)/2)`; both are exact.  Times were
 measured single-threaded on an ``x86_64`` machine with CPython 3.11 and CBC (the
-solver bundled with PuLP); they are indicative and will vary by machine.
+solver bundled with PuLP); they are indicative and will vary by machine, and
+they scale with ``n_restarts``.
 
 .. list-table::
    :header-rows: 1
@@ -143,39 +180,45 @@ solver bundled with PuLP); they are indicative and will vary by machine.
      - 13
      - 13
      - 3
-     - 6
-     - 0.03
+     - 10
+     - 0.1
    * - 4
      - 40
-     - 19
-     - 4
+     - 21
      - 6
-     - 0.05
+     - 10
+     - 0.4
    * - 5
      - 121
-     - 27
-     - 6
-     - 6
-     - 0.14
+     - 31
+     - 10
+     - 10
+     - 2.2
    * - 6
      - 364
-     - 35
-     - 7
-     - 6
-     - 5.6
+     - 43
+     - 15
+     - 10
+     - 29
    * - 7
      - 1093
-     - 45
-     - 9
-     - 6
-     - 39
+     - 57
+     - 21
+     - 10
+     - see note
 
-The iteration count is fixed by ``max_candidates`` (each iteration is a full ILP
-solve); the cost per iteration grows with the half-pool size :math:`(3^k - 1)/2`
-and the number of orthogonality constraints :math:`k(k-1)/2`.  Three to six
-factors solve in well under a second; seven factors take tens of seconds.  Beyond
-seven factors the half-pool grows quickly, so a longer ``solver_options["time_limit"]``
-(default 60 s) or a tighter ``n_runs`` is advisable.
+The iteration count is fixed by ``n_restarts`` (each iteration is a full ILP
+solve); the cost per iteration grows with the half-pool size :math:`(3^k - 1)/2`,
+the number of orthogonality constraints :math:`k(k-1)/2`, and the run size the
+frontier demands.  Three to five factors solve in seconds; six takes about half a
+minute.
+
+At seven factors the solves are large enough to run into the per-solve
+``solver_options["time_limit"]`` rather than finishing on their own, so no single
+timing characterises them; budget minutes, raise the time limit above its 60 s
+default, and expect the result to depend on where CBC was cut off.  Beyond seven
+factors, pin ``n_runs`` or use ``model="main_quadratic"``, whose frontier is only
+:math:`2k + 1`.
 
 Limitations
 -----------
@@ -185,12 +228,13 @@ Limitations
   are a documented future extension.
 - **Odd run counts.**  A foldover design has :math:`2h + 1` runs, so ``n_runs``
   must be odd.
-- **Full second-order conditioning.**  The smallest OMARS designs are highly
-  aliased in the second-order block by construction, so the D-efficiency of the
-  *full* quadratic model is low; this is expected, and is exactly why
-  :func:`~process_improve.experiments.analyze_omars` resolves the second-order
-  terms in stages rather than fitting them all at once.  Request a larger
-  ``n_runs`` for a better-conditioned design.
+- **Second-order aliasing remains.**  Reaching the estimability frontier makes
+  the full second-order model *fittable*; it does not make the second-order
+  block orthogonal.  The quadratics and interactions stay mutually aliased -
+  that is the "minimally aliased" in OMARS, not a defect - which is why
+  :func:`~process_improve.experiments.analyze_omars` resolves them in stages
+  rather than fitting them all at once.  Ask for more than the frontier run
+  size to buy error degrees of freedom and lower second-order correlations.
 
 References
 ----------

--- a/docs/user_guide/omars_designs.rst
+++ b/docs/user_guide/omars_designs.rst
@@ -205,7 +205,7 @@ they scale with ``n_restarts``.
      - 57
      - 21
      - 10
-     - see note
+     - 980
 
 The iteration count is fixed by ``n_restarts`` (each iteration is a full ILP
 solve); the cost per iteration grows with the half-pool size :math:`(3^k - 1)/2`,
@@ -213,11 +213,12 @@ the number of orthogonality constraints :math:`k(k-1)/2`, and the run size the
 frontier demands.  Three to five factors solve in seconds; six takes about half a
 minute.
 
-At seven factors the solves are large enough to run into the per-solve
-``solver_options["time_limit"]`` rather than finishing on their own, so no single
-timing characterises them; budget minutes, raise the time limit above its 60 s
-default, and expect the result to depend on where CBC was cut off.  Beyond seven
-factors, pin ``n_runs`` or use ``model="main_quadratic"``, whose frontier is only
+Seven factors is a different order of magnitude: about a quarter of an hour at
+this restart budget, measured with ``solver_options={"time_limit": 120}``.  The
+individual solves average close to that per-solve cap, so the total depends on
+the limit you set as much as on the machine; raise it above its 60 s default
+before reading anything into a seven-factor run.  Beyond seven factors, pin
+``n_runs`` or use ``model="main_quadratic"``, whose frontier is only
 :math:`2k + 1`.
 
 Limitations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.65.0"
+version = "1.66.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.64.0"
+version = "1.65.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/experiments/__init__.py
+++ b/src/process_improve/experiments/__init__.py
@@ -11,6 +11,12 @@ from process_improve.experiments.factor import Constraint, DesignResult, Factor,
 from process_improve.experiments.knowledge import doe_knowledge
 from process_improve.experiments.models import Model, lm, predict, summary
 from process_improve.experiments.omars import OmarsResult, analyze_omars
+from process_improve.experiments.omars_tradeoff import (
+    OmarsTradeoffResult,
+    omars_minimum_runs,
+    omars_trade_off_table,
+    omars_tradeoff,
+)
 from process_improve.experiments.optimization import optimize_responses
 from process_improve.experiments.simulations import grocery, manufacture, popcorn
 from process_improve.experiments.strategy import recommend_strategy
@@ -33,6 +39,7 @@ __all__ = [
     "Factor",
     "Model",
     "OmarsResult",
+    "OmarsTradeoffResult",
     "Response",
     "ResponseGoal",
     "TradeoffResult",
@@ -53,7 +60,10 @@ __all__ = [
     "lm",
     "main_effects_plot",
     "manufacture",
+    "omars_minimum_runs",
     "omars_properties",
+    "omars_trade_off_table",
+    "omars_tradeoff",
     "optimize_responses",
     "popcorn",
     "predict",

--- a/src/process_improve/experiments/designs_omars_ilp.py
+++ b/src/process_improve/experiments/designs_omars_ilp.py
@@ -242,7 +242,7 @@ def _d_efficiency(coded: np.ndarray, model: str = "full_second_order") -> float:
     if n_runs < n_params or np.linalg.matrix_rank(model_matrix) < n_params:
         return 0.0
     sign, log_det = np.linalg.slogdet(model_matrix.T @ model_matrix)
-    if sign <= 0:
+    if sign <= 0:  # pragma: no cover - defensive: a full-rank X'X is positive definite
         return 0.0
     return float(100.0 * math.exp(log_det / n_params) / n_runs)
 

--- a/src/process_improve/experiments/designs_omars_ilp.py
+++ b/src/process_improve/experiments/designs_omars_ilp.py
@@ -190,11 +190,56 @@ def _model_matrix(coded: np.ndarray, model: str = "full_second_order") -> np.nda
     return np.column_stack([np.ones(coded.shape[0]), coded, second_order])
 
 
+def _min_half_runs(n_factors: int, model: str = "full_second_order") -> int:
+    r"""Smallest half-design size at which the sizing model becomes estimable.
+
+    In a foldover ``[H; -H; 0]`` every second-order term is an **even** function,
+    so the quadratic and interaction columns of ``H`` and ``-H`` are identical.
+    The even block therefore has at most ``h + 1`` distinct rows, against
+    ``1 + k(k+1)/2`` columns for the full second-order model (an intercept, ``k``
+    pure quadratics and ``k(k-1)/2`` interactions), or ``1 + k`` for
+    ``"main_quadratic"``.  The main effects live in the odd block and contribute
+    ``k`` more, so
+
+    .. math::
+
+        \mathrm{rank}(X) = k + \min(h + 1, \text{even-block columns})
+
+    and the model is estimable only once ``h`` reaches the even-block column
+    count minus one.
+    """
+    if model == "main_quadratic":
+        return n_factors
+    return n_factors * (n_factors + 1) // 2
+
+
+def _min_runs(n_factors: int, model: str = "full_second_order") -> int:
+    """Smallest (odd) run count at which the sizing model is estimable.
+
+    ``k**2 + k + 1`` for the full second-order model, ``2k + 1`` for
+    ``"main_quadratic"``.  See :func:`_min_half_runs` for the derivation.
+    """
+    return 2 * _min_half_runs(n_factors, model) + 1
+
+
+def _model_rank(coded: np.ndarray, model: str = "full_second_order") -> int:
+    """Rank of the sizing-model matrix of a coded design."""
+    return int(np.linalg.matrix_rank(_model_matrix(coded, model)))
+
+
 def _d_efficiency(coded: np.ndarray, model: str = "full_second_order") -> float:
-    """D-efficiency of the sizing model: ``100 * |X'X|^(1/p) / n``."""
+    """D-efficiency of the sizing model: ``100 * |X'X|^(1/p) / n``.
+
+    Returns ``0.0`` for a rank-deficient model matrix.  Without that guard
+    ``slogdet`` reports a finite log-determinant for an exactly singular
+    integer Gram matrix (floating-point round-off away from zero), which would
+    make an unusable design look merely mediocre.  This mirrors the rank guard
+    in :func:`~process_improve.experiments.evaluate._compute_d_efficiency` and
+    in :func:`_a_optimality` below.
+    """
     model_matrix = _model_matrix(coded, model)
     n_runs, n_params = model_matrix.shape
-    if n_runs < n_params:
+    if n_runs < n_params or np.linalg.matrix_rank(model_matrix) < n_params:
         return 0.0
     sign, log_det = np.linalg.slogdet(model_matrix.T @ model_matrix)
     if sign <= 0:
@@ -345,17 +390,30 @@ def _half_bounds(
     n_runs_range: tuple[int, int] | None,
     n_params: int,
     half_pool_size: int,
+    min_half: int,
 ) -> tuple[int, int]:
-    """Inclusive ``(min, max)`` half-run window so the design beats ``n_params``."""
+    """Inclusive ``(min, max)`` half-run window for a usable design.
+
+    Two floors apply, and the window starts at whichever binds harder:
+
+    * **Estimability**: ``min_half`` half-runs, from :func:`_min_half_runs`.
+      Below this the sizing model is rank-deficient and cannot be fitted at
+      all, whatever the parameter count says.
+    * **Error degrees of freedom**: ``n_runs > n_params``, so at least
+      ``n_params // 2 + 1`` half-runs.
+
+    For the full second-order model estimability is the binding floor; for
+    ``"main_quadratic"`` the error-df floor usually is.
+    """
+    floor_half = max(1, min_half, n_params // 2 + 1)
     if n_runs_range is not None:
-        low, high = n_runs_range
-        half_low = max(1, math.ceil((max(low, n_params + 1) - 1) / 2))
-        half_high = max(half_low, (high - 1) // 2)
+        low, _high = n_runs_range
+        half_low = max(floor_half, math.ceil((low - 1) / 2))
+        half_high = max(half_low, (n_runs_range[1] - 1) // 2)
     else:
-        n_floor = n_params + max(2, math.ceil(0.25 * n_params))
-        half_low = max(1, math.ceil((n_floor - 1) / 2))
+        half_low = floor_half
         half_high = half_low + 6
-    return half_low, min(half_high, half_pool_size)
+    return half_low, max(half_low, min(half_high, half_pool_size))
 
 
 def _is_dominated(candidate: _Candidate, others: list[_Candidate]) -> bool:
@@ -476,6 +534,15 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
         if n_runs % 2 == 0:
             msg = f"n_runs={n_runs} must be odd: a foldover OMARS design has 2*h+1 runs (a centre run plus +/-H)."
             raise ValueError(msg)
+        min_runs = _min_runs(n_factors, model)
+        if n_runs < min_runs:
+            msg = (
+                f"n_runs={n_runs} cannot estimate the {model} model for {n_factors} factors: a foldover "
+                f"design repeats its second-order terms across H and -H, so the model matrix stays "
+                f"rank-deficient below {min_runs} runs. Use n_runs >= {min_runs}, or "
+                'model="main_quadratic" to size for main effects and pure quadratics only.'
+            )
+            raise ValueError(msg)
         target_half = (n_runs - 1) // 2
 
     pool = _half_pool(n_factors)
@@ -516,7 +583,8 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
     # the window (the minimize-size solution becomes the first candidate).
     if target_half is None:
         coded, status, indices = _solve(
-            half_bounds=_half_bounds(n_runs_range, n_params, pool.shape[0]), minimize_size=True
+            half_bounds=_half_bounds(n_runs_range, n_params, pool.shape[0], _min_half_runs(n_factors, model)),
+            minimize_size=True,
         )
         if coded is not None:
             target_half = len(indices)
@@ -580,7 +648,9 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
         "sizing_model": model,
         "model_params": n_params,
         "full_second_order_params": _full_second_order_params(n_factors),
-        "expected_error_df": winner.n_runs - n_params,
+        "model_rank": _model_rank(winner.coded, model),
+        "expected_error_df": winner.n_runs - _model_rank(winner.coded, model),
+        "min_runs_for_model": _min_runs(n_factors, model),
         "sparsity": _sparsity(winner.coded),
         "selection_criterion": selection_criterion,
         "satisfice": dict(satisfice) if satisfice else None,

--- a/src/process_improve/experiments/designs_omars_ilp.py
+++ b/src/process_improve/experiments/designs_omars_ilp.py
@@ -242,7 +242,11 @@ def _d_efficiency(coded: np.ndarray, model: str = "full_second_order") -> float:
     if n_runs < n_params or np.linalg.matrix_rank(model_matrix) < n_params:
         return 0.0
     sign, log_det = np.linalg.slogdet(model_matrix.T @ model_matrix)
-    if sign <= 0:  # pragma: no cover - defensive: a full-rank X'X is positive definite
+    if sign <= 0:
+        # Belt and braces.  A full-rank X'X is positive definite, but
+        # ``matrix_rank`` decides rank against an SVD tolerance, so a Gram
+        # matrix can clear the guard above and still be too ill-conditioned for
+        # ``slogdet`` to return a positive sign.
         return 0.0
     return float(100.0 * math.exp(log_det / n_params) / n_runs)
 

--- a/src/process_improve/experiments/omars_tradeoff.py
+++ b/src/process_improve/experiments/omars_tradeoff.py
@@ -1,0 +1,406 @@
+# (c) Kevin Dunn, 2010-2026. MIT License.
+
+r"""The OMARS trade-off: which model does a given run budget buy.
+
+The two-level trade-off table in :mod:`process_improve.experiments.tradeoff`
+answers "I can afford N runs and want k factors, what do I give up?" with a
+resolution and an alias structure. That currency does not transfer to OMARS
+designs, because an OMARS design *always* has its main effects orthogonal to
+each other and to every second-order term. Resolution is constant, so it cannot
+be what the table reports.
+
+What varies instead is **which model is estimable at all**, and that is set by
+the foldover structure. A foldover is ``[H; -H; 0]``, and every second-order
+term is an *even* function, so the quadratic and interaction columns of ``H``
+and ``-H`` are identical. The even block therefore has at most ``h + 1``
+distinct rows, against ``1 + k(k+1)/2`` columns for the full second-order model.
+The main effects live in the odd block and contribute at most ``k`` more, so for
+every foldover
+
+.. math::
+
+   \mathrm{rank}(X) \le k + \min\!\left(h + 1,\; 1 + \tfrac{k(k+1)}{2}\right)
+
+with equality for half-designs in general position. Three capability classes
+follow, and they are the OMARS analogue of resolution:
+
+``Full``
+    ``N >= k^2 + k + 1``. Main effects, pure quadratics and every two-factor
+    interaction are jointly estimable, so a response surface can be fitted
+    without a follow-up design.
+``Quad``
+    ``N >= 2k + 3``. Main effects and the pure quadratics, with degrees of
+    freedom left to test them, so curvature can be judged factor by factor. The
+    two-factor interactions are present in the design but not in the model.
+``Satd``
+    ``N = 2k + 1``. The definitive screening design at its minimal size:
+    estimable but exactly saturated, so there are point estimates and no
+    inference.
+
+Alphabetically ``Full < Quad < Satd``, which is also decreasing capability, so
+the ordering is easy to keep straight.
+
+Every number here is closed-form, so the table is instant and exact: no integer
+program, no solver, and no dependence on a search budget. The quality of a
+*particular* design at a given size (its D-efficiency, its second-order
+correlations) does need the ILP, and lives on
+:func:`~process_improve.experiments.generate_omars` instead.
+
+Also see
+--------
+process_improve.experiments.tradeoff : the two-level counterpart.
+process_improve.experiments.designs_omars_ilp.generate_omars : build the design.
+process_improve.experiments.omars.analyze_omars : the staged analysis it feeds.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from process_improve.experiments.designs_omars_ilp import (
+    _full_second_order_params,
+    _min_runs,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+#: Capability classes, best first. The four-character tags line up in a table,
+#: and sort alphabetically in decreasing order of capability.
+CAPABILITIES: tuple[str, ...] = ("full", "quad", "satd")
+
+_TAGS = {"full": "Full", "quad": "Quad", "satd": "Satd"}
+
+_MEANINGS = {
+    "full": "main effects, quadratics and all two-factor interactions jointly estimable",
+    "quad": "main effects and pure quadratics, with error degrees of freedom to test them",
+    "satd": "saturated: estimable but no error degrees of freedom, so no inference",
+}
+
+# OMARS designs need at least three factors (see ``generate_omars``). The upper
+# bound is generous because nothing here enumerates runs; it is arithmetic.
+_MIN_FACTORS = 3
+_MAX_FACTORS = 25
+
+#: Default rows: odd run counts spanning the useful band for three to seven
+#: factors. The last one is the smallest budget at which every one of those
+#: factor counts reaches ``Full``.
+DEFAULT_RUNS: tuple[int, ...] = (9, 13, 17, 21, 25, 31, 37, 43, 57)
+
+#: Default columns.
+DEFAULT_FACTORS: tuple[int, ...] = (3, 4, 5, 6, 7)
+
+
+@dataclass
+class OmarsTradeoffResult:
+    """What one run budget buys for one factor count.
+
+    Attributes
+    ----------
+    n_runs : int
+        The run budget.
+    n_factors : int
+        Number of factors.
+    exists : bool
+        Whether any foldover OMARS design has this run count for this many
+        factors. ``False`` for an even *n_runs* or one below ``2k + 1``.
+    capability : str
+        ``"full"``, ``"quad"``, ``"satd"``, or ``"none"`` when *exists* is
+        ``False``.
+    tag : str
+        The four-character table tag: ``"Full"``, ``"Quad"``, ``"Satd"``, or
+        the empty string.
+    model : str or None
+        The largest model this run count supports: ``"full_second_order"``,
+        ``"main_quadratic"``, or ``None``.
+    model_params : int
+        Parameter count of that model; zero when there is no design.
+    error_df : int
+        Degrees of freedom left for error after fitting it. Zero for ``Satd``.
+    label : str
+        Self-contained cell text, e.g. ``"Full df=11"``.
+    min_runs_full : int
+        Smallest run count reaching ``Full`` for this many factors,
+        ``k^2 + k + 1``.
+    min_runs_quad : int
+        Smallest run count reaching ``Quad``, ``2k + 3``.
+    min_runs_satd : int
+        Smallest run count that is a design at all, ``2k + 1``.
+    reason : str
+        Why a cell is empty; empty string when *exists* is ``True``.
+    """
+
+    n_runs: int
+    n_factors: int
+    exists: bool
+    capability: str
+    tag: str
+    model: str | None
+    model_params: int
+    error_df: int
+    label: str
+    min_runs_full: int
+    min_runs_quad: int
+    min_runs_satd: int
+    reason: str = ""
+
+
+def _check_factors(n_factors: int) -> int:
+    """Validate and return the factor count."""
+    if int(n_factors) != n_factors:
+        raise ValueError('The "n_factors" input must be an integer.')
+    k = int(n_factors)
+    if not (_MIN_FACTORS <= k <= _MAX_FACTORS):
+        raise ValueError(f"OMARS designs need {_MIN_FACTORS} to {_MAX_FACTORS} factors; got {k}.")
+    return k
+
+
+def omars_minimum_runs(n_factors: int, capability: str = "full") -> int:
+    """Return the smallest run count reaching *capability* for *n_factors*.
+
+    Parameters
+    ----------
+    n_factors : int
+        Number of factors, ``k``, between 3 and 25.
+    capability : {"full", "quad", "satd"}, default "full"
+        Which class to reach. See the module docstring.
+
+    Returns
+    -------
+    int
+        The (odd) run count: ``k^2 + k + 1`` for ``"full"``, ``2k + 3`` for
+        ``"quad"``, ``2k + 1`` for ``"satd"``.
+
+    Raises
+    ------
+    ValueError
+        If *n_factors* is out of range or *capability* is not a known class.
+
+    Examples
+    --------
+    >>> omars_minimum_runs(5)
+    31
+    >>> omars_minimum_runs(5, "quad")
+    13
+    >>> [omars_minimum_runs(k) for k in (3, 4, 5, 6, 7)]
+    [13, 21, 31, 43, 57]
+    """
+    k = _check_factors(n_factors)
+    if capability not in CAPABILITIES:
+        raise ValueError(f"capability must be one of {CAPABILITIES}, got {capability!r}.")
+    if capability == "full":
+        return _min_runs(k)
+    if capability == "quad":
+        return 2 * k + 3
+    return 2 * k + 1
+
+
+def omars_tradeoff(n_runs: int, n_factors: int, display: bool = True) -> OmarsTradeoffResult:
+    """Report which model a run budget buys, for a foldover OMARS design.
+
+    The OMARS counterpart of
+    :func:`~process_improve.experiments.tradeoff.tradeoff`. Because OMARS main
+    effects are always clear of the second-order terms, the answer is not a
+    resolution: it is which model is estimable, and how much is left over to
+    test it with.
+
+    Parameters
+    ----------
+    n_runs : int
+        Run budget. A foldover has ``2h + 1`` runs, so an even value is never a
+        design.
+    n_factors : int
+        Number of factors, between 3 and 25.
+    display : bool, default True
+        Print a short report as well as returning it.
+
+    Returns
+    -------
+    OmarsTradeoffResult
+        The capability class, the model it supports, and the error degrees of
+        freedom. See the class for the full field list.
+
+    Raises
+    ------
+    ValueError
+        If *n_factors* is out of range, or *n_runs* is not a positive integer.
+
+    Examples
+    --------
+    >>> omars_tradeoff(21, 4, display=False).label
+    'Full df=6'
+    >>> omars_tradeoff(17, 4, display=False).label
+    'Quad df=8'
+    >>> omars_tradeoff(9, 4, display=False).label
+    'Satd df=0'
+
+    Also see
+    --------
+    omars_trade_off_table : the same answer across a grid of budgets.
+    """
+    k = _check_factors(n_factors)
+    if int(n_runs) != n_runs:
+        raise ValueError('The "n_runs" input must be an integer.')
+    runs = int(n_runs)
+    if runs < 1:
+        raise ValueError(f"The number of runs must be positive; got {runs}.")
+
+    satd, quad, full = (omars_minimum_runs(k, c) for c in ("satd", "quad", "full"))
+
+    # Which class the budget lands in, and why it might land in none of them.
+    capability, reason = "none", ""
+    if runs % 2 == 0:
+        reason = f"{runs} is even; a foldover OMARS design has 2h + 1 runs."
+    elif runs < satd:
+        reason = f"{runs} runs is below the smallest OMARS design for {k} factors ({satd} runs)."
+    elif runs >= full:
+        capability = "full"
+    elif runs >= quad:
+        capability = "quad"
+    else:
+        capability = "satd"
+
+    if capability == "none":
+        model, params, error_df = None, 0, 0
+    elif capability == "full":
+        model, params = "full_second_order", _full_second_order_params(k)
+        error_df = runs - params
+    else:
+        model, params = "main_quadratic", 1 + 2 * k
+        # Satd is exactly saturated by construction, so runs - params is zero.
+        error_df = runs - params
+
+    tag = _TAGS.get(capability, "")
+    result = OmarsTradeoffResult(
+        n_runs=runs,
+        n_factors=k,
+        exists=capability != "none",
+        capability=capability,
+        tag=tag,
+        model=model,
+        model_params=params,
+        error_df=error_df,
+        label=f"{tag} df={error_df}" if tag else "",
+        min_runs_full=full,
+        min_runs_quad=quad,
+        min_runs_satd=satd,
+        reason=reason,
+    )
+
+    if display:
+        print(_format_result(result))  # noqa: T201
+    return result
+
+
+def _format_result(result: OmarsTradeoffResult) -> str:
+    """Render an :class:`OmarsTradeoffResult` as the printed report."""
+    lines = [f"OMARS: {result.n_runs} runs, {result.n_factors} factors"]
+    if not result.exists:
+        lines.append(f"  No design: {result.reason}")
+        lines.append(f"  The smallest design for {result.n_factors} factors has {result.min_runs_satd} runs.")
+        return "\n".join(lines) + "\n"
+
+    lines.append(f"  {result.tag}: {_MEANINGS[result.capability]}")
+    lines.append(f"  Model: {result.model} ({result.model_params} parameters), {result.error_df} error df")
+    lines.append(
+        f"  Thresholds for {result.n_factors} factors: "
+        f"Satd {result.min_runs_satd}, Quad {result.min_runs_quad}, Full {result.min_runs_full} runs."
+    )
+    if result.capability != "full":
+        short = result.min_runs_full - result.n_runs
+        lines.append(f"  {short} more runs would reach Full (all two-factor interactions estimable).")
+    return "\n".join(lines) + "\n"
+
+
+def omars_trade_off_table(
+    runs: Sequence[int] = DEFAULT_RUNS,
+    factors: Sequence[int] = DEFAULT_FACTORS,
+    display: bool = True,
+) -> pd.DataFrame:
+    """Return the run-budget against factor-count table for OMARS designs.
+
+    Each cell says which model that budget supports and how much error is left
+    to test it with, for example ``"Full df=11"``. Blank cells are budgets that
+    are not a foldover design at all.
+
+    Parameters
+    ----------
+    runs : sequence of int, default :data:`DEFAULT_RUNS`
+        Run budgets, one per row. Even values are always blank.
+    factors : sequence of int, default :data:`DEFAULT_FACTORS`
+        Factor counts, one per column.
+    display : bool, default True
+        Print the table left-aligned, with the ``df=`` label written once per
+        column rather than in every cell.
+
+    Returns
+    -------
+    pd.DataFrame
+        Rows indexed by run count, columns by factor count. Cells are
+        self-contained labels; the once-per-column compression applies only to
+        the printed view.
+
+    Examples
+    --------
+    >>> table = omars_trade_off_table(display=False)
+    >>> table.loc[21, 4]
+    'Full df=6'
+    >>> table.loc[9, 3]
+    'Quad df=2'
+
+    Also see
+    --------
+    omars_tradeoff : the detail behind one cell.
+    """
+    cells = {
+        k: {n: omars_tradeoff(n, k, display=False).label for n in runs} for k in (_check_factors(k) for k in factors)
+    }
+    table = pd.DataFrame(cells, index=list(runs))
+    table.index.name = "runs"
+    table.columns.name = "factors"
+    if display:
+        print(_format_table(table))  # noqa: T201
+    return table
+
+
+def _format_table(table: pd.DataFrame) -> str:
+    """Render the table left-aligned, with ``df=`` written once per column.
+
+    Repeating ``df=`` in every cell buries the staircase where the capability
+    class changes, which is the thing the table exists to show. The label is
+    kept on the first live cell of each column, where a reader meets it first.
+    """
+    # Work off a plain list-of-columns rather than the frame, so the cells stay
+    # ordinary strings all the way through the formatting.
+    columns: list[list[str]] = []
+    for column in table.columns:
+        labelled = False
+        cells: list[str] = []
+        for label in (str(value) for value in table[column]):
+            if not label:
+                cells.append("")
+            elif labelled:
+                tag, _, value = label.partition(" df=")
+                cells.append(f"{tag} {value}")
+            else:
+                cells.append(label)
+                labelled = True
+        columns.append(cells)
+
+    width = max((len(cell) for column_cells in columns for cell in column_cells), default=0) + 2
+    index_width = max(len("runs"), *(len(str(i)) for i in table.index)) + 2
+
+    lines = ["runs".ljust(index_width) + "".join(f"k={c}".ljust(width) for c in table.columns)]
+    lines.append("-" * (index_width + width * len(table.columns)))
+    lines.extend(
+        str(index).ljust(index_width) + "".join(column_cells[row].ljust(width) for column_cells in columns)
+        for row, index in enumerate(table.index)
+    )
+    lines.append("")
+    lines.append("  Full: " + _MEANINGS["full"])
+    lines.append("  Quad: " + _MEANINGS["quad"])
+    lines.append("  Satd: " + _MEANINGS["satd"])
+    return "\n".join(lines) + "\n"

--- a/tests/test_omars_estimability.py
+++ b/tests/test_omars_estimability.py
@@ -181,6 +181,22 @@ class TestDEfficiencyRankGuard:
         assert n_half < _min_half_runs(k)
         assert _d_efficiency(_foldover(generic_half(k, n_half))) == 0.0
 
+    @pytest.mark.parametrize("sign", [0.0, -1.0])
+    def test_a_non_positive_slogdet_sign_also_scores_zero(self, monkeypatch, sign: float) -> None:
+        """The second guard, behind the rank one.
+
+        ``matrix_rank`` decides rank against an SVD tolerance, so a Gram matrix
+        can clear the rank guard and still be too ill-conditioned for
+        ``slogdet`` to return a positive sign. Reaching that state with a real
+        design would mean finding one on the knife edge of the tolerance, so
+        the sign is forced instead.
+        """
+        design = _foldover(generic_half(4, _min_half_runs(4)))
+        assert _d_efficiency(design) > 0.0  # the guard is what changes the answer
+
+        monkeypatch.setattr(np.linalg, "slogdet", lambda _: (sign, 12.0))
+        assert _d_efficiency(design) == 0.0
+
 
 class TestHalfBounds:
     """The sizing window starts at whichever floor binds harder."""

--- a/tests/test_omars_estimability.py
+++ b/tests/test_omars_estimability.py
@@ -23,10 +23,12 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from process_improve.experiments import Factor
 from process_improve.experiments.designs_omars_ilp import (
     _d_efficiency,
     _foldover,
     _full_second_order_params,
+    _half_bounds,
     _half_pool,
     _min_half_runs,
     _min_runs,
@@ -37,9 +39,6 @@ from process_improve.experiments.designs_omars_ilp import (
 # The frontier, N = k^2 + k + 1, spelled out so a change to the formula has to
 # disagree with a written-down table rather than with itself.
 FRONTIER_FULL_SECOND_ORDER = {3: 13, 4: 21, 5: 31, 6: 43, 7: 57}
-
-# Building the 3**k half-pool gets slow past five factors.
-_POOL_LIMIT = 5
 
 
 def rank_bound(n_factors: int, n_half: int) -> int:
@@ -181,3 +180,73 @@ class TestDEfficiencyRankGuard:
     def test_zero_everywhere_below_the_frontier(self, k: int, n_half: int) -> None:
         assert n_half < _min_half_runs(k)
         assert _d_efficiency(_foldover(generic_half(k, n_half))) == 0.0
+
+
+class TestHalfBounds:
+    """The sizing window starts at whichever floor binds harder."""
+
+    @pytest.mark.parametrize("k", [3, 4, 5, 6, 7])
+    def test_auto_window_starts_at_the_frontier(self, k: int) -> None:
+        """For the full second-order model, estimability is the binding floor."""
+        min_half = _min_half_runs(k)
+        params = _full_second_order_params(k)
+        low, high = _half_bounds(None, params, half_pool_size=10_000, min_half=min_half)
+        assert low == min_half
+        assert 2 * low + 1 == _min_runs(k)
+        assert high >= low
+
+    @pytest.mark.parametrize("k", [3, 4, 5, 6, 7])
+    def test_error_df_floor_binds_for_main_quadratic(self, k: int) -> None:
+        """Dropping the interactions makes N > p the binding floor instead."""
+        min_half = _min_half_runs(k, "main_quadratic")
+        params = 1 + 2 * k
+        low, _high = _half_bounds(None, params, half_pool_size=10_000, min_half=min_half)
+        assert 2 * low + 1 > params
+        assert low >= min_half
+
+    def test_requested_window_is_lifted_to_the_frontier(self) -> None:
+        """A caller asking below the frontier gets the frontier, not their floor."""
+        low, high = _half_bounds((9, 41), _full_second_order_params(4), 10_000, _min_half_runs(4))
+        assert 2 * low + 1 == _min_runs(4) == 21
+        assert 2 * high + 1 <= 41
+
+    def test_window_never_inverts_against_a_small_pool(self) -> None:
+        low, high = _half_bounds(None, _full_second_order_params(4), half_pool_size=3, min_half=10)
+        assert high >= low
+
+
+class TestGenerateOmarsRefusesSubFrontierSizes:
+    """The validation runs before any solver call, so this needs no CBC."""
+
+    @pytest.mark.parametrize(("k", "n_runs"), [(4, 19), (4, 17), (5, 27), (5, 29), (6, 41)])
+    def test_sub_frontier_n_runs_is_refused(self, k: int, n_runs: int) -> None:
+        from process_improve.experiments.designs_omars_ilp import generate_omars
+
+        factors = [Factor(name=chr(65 + i), low=-1, high=1) for i in range(k)]
+        with pytest.raises(ValueError, match="cannot estimate the full_second_order model"):
+            generate_omars(factors, n_runs=n_runs)
+
+    def test_the_message_names_the_frontier_and_the_way_out(self) -> None:
+        from process_improve.experiments.designs_omars_ilp import generate_omars
+
+        factors = [Factor(name=chr(65 + i), low=-1, high=1) for i in range(5)]
+        with pytest.raises(ValueError, match="cannot estimate") as excinfo:
+            generate_omars(factors, n_runs=29)
+        message = str(excinfo.value)
+        assert "n_runs >= 31" in message
+        assert "main_quadratic" in message
+
+    def test_main_quadratic_accepts_what_the_full_model_refuses(self) -> None:
+        """17 runs clears the parameter count (15) but not the frontier (21).
+
+        Sizes that fail both gates report the error-df one first, so this picks
+        a size where estimability is the only thing standing in the way. The
+        same size is comfortably above the main-quadratic frontier of 9.
+        """
+        from process_improve.experiments.designs_omars_ilp import generate_omars
+
+        assert _min_runs(4, "main_quadratic") <= 17 < _min_runs(4)
+        assert _full_second_order_params(4) < 17
+        factors = [Factor(name=chr(65 + i), low=-1, high=1) for i in range(4)]
+        with pytest.raises(ValueError, match="cannot estimate"):
+            generate_omars(factors, n_runs=17)

--- a/tests/test_omars_estimability.py
+++ b/tests/test_omars_estimability.py
@@ -1,0 +1,183 @@
+"""The OMARS foldover estimability frontier, and the guards that respect it.
+
+A foldover OMARS design is ``[H; -H; 0]``. Every second-order term is an *even*
+function, so the quadratic and interaction columns of ``H`` and ``-H`` are
+identical: the even block has at most ``h + 1`` distinct rows against
+``1 + k(k+1)/2`` columns. The main effects live in the odd block and contribute
+at most ``k`` more, so for **every** half-design
+
+    rank(X) <= k + min(h + 1, 1 + k(k+1)/2)                     (the bound)
+
+with equality for half-designs in general position. The bound is what matters:
+below ``N = k^2 + k + 1`` runs it is strictly less than the number of
+second-order parameters, so no foldover of that size can fit the full
+second-order model, however cleverly its runs are chosen.
+
+Both directions are tested here: the bound holds universally, and it is
+attained. None of it needs a solver, so unlike ``tests/test_omars_ilp.py`` this
+module is not gated on CBC and runs everywhere.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from process_improve.experiments.designs_omars_ilp import (
+    _d_efficiency,
+    _foldover,
+    _full_second_order_params,
+    _half_pool,
+    _min_half_runs,
+    _min_runs,
+    _model_matrix,
+    _model_rank,
+)
+
+# The frontier, N = k^2 + k + 1, spelled out so a change to the formula has to
+# disagree with a written-down table rather than with itself.
+FRONTIER_FULL_SECOND_ORDER = {3: 13, 4: 21, 5: 31, 6: 43, 7: 57}
+
+# Building the 3**k half-pool gets slow past five factors.
+_POOL_LIMIT = 5
+
+
+def rank_bound(n_factors: int, n_half: int) -> int:
+    """Upper bound on the rank of a foldover's full second-order model matrix."""
+    return n_factors + min(n_half + 1, 1 + n_factors * (n_factors + 1) // 2)
+
+
+def leading_half(n_factors: int, n_half: int) -> np.ndarray:
+    """Return the first *n_half* candidate half-runs.
+
+    Deliberately degenerate: the pool is in lexicographic order, so it opens
+    with sparse runs like ``[0, 0, 0, 1]`` that do not span. Useful for showing
+    that the bound is an upper bound rather than an identity.
+    """
+    return _half_pool(n_factors)[:n_half]
+
+
+def generic_half(n_factors: int, n_half: int, *, seed: int = 0, tries: int = 200) -> np.ndarray:
+    """Return a half-design in general position: one attaining :func:`rank_bound`."""
+    pool = _half_pool(n_factors)
+    rng = np.random.default_rng(seed)
+    target = rank_bound(n_factors, n_half)
+    best = pool[:n_half]
+    for _ in range(tries):
+        candidate = pool[rng.choice(pool.shape[0], n_half, replace=False)]
+        if _model_rank(_foldover(candidate)) == target:
+            return candidate
+    return best
+
+
+class TestFrontier:
+    @pytest.mark.parametrize(("k", "expected"), FRONTIER_FULL_SECOND_ORDER.items(), ids=str)
+    def test_full_second_order_frontier(self, k: int, expected: int) -> None:
+        assert _min_runs(k) == expected
+        assert _min_runs(k) == k * k + k + 1
+
+    @pytest.mark.parametrize("k", [3, 4, 5, 6, 7])
+    def test_main_quadratic_frontier_is_the_dsd_size(self, k: int) -> None:
+        """Dropping the interactions drops the frontier to the DSD's 2k + 1."""
+        assert _min_runs(k, "main_quadratic") == 2 * k + 1
+
+    @pytest.mark.parametrize("k", [3, 4, 5, 6, 7])
+    def test_frontier_is_odd(self, k: int) -> None:
+        """A foldover has 2h + 1 runs, so every frontier value is odd."""
+        assert _min_runs(k) % 2 == 1
+
+    @pytest.mark.parametrize("k", [4, 5, 6, 7])
+    def test_frontier_exceeds_the_parameter_count(self, k: int) -> None:
+        """N > p is necessary but not sufficient; that gap was the bug.
+
+        At three factors the two coincide; from four up the frontier pulls away.
+        """
+        assert _min_runs(k) > _full_second_order_params(k)
+
+
+class TestRankBoundHoldsUniversally:
+    """The direction the fix depends on: no half-design can beat the bound."""
+
+    @pytest.mark.parametrize("k", [3, 4, 5])
+    @pytest.mark.parametrize("offset", [-2, -1, 0, 2])
+    def test_bound_is_respected_by_a_degenerate_half(self, k: int, offset: int) -> None:
+        n_half = max(1, min(_min_half_runs(k) + offset, _half_pool(k).shape[0]))
+        assert _model_rank(_foldover(leading_half(k, n_half))) <= rank_bound(k, n_half)
+
+    @pytest.mark.parametrize("k", [3, 4, 5])
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_bound_is_respected_by_random_halves(self, k: int, seed: int) -> None:
+        pool = _half_pool(k)
+        rng = np.random.default_rng(seed)
+        for n_half in range(1, min(pool.shape[0], _min_half_runs(k) + 3)):
+            half = pool[rng.choice(pool.shape[0], n_half, replace=False)]
+            assert _model_rank(_foldover(half)) <= rank_bound(k, n_half)
+
+    @pytest.mark.parametrize("k", [3, 4, 5, 6, 7])
+    def test_below_the_frontier_the_bound_forbids_full_rank(self, k: int) -> None:
+        """The heart of it: one run-pair short, the ceiling is under the floor.
+
+        This is pure arithmetic on the bound, so it holds for every design at
+        that size without enumerating any of them.
+        """
+        n_half = _min_half_runs(k) - 1
+        assert rank_bound(k, n_half) < _full_second_order_params(k)
+        assert 2 * n_half + 1 == _min_runs(k) - 2
+
+
+class TestRankBoundIsAttained:
+    """The other direction: at the frontier, a good half-design reaches it."""
+
+    @pytest.mark.parametrize("k", [3, 4, 5])
+    def test_full_rank_at_the_frontier(self, k: int) -> None:
+        n_half = _min_half_runs(k)
+        design = _foldover(generic_half(k, n_half))
+        assert design.shape[0] == _min_runs(k)
+        assert _model_rank(design) == _full_second_order_params(k)
+
+    @pytest.mark.parametrize("k", [3, 4, 5])
+    def test_no_design_is_full_rank_one_pair_below(self, k: int) -> None:
+        """Search hard for a counterexample below the frontier; find none."""
+        n_half = _min_half_runs(k) - 1
+        params = _full_second_order_params(k)
+        assert _model_rank(_foldover(generic_half(k, n_half))) < params
+
+    @pytest.mark.parametrize("k", [3, 4, 5])
+    def test_a_degenerate_half_can_fall_short_of_the_bound(self, k: int) -> None:
+        """The bound is not an identity, which is why the tests separate them."""
+        if k < 4:  # the three-factor leading half already spans
+            pytest.skip("the three-factor leading half already spans")
+        n_half = _min_half_runs(k)
+        assert _model_rank(_foldover(leading_half(k, n_half))) < rank_bound(k, n_half)
+
+
+class TestDEfficiencyRankGuard:
+    """Regression: ``_d_efficiency`` used to report a number for a singular X.
+
+    ``slogdet`` returns a finite log-determinant for an exactly singular integer
+    Gram matrix, because round-off moves it off zero. Before the guard, a
+    nineteen-run four-factor design reported a D-efficiency near 3, which reads
+    as "poor" rather than "cannot be fitted at all".
+    """
+
+    def test_zero_for_a_rank_deficient_nineteen_run_four_factor_design(self) -> None:
+        design = _foldover(generic_half(4, 9))
+        assert design.shape[0] == 19
+        assert _model_rank(design) < _full_second_order_params(4)
+        assert _d_efficiency(design) == 0.0
+
+    def test_the_gram_matrix_really_is_singular(self) -> None:
+        """Independent confirmation, not routed through the guard."""
+        model_matrix = _model_matrix(_foldover(generic_half(4, 9)))
+        gram = model_matrix.T @ model_matrix
+        assert np.linalg.matrix_rank(gram) < gram.shape[0]
+        assert min(np.linalg.svd(gram, compute_uv=False)) < 1e-6
+
+    @pytest.mark.parametrize("k", [3, 4, 5])
+    def test_positive_at_the_frontier(self, k: int) -> None:
+        assert _d_efficiency(_foldover(generic_half(k, _min_half_runs(k)))) > 0.0
+
+    @pytest.mark.parametrize(("k", "n_half"), [(4, 5), (4, 9), (5, 10), (5, 14)])
+    def test_zero_everywhere_below_the_frontier(self, k: int, n_half: int) -> None:
+        assert n_half < _min_half_runs(k)
+        assert _d_efficiency(_foldover(generic_half(k, n_half))) == 0.0

--- a/tests/test_omars_tradeoff.py
+++ b/tests/test_omars_tradeoff.py
@@ -1,0 +1,294 @@
+"""Tests for ``process_improve.experiments.omars_tradeoff``.
+
+The capability classes are arithmetic on the foldover estimability frontier, so
+the reference values are written down rather than computed: a change to the
+formula has to disagree with a table, not with itself. The frontier itself is
+proved against the rank law in ``tests/test_omars_estimability.py``; here we
+check that the trade-off table reports it faithfully.
+
+Nothing in this module needs a solver.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from process_improve.experiments.designs_omars_ilp import (
+    _foldover,
+    _full_second_order_params,
+    _half_pool,
+    _min_half_runs,
+    _model_rank,
+)
+from process_improve.experiments.omars_tradeoff import (
+    CAPABILITIES,
+    DEFAULT_FACTORS,
+    DEFAULT_RUNS,
+    omars_minimum_runs,
+    omars_trade_off_table,
+    omars_tradeoff,
+)
+
+# k -> (satd, quad, full), spelled out from 2k + 1, 2k + 3 and k^2 + k + 1.
+THRESHOLDS = {
+    3: (7, 9, 13),
+    4: (9, 11, 21),
+    5: (11, 13, 31),
+    6: (13, 15, 43),
+    7: (15, 17, 57),
+}
+
+# The approved rendering: (n_runs, n_factors) -> cell label.
+TABLE_CELLS = {
+    (9, 3): "Quad df=2",
+    (9, 4): "Satd df=0",
+    (9, 5): "",
+    (13, 3): "Full df=3",
+    (13, 4): "Quad df=4",
+    (13, 5): "Quad df=2",
+    (13, 6): "Satd df=0",
+    (13, 7): "",
+    (21, 4): "Full df=6",
+    (31, 5): "Full df=10",
+    (43, 6): "Full df=15",
+    (57, 7): "Full df=21",
+    (17, 7): "Quad df=2",
+}
+
+
+class TestMinimumRuns:
+    @pytest.mark.parametrize(("k", "expected"), THRESHOLDS.items(), ids=str)
+    def test_thresholds_match_the_written_table(self, k, expected):
+        satd, quad, full = expected
+        assert omars_minimum_runs(k, "satd") == satd
+        assert omars_minimum_runs(k, "quad") == quad
+        assert omars_minimum_runs(k, "full") == full
+
+    @pytest.mark.parametrize("k", [3, 4, 5, 6, 7])
+    def test_full_is_the_default(self, k):
+        assert omars_minimum_runs(k) == omars_minimum_runs(k, "full")
+
+    @pytest.mark.parametrize("k", list(range(3, 26)))
+    def test_every_threshold_is_odd(self, k):
+        """A foldover has 2h + 1 runs, so no threshold can be even."""
+        assert all(omars_minimum_runs(k, c) % 2 == 1 for c in CAPABILITIES)
+
+    @pytest.mark.parametrize("k", list(range(3, 26)))
+    def test_thresholds_increase_with_capability(self, k):
+        satd, quad, full = (omars_minimum_runs(k, c) for c in ("satd", "quad", "full"))
+        assert satd < quad <= full
+
+    def test_unknown_capability_is_refused(self):
+        with pytest.raises(ValueError, match="capability must be one of"):
+            omars_minimum_runs(4, "resolution_v")
+
+    @pytest.mark.parametrize("bad", [2, 0, -1, 26, 100])
+    def test_factor_count_out_of_range(self, bad):
+        with pytest.raises(ValueError, match="OMARS designs need"):
+            omars_minimum_runs(bad)
+
+    def test_non_integer_factor_count(self):
+        with pytest.raises(ValueError, match='"n_factors" input must be an integer'):
+            omars_minimum_runs(4.5)
+
+
+class TestFullThresholdAgreesWithTheRankLaw:
+    """The `Full` threshold is not a convention: it is where the rank arrives.
+
+    Checked directly against the model matrix, so the trade-off table and
+    ``designs_omars_ilp`` cannot drift apart silently.
+    """
+
+    @pytest.mark.parametrize("k", [3, 4, 5])
+    def test_rank_reaches_the_parameter_count_exactly_at_the_threshold(self, k):
+        n_half = _min_half_runs(k)
+        assert 2 * n_half + 1 == omars_minimum_runs(k, "full")
+        pool = _half_pool(k)
+        rng = np.random.default_rng(0)
+        params = _full_second_order_params(k)
+        reached = any(
+            _model_rank(_foldover(pool[rng.choice(pool.shape[0], n_half, replace=False)])) == params for _ in range(200)
+        )
+        assert reached
+
+    @pytest.mark.parametrize("k", [3, 4, 5, 6, 7])
+    def test_two_runs_short_no_design_can_reach_it(self, k):
+        """Pure arithmetic on the bound, so it covers every design at that size."""
+        n_half = _min_half_runs(k) - 1
+        bound = k + min(n_half + 1, 1 + k * (k + 1) // 2)
+        assert bound < _full_second_order_params(k)
+        assert 2 * n_half + 1 == omars_minimum_runs(k, "full") - 2
+
+
+class TestSingleCell:
+    @pytest.mark.parametrize(("cell", "label"), TABLE_CELLS.items(), ids=str)
+    def test_label_matches_the_approved_rendering(self, cell, label):
+        n_runs, n_factors = cell
+        assert omars_tradeoff(n_runs, n_factors, display=False).label == label
+
+    def test_full_cell_reports_the_second_order_model(self):
+        result = omars_tradeoff(21, 4, display=False)
+        assert result.exists
+        assert result.capability == "full"
+        assert result.tag == "Full"
+        assert result.model == "full_second_order"
+        assert result.model_params == _full_second_order_params(4) == 15
+        assert result.error_df == 6
+        assert result.reason == ""
+
+    def test_quad_cell_drops_the_interactions(self):
+        result = omars_tradeoff(17, 4, display=False)
+        assert result.capability == "quad"
+        assert result.model == "main_quadratic"
+        assert result.model_params == 1 + 2 * 4
+        assert result.error_df == 17 - 9
+
+    def test_saturated_cell_has_no_error_df(self):
+        result = omars_tradeoff(9, 4, display=False)
+        assert result.capability == "satd"
+        assert result.model == "main_quadratic"
+        assert result.model_params == 9
+        assert result.error_df == 0
+
+    def test_error_df_is_runs_minus_parameters(self):
+        for n_runs in (13, 21, 31, 43):
+            result = omars_tradeoff(n_runs, 4, display=False)
+            if result.capability != "satd":
+                assert result.error_df == n_runs - result.model_params
+
+    def test_even_run_counts_are_never_a_design(self):
+        result = omars_tradeoff(20, 4, display=False)
+        assert not result.exists
+        assert result.capability == "none"
+        assert result.tag == ""
+        assert result.label == ""
+        assert result.model is None
+        assert "even" in result.reason
+
+    def test_below_the_smallest_design_there_is_nothing(self):
+        result = omars_tradeoff(7, 4, display=False)
+        assert not result.exists
+        assert "below the smallest OMARS design" in result.reason
+        assert result.min_runs_satd == 9
+
+    def test_thresholds_travel_with_every_result(self):
+        """Even an empty cell says what it would take, which is the point."""
+        result = omars_tradeoff(4, 6, display=False)
+        assert (result.min_runs_satd, result.min_runs_quad, result.min_runs_full) == THRESHOLDS[6]
+
+    @pytest.mark.parametrize("k", [3, 4, 5, 6, 7])
+    def test_capability_never_goes_backwards_as_runs_grow(self, k):
+        seen = [omars_tradeoff(n, k, display=False).capability for n in range(1, omars_minimum_runs(k, "full") + 8, 2)]
+        order = {"none": 0, "satd": 1, "quad": 2, "full": 3}
+        ranks = [order[c] for c in seen]
+        assert ranks == sorted(ranks)
+
+    def test_non_integer_runs_rejected(self):
+        with pytest.raises(ValueError, match='"n_runs" input must be an integer'):
+            omars_tradeoff(13.5, 4, display=False)
+
+    @pytest.mark.parametrize("bad", [0, -1, -13])
+    def test_non_positive_runs_rejected(self, bad):
+        with pytest.raises(ValueError, match="number of runs must be positive"):
+            omars_tradeoff(bad, 4, display=False)
+
+
+class TestDisplay:
+    def test_report_names_the_class_the_model_and_the_gap(self, capsys):
+        omars_tradeoff(17, 4, display=True)
+        out = capsys.readouterr().out
+        assert "OMARS: 17 runs, 4 factors" in out
+        assert "Quad:" in out
+        assert "main_quadratic (9 parameters), 8 error df" in out
+        assert "Satd 9, Quad 11, Full 21 runs" in out
+        assert "4 more runs would reach Full" in out
+
+    def test_a_full_cell_is_not_told_to_buy_more_runs(self, capsys):
+        omars_tradeoff(21, 4, display=True)
+        assert "more runs would reach Full" not in capsys.readouterr().out
+
+    def test_an_empty_cell_says_what_the_smallest_design_is(self, capsys):
+        omars_tradeoff(20, 4, display=True)
+        out = capsys.readouterr().out
+        assert "No design" in out
+        assert "smallest design for 4 factors has 9 runs" in out
+
+    def test_display_is_silent_when_switched_off(self, capsys):
+        omars_tradeoff(21, 4, display=False)
+        assert capsys.readouterr().out == ""
+
+
+class TestTable:
+    def test_default_shape_and_axis_names(self):
+        table = omars_trade_off_table(display=False)
+        assert table.shape == (len(DEFAULT_RUNS), len(DEFAULT_FACTORS))
+        assert table.index.name == "runs"
+        assert table.columns.name == "factors"
+
+    @pytest.mark.parametrize(("cell", "label"), TABLE_CELLS.items(), ids=str)
+    def test_cells_match_the_approved_rendering(self, cell, label):
+        n_runs, n_factors = cell
+        assert omars_trade_off_table(display=False).loc[n_runs, n_factors] == label
+
+    def test_cells_are_self_contained(self):
+        """The stored frame repeats ``df=``; only the printed view compresses it."""
+        table = omars_trade_off_table(display=False)
+        live = [cell for cell in table.to_numpy().ravel() if cell]
+        assert all(" df=" in cell for cell in live)
+
+    def test_shape_follows_its_arguments(self):
+        table = omars_trade_off_table(runs=(13, 21), factors=(4, 5), display=False)
+        assert table.shape == (2, 2)
+        assert list(table.index) == [13, 21]
+        assert list(table.columns) == [4, 5]
+
+    def test_the_last_row_is_full_everywhere(self):
+        """57 runs is the smallest budget reaching Full for all of k = 3..7."""
+        row = omars_trade_off_table(display=False).loc[57]
+        assert all(cell.startswith("Full") for cell in row)
+
+    def test_capability_worsens_across_a_row(self):
+        """More factors on a fixed budget can only buy less."""
+        table = omars_trade_off_table(display=False)
+        for n_runs in DEFAULT_RUNS:
+            tags = [cell.split()[0] for cell in table.loc[n_runs] if cell]
+            assert tags == sorted(tags), f"row {n_runs} is not monotone"
+
+    def test_an_out_of_range_factor_count_is_refused(self):
+        with pytest.raises(ValueError, match="OMARS designs need"):
+            omars_trade_off_table(factors=(3, 30), display=False)
+
+
+class TestPrintedTable:
+    @pytest.fixture
+    def printed(self, capsys):
+        omars_trade_off_table()
+        return capsys.readouterr().out
+
+    def test_header_is_padded_away_from_the_first_column(self, printed):
+        header = printed.splitlines()[0]
+        assert header.startswith("runs ")
+        assert "k=3" in header
+        assert "k=7" in header
+
+    def test_df_label_is_written_once_per_column(self, printed):
+        assert printed.count("df=") == len(DEFAULT_FACTORS)
+
+    def test_the_label_sits_on_the_first_live_cell_of_the_column(self, printed):
+        """For k = 3 that is the 9-run row, its first non-blank entry."""
+        row = next(line for line in printed.splitlines() if line.startswith("9 "))
+        assert "Quad df=2" in row
+        later = next(line for line in printed.splitlines() if line.startswith("13 "))
+        assert "Full 3" in later
+        assert "Full df=3" not in later
+
+    def test_cells_are_left_aligned(self, printed):
+        """The capability staircase should read as an edge, not a ragged column."""
+        lines = printed.splitlines()
+        starts = [line.index("Full") for line in lines if line.startswith(("13 ", "21 ", "57 "))]
+        assert len(set(starts)) == 1
+
+    def test_the_legend_explains_every_tag(self, printed):
+        for tag in ("Full:", "Quad:", "Satd:"):
+            assert tag in printed


### PR DESCRIPTION
## Summary

This PR started as an OMARS analogue of the two-level trade-off table. Building it surfaced a bug in `generate_omars`, so it now carries both: the fix (1.65.0) and the table it was written for (1.66.0). The two are the same piece of arithmetic seen from either end.

**The fact that was missed.** A foldover OMARS design is `[H; -H; 0]`, and every second-order term is an *even* function, so the quadratic and interaction columns of `H` and `-H` are identical. The even block therefore has at most `h + 1` distinct rows against `1 + k(k+1)/2` columns; the main effects contribute at most `k` more from the odd block. So for **every** foldover:

```
rank(X) <= k + min(h + 1, 1 + k(k+1)/2)
```

with equality for half-designs in general position. The full second-order model is estimable only from `N = k^2 + k + 1` runs: **13, 21, 31, 43, 57** for k = 3 to 7. That is strictly more than the parameter count `1 + 2k + k(k-1)/2` from four factors up, so "more runs than parameters" is not a sufficient test.

## Part 1: the three defects (1.65.0)

| Site | Before | After |
|---|---|---|
| `_half_bounds` | 25% slack over the parameter count: 13, 19, 27, 35, 45 | starts at the frontier: 13, 21, 31, 43, 57 |
| `_d_efficiency` | no rank guard | `0.0` when rank-deficient |
| `expected_error_df` | `N - n_params` | `N - rank` |

`_d_efficiency` was the subtle one. `slogdet` returns a finite log-determinant for an exactly singular integer Gram matrix, because round-off moves it off zero. So a design that **cannot be fitted at all** reported a D-efficiency of about 3, which reads as "poor" rather than "impossible". Its immediate neighbour `_a_optimality` already had the rank guard, and so does `evaluate._compute_d_efficiency` - the two metadata fields had been contradicting each other in the same result dict, `a_optimality: inf` beside a fabricated `d_efficiency`.

Verified with an exact rational-arithmetic determinant, not floating point:

| k | N | predicted rank | actual rank | params | exact det(X'X) | D-eff reported |
|---|---|---|---|---|---|---|
| 4 | 19 | 14 | 14 | 15 | **0** | 2.83 |
| 4 | 21 | 15 | 15 | 15 | 45289876488192 | 38.74 |
| 5 | 27 | 19 | 19 | 21 | **0** | 1.03 |
| 5 | 31 | 21 | 21 | 21 | 2.75e17 | 30.34 |

### Effect on `generate_omars`

Auto-sized designs are larger for k >= 4, because the previous sizes were not estimable:

| k | old N | new N | err df | D-eff before | D-eff after |
|---|---|---|---|---|---|
| 3 | 13 | 13 | 3 | 42.35 | 42.35 |
| 4 | 19 | **21** | 6 | 2.83 *(fabricated)* | **38.74** |
| 5 | 27 | **31** | 10 | 1.03 *(fabricated)* | **30.34** |

An explicit `n_runs` below the frontier is now refused with a message naming the frontier and pointing at `model="main_quadratic"` (whose frontier is the DSD's `2k + 1`). Metadata gains `model_rank` and `min_runs_for_model`.

## Part 2: the trade-off table (1.66.0)

Resolution cannot be the currency for OMARS designs: an OMARS design *always* has its main effects orthogonal to each other and to every second-order term, so resolution is constant. What a run budget actually buys is **which model is estimable**, and the frontier above is what sets it. Three capability classes, reported per cell with the error degrees of freedom left to test that model with:

| Tag | Condition | Meaning |
|---|---|---|
| `Full` | `N >= k^2 + k + 1` | main effects, quadratics and all two-factor interactions jointly estimable |
| `Quad` | `N >= 2k + 3` | main effects and pure quadratics, with error df to test them |
| `Satd` | `N = 2k + 1` | estimable but exactly saturated, so no inference |

The tags are four characters so cells line up, and they sort alphabetically in decreasing order of capability, so the staircase reads as a left-aligned edge:

```
runs  k=3        k=4        k=5        k=6        k=7
-------------------------------------------------------------
9     Quad df=2  Satd df=0
13    Full 3     Quad 4     Quad df=2  Satd df=0
17    Full 7     Quad 8     Quad 6     Quad 4     Quad df=2
21    Full 11    Full 6     Quad 10    Quad 8     Quad 6
25    Full 15    Full 10    Quad 14    Quad 12    Quad 10
31    Full 21    Full 16    Full 10    Quad 18    Quad 16
37    Full 27    Full 22    Full 16    Quad 24    Quad 22
43    Full 33    Full 28    Full 22    Full 15    Quad 28
57    Full 47    Full 42    Full 36    Full 29    Full 21
```

`df=` is written once per column rather than in every cell; the returned frame keeps self-contained labels (`"Full df=11"`) and the compression is presentation-only. Blank cells are budgets that are not a foldover design at all.

New public API, exported from `process_improve.experiments`: `omars_tradeoff`, `omars_trade_off_table`, `omars_minimum_runs`, and the `OmarsTradeoffResult` dataclass. Every number is closed-form, so the table needs no integer program and no solver, and is exact rather than dependent on a search budget. The quality of a *particular* design at a given size (D-efficiency, second-order correlations) still needs the ILP and stays on `generate_omars`.

## Test plan

- [x] `tests/test_omars_estimability.py` (new, 82 tests) - **needs no solver**, so unlike `tests/test_omars_ilp.py` it is not gated on CBC and runs on macOS where the bundled binary is flaky.
- [x] The two directions are tested separately, because the rank formula is an upper **bound** and not an identity: it holds for every half-design (which is what forbids sub-frontier designs), and it is attained by half-designs in general position (which is what makes the frontier the right floor rather than a conservative one). A degenerate half-design that falls short of the bound is tested too, so the distinction cannot silently rot.
- [x] `tests/test_omars_tradeoff.py` (new, 128 tests) - also solver-free. Thresholds and every table cell are pinned against written-down reference values, so a change to the formula has to disagree with a table rather than with itself. The `Full` threshold is additionally checked against the model matrix rank directly, so the table and `designs_omars_ilp` cannot drift apart silently.
- [x] Existing OMARS suite unchanged and green.
- [x] Full suite: 2473 passed, 5 skipped, 94.07% coverage.
- [x] `ruff check .` and `mypy src/process_improve` clean.

## Checklist

- [x] Version bumped in `pyproject.toml` (1.64.0 -> 1.65.0 for the fix, -> 1.66.0 for the table), `CITATION.cff` in sync
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated