### PR TITLE
fix(experiments): reject an OMARS design that never varies a factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ those changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- `omars_properties` and `is_omars` now reject a design that leaves a factor at
+  the middle level in every run. The check that each factor is genuinely
+  three-level tested only that the factor reaches the middle level at least
+  once, which catches a two-level factor (constant quadratic `1`) but not the
+  mirror case of a factor the design never varies (constant quadratic `0`).
+  Both are inestimable, and the second was being reported as a valid OMARS
+  design whose main-and-quadratic model matrix is rank deficient.
+
+  This also removes a bias in the `min_second_order_correlation` selection
+  criterion of `generate_omars`. `max_second_order_correlation` skips constant
+  columns, so a factor pinned at the centre removed its own quadratic and all
+  of its interactions from the comparison and improved the score. The criterion
+  therefore had an incentive to produce exactly the degenerate designs the
+  verifier was failing to catch, and did: in a sweep across three to six
+  factors it returned one, including a spurious perfect `0.000`, in roughly a
+  third of cells. With the verifier corrected those candidates are rejected
+  during the search, and two sizes that previously yielded no usable design at
+  all (three factors in nine runs, five factors in thirteen) now yield one.
+
 ### Added
 
 - Minimum moment aberration (Xu, 2003) for two-level designs, as

--- a/src/process_improve/experiments/designs_omars.py
+++ b/src/process_improve/experiments/designs_omars.py
@@ -157,10 +157,13 @@ def omars_properties(matrix: np.ndarray, *, tol: float = _DEFAULT_TOL) -> dict:
     is_three_level = bool(np.all(np.abs(matrix - nearest) <= tol) and np.all(np.isin(nearest, (-1.0, 0.0, 1.0))))
 
     # OMARS factors are genuinely three-level: each must take the middle (0)
-    # level at least once, otherwise its pure quadratic is a constant column
-    # and cannot be estimated (as in a two-level factorial).
+    # level at least once and an outer level at least once.  A pure quadratic is
+    # a constant column, and so not estimable, in either degenerate case: the
+    # factor never sits at the middle (x^2 == 1, as in a two-level factorial) or
+    # it never leaves it (x^2 == 0, a factor the design never actually varies).
     uses_middle_level = np.any(np.abs(matrix) <= tol, axis=0)
-    quadratics_estimable = bool(np.all(uses_middle_level))
+    uses_outer_level = np.any(np.abs(matrix) > tol, axis=0)
+    quadratics_estimable = bool(np.all(uses_middle_level & uses_outer_level))
 
     column_sums = np.abs(matrix.sum(axis=0))
     is_balanced = bool(np.all(column_sums <= tol))

--- a/tests/test_experiments_omars.py
+++ b/tests/test_experiments_omars.py
@@ -64,6 +64,40 @@ class TestOMARSProperties:
         assert props["is_omars"] is False
         assert is_omars(ff) is False
 
+    def test_factor_never_leaving_the_middle_is_not_omars(self) -> None:
+        """A factor pinned at the centre has a constant quadratic, so it is not OMARS.
+
+        The mirror of :meth:`test_full_factorial_is_not_omars`: a two-level factor
+        gives the constant quadratic ``1``, and a factor the design never varies
+        gives the constant quadratic ``0``.  Neither is estimable.
+        """
+        # x3 sits at the middle level in every run, so its main effect and its
+        # quadratic are both identically zero.
+        pinned = np.array(
+            [
+                [1, 1, 0],
+                [-1, 1, 0],
+                [1, -1, 0],
+                [-1, -1, 0],
+                [0, 0, 0],
+            ],
+            dtype=float,
+        )
+        props = omars_properties(pinned)
+        assert props["quadratics_estimable"] is False
+        assert props["is_omars"] is False
+        assert is_omars(pinned) is False
+
+        # The failure it stands for: the main-and-quadratic model is not estimable,
+        # even though every other OMARS property is satisfied.
+        n_runs = pinned.shape[0]
+        model_matrix = np.column_stack(
+            [np.ones(n_runs), *pinned.T, *(pinned**2).T],
+        )
+        assert np.linalg.matrix_rank(model_matrix) < model_matrix.shape[1]
+        assert props["is_balanced"] is True
+        assert props["main_effects_orthogonal"] is True
+
     def test_main_effect_aliased_with_interaction_fails(self) -> None:
         """A design whose main effect correlates with an interaction is not OMARS."""
         # x3 deliberately equals x1*x2 on the non-zero rows -> ME3 aliased with x1:x2.


### PR DESCRIPTION
## Summary

- `omars_properties` checked that each factor reaches the middle level at least once, so that its pure quadratic is not the constant column a two-level factor gives. The mirror case was unchecked: a factor left at the middle level in **every** run has the constant quadratic `0`. Both are inestimable; only the first was caught, so `is_omars` was returning `True` for designs whose main-and-quadratic model matrix is rank deficient.
- That permissiveness fed a bias in the search. `max_second_order_correlation` skips constant columns, which is correct on its own terms, but a factor pinned at the centre removes its own quadratic and all of its interaction columns from the comparison, so the score improves. `generate_omars(selection_criterion="min_second_order_correlation")` minimises exactly that quantity, so it had a direct incentive to produce the degenerate designs the verifier was accepting, and did: across a three-to-six factor sweep it returned one in roughly a third of cells, including a spurious perfect `0.000` at three factors in nine runs.
- The fix requires an outer level as well as a middle one. With the verifier corrected the ILP rejects those candidates during the search and spends its budget on real ones: degenerate results fell from twelve to three, and two sizes that previously produced no usable design at all (three factors in nine runs, five factors in thirteen) now produce one.

```python
uses_middle_level = np.any(np.abs(matrix) <= tol, axis=0)
uses_outer_level  = np.any(np.abs(matrix) >  tol, axis=0)      # new
quadratics_estimable = bool(np.all(uses_middle_level & uses_outer_level))
```

### Behaviour change

`is_omars` now returns `False` for matrices it previously accepted. Every such matrix has an inestimable quadratic, so no correct caller can depend on the old answer. It is corrected in place rather than put through the deprecation schedule.

## Test plan

How this was verified:

- [x] New regression test, `test_factor_never_leaving_the_middle_is_not_omars`, the mirror of the existing `test_full_factorial_is_not_omars`. Five runs in three factors is the smallest case that shows it: with the third factor pinned at the centre, `is_omars` returned `True` while the main-and-quadratic model matrix had rank 4 of 7. The test asserts the rank deficiency alongside the verdict, and that `is_balanced` and `main_effects_orthogonal` are both still `True`, so it is clear which check was the missing one.
- [x] `pytest -k omars`: 291 passed, 2 skipped.
- [x] The 13-run definitive screening design still verifies, so the new condition does not reject valid designs.
- [x] `ruff check .` and `ruff format --check .` clean; `mypy src/process_improve` clean over 146 source files.

## Checklist

- [ ] Version bumped in `pyproject.toml` (PATCH for fixes/docs/config, MINOR for new features)
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1daHPaXLs7PPRsq8CmMMm)_