### PR TITLE
Repo-wide error audit: fix statistical and robustness bugs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,10 +7,12 @@ on:
     branches: ['**']
   workflow_dispatch:  # allow manual trigger
 
+# Only the read scope at workflow level. The Pages-deploy scopes are
+# granted to the `deploy` job alone: the `build` job executes arbitrary
+# dependency and notebook code on every same-repo PR and must not carry
+# deploy credentials while doing so.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -19,6 +21,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: read  # configure-pages (main-branch pushes only) queries the Pages config
     steps:
       - uses: actions/checkout@v7
       - name: Install uv
@@ -44,6 +49,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,16 +3,23 @@
 
 name: Unit tests
 
+# NOTE: no `create` trigger. The create event does not support
+# branches/tags filters (they are silently ignored), so the old
+#   create: {branches: [main], tags: ['**']}
+# ran the full matrix on EVERY branch creation, duplicating the
+# push / pull_request runs.
 on:
   push:
     branches: [main]
   pull_request:
     branches: ['**']
-  create:
-    branches: [main]
-    tags: ['**']
   # schedule:
   #   - cron: "0 4 * * *"
+
+# The workflow only reads the repository; the default token needs no
+# write scopes (codecov uploads use their own OIDC/token path).
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,147 @@ those changes.
 
 ## [Unreleased]
 
+## [1.67.0] - 2026-08-14
+
+A repo-wide correctness audit. Most entries below change numerical results
+because the previous values were statistically or numerically wrong; the
+regression tests in `tests/test_audit_regressions_*.py` pin each fix.
+
+### Fixed
+
+- PCA with `algorithm="tsr"`: the missing-data imputation used a wrongly
+  transposed singular-vector matrix whenever the data had at least as many
+  columns as rows (an `IndexError` for wide matrices, silently wrong imputation
+  for square ones), and the fitted scores were centred while `transform()`
+  projects uncentred, so `scores_`, SPE and R2 disagreed with `transform` on
+  the same data. TSR loadings now also follow the same sign convention as the
+  SVD and NIPALS fits.
+- The score-plot T2 confidence ellipse (`ellipse_coordinates`) now uses the
+  bivariate limit (2 degrees of freedom) instead of the full model's component
+  count. The old ellipse was ~42 percent too wide per axis for a 5-component
+  model on 50 observations, hiding genuine outliers.
+- `spe_plot(with_a=...)` and `t2_plot(with_a=...)` now draw the confidence
+  limit computed at the plotted component count instead of always the full
+  model's; the y-axis title no longer shows the limit legend text.
+- `PCA.select_n_components`: the 1-SE selection band compared the total PRESS
+  against a per-fold standard error (about n_folds times too narrow, silently
+  degenerating the `"1se"` rule to `"min"`), and the Q2 null model used the
+  uncentred sum of squares. `PLS.select_n_components` had the same too-narrow
+  Q2 standard-error band.
+- `PLS.cross_validate` with K-fold resampling: beta confidence intervals now
+  use the delete-a-block jackknife standard error; the plain sample standard
+  deviation previously used is `(K-1)/sqrt(K)` times too small (1.79x for
+  K=5), over-declaring significance.
+- PLS and PCA NIPALS now actually warn when the iteration cap is reached (the
+  PLS warning condition could never fire; PCA had no warning at all).
+- `target_projection` and `selectivity_ratio` used the raw-units regression
+  vector as a direction in the model's internal (scaled) space; with
+  `scale=True` (the default) the direction was wrong whenever the X columns
+  have different raw scales. The projection now uses the scaled-space beta and
+  maps X through the model's own scaler.
+- `TPLS.diagnose` poisoned an observation's scores, T2, SPE and predictions
+  with NaN if a single F or Z cell was missing (fit() handled the same case
+  correctly).
+- Hotelling's T2 in `fit()` skips components with ~zero score variance instead
+  of dividing by ~zero (a rank-deficient fit produced inf/NaN T2 for every
+  observation); `n_components < 1` is now rejected.
+- `MCUVScaler` treats a column with fewer than two observed values (NaN
+  standard deviation) as constant instead of emitting an all-NaN column;
+  `center()`/`scale()` with `axis=1` no longer broadcast the row statistic
+  across columns (a `ValueError` for rectangular input, silently wrong for
+  square input).
+- Generalized ESD outlier test (`detect_outliers_esd`): the number of outliers
+  is the LARGEST i with `R_i > lambda_i` (NIST/Rosner); the first crossing was
+  used, under-reporting in exactly the masking scenarios the test exists for.
+- Robust confidence interval for the median (metrics and the agent tool): the
+  missing `sqrt(pi/2)` factor on the median's standard error gave ~87 percent
+  coverage for a nominal 95 percent interval.
+- `variance_decomposition`: `between_stddev` now reports the between-group
+  variance component `sqrt((MS_between - MS_within)/n0)` instead of
+  `sqrt(MS_between)`, which mixed the within-group noise into the "between"
+  number (the docstring example itself showed the wrong value).
+- `biweight_midvariance` now uses the midvariance tuning constant c = 9; the
+  previous c = 6 is the biweight location constant and biased the scale low.
+- Holt-Winters control chart: the biweight rho function conflated the
+  consistency constant with the cutoff k = 2.52, making every derived scale
+  estimate 12 percent too small (nominal +/-3S limits were really +/-2.63
+  sigma, about 3x the false-alarm rate). Warm-up residuals now subtract the
+  fitted trend `beta_0 * t` rather than the constant `beta_0`. The lambda grid
+  search is NaN-aware (for 10 <= N < 20 every grid cell was NaN and (0.1, 0.1)
+  always won silently). An explicit `ld_1=0.0` is respected. Unknown chart
+  variants are rejected at construction with a clear message.
+- `calculate_cpk`: `rsd` is now the relative standard deviation of the data
+  itself; it previously divided by the distance-to-spec centre and changed
+  value when the specification moved. The capability tool reports an undefined
+  Cpk as "could not be computed" instead of "Poor capability".
+- Clear effects (`evaluate_design(metric="clear_effects")`) now follow Wu and
+  Hamada: an effect is clear only when every alias has order >= 3. The old
+  rule declared every main effect of a resolution-III design clear.
+- Explicit fractional-factorial generators: a generator on a non-last factor
+  (for example `"B=AC"`) silently swapped factor columns, and multi-character
+  factor names were misread as products of single letters. Generators are now
+  parsed against the real factor names and the columns mapped back to the
+  requested factor order; negative generators are supported and inconsistent
+  generator sets are rejected.
+- `Column.to_coded`/`to_realworld` no longer ignore an explicit `center=0`
+  (falsy); missing or zero-width ranges raise a clear error. `gather()` no
+  longer silently discards positional arguments.
+- D-optimal point exchange: the scorer no longer de-duplicates the design
+  before computing `|X'X|` (replicated runs carry information), and an
+  improving swap onto the row with index label 0 is no longer discarded;
+  `point_exchange` accepts `random_state`.
+- The lack-of-fit test can now find replicates on generated designs: it groups
+  on the model's factor columns (with rounded numeric values) instead of the
+  whole frame, whose unique-per-row `RunOrder` column made every group a
+  singleton.
+- Robust regression: the degenerate-x guard branch itself divided by the
+  ~zero x sum-of-squares; the leverage there is exactly 1/N.
+- Batch DTW: the reported alignment distance summed the cumulative cost matrix
+  entries along the warping path (not a distance); it is now the accumulated
+  cost `D[-1, -1]`. Kassidas alignment weights now up-weight (rather than
+  effectively zero out) variables whose trajectories align near-perfectly.
+- Residual diagnostics (`analyze_experiment`): p-values that underflow to
+  exactly 0.0 (the most significant possible result) are no longer rendered as
+  "not available".
+- `Settings` (config) now genuinely caches on first access (the `setdefault`
+  pattern re-read the environment on every access and re-raised later if the
+  env var went bad after a successful read); numeric knobs must be positive.
+- `clean()` now serialises `numpy.bool_`, numpy-keyed dicts, sets and the
+  remaining numpy scalar types, closing "internal error" failures at the MCP
+  boundary.
+- `discover_tools` no longer swallows a missing FIRST-PARTY module as an
+  optional dependency: a typo'd or renamed `process_improve` module now
+  propagates instead of silently dropping a whole tool category.
+- `safe_execute_tool_call` runs each default-path call in a private worker
+  pool. The shared module pool was not thread-safe: with concurrent calls
+  (the MCP server runs tools on executor threads) one thread's teardown could
+  kill the worker running another thread's task, mis-diagnosed as a memory
+  limit kill, or leak an orphaned worker.
+- `raincloud` without the `plotting` extra now raises the documented
+  "install the extra" `ImportError` at the call site instead of an
+  `AttributeError` from the module stub.
+
+### Changed
+
+- `detect_outliers_esd` and the `detect_outliers` agent tool now default to
+  the classical (mean/std) statistic, `robust_variant=False`. The MAD-scaled
+  variant is tested against critical values derived for the classical
+  statistic and declares outliers in clean data; it stays available as an
+  explicitly documented screening heuristic. This changes results for callers
+  who relied on the old default.
+- `PROCESS_IMPROVE_*` boolean environment variables now reject unrecognized
+  values with a `ValueError` instead of silently reading them as false; a typo
+  in `PROCESS_IMPROVE_MCP_SAFE_MODE` previously disabled safe mode with no
+  error.
+- The agent-facing `control_chart` tool no longer advertises a `cusum` chart
+  type: it never existed and always failed with a misleading error. The
+  package docstring's "CUSUM, EWMA" claim is corrected likewise.
+- CI: the no-op `create` trigger is removed from the test workflow, and both
+  workflows now grant least-privilege token scopes (the docs build job no
+  longer carries Pages-deploy credentials while executing PR code).
+
+## [1.66.2] - 2026-08-14
+
 ### Fixed
 
 - `omars_properties` and `is_omars` now reject a design that leaves a factor at
@@ -3104,7 +3245,9 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.66.1...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.67.0...HEAD
+[1.67.0]: https://github.com/kgdunn/process-improve/compare/v1.66.2...v1.67.0
+[1.66.2]: https://github.com/kgdunn/process-improve/compare/v1.66.1...v1.66.2
 [1.66.1]: https://github.com/kgdunn/process-improve/compare/v1.66.0...v1.66.1
 [1.66.0]: https://github.com/kgdunn/process-improve/compare/v1.65.0...v1.66.0
 [1.65.0]: https://github.com/kgdunn/process-improve/compare/v1.64.0...v1.65.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.66.2
+version: 1.67.0
 date-released: "2026-08-14"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.66.2"
+version = "1.67.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/__init__.py
+++ b/src/process_improve/__init__.py
@@ -13,7 +13,8 @@ univariate
 experiments
     Factorial and response surface experiment designs.
 monitoring
-    Control charts (Shewhart, CUSUM, EWMA).
+    Control charts (Shewhart, and a robust Holt-Winters chart that blends
+    Shewhart and CUSUM-like behaviour) and process capability metrics.
 batch
     Batch process data analysis.
 regression

--- a/src/process_improve/batch/alignment_helpers.py
+++ b/src/process_improve/batch/alignment_helpers.py
@@ -58,21 +58,26 @@ def distance_matrix(test: np.ndarray, ref: np.ndarray, weight_matrix: np.ndarray
 
 @jit(nopython=True)
 def backtrack_optimal_path(D: np.ndarray) -> tuple[np.ndarray, float]:
-    """Backtrack through the distance matrix to find the optimal warping path."""
+    """Backtrack through the distance matrix to find the optimal warping path.
+
+    Returns the path and the DTW distance, which is the ACCUMULATED cost at
+    the end of the alignment, ``D[-1, -1]``. An earlier version summed the
+    cumulative ``D`` entries along the path - a sum of prefix sums that grows
+    super-linearly with path length and is not a distance; the per-batch
+    alignment-quality numbers built from it were meaningless.
+    """
     nr, nt = D.shape
     nr -= 1
     nt -= 1
-    path_sum = 0.0
+    distance = float(D[nr, nt])
     path = [
         [nr, nt],
     ]
     while (nt + nr) != 0:
         if nt == 0:
             nr -= 1
-            path_sum = path_sum + float(D[nr, nt])
         elif nr == 0:
             nt -= 1
-            path_sum = path_sum + float(D[nr, nt])
         else:
             # Commented-code here is to read, but for Numba JIT, the other code is able to be
             # compiled. They give the same results in regular Python.
@@ -80,16 +85,13 @@ def backtrack_optimal_path(D: np.ndarray) -> tuple[np.ndarray, float]:
             a, b, c = D[nr - 1, nt - 1], D[nr, nt - 1], D[nr - 1, nt]
             if (a <= b) & (a <= c):
                 # assert number == 0
-                path_sum = path_sum + D[nr - 1, nt - 1]
                 nt -= 1
                 nr -= 1
             elif (b <= a) & (b <= c):
                 # assert number == 1
-                path_sum = path_sum + D[nr, nt - 1]
                 nt -= 1
             elif (c <= a) & (c <= b):
                 # assert number == 2
-                path_sum = path_sum + D[nr - 1, nt]
                 nr -= 1
             else:
                 raise AssertionError
@@ -98,4 +100,4 @@ def backtrack_optimal_path(D: np.ndarray) -> tuple[np.ndarray, float]:
 
     # All done:
     path.reverse()
-    return np.array(path), path_sum
+    return np.array(path), distance

--- a/src/process_improve/batch/preprocessing.py
+++ b/src/process_improve/batch/preprocessing.py
@@ -402,7 +402,16 @@ def batch_dtw(  # noqa: C901, PLR0915
             # TODO: make this a configurable setting
             # problematic_threshold = dist_df["Distance"].quantile(0.95)
 
-        next_weights = 1.0 / np.where(next_weights > epsqrt, next_weights, 10000)
+        # Kassidas: each variable's weight is inversely proportional to its
+        # summed squared deviation from the average trajectory, so a variable
+        # that aligns consistently (SSQ ~ 0) must get a LARGE weight. The
+        # previous guard substituted the magic value 10000 for a near-zero
+        # SSQ, handing the best-aligned variables a weight of ~1e-4 - the
+        # exact opposite - and the constant was scale-dependent. Floor the
+        # SSQ (relative to the largest observed SSQ) instead, so the weight
+        # stays large but finite.
+        ssq_floor = max(epsqrt, 1e-6 * float(np.max(next_weights)))
+        next_weights = 1.0 / np.maximum(next_weights, ssq_floor)
         weight_vector = (next_weights / np.sum(next_weights) * len(columns_to_align)).ravel()
         # If change in delta_weight is small, we terminate early; no need to fine-tune excessively.
         delta_weight = np.diag(weight_matrix) - weight_vector  # old - new

--- a/src/process_improve/config.py
+++ b/src/process_improve/config.py
@@ -56,7 +56,10 @@ class with explicit env-var reads keeps that decision unfettered.
 from __future__ import annotations
 
 import os
-from typing import Any, Final
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _read_env_float(name: str, default: float) -> float:
@@ -64,9 +67,14 @@ def _read_env_float(name: str, default: float) -> float:
     if raw is None:
         return default
     try:
-        return float(raw)
+        value = float(raw)
     except ValueError as exc:
         raise ValueError(f"Environment variable {name}={raw!r} is not a valid float.") from exc
+    # Every float knob is a budget/limit; zero or negative values would fail
+    # much later with confusing errors (e.g. future.result(timeout=-5)).
+    if value <= 0:
+        raise ValueError(f"Environment variable {name}={raw!r} must be positive.")
+    return value
 
 
 def _read_env_int(name: str, default: int) -> int:
@@ -74,16 +82,37 @@ def _read_env_int(name: str, default: int) -> int:
     if raw is None:
         return default
     try:
-        return int(raw)
+        value = int(raw)
     except ValueError as exc:
         raise ValueError(f"Environment variable {name}={raw!r} is not a valid integer.") from exc
+    # Every int knob is a size/limit; a zero or negative cap would reject
+    # every payload (or fail to start a worker) with confusing errors.
+    if value <= 0:
+        raise ValueError(f"Environment variable {name}={raw!r} must be positive.")
+    return value
+
+
+_TRUE_STRINGS: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
+_FALSE_STRINGS: Final[frozenset[str]] = frozenset({"0", "false", "no", "off", ""})
 
 
 def _read_env_bool(name: str, default: bool) -> bool:
     raw = os.environ.get(name)
     if raw is None:
         return default
-    return raw.lower() in {"1", "true", "yes", "on"}
+    value = raw.strip().lower()
+    if value in _TRUE_STRINGS:
+        return True
+    if value in _FALSE_STRINGS:
+        return False
+    # Raise on anything else, matching the int/float readers. The previous
+    # behaviour silently returned False for any unrecognized value, so a typo
+    # like MCP_SAFE_MODE="treu" disabled the security-relevant safe mode with
+    # no error and no log line - a fail-open.
+    raise ValueError(
+        f"Environment variable {name}={raw!r} is not a valid boolean; "
+        f"use one of {sorted(_TRUE_STRINGS)} or {sorted(_FALSE_STRINGS - {''})}."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -144,6 +173,20 @@ class Settings:
     def __init__(self) -> None:
         self._cache: dict[str, Any] = {}
 
+    def _get(self, name: str, reader: Callable[[str, Any], Any]) -> Any:  # noqa: ANN401  - knobs are heterogeneous
+        """Read a knob, caching genuinely on FIRST access.
+
+        The previous ``self._cache.setdefault(name, _read_env_...(...))``
+        pattern evaluated the env read on EVERY access (Python evaluates the
+        default argument before calling setdefault), so nothing was cached: a
+        hot-path attribute read cost an environ lookup plus a conversion, and
+        a knob that had already been served successfully would suddenly raise
+        if the env var was later mutated to an invalid value.
+        """
+        if name not in self._cache:
+            self._cache[name] = reader(ENV_VAR_NAMES[name], DEFAULTS[name])
+        return self._cache[name]
+
     # ------------------------------------------------------------------
     # Typed properties (one per knob).
     # We list them explicitly rather than using ``__getattr__`` so IDEs
@@ -153,10 +196,7 @@ class Settings:
     @property
     def tool_timeout(self) -> float:
         """Wall-clock seconds budget for a single tool call."""
-        return self._cache.setdefault(
-            "tool_timeout",
-            _read_env_float(ENV_VAR_NAMES["tool_timeout"], DEFAULTS["tool_timeout"]),
-        )
+        return self._get("tool_timeout", _read_env_float)
 
     @tool_timeout.setter
     def tool_timeout(self, value: float) -> None:
@@ -165,10 +205,7 @@ class Settings:
     @property
     def max_cells(self) -> int:
         """Maximum number of numeric leaves anywhere in a tool input payload."""
-        return self._cache.setdefault(
-            "max_cells",
-            _read_env_int(ENV_VAR_NAMES["max_cells"], DEFAULTS["max_cells"]),
-        )
+        return self._get("max_cells", _read_env_int)
 
     @max_cells.setter
     def max_cells(self, value: int) -> None:
@@ -177,10 +214,7 @@ class Settings:
     @property
     def max_string(self) -> int:
         """Maximum length of any single string in a tool input payload."""
-        return self._cache.setdefault(
-            "max_string",
-            _read_env_int(ENV_VAR_NAMES["max_string"], DEFAULTS["max_string"]),
-        )
+        return self._get("max_string", _read_env_int)
 
     @max_string.setter
     def max_string(self, value: int) -> None:
@@ -189,10 +223,7 @@ class Settings:
     @property
     def max_depth(self) -> int:
         """Maximum nesting depth of any tool input payload."""
-        return self._cache.setdefault(
-            "max_depth",
-            _read_env_int(ENV_VAR_NAMES["max_depth"], DEFAULTS["max_depth"]),
-        )
+        return self._get("max_depth", _read_env_int)
 
     @max_depth.setter
     def max_depth(self, value: int) -> None:
@@ -201,10 +232,7 @@ class Settings:
     @property
     def max_memory_mb(self) -> int:
         """Per-subprocess RSS cap for tool execution (MiB)."""
-        return self._cache.setdefault(
-            "max_memory_mb",
-            _read_env_int(ENV_VAR_NAMES["max_memory_mb"], DEFAULTS["max_memory_mb"]),
-        )
+        return self._get("max_memory_mb", _read_env_int)
 
     @max_memory_mb.setter
     def max_memory_mb(self, value: int) -> None:
@@ -218,10 +246,7 @@ class Settings:
         :func:`process_improve.tool_safety.safe_execute_tool_call`
         (validation, subprocess isolation, memory cap).
         """
-        return self._cache.setdefault(
-            "mcp_safe_mode",
-            _read_env_bool(ENV_VAR_NAMES["mcp_safe_mode"], DEFAULTS["mcp_safe_mode"]),
-        )
+        return self._get("mcp_safe_mode", _read_env_bool)
 
     @mcp_safe_mode.setter
     def mcp_safe_mode(self, value: bool) -> None:
@@ -239,13 +264,7 @@ class Settings:
         ``fullfact``, simplex centroid / lattice). Default 15 caps
         ``2**k`` rows at ~32 KiB of memory per cell.
         """
-        return self._cache.setdefault(
-            "max_factors_combinatorial",
-            _read_env_int(
-                ENV_VAR_NAMES["max_factors_combinatorial"],
-                DEFAULTS["max_factors_combinatorial"],
-            ),
-        )
+        return self._get("max_factors_combinatorial", _read_env_int)
 
     @max_factors_combinatorial.setter
     def max_factors_combinatorial(self, value: int) -> None:
@@ -256,13 +275,7 @@ class Settings:
         """Maximum ``len(x)`` / ``len(y)`` for the O(N^2) regression
         kernels (``repeated_median_slope`` etc.).
         """
-        return self._cache.setdefault(
-            "max_regression_points",
-            _read_env_int(
-                ENV_VAR_NAMES["max_regression_points"],
-                DEFAULTS["max_regression_points"],
-            ),
-        )
+        return self._get("max_regression_points", _read_env_int)
 
     @max_regression_points.setter
     def max_regression_points(self, value: int) -> None:
@@ -273,10 +286,7 @@ class Settings:
         """Maximum row count for ``data`` / ``x_data`` matrix inputs to
         ``fit_pca`` / ``fit_pls`` / ``detect_multivariate_outliers``.
         """
-        return self._cache.setdefault(
-            "max_matrix_rows",
-            _read_env_int(ENV_VAR_NAMES["max_matrix_rows"], DEFAULTS["max_matrix_rows"]),
-        )
+        return self._get("max_matrix_rows", _read_env_int)
 
     @max_matrix_rows.setter
     def max_matrix_rows(self, value: int) -> None:
@@ -285,10 +295,7 @@ class Settings:
     @property
     def max_matrix_cols(self) -> int:
         """Maximum column count for matrix inputs to the multivariate tools."""
-        return self._cache.setdefault(
-            "max_matrix_cols",
-            _read_env_int(ENV_VAR_NAMES["max_matrix_cols"], DEFAULTS["max_matrix_cols"]),
-        )
+        return self._get("max_matrix_cols", _read_env_int)
 
     @max_matrix_cols.setter
     def max_matrix_cols(self, value: int) -> None:
@@ -299,10 +306,7 @@ class Settings:
         """Maximum length (chars) of a model-formula string accepted by
         ``fit_linear_model`` and ``analyze_experiment``.
         """
-        return self._cache.setdefault(
-            "max_formula_chars",
-            _read_env_int(ENV_VAR_NAMES["max_formula_chars"], DEFAULTS["max_formula_chars"]),
-        )
+        return self._get("max_formula_chars", _read_env_int)
 
     @max_formula_chars.setter
     def max_formula_chars(self, value: int) -> None:
@@ -311,10 +315,7 @@ class Settings:
     @property
     def max_formula_terms(self) -> int:
         """Maximum number of terms after patsy expansion of a model formula."""
-        return self._cache.setdefault(
-            "max_formula_terms",
-            _read_env_int(ENV_VAR_NAMES["max_formula_terms"], DEFAULTS["max_formula_terms"]),
-        )
+        return self._get("max_formula_terms", _read_env_int)
 
     @max_formula_terms.setter
     def max_formula_terms(self, value: int) -> None:

--- a/src/process_improve/experiments/_analyses/diagnostics.py
+++ b/src/process_improve/experiments/_analyses/diagnostics.py
@@ -48,16 +48,19 @@ def _run_residual_diagnostics(ols_result: RegressionResultsWrapper) -> dict[str,
     # Leverage
     leverage = influence.hat_matrix_diag
 
+    # ``is not None``, not truthiness: a p-value that underflows to exactly
+    # 0.0 is the MOST significant possible result, and the previous truthiness
+    # test rendered it as "not available".
     return {
         "residual_diagnostics": {
             "shapiro_wilk": {
-                "statistic": float(sw_stat) if sw_stat else None,
-                "p_value": float(sw_p) if sw_p else None,
+                "statistic": float(sw_stat) if sw_stat is not None else None,
+                "p_value": float(sw_p) if sw_p is not None else None,
             },
             "durbin_watson": dw,
             "breusch_pagan": {
-                "statistic": float(bp_stat) if bp_stat else None,
-                "p_value": float(bp_p) if bp_p else None,
+                "statistic": float(bp_stat) if bp_stat is not None else None,
+                "p_value": float(bp_p) if bp_p is not None else None,
             },
             "cooks_distance": [float(c) for c in cooks_d],
             "leverage": [float(h) for h in leverage],

--- a/src/process_improve/experiments/_analyses/lack_of_fit.py
+++ b/src/process_improve/experiments/_analyses/lack_of_fit.py
@@ -14,21 +14,36 @@ def _run_lack_of_fit(
     ols_result: RegressionResultsWrapper,
     design_df: pd.DataFrame,
     response_col: str,
+    factor_cols: list[str] | None = None,
 ) -> dict[str, Any]:
     """Lack-of-fit F-test using pure error from replicated points.
 
     Separates residual SS into pure-error SS (from n_replicates) and
     lack-of-fit SS.  Custom implementation (~40 lines).
+
+    ``factor_cols`` must be the MODEL's factor columns. When the caller
+    passes a full design frame, bookkeeping columns like ``RunOrder`` (unique
+    per row) or ``Block`` must be excluded: grouping on them previously made
+    every group a singleton, so no generated design ever had detectable
+    replicates and the test always reported "No replicated points".
     """
     residuals = ols_result.resid
     y = design_df[response_col]
 
-    # Identify replicate groups by rounding factor values
-    factor_cols = [c for c in design_df.columns if c != response_col]
+    if factor_cols is None:
+        _non_factor = {response_col, "RunOrder", "Block"}
+        factor_cols = [c for c in design_df.columns if c not in _non_factor]
     if not factor_cols:
         return {"lack_of_fit": {"error": "No factor columns found."}}
 
-    groups = design_df.groupby(factor_cols, sort=False)
+    # Identify replicate groups by ROUNDED factor values: a coded -> actual ->
+    # coded round trip can perturb the last few bits, which would silently
+    # split replicates into distinct groups under exact groupby matching.
+    group_frame = design_df[factor_cols].copy()
+    for col in factor_cols:
+        if pd.api.types.is_numeric_dtype(group_frame[col]):
+            group_frame[col] = group_frame[col].astype(float).round(8)
+    groups = design_df.groupby([group_frame[c] for c in factor_cols], sort=False)
 
     ss_pure_error = 0.0
     df_pure_error = 0

--- a/src/process_improve/experiments/analysis.py
+++ b/src/process_improve/experiments/analysis.py
@@ -351,7 +351,7 @@ def analyze_experiment(  # noqa: PLR0912, PLR0913, PLR0915, C901
         elif t == "residual_diagnostics":
             results.update(_run_residual_diagnostics(ols_result))
         elif t == "lack_of_fit":
-            results.update(_run_lack_of_fit(ols_result, df, response_col))
+            results.update(_run_lack_of_fit(ols_result, df, response_col, factor_cols))
         elif t == "curvature_test":
             results.update(_run_curvature_test(ols_result, df, response_col, factor_cols))
         elif t == "model_selection":

--- a/src/process_improve/experiments/designs_screening.py
+++ b/src/process_improve/experiments/designs_screening.py
@@ -55,17 +55,7 @@ def dispatch_fractional_factorial(
     meta: dict = {}
 
     if generators:
-        # Convert ["D=ABC", "E=AC"] to pyDOE3 gen string "a b c abc ac"
-        # The base factors are the first ones not appearing on the LHS
-        lhs_names = [g.split("=")[0].strip() for g in generators]
-        factor_names = [f.name for f in factors]
-        base_names = [n for n in factor_names if n not in lhs_names]
-        gen_parts = [n.lower() for n in base_names]
-        for g in generators:
-            rhs = g.split("=")[1].strip().lower()
-            gen_parts.append(rhs)
-        gen_string = " ".join(gen_parts)
-        coded_matrix = fracfact(gen_string)
+        coded_matrix = _fracfact_from_generators(factors, generators)
         meta["generators_used"] = generators
     elif resolution is not None:
         coded_matrix = fracfact_by_res(k, resolution)
@@ -82,6 +72,103 @@ def dispatch_fractional_factorial(
         coded_matrix = coded_matrix[:, :k]
 
     return coded_matrix, meta
+
+
+def _parse_generator_word(word: str, factor_names: list[str]) -> list[int]:
+    """Parse a generator word (e.g. ``"ABC"``) into factor indices by NAME.
+
+    Uses the same convention as ``evaluate._parse_word``: character-by-character
+    when every factor name is a single character, greedy longest-name-first
+    matching otherwise. Unlike that helper, unparseable content raises instead
+    of being silently skipped: a generator that does not resolve to real
+    factors would otherwise produce a design for the wrong fraction.
+    """
+    name_to_idx = {name: i for i, name in enumerate(factor_names)}
+    indices: list[int] = []
+    if all(len(n) == 1 for n in factor_names):
+        for ch in word:
+            if ch not in name_to_idx:
+                raise ValueError(f"Generator word {word!r} refers to {ch!r}, which is not a factor name.")
+            indices.append(name_to_idx[ch])
+        return indices
+    remaining = word
+    sorted_names = sorted(name_to_idx, key=len, reverse=True)
+    while remaining:
+        for name in sorted_names:
+            if remaining.startswith(name):
+                indices.append(name_to_idx[name])
+                remaining = remaining[len(name) :]
+                break
+        else:
+            raise ValueError(f"Generator word {word!r} does not resolve to factor names {factor_names}.")
+    return indices
+
+
+def _parse_generators(factor_names: list[str], generators: list[str]) -> tuple[list[int], list[tuple[list[int], bool]]]:
+    """Parse and validate generator strings into (derived indices, rhs terms)."""
+    derived_idx: list[int] = []
+    rhs_indices: list[tuple[list[int], bool]] = []
+    for g in generators:
+        if "=" not in g:
+            raise ValueError(f"Generator {g!r} must have the form 'D=ABC' (or 'D=-ABC').")
+        lhs_word, rhs_word = (part.strip() for part in g.split("=", 1))
+        negated = rhs_word.startswith("-")
+        rhs_word = rhs_word.lstrip("+-").strip()
+        lhs = _parse_generator_word(lhs_word, factor_names)
+        if len(lhs) != 1:
+            raise ValueError(f"Generator {g!r}: the left-hand side must be exactly one factor.")
+        rhs = _parse_generator_word(rhs_word, factor_names)
+        if lhs[0] in rhs:
+            raise ValueError(f"Generator {g!r}: the left-hand factor may not appear on the right-hand side.")
+        if lhs[0] in derived_idx:
+            raise ValueError(f"Generator {g!r}: factor {factor_names[lhs[0]]!r} is derived more than once.")
+        derived_idx.append(lhs[0])
+        rhs_indices.append((rhs, negated))
+
+    base_idx = [i for i in range(len(factor_names)) if i not in derived_idx]
+    for (rhs, _neg), g in zip(rhs_indices, generators, strict=True):
+        not_base = [i for i in rhs if i not in base_idx]
+        if not_base:
+            names = [factor_names[i] for i in not_base]
+            raise ValueError(f"Generator {g!r}: right-hand factors {names} are themselves derived factors.")
+    return derived_idx, rhs_indices
+
+
+def _fracfact_from_generators(factors: list[Factor], generators: list[str]) -> np.ndarray:
+    """Build a coded fractional-factorial matrix from explicit generators.
+
+    The previous implementation handed pyDOE3 the base factors followed by the
+    derived ones and returned the columns in that order, while the caller
+    assigns column ``i`` to ``factors[i]``: whenever a generator's left-hand
+    factor was not the LAST factor (e.g. ``"B=AC"`` with factors A, B, C), the
+    factor columns were silently swapped. It also lower-cased raw factor names
+    into the pyDOE3 string, so any multi-character name was misread as a
+    product of single-letter factors. Generators are now parsed against the
+    real factor names, translated to canonical single letters for pyDOE3, and
+    the resulting columns are re-ordered back to the caller's factor order.
+    """
+    factor_names = [f.name for f in factors]
+    k = len(factors)
+    derived_idx, rhs_indices = _parse_generators(factor_names, generators)
+    base_idx = [i for i in range(k) if i not in derived_idx]
+
+    letters = "abcdefghijklmnopqrstuvwxyz"
+    if len(base_idx) > len(letters):
+        raise ValueError(f"At most {len(letters)} base factors are supported; got {len(base_idx)}.")
+    base_letter = {factor_index: letters[pos] for pos, factor_index in enumerate(base_idx)}
+    tokens = [base_letter[i] for i in base_idx]
+    for rhs, negated in rhs_indices:
+        word = "".join(base_letter[i] for i in rhs)
+        tokens.append(f"-{word}" if negated else word)
+
+    coded = fracfact(" ".join(tokens))
+    if coded.shape[1] != k:
+        raise ValueError(f"pyDOE3 returned {coded.shape[1]} columns for {k} factors; the generators are inconsistent.")
+    # pyDOE3 column order is (bases..., derived...); map back to factor order.
+    reordered = np.empty_like(coded)
+    for position, factor_index in enumerate(base_idx + derived_idx):
+        reordered[:, factor_index] = coded[:, position]
+    return reordered
 
 
 def dispatch_plackett_burman(factors: list[Factor]) -> tuple[np.ndarray, dict]:

--- a/src/process_improve/experiments/evaluate.py
+++ b/src/process_improve/experiments/evaluate.py
@@ -987,7 +987,16 @@ def _effect_order(term: str, factor_names: list[str]) -> int:
 
 
 def _compute_clear_effects(ctx: _EvalContext) -> dict[str, Any]:
-    """Identify effects whose aliases are all of higher order."""
+    """Identify clear effects per Wu & Hamada's definition.
+
+    An effect (a main effect or a two-factor interaction) is *clear* when it
+    is aliased with no other main effect AND no two-factor interaction, i.e.
+    every alias has order >= 3. The previous rule only required the aliases
+    to be of *higher* order than the effect itself, which declared every main
+    effect of a resolution-III design "clear" (A = BC has order 2 > 1) -
+    exactly the designs whose whole point is that the main effects are NOT
+    clear of two-factor interactions.
+    """
     alias_result = _compute_alias_structure(ctx)
     alias_chains = alias_result.get("alias_structure", [])
 
@@ -1002,11 +1011,12 @@ def _compute_clear_effects(ctx: _EvalContext) -> dict[str, Any]:
         order = _effect_order(effect, ctx.factor_names)
 
         alias_terms = [a.strip().lstrip("+-") for a in aliases_str.strip().split(" + ")]
-        all_higher = all(_effect_order(a, ctx.factor_names) > order for a in alias_terms)
+        min_alias_order = 3
+        all_clear = all(_effect_order(a, ctx.factor_names) >= min_alias_order for a in alias_terms)
 
-        if all_higher and order == 1:
+        if all_clear and order == 1:
             clear_main.append(effect)
-        elif all_higher and order == 2:
+        elif all_clear and order == 2:
             clear_2fi.append(effect)
 
     return {

--- a/src/process_improve/experiments/optimal.py
+++ b/src/process_improve/experiments/optimal.py
@@ -3,8 +3,6 @@ from collections.abc import Callable
 import numpy as np
 import pandas as pd
 
-IndexOrList = int | list
-
 
 def optimization_function(x: pd.DataFrame) -> float:
     """Score a design for the point-exchange D-optimal search (lower is better).
@@ -17,7 +15,10 @@ def optimization_function(x: pd.DataFrame) -> float:
     Returns ``+inf`` when ``X'X`` is singular (no improvement possible).
     """
     try:
-        x = pd.DataFrame(x).drop_duplicates()
+        # Do NOT de-duplicate here: replicated runs carry real information
+        # (|X'X| for n copies of a point differs from one copy), so dropping
+        # them would score a different design from the one being evaluated.
+        x = pd.DataFrame(x)
         xtx_i = np.linalg.inv(np.dot(np.transpose(x), x))
     except np.linalg.LinAlgError:
         return float(np.inf)
@@ -29,7 +30,7 @@ def index_to_replace_in_design_row(
     candidate_point: pd.DataFrame,
     current_optimum: float,
     optimization_function: Callable,
-) -> IndexOrList:
+) -> int | None:
     """Find the row index in ``design`` to replace with ``candidate_point``.
 
     Iterates over each row of ``design`` and evaluates the D-optimality of the
@@ -37,10 +38,13 @@ def index_to_replace_in_design_row(
 
     Returns
     -------
-    int | list
+    int | None
         The index of the row whose replacement yields the best (lowest)
         optimality score. If no row produces an improvement over
-        ``current_optimum``, an empty list is returned.
+        ``current_optimum``, ``None`` is returned. (An earlier version
+        returned an empty list here and the caller tested the result for
+        truthiness, which also discarded a legitimate improving swap onto
+        the row whose index LABEL is 0 - 0 is falsy.)
     """
     design_index = []
     new_optimimum = []
@@ -53,13 +57,14 @@ def index_to_replace_in_design_row(
         if current_optimum > candidate_optimum:
             design_index.append(row_idx)
             new_optimimum.append(candidate_optimum)
-    try:
-        return design_index[np.argmin(new_optimimum)]
-    except ValueError:
-        return design_index
+    if not design_index:
+        return None
+    return design_index[int(np.argmin(new_optimimum))]
 
 
-def point_exchange(x: pd.DataFrame, number_points: int = 10) -> tuple[pd.DataFrame, float]:
+def point_exchange(
+    x: pd.DataFrame, number_points: int = 10, random_state: int | None = None
+) -> tuple[pd.DataFrame, float]:
     """
     Return a design that is optimal in terms of D-optimality.
 
@@ -83,12 +88,15 @@ def point_exchange(x: pd.DataFrame, number_points: int = 10) -> tuple[pd.DataFra
     x = pd.DataFrame(x).drop_duplicates()
 
     number_points = min(number_points, x.shape[0])
-    # Continually try to pick rows from x, until it is not singular
+    # Continually try to pick rows from x, until it is not singular.
+    # A seedable Generator (rather than the global numpy RNG) makes the
+    # point-exchange result reproducible; see docs/development/reproducibility.rst.
+    rng = np.random.default_rng(random_state)
     max_attempts = 1000
     xtx_i = None
     for _attempt in range(max_attempts):
         try:
-            x = x.sample(frac=1)
+            x = x.sample(frac=1, random_state=rng)
             design = x.iloc[0 : x.shape[1]]
             xtx_i = np.linalg.inv(np.dot(np.transpose(design), design))
             break
@@ -113,7 +121,7 @@ def point_exchange(x: pd.DataFrame, number_points: int = 10) -> tuple[pd.DataFra
             current_optimum=d_optimality_i,
             optimization_function=optimization_function,
         )
-        if design_row_to_replace:
+        if design_row_to_replace is not None:
             design_index = design.index.tolist()
             # Replace the row in `design` which as index of `design_row_to_replace`:
             design_index[design_index.index(design_row_to_replace)] = candidate_point.index[0]

--- a/src/process_improve/experiments/structures.py
+++ b/src/process_improve/experiments/structures.py
@@ -56,8 +56,12 @@ class Column(pd.Series):
         if self.pi_is_coded:
             return out
 
-        x_center = center or self.pi_center
-        x_range = range or self.pi_range
+        # ``is not None``, not ``or``: an explicit center of 0 (or range
+        # spanning 0) is the most natural coded-units choice and is falsy,
+        # so a truthiness test silently fell back to the stored metadata.
+        x_center = center if center is not None else self.pi_center
+        x_range = range if range is not None else self.pi_range
+        self._validate_affine_map(x_center, x_range)
 
         # Simply override the values and the `pi_is_coded` flag, but all the
         # rest remains as is.
@@ -74,8 +78,10 @@ class Column(pd.Series):
         if not self.pi_is_coded:
             return out
 
-        x_center = center or self.pi_center
-        x_range = range or self.pi_range
+        # See the ``is not None`` note in ``to_coded``.
+        x_center = center if center is not None else self.pi_center
+        x_range = range if range is not None else self.pi_range
+        self._validate_affine_map(x_center, x_range)
         # Simply override the values and the `pi_is_coded` flag, but all the
         # rest remains as is.
         out.iloc[:] = np.asarray(self.values) * (0.5 * np.diff(np.asarray(x_range))[0]) + x_center
@@ -84,6 +90,23 @@ class Column(pd.Series):
             out.name = f"{out.pi_name} [{out.pi_units}]"
 
         return out
+
+    @staticmethod
+    def _validate_affine_map(center: float | None, range_: tuple | None) -> None:
+        """Reject a missing or degenerate coded<->real affine map up front.
+
+        Previously a missing range raised a bare ``TypeError`` from
+        ``np.diff(None)`` and a zero-width range silently produced
+        inf/NaN values.
+        """
+        if center is None or range_ is None:
+            raise ValueError(
+                "Cannot convert between coded and real-world units: no center/range is available. "
+                "Pass `center=` and `range=` explicitly, or create the column with `lo=` and `hi=`."
+            )
+        span = float(np.diff(np.asarray(range_))[0])
+        if span == 0:
+            raise ValueError(f"The range {range_} has zero width; the coded<->real conversion is undefined.")
 
     def copy(self, deep: bool = True) -> Column:  # type: ignore[misc]  # pandas marks Series.copy @final; subclassing is intentional here
         """Create a copy of this Column, preserving the name."""
@@ -409,10 +432,31 @@ def gather(*args: Column, title: str | None = None, **kwargs: Column | list) -> 
     A multi-column input (a ``pandas.DataFrame``, e.g. a categorical factor
     expanded into several indicator columns) is gathered column by column.
 
+    Positional arguments are accepted for columns that already carry a name
+    (``pi_name`` or the pandas ``.name``): ``gather(A, B, y=y)``. A nameless
+    positional argument raises, since its column label cannot be inferred.
+    (Earlier versions accepted positional arguments and silently discarded
+    them.)
     """
     out = Expt(data=None, index=None, columns=None, dtype=None)
     out.pi_source = defaultdict(str)
     out.pi_units = defaultdict(str)
+
+    # Fold positional args into the keyword dict via their own names, so a
+    # natural gather(A, B, y=y) call keeps every input.
+    merged: dict[str, Column | list] = {}
+    for position, positional in enumerate(args):
+        name = getattr(positional, "pi_name", None) or getattr(positional, "name", None)
+        if not name:
+            raise ValueError(
+                f"Positional argument {position + 1} to gather() has no name; "
+                "create it with c(..., name='...') or pass it as a keyword argument."
+            )
+        if str(name) in merged or str(name) in kwargs:
+            raise ValueError(f"Duplicate column name {name!r} in gather().")
+        merged[str(name)] = positional
+    merged.update(kwargs)
+    kwargs = merged
 
     # Every input is merged positionally (row i with row i), so they must all
     # contribute the same number of rows.

--- a/src/process_improve/monitoring/control_charts.py
+++ b/src/process_improve/monitoring/control_charts.py
@@ -12,14 +12,32 @@ from ..univariate.metrics import median_absolute_deviation
 logger = logging.getLogger(__name__)
 
 
+#: Consistency constant for the bounded biweight rho with cutoff k = 2.52,
+#: c_k = 1 / E[rho_norm(Z)] for Z ~ N(0, 1), where rho_norm is the biweight
+#: rho normalised to a maximum of 1. Computed via numerical integration
+#: (scipy.integrate.quad of rho_norm(z) * phi(z); E = 0.3061160, so
+#: c_k = 3.266736). This makes E[rho(Z)] = 1, the condition for the scale
+#: estimates built from rho to be consistent for sigma on Gaussian data.
+BIWEIGHT_RHO_CONSISTENCY = 3.266736
+
+
 def rho(x: float, k: float = 2.52) -> float:
     """
     Bi-weight rho function.
 
-    Fixed constant of k=2.52 is from p 289 of the paper
+    Fixed cutoff of k=2.52 is from p 289 of the paper
     https://onlinelibrary.wiley.com/doi/abs/10.1002/for.1125
+
+    The multiplier is the consistency constant c_k (chosen so that
+    ``E[rho(Z)] = 1`` for standard-normal Z), NOT the cutoff k. The paper
+    treats the two as separate constants; an earlier version of this code
+    conflated them and used k = 2.52 as the multiplier, which made every
+    scale estimate derived from rho a factor ``sqrt(2.52 * 0.30612) = 0.878``
+    too small, i.e. +/-3S control limits that were really +/-2.63 sigma
+    (a ~3x inflation of the false-alarm rate).
     """
-    return k if np.abs(x) > k else k * (1 - np.power(1 - np.power(x / k, 2), 3))
+    c_k = BIWEIGHT_RHO_CONSISTENCY
+    return c_k if np.abs(x) > k else c_k * (1 - np.power(1 - np.power(x / k, 2), 3))
 
 
 def psi(x: float, k: float = 2.0) -> float:
@@ -66,6 +84,16 @@ class ControlChart:
         """
         self.style = style.strip()
         self.variant = variant.strip().lower()
+        # An unknown variant previously slipped through every fit branch and
+        # surfaced much later as a misleading "input is likely constant or too
+        # short" error from calculate_limits. Reject it up front instead.
+        _supported = {"hw", "xbar.no.subgroup"}
+        if self.variant not in _supported:
+            raise ValueError(
+                f"Control chart variant {variant!r} is not implemented; supported variants are {sorted(_supported)}. "
+                "(A standalone CUSUM chart is a possible future variant; the 'hw' chart already blends "
+                "CUSUM-style history with Shewhart behaviour.)"
+            )
 
         # Will be calculated by the self.calculate_limits() function
         self.target: float | None = None
@@ -228,7 +256,10 @@ class ControlChart:
         self.ld_s = ld_s = 0.2
         rho_func = np.vectorize(rho)
 
-        if self.ld_1 and self.ld_2:
+        # ``is not None``: an explicit ld_1=0.0 (or ld_2=0.0) is a legitimate
+        # user choice, but 0.0 is falsy and a plain truthiness test silently
+        # discarded it and ran the grid search instead.
+        if self.ld_1 is not None and self.ld_2 is not None:
             # User has provided their own lambda_1 and lambda_2 values.
             for _name, _val in (("Lambda_1", self.ld_1), ("Lambda_2", self.ld_2), ("Lambda_s", self.ld_s)):
                 if _val < 0.0:
@@ -249,15 +280,24 @@ class ControlChart:
                     self._holt_winters_warmup_fit(ld_1=ld_1, ld_2=ld_2, ld_s=ld_s)
 
                     # Apply equation 16 from the paper to the residuals in the 'training' period,
-                    # that is the samples after the warm-up period.
+                    # that is the samples after the warm-up period. NaN-aware
+                    # statistics are required: row 0 never receives an "error"
+                    # value, and for small samples (2 * warm_up_M > N) the
+                    # training window includes row 0. With plain
+                    # np.median/np.average every grid cell became NaN and the
+                    # search silently "chose" (0.1, 0.1) via argmin-of-NaN.
                     future_errors = self.df["error"].iloc[np.asarray(self.train_samples, dtype=int)]
-                    S_T_median_error = 1.48 * np.median(abs(future_errors))
-                    residuals[i, j] = np.power(S_T_median_error, 2) * np.average(
+                    S_T_median_error = 1.48 * np.nanmedian(np.abs(future_errors))
+                    residuals[i, j] = np.power(S_T_median_error, 2) * np.nanmean(
                         rho_func(future_errors / S_T_median_error)
                     )
-                    # print(f"{i}, {j}, {residuals[i, j]:.5f}")
 
-            min_idx = np.argmin(residuals)
+            if np.all(np.isnan(residuals)):
+                raise ValueError(
+                    "The Holt-Winters lambda grid search produced no usable residuals; "
+                    "the input is likely constant, too short, or entirely missing."
+                )
+            min_idx = np.nanargmin(residuals)
             best_ld_1 = ld_1_index[np.unravel_index(min_idx, residuals.shape)[0]]
             best_ld_2 = ld_2_index[np.unravel_index(min_idx, residuals.shape)[1]]
             # Store the parameters that were calculated, even if a `target` or `s` were provided.
@@ -320,7 +360,14 @@ class ControlChart:
 
         else:
             # p 290 of the paper, https://onlinelibrary.wiley.com/doi/abs/10.1002/for.1125
-            warm_up_residuals = y_warm_up - self.warm_up["alpha_0"] - self.warm_up["beta_0"]
+            # The residual is y_t - alpha_0 - beta_0 * t (alpha_0 above is the
+            # median of exactly that de-trended series). Subtracting beta_0 as
+            # a constant, as an earlier version did, leaves the whole warm-up
+            # trend inside the residuals and inflates sigma_0 whenever the
+            # window drifts - precisely the situation this chart is for.
+            warm_up_residuals = y_warm_up - self.warm_up["alpha_0"] - self.warm_up["beta_0"] * np.arange(
+                self.warm_up_M
+            )
 
             # Some other method that does not rely on SciPy for 1 function.
             self.warm_up["sigma_0"] = median_absolute_deviation(np.asarray(warm_up_residuals), nan_policy="omit")

--- a/src/process_improve/monitoring/control_charts.py
+++ b/src/process_improve/monitoring/control_charts.py
@@ -365,9 +365,7 @@ class ControlChart:
             # a constant, as an earlier version did, leaves the whole warm-up
             # trend inside the residuals and inflates sigma_0 whenever the
             # window drifts - precisely the situation this chart is for.
-            warm_up_residuals = y_warm_up - self.warm_up["alpha_0"] - self.warm_up["beta_0"] * np.arange(
-                self.warm_up_M
-            )
+            warm_up_residuals = y_warm_up - self.warm_up["alpha_0"] - self.warm_up["beta_0"] * np.arange(self.warm_up_M)
 
             # Some other method that does not rely on SciPy for 1 function.
             self.warm_up["sigma_0"] = median_absolute_deviation(np.asarray(warm_up_residuals), nan_policy="omit")

--- a/src/process_improve/monitoring/metrics.py
+++ b/src/process_improve/monitoring/metrics.py
@@ -51,10 +51,22 @@ def calculate_cpk(  # noqa: C901
         A bunch with the following fields:
 
         * ``cpk``: the Cpk value (the limiting, i.e. smaller, of the two sides).
-        * ``center``: the center (mean or median) of the limiting side.
+        * ``center``: the center (mean or median) of the limiting side, i.e. of
+          the distance-to-specification metric.
         * ``spread``: the spread (standard deviation or Sn) of the limiting side.
-        * ``rsd``: the relative standard deviation of the limiting side, as a
-          percentage, ``(spread / center) * 100``.
+        * ``rsd``: the relative standard deviation OF THE DATA COLUMN, as a
+          percentage: ``spread / center-of-the-data * 100``. (Earlier versions
+          divided by the distance-to-spec centre, which is not an RSD of
+          anything and changed value when the spec limit moved.)
+
+    Notes
+    -----
+    The spread is estimated from ALL the values in the column (the overall
+    long-term variation), not from a within-subgroup range or moving range.
+    Strictly this makes the statistic a *performance* index (Ppk-style) rather
+    than a short-term capability index (Cpk with sigma-hat = Rbar/d2); on a
+    stable process the two coincide, and on an unstable one this value is the
+    more honest of the two.
     """
     if trim_percentile < 0:
         raise ValueError(f"trim_percentile must be non-negative; got {trim_percentile}.")
@@ -115,7 +127,19 @@ def calculate_cpk(  # noqa: C901
     else:
         cpk, center, spread = cpk_upper, center_upper, spread_upper
 
-    rsd = (spread / center) * 100 if center else float("nan")
+    # RSD of the DATA: the spread of (x - constant) equals the spread of x,
+    # but the centre must be the centre of the data itself, not the centre of
+    # the distance-to-spec metric (which made the "RSD" depend on where the
+    # specification sat). With a per-row (column-name) specification the
+    # metric spread can differ from the data spread, so recompute both pieces
+    # from the data column directly.
+    if trim_percentile > 0:
+        data_center = float(df[which_column].median())
+        data_spread = float(Sn(df[which_column]))
+    else:
+        data_center = float(df[which_column].mean())
+        data_spread = float(df[which_column].std())
+    rsd = (data_spread / data_center) * 100 if abs(data_center) > 0 else float("nan")
     return Bunch(cpk=cpk, center=center, spread=spread, rsd=rsd)
 
 

--- a/src/process_improve/monitoring/metrics.py
+++ b/src/process_improve/monitoring/metrics.py
@@ -94,9 +94,11 @@ def calculate_cpk(  # noqa: C901
     if trim_percentile > 0:
         center_lower, center_upper = float(metric_lower.median()), float(metric_upper.median())
         spread_lower, spread_upper = float(Sn(metric_lower)), float(Sn(metric_upper))
+        data_center, data_spread = float(df[which_column].median()), float(Sn(df[which_column]))
     else:
         center_lower, center_upper = float(metric_lower.mean()), float(metric_upper.mean())
         spread_lower, spread_upper = float(metric_lower.std()), float(metric_upper.std())
+        data_center, data_spread = float(df[which_column].mean()), float(df[which_column].std())
 
     # A column with no spread (constant data, or only one non-NaN value)
     # makes Cpk undefined: a bare division would silently yield inf / NaN.
@@ -130,15 +132,8 @@ def calculate_cpk(  # noqa: C901
     # RSD of the DATA: the spread of (x - constant) equals the spread of x,
     # but the centre must be the centre of the data itself, not the centre of
     # the distance-to-spec metric (which made the "RSD" depend on where the
-    # specification sat). With a per-row (column-name) specification the
-    # metric spread can differ from the data spread, so recompute both pieces
-    # from the data column directly.
-    if trim_percentile > 0:
-        data_center = float(df[which_column].median())
-        data_spread = float(Sn(df[which_column]))
-    else:
-        data_center = float(df[which_column].mean())
-        data_spread = float(df[which_column].std())
+    # specification sat). data_center / data_spread are computed from the data
+    # column directly above, alongside the per-side statistics.
     rsd = (data_spread / data_center) * 100 if abs(data_center) > 0 else float("nan")
     return Bunch(cpk=cpk, center=center, spread=spread, rsd=rsd)
 

--- a/src/process_improve/monitoring/tools.py
+++ b/src/process_improve/monitoring/tools.py
@@ -40,12 +40,13 @@ class ControlChartInput(BaseModel):
         min_length=5,
         description="Time-ordered sequence of numeric observations.",
     )
-    chart_type: Literal["shewhart", "cusum", "holt_winters"] = Field(
+    chart_type: Literal["shewhart", "holt_winters"] = Field(
         "holt_winters",
         description=(
             "Type of control chart. 'shewhart': individual observations chart. "
-            "'cusum': cumulative sum chart. 'holt_winters' (default): a blend of "
-            "Shewhart and CUSUM properties."
+            "'holt_winters' (default): a robust chart blending Shewhart "
+            "(no-history) and CUSUM-like (infinite-history) properties via its "
+            "smoothing parameters. A standalone CUSUM chart is not implemented."
         ),
     )
     style: Literal["robust", "regular"] = Field(
@@ -58,7 +59,8 @@ class ControlChartInput(BaseModel):
     name="control_chart",
     description=(
         "Build a control chart for a sequence of numeric observations and identify out-of-control points. "
-        "Supports Shewhart (xbar), CUSUM, and Holt-Winters (HW) chart types. "
+        "Supports Shewhart (xbar) and Holt-Winters (HW) chart types; the Holt-Winters chart blends "
+        "Shewhart and CUSUM-like behaviour through its smoothing parameters. "
         "The robust style (default) uses median and MAD instead of mean and std, making it resistant "
         "to outliers in the Phase-I data. "
         "Returns the calculated target (center line), upper and lower control limits, and indices of "
@@ -80,7 +82,6 @@ def control_chart(spec: ControlChartInput) -> dict[str, Any]:
 
     variant_map = {
         "shewhart": "xbar.no.subgroup",
-        "cusum": "cusum",
         "holt_winters": "hw",
     }
     variant = variant_map.get(spec.chart_type, "hw")
@@ -182,7 +183,15 @@ def process_capability(spec: ProcessCapabilityInput) -> dict[str, Any]:
         cpk_result = calculate_cpk(df, which_column="value", specifications=specs, trim_percentile=trim)
         cpk_float = float(cpk_result.cpk)
 
-        if cpk_float >= 1.67:
+        # A NaN Cpk (no usable spec side, or zero spread) previously fell
+        # through every >= comparison into the "Poor capability" branch,
+        # reporting a confident verdict for an undefined statistic.
+        if np.isnan(cpk_float):
+            interpretation = (
+                "Cpk could not be computed (undefined): check that at least one "
+                "specification limit is usable and that the data have non-zero spread."
+            )
+        elif cpk_float >= 1.67:
             interpretation = f"Cpk = {cpk_float:.3f}. Excellent capability - process is well within spec limits."
         elif cpk_float >= 1.33:
             interpretation = f"Cpk = {cpk_float:.3f}. Good capability - process fits within spec limits."

--- a/src/process_improve/multivariate/_diagnostics.py
+++ b/src/process_improve/multivariate/_diagnostics.py
@@ -143,7 +143,15 @@ def _target_projection_arrays(
         raise ValueError(msg)
     beta = model.beta_coefficients_
     label = _select_response(beta, response)
-    b = beta[label].to_numpy(dtype=float)
+    # The TP direction must live in the SAME space as the X the scores are
+    # computed from. ``beta_coefficients_`` is deliberately rescaled to raw
+    # X -> raw Y units in fit(); with scale=True (the default) that vector is
+    # NOT a direction in the model's internal (scaled) space, and normalising
+    # it does not repair the per-column unit mismatch. Use the scaled-space
+    # regression vector (direct_weights_ @ y_loadings_.T) instead, and map X
+    # into the same internal space via the model's own scaler when present.
+    b_scaled = model.direct_weights_.to_numpy(dtype=float) @ model.y_loadings_.to_numpy(dtype=float).T
+    b = b_scaled[:, list(beta.columns).index(label)]
     norm_b = float(np.sqrt(b @ b))
     if norm_b <= epsqrt:
         msg = f"The regression vector for response {label!r} is ~0; it is not predicted by X."
@@ -153,6 +161,9 @@ def _target_projection_arrays(
     if not isinstance(X, pd.DataFrame):
         X = pd.DataFrame(X)
     X = _align_to_fit_features(X, beta.index)
+    x_scaler = getattr(model, "_x_scaler", None)
+    if x_scaler is not None:
+        X = x_scaler.transform(X)
     X_values = X.to_numpy(dtype=float)
     t_tp = X_values @ w_tp
     ttt = float(t_tp @ t_tp)

--- a/src/process_improve/multivariate/_diagnostics.py
+++ b/src/process_improve/multivariate/_diagnostics.py
@@ -160,18 +160,18 @@ def _target_projection_arrays(
 
     if not isinstance(X, pd.DataFrame):
         X = pd.DataFrame(X)
-    X = _align_to_fit_features(X, beta.index)
+    x_frame: pd.DataFrame = _align_to_fit_features(X, beta.index)
     x_scaler = getattr(model, "_x_scaler", None)
     if x_scaler is not None:
-        X = x_scaler.transform(X)
-    X_values = X.to_numpy(dtype=float)
+        x_frame = x_scaler.transform(x_frame)
+    X_values = x_frame.to_numpy(dtype=float)
     t_tp = X_values @ w_tp
     ttt = float(t_tp @ t_tp)
     if ttt <= epsqrt:
         msg = "The target-projected scores have ~0 variance; cannot form the TP loading."
         raise ValueError(msg)
     p_tp = (X_values.T @ t_tp) / ttt
-    return X, t_tp, p_tp, w_tp, label
+    return x_frame, t_tp, p_tp, w_tp, label
 
 
 def target_projection(model: BaseEstimator, X: DataMatrix, response: str | int | None = None) -> Bunch:

--- a/src/process_improve/multivariate/_limits.py
+++ b/src/process_improve/multivariate/_limits.py
@@ -227,10 +227,19 @@ def ellipse_coordinates(  # noqa: PLR0913
         raise ValueError(f"conf_level must lie in (0, 1); got {conf_level}.")
     if n_rows <= 0:
         raise ValueError(f"n_rows must be positive; got {n_rows}.")
+    if n_points < 2:
+        raise ValueError(f"n_points must be >= 2 to draw an ellipse; got {n_points}.")
     assert scaling_factor_for_scores is not None  # required for the ellipse scaling
     s_h = scaling_factor_for_scores.iloc[score_horiz - 1]
     s_v = scaling_factor_for_scores.iloc[score_vert - 1]
-    t2_limit_specific = np.sqrt(hotellings_t2_limit(conf_level, n_components=n_components, n_rows=n_rows))
+    # The ellipse is the joint confidence region for the TWO plotted scores,
+    # so the T2 limit is computed with 2 degrees of freedom:
+    # 2 (N^2 - 1) / (N (N - 2)) * F(alpha; 2, N - 2), the convention used by
+    # SIMCA / ProMV and in Wold's texts. Using the full model's A here (the
+    # previous behaviour) draws a strictly larger ellipse (~42% too wide per
+    # axis at A=5, N=50; ~2x the area), silently hiding genuine outliers.
+    # ``n_components`` is still used above to bound the score indices.
+    t2_limit_specific = np.sqrt(hotellings_t2_limit(conf_level, n_components=2, n_rows=n_rows))
     dt = 2 * np.pi / (n_points - 1)
     steps = np.linspace(0, n_points - 1, n_points)
     x = np.cos(steps * dt) * t2_limit_specific * s_h

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -388,6 +388,8 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
 
         # Clamp n_components
         min_dim = int(min(N, K))
+        if self.n_components is not None and int(self.n_components) < 1:
+            raise ValueError(f"n_components must be >= 1; got {self.n_components}.")
         A = min_dim if self.n_components is None else int(self.n_components)
         if min_dim < A:
             warnings.warn(
@@ -471,17 +473,23 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             name="Standard deviation per score",
         )
 
-        # Hotelling's T² (cumulative across components)
+        # Hotelling's T² (cumulative across components). A component whose
+        # score standard deviation is ~0 (a rank-deficient fit, e.g. asking
+        # for min(N, K) components from mean-centred data, whose rank is at
+        # most min(N-1, K)) carries no T² information: its standardized score
+        # is 0/0. Skip such components rather than dividing by ~zero, which
+        # previously poisoned T² (and everything downstream of it) with
+        # inf/NaN for every observation.
         self.hotellings_t2_ = pd.DataFrame(
             np.zeros((N, A)),
             columns=component_names,
             index=self._sample_index,
         )
+        scaling_factors = self.scaling_factor_for_scores_.to_numpy()
+        t2_tol = epsqrt * max(1.0, float(np.max(scaling_factors, initial=0.0)))
         for a in range(A):
-            self.hotellings_t2_.iloc[:, a] = (
-                self.hotellings_t2_.iloc[:, max(0, a - 1)]
-                + (self._scores[:, a] / self.scaling_factor_for_scores_.iloc[a]) ** 2
-            )
+            contribution = (self._scores[:, a] / scaling_factors[a]) ** 2 if scaling_factors[a] > t2_tol else 0.0
+            self.hotellings_t2_.iloc[:, a] = self.hotellings_t2_.iloc[:, max(0, a - 1)] + contribution
 
         # Clean up temporary numpy staging names (the kept ndarrays above alias
         # the same arrays, so they survive these del statements).
@@ -599,6 +607,15 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             iterations_arr = typing.cast("np.ndarray", self.fitting_info_["iterations"])
             timing_arr[a] = time.time() - start_time
             iterations_arr[a] = itern
+            # terminate_check stops the loop at ``iterations >= md_max_iter``;
+            # warn on non-convergence (previously the PCA path was silent).
+            if itern >= settings["md_max_iter"]:
+                warnings.warn(
+                    f"PCA NIPALS: component {a + 1} reached the maximum number of "
+                    f"iterations ({settings['md_max_iter']}) without converging.",
+                    SpecificationWarning,
+                    stacklevel=2,
+                )
             logger.debug(
                 "PCA NIPALS: component %d converged in %d iterations (md_tol=%g)",
                 a + 1,
@@ -648,18 +665,28 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         mmap = np.isnan(Xd)
         Xd[mmap] = 0.0
         itern = 0
-        while (itern < settings["md_max_iter"]) and (delta > settings["md_tol"]):
+        # No missing cells means nothing to impute: skip the EM loop entirely
+        # (previously ``np.mean`` over the empty ``Xd[mmap]`` emitted a
+        # RuntimeWarning every iteration and produced a NaN delta).
+        while np.any(mmap) and (itern < settings["md_max_iter"]) and (delta > settings["md_tol"]):
             itern += 1
             missing_X = Xd[mmap]
             mean_X = np.mean(Xd, axis=0)
             S = np.cov(Xd, rowvar=False, ddof=1)
             Xc = Xd - mean_X
+            # Both branches must end with V of shape (K, A): rows indexed by
+            # feature, columns by component. svd(Xc) returns the loadings as
+            # the ROWS of Vt (so transpose), while svd(Xc.T) returns them as
+            # the COLUMNS of U (already oriented; do not transpose). The
+            # previous shared ``V = V.T[:, 0:A]`` transposed the second branch
+            # wrongly: an IndexError for N < K, and a silently wrong
+            # imputation regression for N == K.
             if N > K:
-                _, _, V = np.linalg.svd(Xc, full_matrices=False)
+                _, _, Vt = np.linalg.svd(Xc, full_matrices=False)
+                V = Vt.T[:, 0:A]
             else:
-                V, _, _ = np.linalg.svd(Xc.T, full_matrices=False)
-
-            V = V.T[:, 0:A]
+                U, _, _ = np.linalg.svd(Xc.T, full_matrices=False)
+                V = U[:, 0:A]
             for n in range(N):
                 row_mis = mmap[n, :]
                 row_obs = ~row_mis
@@ -677,7 +704,22 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         _, _, V = np.linalg.svd(S, full_matrices=False)
 
         self._loadings_np = (V[0:A, :]).T  # K x A
-        self._scores_np = (Xd - np.mean(Xd, axis=0)) @ self._loadings_np
+
+        # Sign convention: flip so the largest-magnitude element in each
+        # loading is positive, matching _fit_svd / _fit_nipals (previously
+        # the TSR loading signs were LAPACK-dependent).
+        for a in range(A):
+            max_el_idx = np.argmax(np.abs(self._loadings_np[:, a]))
+            if self._loadings_np[max_el_idx, a] < 0:
+                self._loadings_np[:, a] *= -1.0
+
+        # Project the imputed matrix as-is (no extra centring), exactly as
+        # transform() will project new data: the package convention is that X
+        # is preprocessed (e.g. MCUVScaler) before fit. The previous code
+        # centred here, so scores_ disagreed with transform(X) on the very
+        # same data, and the residuals below mixed centred reconstructions
+        # with uncentred data (inflating SPE and deflating R2).
+        self._scores_np = Xd @ self._loadings_np
 
         # R2 and SPE
         self._r2_np = np.zeros(A)
@@ -1189,10 +1231,13 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
                 columns=[f"fold_{i + 1}" for i in range(per_fold_press_arr.shape[1])],
             )
             cv_scores = per_fold_press
-            # Q^2 normalisation: total sum-of-squares of X (the null-model
-            # "predict the column mean" reference, which on mean-centred data
-            # is the total variance). Bro 2008's q^2_x normalisation.
-            null_model_ss = float(np.nansum(X_arr**2))
+            # Q^2 normalisation: the null-model "predict the column mean"
+            # reference is the CENTRED total sum-of-squares, sum((x - x_bar)^2).
+            # PRESS is accumulated in the original units, so the raw unscaled
+            # matrix may be passed here; the uncentred sum(x^2) previously used
+            # coincides only when X is already mean-centred and otherwise
+            # inflates the denominator, biasing Q^2 optimistically.
+            null_model_ss = float(np.nansum((X_arr - np.nanmean(X_arr, axis=0)) ** 2))
             q2 = 1.0 - press / null_model_ss if null_model_ss > epsqrt else press * np.nan
         elif cv_scheme == "row_wise":
             warnings.warn(
@@ -1219,7 +1264,7 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             # PRESS contributions, so don't pretend they are. Build a parallel
             # per_fold_press by undoing the negation.
             per_fold_press = -cv_scores
-            null_model_ss = float(np.nanmean(X_arr**2))
+            null_model_ss = float(np.nanmean((X_arr - np.nanmean(X_arr, axis=0)) ** 2))
             q2 = 1.0 - press / null_model_ss if null_model_ss > epsqrt else press * np.nan
         else:
             raise ValueError(f"Unknown cv_scheme {cv_scheme!r}; expected 'ekf' or 'row_wise'.")
@@ -1238,6 +1283,15 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             per_fold_arr = per_fold_press.to_numpy()
             n_folds_per_a = np.maximum(1, np.sum(~np.isnan(per_fold_arr), axis=1))
             se_values = np.nanstd(per_fold_arr, axis=1, ddof=1) / np.sqrt(n_folds_per_a)
+        if cv_scheme == "ekf":
+            # ``press`` under ekf is the TOTAL PRESS per repeat, i.e. n_folds
+            # times the mean per-fold PRESS, while ``se_values`` above is the
+            # standard error of the per-fold MEAN. Rescale so the 1-SE rule
+            # (and the Q2 band below) compares like with like; previously the
+            # band was ~n_folds times too narrow, silently degenerating
+            # selection_rule="1se" to "min". (row_wise's press IS a per-fold
+            # mean, so its SE is already on the right scale.)
+            se_values = se_values * n_folds
         se_press = pd.Series(se_values, index=component_index, name="SE(PRESS)")
 
         # The same constant null-model sum-of-squares that normalises Q2

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -1210,8 +1210,14 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         component_index = pd.Index(range(1, max_components + 1), name="n_components")
         X_arr = np.asarray(X, dtype=float)
 
+        # ``press`` under ekf is the TOTAL PRESS per repeat (n_folds times the
+        # mean per-fold PRESS), while row_wise's press is already a per-fold
+        # mean; the per-fold SE computed further below must be rescaled by
+        # this factor so the 1-SE rule compares like with like.
+        press_scale_multiplier = 1
         if cv_scheme == "ekf":
             n_folds = cv if isinstance(cv, int) else 5
+            press_scale_multiplier = n_folds
             if n_repeats < 1:
                 raise ValueError(f"n_repeats must be >= 1; got {n_repeats}.")
             press_arr, per_fold_press_arr = _pca_ekf_press(
@@ -1283,15 +1289,11 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             per_fold_arr = per_fold_press.to_numpy()
             n_folds_per_a = np.maximum(1, np.sum(~np.isnan(per_fold_arr), axis=1))
             se_values = np.nanstd(per_fold_arr, axis=1, ddof=1) / np.sqrt(n_folds_per_a)
-        if cv_scheme == "ekf":
-            # ``press`` under ekf is the TOTAL PRESS per repeat, i.e. n_folds
-            # times the mean per-fold PRESS, while ``se_values`` above is the
-            # standard error of the per-fold MEAN. Rescale so the 1-SE rule
-            # (and the Q2 band below) compares like with like; previously the
-            # band was ~n_folds times too narrow, silently degenerating
-            # selection_rule="1se" to "min". (row_wise's press IS a per-fold
-            # mean, so its SE is already on the right scale.)
-            se_values = se_values * n_folds
+        # Rescale the per-fold-mean SE onto the same scale as ``press`` (see
+        # press_scale_multiplier above). Previously the ekf band was ~n_folds
+        # times too narrow, silently degenerating selection_rule="1se" to
+        # "min".
+        se_values = se_values * press_scale_multiplier
         se_press = pd.Series(se_values, index=component_index, name="SE(PRESS)")
 
         # The same constant null-model sum-of-squares that normalises Q2

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -484,9 +484,14 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
                 settings["md_tol"],
             )
 
-            if itern > settings["md_max_iter"]:
+            # ``terminate_check`` stops the loop when ``iterations >=
+            # md_max_iter``, so ``itern`` is capped AT the maximum and the
+            # previous strict ``>`` comparison could never fire: non-convergent
+            # fits returned silently.
+            if itern >= settings["md_max_iter"]:
                 warnings.warn(
-                    "PLS NIPALS: maximum number of iterations reached!",
+                    f"PLS NIPALS: component {a + 1} reached the maximum number of "
+                    f"iterations ({settings['md_max_iter']}) without converging.",
                     SpecificationWarning,
                     stacklevel=2,
                 )
@@ -668,6 +673,8 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
 
         # Check if number of components is supported against maximum requested
         min_dim = min(N, K)
+        if self.n_components is not None and int(self.n_components) < 1:
+            raise ValueError(f"n_components must be >= 1; got {self.n_components}.")
         A = min_dim if self.n_components is None else int(self.n_components)
         if min_dim < A:
             warn = (
@@ -774,11 +781,16 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         prior_SSX_col = ssq(Xd.values, axis=0)
         prior_SSY_col = ssq(Yd.values, axis=0)
         base_variance_Y = np.sum(prior_SSY_col)
+        # A component with ~0 score standard deviation (rank-deficient fit)
+        # contributes 0/0 to T²; skip it rather than dividing by ~zero and
+        # poisoning T² with inf/NaN (mirrors the PCA fit path).
+        scaling_factors = self.scaling_factor_for_scores_.to_numpy()
+        t2_tol = epsqrt * max(1.0, float(np.max(scaling_factors, initial=0.0)))
         for a in range(A):
-            self.hotellings_t2_.iloc[:, a] = (
-                self.hotellings_t2_.iloc[:, max(0, a - 1)]
-                + (self.scores_.iloc[:, a] / self.scaling_factor_for_scores_.iloc[a]) ** 2
+            t2_contribution = (
+                (self.scores_.iloc[:, a] / scaling_factors[a]) ** 2 if scaling_factors[a] > t2_tol else 0.0
             )
+            self.hotellings_t2_.iloc[:, a] = self.hotellings_t2_.iloc[:, max(0, a - 1)] + t2_contribution
             Xd = Xd - self.scores_.iloc[:, [a]] @ self.x_loadings_.iloc[:, [a]].T
             y_hat = self.scores_.iloc[:, 0 : (a + 1)] @ self.y_loadings_.iloc[:, 0 : (a + 1)].T
             row_SSX = ssq(Xd.values, axis=1)
@@ -1521,6 +1533,12 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             se_press_total = np.nanstd(per_fold_press_total, axis=1, ddof=1) / np.sqrt(
                 np.maximum(1, np.sum(~np.isnan(per_fold_press_total), axis=1))
             )
+        # The Q2 curve normalises the TOTAL PRESS per repeat (the sum over the
+        # folds of one pass), which is ``first_repeat_fold_count`` times the
+        # mean per-fold PRESS whose standard error was just computed. Rescale
+        # so the +/-1 SE band is on the same scale as the Q2 values; the
+        # unscaled band was ~n_folds times too narrow.
+        se_press_total = se_press_total * max(1, first_repeat_fold_count)
         q2_se_values = se_press_total / ss_y_total if ss_y_total > 0 else se_press_total * np.nan
         q2_se = pd.Series(q2_se_values, index=component_index, name="SE(Q2)")
 
@@ -2110,8 +2128,15 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             beta_ci_lower_arr = beta_mean_arr - t_crit * beta_std_arr
             beta_ci_upper_arr = beta_mean_arr + t_crit * beta_std_arr
         elif method == "kfold":
-            # For K-fold, use sample std of the K beta estimates
-            beta_std_arr = beta_samples.std(axis=0, ddof=1)
+            # The K sub-models are delete-a-block (delete-d) jackknife
+            # estimates, not independent replicates: their training sets
+            # overlap pairwise in (K-2)/K of the rows. The delete-a-block
+            # jackknife standard error is sqrt((K-1)/K * sum(dev^2))
+            # (Westad & Martens, 2000, modified jackknife for PLS); the
+            # plain sample SD used previously is (K-1)/sqrt(K) times too
+            # small (1.79x for K=5), over-declaring significance.
+            deviations_sq = np.sum((beta_samples - beta_mean_arr) ** 2, axis=0)
+            beta_std_arr = np.sqrt((actual_n_resamples - 1) / actual_n_resamples * deviations_sq)
             alpha = 1 - conf_level
             t_crit = t_dist.ppf(1 - alpha / 2, df=actual_n_resamples - 1)
             beta_ci_lower_arr = beta_mean_arr - t_crit * beta_std_arr
@@ -2144,7 +2169,9 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             y_hat_cv_df = pd.DataFrame(y_hat_cv, index=Y.index, columns=Y.columns)
             residuals = Y.values - y_hat_cv
             press_val = float(np.nansum(residuals**2))
-            ss_total = np.nansum((Y.values - Y.values.mean(axis=0)) ** 2, axis=0)
+            # nanmean, not mean: a single NaN in Y otherwise propagates through
+            # the column mean and turns the whole ss_total (and Q2) into NaN.
+            ss_total = np.nansum((Y.values - np.nanmean(Y.values, axis=0)) ** 2, axis=0)
             ss_res = np.nansum(residuals**2, axis=0)
 
             rmse_vals = np.sqrt(np.nanmean(residuals**2, axis=0))

--- a/src/process_improve/multivariate/_preprocessing.py
+++ b/src/process_improve/multivariate/_preprocessing.py
@@ -8,6 +8,7 @@ utilities. Depends only on :mod:`process_improve.multivariate._common`.
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 
 import numpy as np
@@ -94,11 +95,25 @@ class MCUVScaler(TransformerMixin, BaseEstimator):
         # column-level statistics (the chemometric pipeline's missing-data
         # contract). std uses ddof=1: this is the difference from
         # sklearn.preprocessing.StandardScaler.
-        center = np.nanmean(X_arr, axis=0)
-        scale = np.nanstd(X_arr, axis=0, ddof=1)
+        with warnings.catch_warnings():
+            # An all-NaN or single-observation column raises numpy
+            # RuntimeWarnings here; both cases are handled explicitly below,
+            # so the warnings are noise for the caller.
+            warnings.simplefilter("ignore", RuntimeWarning)
+            center = np.nanmean(X_arr, axis=0)
+            scale = np.nanstd(X_arr, axis=0, ddof=1)
         # Constant columns are left as-is (scale to 1.0) rather than
-        # producing inf / nan when transform divides.
-        scale = np.where(scale == 0, 1.0, scale)
+        # producing inf / nan when transform divides. The guard must also
+        # catch: a column with fewer than two observed values, whose
+        # nanstd(ddof=1) is NaN (NaN == 0 is False, so the equality test
+        # missed it and transform emitted an all-NaN column); and a
+        # denormal-tiny standard deviation, whose reciprocal overflows.
+        # An all-NaN column additionally has a NaN center; treat it as
+        # constant-at-zero so transform passes the NaN cells through
+        # unchanged instead of poisoning them further.
+        tiny = float(np.finfo(float).tiny) ** 0.5
+        scale = np.where(~np.isfinite(scale) | (scale <= tiny), 1.0, scale)
+        center = np.where(np.isfinite(center), center, 0.0)
 
         self.center_ = pd.Series(center, index=index)
         self.scale_ = pd.Series(scale, index=index)
@@ -165,6 +180,12 @@ def center(
     # pandas-stubs types apply()'s axis as a Literal, so a plain ``int`` axis does
     # not match any overload; the call is valid at runtime.
     vector = pd.DataFrame(X).apply(func, axis=axis).to_numpy()  # type: ignore[call-overload]  # pandas-stubs axis is Literal
+    if axis == 1:
+        # Row-wise centring: the statistic is one value per ROW, so it must
+        # broadcast down the column axis. Without the reshape numpy broadcasts
+        # the length-N vector across the columns instead: a ValueError for
+        # N != K and a silently wrong answer for square matrices.
+        vector = vector.reshape(-1, 1)
     if extra_output:
         return np.subtract(X, vector), vector
     else:
@@ -238,6 +259,9 @@ def scale(
     # that ``1.0 / vector`` does not introduce inf/NaN.
     vector = np.where(vector == 0, 1.0, vector)
     vector = 1.0 / vector
+    if axis == 1:
+        # Row-wise scaling: one value per ROW; see the reshape note in center().
+        vector = vector.reshape(-1, 1)
 
     if extra_output:
         return np.multiply(X, vector), vector

--- a/src/process_improve/multivariate/_tpls.py
+++ b/src/process_improve/multivariate/_tpls.py
@@ -670,6 +670,13 @@ class TPLS(RegressorMixin, BaseEstimator):
 
         not_na_f = {key: ~np.isnan(X["F"][key].values) for key in X["F"]}
         not_na_z = {key: ~np.isnan(X["Z"][key].values) for key in X["Z"]}
+        # Zero out missing cells AFTER building the presence maps, exactly as
+        # fit() does via nan_to_zeros. The score numerators below multiply the
+        # data by a zeroed weight at missing positions, but NaN * 0.0 is NaN,
+        # not 0.0: without this step a single missing F or Z cell previously
+        # poisoned that observation's scores, T2, SPE and predictions.
+        x_f = {key: df.fillna(0.0) for key, df in x_f.items()}
+        x_z = {key: df.fillna(0.0) for key, df in x_z.items()}
         names_observations = X["F"][next(iter(X["F"]))].index
         num_obs = names_observations.shape[0]
         spe_f: dict[str, pd.DataFrame] = {

--- a/src/process_improve/multivariate/plots.py
+++ b/src/process_improve/multivariate/plots.py
@@ -11,6 +11,8 @@ import pandas as pd
 from pydantic import BaseModel, field_validator
 from sklearn.base import BaseEstimator
 
+from ._limits import hotellings_t2_limit, spe_calculation
+
 try:
     import plotly.graph_objects as go
 except ImportError:  # pragma: no cover - exercised via env-without-plotly
@@ -527,14 +529,18 @@ def spe_plot(  # noqa: C901
             )
         )
 
-    limit_SPE_conf_level = model.spe_limit(conf_level=setdict["conf_level"])
-    name = f"{setdict['conf_level'] * 100:.3g}% limit"
+    # The limit must be computed from the SPE values at the SAME component
+    # count as is being plotted. model.spe_limit() is hard-wired to the last
+    # component, so for with_a < n_components it previously drew a limit that
+    # is far too low and flagged nearly everything as an outlier.
+    limit_SPE_conf_level = spe_calculation(model.spe_[with_a], conf_level=setdict["conf_level"])
+    limit_name = f"{setdict['conf_level'] * 100:.3g}% limit"
     fig.add_hline(
         y=limit_SPE_conf_level,
         line_color=LIMIT_LINE_COLOR,
-        annotation_text=name,
+        annotation_text=limit_name,
         annotation_position="bottom right",
-        name=name,
+        name=limit_name,
     )
     fig.add_hline(y=0, line_color=REFERENCE_LINE_COLOR)
     fig.update_layout(
@@ -678,14 +684,23 @@ def t2_plot(  # noqa: C901
             )
         )
 
-    limit_HT2_conf_level = model.hotellings_t2_limit(conf_level=setdict["conf_level"])
-    name = f"{setdict['conf_level'] * 100:.3g}% limit"
+    # The T2 limit must use the SAME component count as the plotted statistic.
+    # model.hotellings_t2_limit() is hard-wired to the full model's A, so for
+    # with_a < n_components it previously drew a limit that is too high,
+    # hiding genuine outliers. (Component names are 1-based integers, so the
+    # resolved ``with_a`` column label equals the component count.)
+    limit_HT2_conf_level = hotellings_t2_limit(
+        conf_level=setdict["conf_level"],
+        n_components=int(with_a),
+        n_rows=model.hotellings_t2_.shape[0],
+    )
+    limit_name = f"{setdict['conf_level'] * 100:.3g}% limit"
     fig.add_hline(
         y=limit_HT2_conf_level,
         line_color=LIMIT_LINE_COLOR,
-        annotation_text=name,
+        annotation_text=limit_name,
         annotation_position="bottom right",
-        name=name,
+        name=limit_name,
     )
     fig.add_hline(y=0, line_color=REFERENCE_LINE_COLOR)
     fig.update_layout(

--- a/src/process_improve/regression/_robust_regression.py
+++ b/src/process_improve/regression/_robust_regression.py
@@ -229,7 +229,12 @@ def robust_regression(  # noqa: PLR0913, PLR0915
             np.nan,
         ]
         out["pi_range"] = np.vstack([pi_range, pi_y_pred, pi_y_pred]).T
-        out["leverage"] = 1 / out["N"] + np.power(x - mean_x, 2) / out["x_ssq"]
+        # With no variation in x every observation carries the same weight:
+        # the leverage is exactly 1/N. The previous code divided the ~zero
+        # deviations by the ~zero x_ssq (0/0), poisoning the leverage and
+        # the influence values computed from it with NaN/inf - inside the
+        # very branch that exists to guard against the degenerate x.
+        out["leverage"] = np.full(int(out["N"]), 1.0 / out["N"])
 
     else:
         out["standard_errors"] = [

--- a/src/process_improve/tool_safety.py
+++ b/src/process_improve/tool_safety.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import contextlib
 import multiprocessing
 import sys
+import threading
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from concurrent.futures.process import BrokenProcessPool
@@ -328,6 +329,25 @@ def _worker_run(tool_name: str, tool_input: dict[str, Any]) -> Any:  # noqa: ANN
 
 _pool: ProcessPoolExecutor | None = None
 _pool_memory_mb: int | None = None
+#: Guards the module-level ``_pool`` / ``_pool_memory_mb`` pair. The MCP
+#: server runs tool calls on executor threads, so pool creation and teardown
+#: race without it: two threads could each construct an executor (orphaning
+#: one worker forever), and one thread's teardown could SIGKILL a worker
+#: still running another thread's task, which then surfaced as a bogus
+#: "likely exceeded memory limit" BrokenProcessPool diagnosis.
+_pool_lock = threading.Lock()
+
+
+def _create_pool(memory_mb: int, max_workers: int = 1) -> ProcessPoolExecutor:
+    """Construct a new worker pool with the standard initializer/context."""
+    kwargs: dict[str, Any] = {
+        "max_workers": max_workers,
+        "initializer": _pool_initializer,
+        "initargs": (memory_mb,),
+    }
+    if _DEFAULT_MP_CONTEXT is not None:
+        kwargs["mp_context"] = _DEFAULT_MP_CONTEXT
+    return ProcessPoolExecutor(**kwargs)
 
 
 def get_pool(memory_mb: int | None = None, max_workers: int = 1) -> ProcessPoolExecutor:
@@ -335,23 +355,17 @@ def get_pool(memory_mb: int | None = None, max_workers: int = 1) -> ProcessPoolE
 
     The pool is recreated if ``memory_mb`` changes (e.g. tests override it).
     Passing ``None`` resolves the cap from :data:`settings.max_memory_mb` at
-    call time (ENG-09 / ENG-27).
+    call time (ENG-09 / ENG-27). Thread-safe.
     """
     if memory_mb is None:
         memory_mb = settings.max_memory_mb
     global _pool, _pool_memory_mb  # noqa: PLW0603
-    if _pool is None or _pool_memory_mb != memory_mb:
-        shutdown_pool()
-        kwargs: dict[str, Any] = {
-            "max_workers": max_workers,
-            "initializer": _pool_initializer,
-            "initargs": (memory_mb,),
-        }
-        if _DEFAULT_MP_CONTEXT is not None:
-            kwargs["mp_context"] = _DEFAULT_MP_CONTEXT
-        _pool = ProcessPoolExecutor(**kwargs)
-        _pool_memory_mb = memory_mb
-    return _pool
+    with _pool_lock:
+        if _pool is None or _pool_memory_mb != memory_mb:
+            _shutdown_pool_locked()
+            _pool = _create_pool(memory_mb, max_workers=max_workers)
+            _pool_memory_mb = memory_mb
+        return _pool
 
 
 def _terminate_workers(pool: ProcessPoolExecutor) -> None:
@@ -381,18 +395,24 @@ def _terminate_workers(pool: ProcessPoolExecutor) -> None:
                 proc.kill()
 
 
-def shutdown_pool() -> None:
-    """Shut down the module-level pool, if any. Safe to call repeatedly.
-
-    Worker processes are force-terminated first so a runaway task cannot keep
-    holding a CPU after the executor is torn down.
-    """
+def _shutdown_pool_locked() -> None:
+    """Tear down the module-level pool. Caller must hold ``_pool_lock``."""
     global _pool, _pool_memory_mb  # noqa: PLW0603
     if _pool is not None:
         _terminate_workers(_pool)
         _pool.shutdown(wait=False, cancel_futures=True)
         _pool = None
         _pool_memory_mb = None
+
+
+def shutdown_pool() -> None:
+    """Shut down the module-level pool, if any. Safe to call repeatedly.
+
+    Worker processes are force-terminated first so a runaway task cannot keep
+    holding a CPU after the executor is torn down. Thread-safe.
+    """
+    with _pool_lock:
+        _shutdown_pool_locked()
 
 
 # ---------------------------------------------------------------------------
@@ -428,11 +448,13 @@ def safe_execute_tool_call(  # noqa: PLR0913
         On overrun the subprocess dies and :class:`ToolMemoryExceededError`
         is raised.
     executor:
-        Optional caller-provided pool. When *None* (default) a module-level
-        singleton is used and is recycled after every call, so each call runs
+        Optional caller-provided pool. When *None* (default) a PRIVATE pool
+        is created for this call and torn down afterwards, so each call runs
         in a fresh worker with isolated process-global state and reclaimed
-        memory. A caller-provided executor is never recycled or terminated by
-        this function - the caller owns its lifecycle.
+        memory, and concurrent calls (e.g. from the threaded MCP server)
+        never share or tear down each other's workers. A caller-provided
+        executor is never recycled or terminated by this function - the
+        caller owns its lifecycle.
 
     Raises
     ------
@@ -473,7 +495,16 @@ def safe_execute_tool_call(  # noqa: PLR0913
     if model_cls is not None:
         _validate_against_model(tool_name, tool_input, model_cls)
 
-    pool = executor if executor is not None else get_pool(memory_mb=memory_mb)
+    # The default path builds a PRIVATE pool per call rather than sharing the
+    # module-level singleton. The previous design shared the singleton across
+    # calls and tore it down in ``finally``, which was not thread-safe: with
+    # concurrent calls (the MCP server runs tools on executor threads), one
+    # thread's teardown SIGKILLed the worker still running another thread's
+    # task, whose failure was then mis-diagnosed as a memory-limit kill.
+    # A private pool keeps the per-call fresh-worker guarantee (clean
+    # process-global state, reclaimed memory) with no cross-thread coupling,
+    # at the same cost as the old create-per-call recycling.
+    pool = executor if executor is not None else _create_pool(memory_mb)
     future = pool.submit(_worker_run, tool_name, tool_input)
 
     try:
@@ -497,11 +528,10 @@ def safe_execute_tool_call(  # noqa: PLR0913
             details={"tool_name": tool_name, "memory_mb": memory_mb},
         ) from exc
     finally:
-        # Recycle the module-managed pool after every call: each call then runs in
-        # a fresh worker with clean process-global state (RNG, matplotlib, cached
-        # imports) and reclaimed memory, and any worker that overran the timeout
-        # or hit the memory cap is force-terminated here rather than left holding
-        # a CPU. A caller-provided executor is left untouched - the caller owns
-        # its lifecycle.
+        # Tear down the private per-call pool: any worker that overran the
+        # timeout or hit the memory cap is force-terminated here rather than
+        # left holding a CPU. A caller-provided executor is left untouched -
+        # the caller owns its lifecycle.
         if executor is None:
-            shutdown_pool()
+            _terminate_workers(pool)
+            pool.shutdown(wait=False, cancel_futures=True)

--- a/src/process_improve/tool_safety.py
+++ b/src/process_improve/tool_safety.py
@@ -327,9 +327,9 @@ def _worker_run(tool_name: str, tool_input: dict[str, Any]) -> Any:  # noqa: ANN
 # ---------------------------------------------------------------------------
 
 
-_pool: ProcessPoolExecutor | None = None
-_pool_memory_mb: int | None = None
-#: Guards the module-level ``_pool`` / ``_pool_memory_mb`` pair. The MCP
+#: The module-level pool and the memory cap it was built with, or None.
+_pool_state: tuple[ProcessPoolExecutor, int] | None = None
+#: Guards the module-level ``_pool_state``. The MCP
 #: server runs tool calls on executor threads, so pool creation and teardown
 #: race without it: two threads could each construct an executor (orphaning
 #: one worker forever), and one thread's teardown could SIGKILL a worker
@@ -359,13 +359,12 @@ def get_pool(memory_mb: int | None = None, max_workers: int = 1) -> ProcessPoolE
     """
     if memory_mb is None:
         memory_mb = settings.max_memory_mb
-    global _pool, _pool_memory_mb  # noqa: PLW0603
+    global _pool_state  # noqa: PLW0603
     with _pool_lock:
-        if _pool is None or _pool_memory_mb != memory_mb:
+        if _pool_state is None or _pool_state[1] != memory_mb:
             _shutdown_pool_locked()
-            _pool = _create_pool(memory_mb, max_workers=max_workers)
-            _pool_memory_mb = memory_mb
-        return _pool
+            _pool_state = (_create_pool(memory_mb, max_workers=max_workers), memory_mb)
+        return _pool_state[0]
 
 
 def _terminate_workers(pool: ProcessPoolExecutor) -> None:
@@ -397,12 +396,12 @@ def _terminate_workers(pool: ProcessPoolExecutor) -> None:
 
 def _shutdown_pool_locked() -> None:
     """Tear down the module-level pool. Caller must hold ``_pool_lock``."""
-    global _pool, _pool_memory_mb  # noqa: PLW0603
-    if _pool is not None:
-        _terminate_workers(_pool)
-        _pool.shutdown(wait=False, cancel_futures=True)
-        _pool = None
-        _pool_memory_mb = None
+    global _pool_state  # noqa: PLW0603
+    if _pool_state is not None:
+        pool = _pool_state[0]
+        _terminate_workers(pool)
+        pool.shutdown(wait=False, cancel_futures=True)
+        _pool_state = None
 
 
 def shutdown_pool() -> None:

--- a/src/process_improve/tool_spec.py
+++ b/src/process_improve/tool_spec.py
@@ -201,9 +201,18 @@ def clean(value: Any) -> Any:  # noqa: PLR0911, ANN401
     so that every tool output is JSON-serialisable.
     """
     if isinstance(value, dict):
-        return {k: clean(v) for k, v in value.items()}
-    if isinstance(value, (list, tuple)):
+        # Keys need unwrapping too: json.dumps rejects numpy scalar keys (a
+        # dict keyed by np.int64 group labels from a pandas groupby is the
+        # common case), and previously they leaked through untouched. Only
+        # numpy scalars are unwrapped - other key types pass through so
+        # hashability is never at risk.
+        return {(k.item() if isinstance(k, np.generic) else k): clean(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set, frozenset)):
         return [clean(v) for v in value]
+    # np.bool_ subclasses neither np.integer nor Python bool, and json.dumps
+    # rejects it; it must be tested before the numeric branches.
+    if isinstance(value, np.bool_):
+        return bool(value)
     if isinstance(value, np.integer):
         return int(value)
     if isinstance(value, np.floating):
@@ -213,6 +222,10 @@ def clean(value: Any) -> Any:  # noqa: PLR0911, ANN401
         return None if math.isnan(value) or math.isinf(value) else value
     if isinstance(value, np.ndarray):
         return clean(value.tolist())
+    if isinstance(value, np.generic):
+        # Catch-all for the remaining numpy scalar types (datetime64,
+        # complex, str_, ...): unwrap to the closest Python equivalent.
+        return clean(value.item())
     return value
 
 
@@ -236,7 +249,16 @@ def _import_tool_module(module: str) -> None:
     try:
         importlib.import_module(module)
     except ModuleNotFoundError as exc:
-        logger.warning("Tool module %r not loaded (missing dependency): %s", module, exc)
+        # ModuleNotFoundError is raised for ANY unresolvable module path,
+        # including a typo inside the tools module itself or a renamed
+        # internal module after a refactor. Only tolerate it when the module
+        # that is actually missing (exc.name) is a third-party dependency;
+        # a missing first-party module is a real bug and must propagate,
+        # exactly as the docstring above promises.
+        missing = exc.name or ""
+        if missing.split(".")[0] == "process_improve":
+            raise
+        logger.warning("Tool module %r not loaded (missing dependency %r): %s", module, missing, exc)
 
 
 def discover_tools() -> None:

--- a/src/process_improve/univariate/metrics.py
+++ b/src/process_improve/univariate/metrics.py
@@ -461,7 +461,12 @@ def confidence_interval(df: pd.DataFrame, column_name: str, conflevel: float = 0
 
     if style.lower() == "robust":
         center = data.median()
-        spread = median_absolute_deviation(data.to_numpy(), nan_policy="omit")
+        # MAD (scale="normal") consistently estimates sigma, but the interval
+        # is for the MEDIAN, whose asymptotic standard error is
+        # sigma * sqrt(pi / 2) / sqrt(n), not sigma / sqrt(n). Without the
+        # sqrt(pi/2) factor the advertised 95% interval has roughly 87%
+        # coverage.
+        spread = median_absolute_deviation(data.to_numpy(), nan_policy="omit") * float(np.sqrt(np.pi / 2.0))
     else:
         center = data.mean()
         spread = data.std()
@@ -689,7 +694,11 @@ def biweight_midvariance(x: np.ndarray | pd.Series, nan_policy: str = "omit") ->
     if spread_mad == 0:
         return 0.0
 
-    ui = (a - location) / (6.0 * spread_mad)
+    # c = 9 is the biweight MIDVARIANCE tuning constant (Mosteller & Tukey;
+    # also NIST DATAPLOT and astropy); c = 6, previously used here, is the
+    # biweight LOCATION constant and rejects far too much of the sample for
+    # a scale estimate to be consistent with sigma^2 on Gaussian data.
+    ui = (a - location) / (9.0 * spread_mad)
     valid = ui**2 <= 1.0
     a_valid, ui_valid = a[valid], ui[valid]
 
@@ -891,8 +900,16 @@ def detect_outliers_esd(
 
             'esd':
 
-                'robust_variant' = True. Uses the median and MAD for the center
-                and the standard deviation respectively.
+                'robust_variant' = False. When True, uses the median and MAD
+                for the center and the spread respectively. WARNING: the ESD
+                critical values (lambda_i) are derived for the classical
+                statistic max|x - mean| / std, which is bounded above by
+                (N-1)/sqrt(N); a MAD-scaled statistic has no such bound and is
+                routinely 2-3x larger on contaminated data, so the robust
+                variant declares far more outliers than the nominal alpha
+                implies (it can flag points in perfectly clean data). It was
+                previously the default; it is now opt-in and should be treated
+                as a screening heuristic, not a calibrated test.
 
                 'alpha' = 0.05. The significance level of the testing.
 
@@ -909,8 +926,10 @@ def detect_outliers_esd(
         Note: the two-sided test is implemented here. p = 1-alpha/(2*(n-i+1))
         """
 
-        # 0. Default settings
-        robust_variant = bool(kwargs.get("robust_variant", True))
+        # 0. Default settings. robust_variant defaults to False: the ESD
+        # critical values are calibrated for the mean/std statistic (see the
+        # docstring warning about the MAD-scaled variant).
+        robust_variant = bool(kwargs.get("robust_variant", False))
         alpha = float(kwargs.get("alpha", 0.05))
 
         if alpha > 1.0:
@@ -957,9 +976,13 @@ def detect_outliers_esd(
                 x = x.drop(R_i_idx)
 
         try:
+            # NIST / Rosner: "the number of outliers is determined by finding
+            # the LARGEST i such that R_i > lambda_i". The crossings are not
+            # monotone in general (that is the masking effect this test
+            # exists to handle), so take the last crossing, not the first.
             cutoff_i = np.where(
                 np.array(extra_out["R_i"]) - np.array(extra_out["lambda"]) >= 0,
-            )[0][0]
+            )[0][-1]
         except IndexError:
             cutoff_i = -1
 
@@ -1135,13 +1158,19 @@ def variance_decomposition(df: pd.DataFrame, measured: str, repeat: str) -> dict
      'within_stddev':  0.70711,
      'within_dof':     2,
      'between_ms':     49.0,
-     'between_stddev': 7.0,
+     'between_stddev': 4.9244,
      'between_dof':    1}
 
     Note
     * SSQ = sum of squares
     * DOF= degrees of freedom
     * MS = mean square = (sum of squares) / (degrees of freedom) = SSQ / DOF = variance
+    * ``between_ms`` is the raw ANOVA mean square, which estimates
+      ``sigma_within^2 + n0 * sigma_between^2`` (n0 = average group size), NOT
+      the between-group variance itself. ``between_stddev`` reports the actual
+      between-group variance COMPONENT, ``sqrt(max(0, (MS_between - MS_within)
+      / n0))``; earlier versions reported ``sqrt(MS_between)``, which mixes the
+      within-group variance into the "between" number.
     """
 
     # Overall statistics:
@@ -1165,6 +1194,20 @@ def variance_decomposition(df: pd.DataFrame, measured: str, repeat: str) -> dict
     between_dof = max(0, total_dof - within_dof)
     between_ms = 0 if between_dof == 0 else max(0.0, (total_ms * total_dof - within_ms * within_dof) / between_dof)
 
+    # MS_between estimates sigma_within^2 + n0 * sigma_between^2, so the
+    # between-group VARIANCE COMPONENT is (MS_between - MS_within) / n0,
+    # clipped at zero when the between mean square is smaller than the noise
+    # floor. n0 is the effective (average) group size; for unbalanced data the
+    # standard ANOVA n0 = (N - sum(n_i^2)/N) / (k - 1) is used.
+    group_sizes = np.array([group[measured].count() for _, group in df.groupby(repeat)], dtype=float)
+    n_total = float(group_sizes.sum())
+    k_groups = int((group_sizes > 0).sum())
+    if k_groups > 1 and n_total > 0:
+        n0 = (n_total - float(np.sum(group_sizes**2)) / n_total) / (k_groups - 1)
+    else:
+        n0 = 0.0
+    between_variance_component = max(0.0, (between_ms - within_ms) / n0) if n0 > 0 else 0.0
+
     return {
         "total_ms": total_ms,
         "total_dof": total_dof,
@@ -1172,7 +1215,7 @@ def variance_decomposition(df: pd.DataFrame, measured: str, repeat: str) -> dict
         "within_stddev": np.sqrt(within_ms),
         "within_dof": within_dof,
         "between_ms": between_ms,
-        "between_stddev": np.sqrt(between_ms),
+        "between_stddev": np.sqrt(between_variance_component),
         "between_dof": between_dof,
     }
 

--- a/src/process_improve/univariate/metrics.py
+++ b/src/process_improve/univariate/metrics.py
@@ -1202,10 +1202,7 @@ def variance_decomposition(df: pd.DataFrame, measured: str, repeat: str) -> dict
     group_sizes = np.array([group[measured].count() for _, group in df.groupby(repeat)], dtype=float)
     n_total = float(group_sizes.sum())
     k_groups = int((group_sizes > 0).sum())
-    if k_groups > 1 and n_total > 0:
-        n0 = (n_total - float(np.sum(group_sizes**2)) / n_total) / (k_groups - 1)
-    else:
-        n0 = 0.0
+    n0 = (n_total - float(np.sum(group_sizes**2)) / n_total) / (k_groups - 1) if k_groups > 1 and n_total > 0 else 0.0
     between_variance_component = max(0.0, (between_ms - within_ms) / n0) if n0 > 0 else 0.0
 
     return {

--- a/src/process_improve/univariate/metrics.py
+++ b/src/process_improve/univariate/metrics.py
@@ -1161,16 +1161,18 @@ def variance_decomposition(df: pd.DataFrame, measured: str, repeat: str) -> dict
      'between_stddev': 4.9244,
      'between_dof':    1}
 
-    Note
+    Notes
+    -----
     * SSQ = sum of squares
-    * DOF= degrees of freedom
+    * DOF = degrees of freedom
     * MS = mean square = (sum of squares) / (degrees of freedom) = SSQ / DOF = variance
-    * ``between_ms`` is the raw ANOVA mean square, which estimates
-      ``sigma_within^2 + n0 * sigma_between^2`` (n0 = average group size), NOT
-      the between-group variance itself. ``between_stddev`` reports the actual
-      between-group variance COMPONENT, ``sqrt(max(0, (MS_between - MS_within)
-      / n0))``; earlier versions reported ``sqrt(MS_between)``, which mixes the
-      within-group variance into the "between" number.
+    * ``between_ms`` is the raw ANOVA mean square, which estimates the sum of
+      the within-group variance and n0 times the between-group variance (n0 =
+      average group size), NOT the between-group variance itself.
+      ``between_stddev`` reports the actual between-group variance COMPONENT,
+      the square root of ``max(0, (MS_between - MS_within) / n0)``. Earlier
+      versions reported ``sqrt(MS_between)``, which mixes the within-group
+      variance into the "between" number.
     """
 
     # Overall statistics:

--- a/src/process_improve/univariate/tools.py
+++ b/src/process_improve/univariate/tools.py
@@ -145,10 +145,12 @@ class DetectOutliersInput(BaseModel):
         description="Significance level for each individual test (default 0.05).",
     )
     robust_variant: bool = Field(
-        True,
+        False,
         description=(
-            "When true (default), use median and MAD instead of mean and std. "
-            "Recommended when outliers may already be present."
+            "When true, use median and MAD instead of mean and std. The ESD "
+            "critical values are calibrated for the classical statistic, so "
+            "the robust variant over-declares outliers (it is a screening "
+            "heuristic, not a calibrated test). Default false."
         ),
     )
 
@@ -428,7 +430,10 @@ def confidence_interval_tool(spec: ConfidenceIntervalInput) -> dict:
     n = len(arr_clean)
     if spec.method == "robust":
         center = float(np.median(arr_clean))
-        spread = float(median_absolute_deviation(arr_clean))
+        # sqrt(pi/2): the asymptotic standard error of the MEDIAN is
+        # sigma * sqrt(pi/2) / sqrt(n); MAD("normal") estimates sigma.
+        # Mirrors univariate.metrics.confidence_interval.
+        spread = float(median_absolute_deviation(arr_clean)) * float(np.sqrt(np.pi / 2.0))
     else:
         center = float(np.mean(arr_clean))
         spread = float(np.std(arr_clean, ddof=1))

--- a/src/process_improve/visualization/raincloud.py
+++ b/src/process_improve/visualization/raincloud.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 
 import pandas as pd
 
+from process_improve._extras import _MissingExtra, require_extra
+
 try:
     import plotly.graph_objects as go
 except ImportError:  # pragma: no cover - exercised via env-without-plotly
-    from process_improve._extras import _MissingExtra
-
     go = _MissingExtra("plotly", "plotting")  # type: ignore[assignment]
 
 
@@ -59,6 +59,13 @@ def raincloud(  # noqa: PLR0913
     >>> raincloud(df, value="yield", group="reactor")
     >>> raincloud(pd.Series([1.0, 2.0, 3.0]))
     """
+    # Check the optional dependency at the entry point so callers get the
+    # DOCUMENTED "install the extra" ImportError. Without this, the missing
+    # plotly only surfaced later as an AttributeError from the module stub
+    # (whose __getattr__ must raise AttributeError per the data model), so
+    # `except ImportError:` around an optional plotting path never caught it.
+    if isinstance(go, _MissingExtra):
+        raise require_extra("plotly", "plotting")
     if orientation not in ("h", "v"):
         raise ValueError(f"orientation must be 'h' or 'v', got {orientation!r}.")
 

--- a/tests/fuzz/test_mcp_boundary.py
+++ b/tests/fuzz/test_mcp_boundary.py
@@ -31,7 +31,16 @@ _EXPECTED = (ValueError, TypeError, KeyError, ToolInputInvalidError)
 _finite_floats = st.floats(allow_nan=False, allow_infinity=False, width=64)
 
 discover_tools()
-_SPECS = sorted(get_tool_specs(), key=lambda s: s["name"])
+# Exclude test-only tools (leading underscore). tests/test_tool_safety.py
+# registers real tools at import time, including a deliberate infinite loop
+# (_safety_test_busy_loop) and a memory bomb; whether they are visible here
+# depends only on module import order (the pytest command line, xdist worker
+# assignment), and fuzzing them IN-PROCESS with no timeout hangs the run
+# until CI's 6-hour limit. Production tools never start with "_".
+_SPECS = sorted(
+    (s for s in get_tool_specs() if not s["name"].startswith("_")),
+    key=lambda s: s["name"],
+)
 
 
 def _scalar_strategy(schema: dict[str, Any]) -> st.SearchStrategy:  # noqa: C901, PLR0911

--- a/tests/test_audit_regressions_experiments.py
+++ b/tests/test_audit_regressions_experiments.py
@@ -1,0 +1,190 @@
+"""Regression tests for the 2026-08 repo-wide correctness audit: experiments/DOE.
+
+Each test pins a specific defect found and fixed in the audit.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from process_improve.experiments.analysis import analyze_experiment
+from process_improve.experiments.designs import generate_design
+from process_improve.experiments.evaluate import evaluate_design
+from process_improve.experiments.factor import Factor
+from process_improve.experiments.optimal import (
+    index_to_replace_in_design_row,
+    optimization_function,
+    point_exchange,
+)
+from process_improve.experiments.structures import c, gather
+
+pytest.importorskip("pyDOE3")
+
+
+def _factors(names: list[str]) -> list[Factor]:
+    return [Factor(name=n, low=-1, high=1) for n in names]
+
+
+class TestClearEffects:
+    """Wu & Hamada: clear = aliased only with third-order-or-higher effects."""
+
+    @staticmethod
+    def _clear(names: list[str], generators: list[str]) -> dict:
+        result = generate_design(
+            _factors(names),
+            design_type="fractional_factorial",
+            generators=generators,
+            n_center_points=0,
+        )
+        evaluation = evaluate_design(result, metric="clear_effects")
+        return evaluation["clear_effects"]
+
+    def test_resolution_iii_has_no_clear_main_effects(self) -> None:
+        """2^(3-1) with C=AB: every main effect is aliased with a 2FI.
+
+        The pre-fix rule ("aliases of higher order than the effect") declared
+        all three main effects clear.
+        """
+        clear = self._clear(["A", "B", "C"], ["C=AB"])
+        assert clear["main_effects"] == []
+        assert clear["two_factor_interactions"] == []
+
+    def test_resolution_iv_mains_clear_2fis_not(self) -> None:
+        """2^(4-1) with D=ABC: mains aliased with 3FIs (clear); 2FIs aliased
+        with 2FIs (not clear).
+        """
+        clear = self._clear(["A", "B", "C", "D"], ["D=ABC"])
+        assert set(clear["main_effects"]) == {"A", "B", "C", "D"}
+        assert clear["two_factor_interactions"] == []
+
+    def test_resolution_v_mains_and_2fis_clear(self) -> None:
+        """2^(5-1) with E=ABCD: mains and all 2FIs are clear."""
+        clear = self._clear(["A", "B", "C", "D", "E"], ["E=ABCD"])
+        assert set(clear["main_effects"]) == {"A", "B", "C", "D", "E"}
+        assert len(clear["two_factor_interactions"]) == 10
+
+
+class TestFractionalFactorialGenerators:
+    """Explicit generators: correct factor-column mapping, any factor names."""
+
+    @staticmethod
+    def _coded_frame(names: list[str], generators: list[str]) -> pd.DataFrame:
+        result = generate_design(
+            _factors(names),
+            design_type="fractional_factorial",
+            generators=generators,
+            n_center_points=0,
+        )
+        return pd.DataFrame({name: np.asarray(result.design[name], dtype=float) for name in names})
+
+    def test_generator_on_a_middle_factor(self) -> None:
+        """B=AC previously swapped the B and C columns silently."""
+        frame = self._coded_frame(["A", "B", "C"], ["B=AC"])
+        np.testing.assert_allclose(frame["B"], frame["A"] * frame["C"])
+        # And the base factors must form the full 2^2 factorial.
+        assert len(set(zip(frame["A"], frame["C"], strict=True))) == 4
+
+    def test_last_factor_generator_still_correct(self) -> None:
+        frame = self._coded_frame(["A", "B", "C", "D"], ["D=ABC"])
+        np.testing.assert_allclose(frame["D"], frame["A"] * frame["B"] * frame["C"])
+
+    def test_multi_character_factor_names(self) -> None:
+        """Real factor names were previously lower-cased into pyDOE3's
+        single-letter notation and misread as products of letters.
+        """
+        frame = self._coded_frame(["Temp", "Press", "Flow"], ["Flow=TempPress"])
+        np.testing.assert_allclose(frame["Flow"], frame["Temp"] * frame["Press"])
+
+    def test_negative_generator(self) -> None:
+        frame = self._coded_frame(["A", "B", "C"], ["C=-AB"])
+        np.testing.assert_allclose(frame["C"], -frame["A"] * frame["B"])
+
+    def test_unknown_factor_in_generator_raises(self) -> None:
+        with pytest.raises(ValueError, match="not a factor name"):
+            self._coded_frame(["A", "B", "C"], ["C=AZ"])
+
+
+class TestColumnCoding:
+    def test_explicit_zero_center_is_respected(self) -> None:
+        """to_coded(center=0) previously fell back to pi_center (0 is falsy)."""
+        col = c([4.0, 6.0], name="x", lo=4, hi=6)  # pi_center = 5
+        coded = col.to_coded(center=0.0, range=(-10, 10))
+        np.testing.assert_allclose(np.asarray(coded.values, dtype=float), [0.4, 0.6])
+
+    def test_zero_width_range_raises(self) -> None:
+        """Previously a zero-width range silently produced inf/NaN values."""
+        col = c([1.0, 2.0], name="x", lo=3, hi=3)
+        with pytest.raises(ValueError, match="zero width"):
+            col.to_coded()
+
+
+class TestGather:
+    def test_positional_columns_are_kept(self) -> None:
+        """gather(A, B, y=y) previously dropped A and B silently."""
+        a = c([1.0, 2.0, 3.0], name="A")
+        b = c([4.0, 5.0, 6.0], name="B")
+        y = c([7.0, 8.0, 9.0], name="y")
+        expt = gather(a, b, y=y, title="positional")
+        assert set(expt.columns) == {"A", "B", "y"}
+
+    def test_nameless_positional_raises(self) -> None:
+        nameless = pd.Series([1.0, 2.0])
+        with pytest.raises(ValueError, match="has no name"):
+            gather(nameless, y=c([1.0, 2.0], name="y"))
+
+
+class TestDOptimal:
+    def test_replicates_change_the_score(self) -> None:
+        """The scorer must NOT de-duplicate: n copies of a point carry more
+        information than one copy.
+        """
+        base = pd.DataFrame([[1.0, 1.0], [1.0, -1.0]])
+        replicated = pd.DataFrame([[1.0, 1.0], [1.0, -1.0], [1.0, 1.0]])
+        assert optimization_function(replicated) < optimization_function(base)  # lower = better
+
+    def test_swap_onto_row_label_zero_is_not_discarded(self) -> None:
+        """A best-swap row with index LABEL 0 is falsy; the caller previously
+        skipped the improving swap entirely.
+        """
+        design = pd.DataFrame([[1.0, 0.05], [1.0, -1.0]], index=[0, 1])
+        candidate = pd.DataFrame([[1.0, 1.0]], index=[99])
+        current = optimization_function(design)
+        chosen = index_to_replace_in_design_row(design, candidate, current, optimization_function)
+        assert chosen == 0
+        assert chosen is not None
+
+    def test_point_exchange_is_reproducible_with_random_state(self) -> None:
+        rng = np.random.default_rng(0)
+        candidates = pd.DataFrame(rng.choice([-1.0, 0.0, 1.0], size=(40, 3)))
+        d1, v1 = point_exchange(candidates, number_points=6, random_state=7)
+        d2, v2 = point_exchange(candidates, number_points=6, random_state=7)
+        assert v1 == v2
+        pd.testing.assert_frame_equal(d1, d2)
+
+
+class TestLackOfFit:
+    def test_generated_design_with_replicates_is_testable(self) -> None:
+        """RunOrder (unique per row) previously made every replicate group a
+        singleton, so the test always reported 'No replicated points'.
+        """
+        rng = np.random.default_rng(1)
+        base = pd.DataFrame(
+            {
+                "A": [-1, 1, -1, 1] * 2,
+                "B": [-1, -1, 1, 1] * 2,
+            }
+        )
+        base["RunOrder"] = np.arange(len(base)) + 1
+        base["y"] = 5 + 2 * base["A"] - base["B"] + 0.5 * rng.standard_normal(len(base))
+        result = analyze_experiment(
+            base,
+            response_column="y",
+            model="main_effects",
+            analysis_type="lack_of_fit",
+        )
+        lof = result["lack_of_fit"]
+        assert "error" not in lof
+        assert lof["df_pure_error"] == 4  # four pairs of replicated settings
+        assert np.isfinite(lof["f_statistic"])

--- a/tests/test_audit_regressions_infra.py
+++ b/tests/test_audit_regressions_infra.py
@@ -1,0 +1,112 @@
+"""Regression tests for the 2026-08 repo-wide correctness audit: infrastructure.
+
+Each test pins a specific defect found and fixed in the audit: the Settings
+cache, strict boolean env parsing, JSON gaps in clean(), discover_tools
+error scoping, and thread-safety of the safe tool-execution path.
+"""
+
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pytest
+
+from process_improve.config import Settings
+from process_improve.tool_spec import _import_tool_module, clean
+
+
+class TestSettings:
+    def test_bool_env_rejects_typos(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A typo in the security-relevant safe-mode knob previously failed
+        OPEN (silently returned False).
+        """
+        monkeypatch.setenv("PROCESS_IMPROVE_MCP_SAFE_MODE", "treu")
+        with pytest.raises(ValueError, match="not a valid boolean"):
+            _ = Settings().mcp_safe_mode
+
+    def test_bool_env_accepts_explicit_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PROCESS_IMPROVE_MCP_SAFE_MODE", "off")
+        assert Settings().mcp_safe_mode is False
+
+    def test_value_is_really_cached_on_first_access(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Setdefault evaluated the env read on EVERY access, so a knob that
+        had been served successfully raised later if the env var went bad.
+        """
+        monkeypatch.setenv("PROCESS_IMPROVE_MAX_CELLS", "123")
+        settings = Settings()
+        assert settings.max_cells == 123
+        monkeypatch.setenv("PROCESS_IMPROVE_MAX_CELLS", "not-a-number")
+        # Still served from the cache; no ValueError, no re-read.
+        assert settings.max_cells == 123
+
+    def test_non_positive_limits_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PROCESS_IMPROVE_TOOL_TIMEOUT", "-5")
+        with pytest.raises(ValueError, match="must be positive"):
+            _ = Settings().tool_timeout
+        monkeypatch.setenv("PROCESS_IMPROVE_MAX_MEMORY_MB", "0")
+        with pytest.raises(ValueError, match="must be positive"):
+            _ = Settings().max_memory_mb
+
+
+class TestClean:
+    def test_numpy_bool_is_serialisable(self) -> None:
+        result = clean({"significant": np.bool_(True), "flags": np.array([1, 2]) > 1})
+        json.dumps(result)
+        assert result["significant"] is True
+        assert result["flags"] == [False, True]
+
+    def test_numpy_scalar_dict_keys_are_unwrapped(self) -> None:
+        """A dict keyed by np.int64 (e.g. pandas groupby labels) previously
+        survived clean() and made json.dumps raise TypeError.
+        """
+        result = clean({np.int64(3): "a", np.str_("k"): np.float64(1.5)})
+        json.dumps(result)
+        assert result == {3: "a", "k": 1.5}
+
+    def test_sets_and_generic_scalars(self) -> None:
+        result = clean({"s": {np.int64(1), np.int64(2)}, "c": np.complex128(1 + 0j)})
+        json.dumps({"s": result["s"]})
+        assert sorted(result["s"]) == [1, 2]
+
+
+class TestDiscoverTools:
+    def test_missing_first_party_module_raises(self) -> None:
+        """A typo'd or renamed process_improve module is a real bug and must
+        propagate; previously it was logged as a 'missing dependency' and the
+        whole tool category silently vanished.
+        """
+        with pytest.raises(ModuleNotFoundError):
+            _import_tool_module("process_improve.no_such_tools_module")
+
+    def test_missing_third_party_module_is_tolerated(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level("WARNING"):
+            _import_tool_module("no_such_third_party_pkg_xyz.tools")
+        assert any("not loaded" in record.message for record in caplog.records)
+
+
+class TestSafeExecutionConcurrency:
+    @pytest.mark.slow
+    def test_concurrent_safe_calls_do_not_kill_each_other(self) -> None:
+        """Two threads previously shared (and tore down) one module pool: one
+        thread's teardown SIGKILLed the worker running the other thread's
+        task, surfacing as a bogus 'likely exceeded memory limit' error.
+        """
+        from process_improve.tool_safety import safe_execute_tool_call
+        from process_improve.tool_spec import discover_tools
+
+        discover_tools()
+
+        def one_call(_: int) -> dict:
+            return safe_execute_tool_call(
+                "confidence_interval",
+                {"values": [10.0, 11.0, 12.0, 10.5, 9.5, 10.2]},
+                timeout=60.0,
+            )
+
+        with ThreadPoolExecutor(max_workers=4) as tp:
+            results = list(tp.map(one_call, range(8)))
+        for result in results:
+            assert "lower" in result
+            assert "upper" in result

--- a/tests/test_audit_regressions_multivariate.py
+++ b/tests/test_audit_regressions_multivariate.py
@@ -1,0 +1,372 @@
+"""Regression tests for the 2026-08 repo-wide correctness audit: multivariate core.
+
+Each test pins a specific defect that was found and fixed in the audit; the
+test fails on the pre-fix code and passes afterwards. Grouped by module.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from process_improve.multivariate._common import SpecificationWarning
+from process_improve.multivariate._limits import hotellings_t2_limit, spe_calculation
+from process_improve.multivariate.methods import (
+    PCA,
+    PLS,
+    TPLS,
+    DataFrameDict,
+    MCUVScaler,
+    center,
+    ellipse_coordinates,
+    scale,
+)
+
+
+def _low_rank_matrix(n: int, k: int, rank: int, noise: float, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    scores = rng.standard_normal((n, rank))
+    loadings = np.linalg.qr(rng.standard_normal((k, rank)))[0]
+    return scores @ loadings.T + noise * rng.standard_normal((n, k))
+
+
+class TestTSR:
+    """PCA(algorithm="tsr"): the N <= K SVD branch and the centring mismatch."""
+
+    def test_wide_matrix_with_missing_data_fits(self) -> None:
+        """N < K previously crashed with IndexError inside the imputation loop."""
+        x = _low_rank_matrix(n=12, k=25, rank=2, noise=0.01, seed=1)
+        x -= x.mean(axis=0)
+        rng = np.random.default_rng(2)
+        mask = rng.random(x.shape) < 0.05
+        x_missing = x.copy()
+        x_missing[mask] = np.nan
+
+        model = PCA(n_components=2, algorithm="tsr").fit(pd.DataFrame(x_missing))
+        gram = model.loadings_.values.T @ model.loadings_.values
+        assert np.allclose(gram, np.eye(2), atol=1e-2)
+        assert np.isfinite(model.scores_.values).all()
+
+    def test_square_matrix_imputation_recovers_low_rank_cells(self) -> None:
+        """N == K previously ran the imputation against a transposed matrix.
+
+        No exception was raised; the imputed values were garbage. On low-rank
+        data the reconstruction at the masked cells must be close to the true
+        (hidden) values.
+        """
+        n = 30
+        x = _low_rank_matrix(n=n, k=n, rank=2, noise=0.01, seed=3)
+        x -= x.mean(axis=0)
+        rng = np.random.default_rng(4)
+        flat = rng.choice(n * n, size=25, replace=False)
+        mask = np.zeros((n, n), dtype=bool)
+        mask.ravel()[flat] = True
+        x_missing = x.copy()
+        x_missing[mask] = np.nan
+
+        model = PCA(n_components=2, algorithm="tsr").fit(pd.DataFrame(x_missing))
+        reconstruction = model.scores_.values @ model.loadings_.values.T
+        residual_at_masked = reconstruction[mask] - x[mask]
+        assert np.sqrt(np.mean(residual_at_masked**2)) < 0.2 * float(x.std())
+
+    def test_scores_match_projection_of_complete_data(self) -> None:
+        """TSR scores must agree with transform() on the same (complete) data.
+
+        The pre-fix code centred the scores inside fit() while transform()
+        projects without centring, so fitted and projected scores disagreed by
+        the column-mean offset for any not-exactly-centred input.
+        """
+        x = _low_rank_matrix(n=40, k=6, rank=2, noise=0.05, seed=5) + 3.0  # deliberate offset
+        frame = pd.DataFrame(x)
+        model = PCA(n_components=2, algorithm="tsr").fit(frame)
+        projected = model.transform(frame)
+        np.testing.assert_allclose(projected.values, model.scores_.values, atol=1e-8)
+
+    def test_sign_convention_matches_svd(self) -> None:
+        """Largest-magnitude loading element is positive, matching _fit_svd."""
+        x = _low_rank_matrix(n=25, k=8, rank=3, noise=0.05, seed=6)
+        x -= x.mean(axis=0)
+        model = PCA(n_components=3, algorithm="tsr").fit(pd.DataFrame(x))
+        for a in range(3):
+            column = model.loadings_.values[:, a]
+            assert column[np.argmax(np.abs(column))] > 0
+
+
+class TestEllipse:
+    """Score-plot T2 ellipse: bivariate limit, not the full-model limit."""
+
+    @pytest.fixture
+    def model(self) -> PCA:
+        x = _low_rank_matrix(n=50, k=8, rank=6, noise=0.2, seed=7)
+        frame = pd.DataFrame(MCUVScaler().fit_transform(pd.DataFrame(x)))
+        return PCA(n_components=5).fit(frame)
+
+    def test_uses_two_component_limit(self, model: PCA) -> None:
+        x_coords, y_coords = model.ellipse_coordinates(1, 2)
+        expected_radius = np.sqrt(hotellings_t2_limit(0.95, n_components=2, n_rows=50))
+        # rtol accounts for the discrete parametrisation: no sample point
+        # lands exactly on the semi-axis for the vertical direction.
+        assert np.isclose(np.max(x_coords), expected_radius * model.scaling_factor_for_scores_.iloc[0], rtol=1e-3)
+        assert np.isclose(np.max(y_coords), expected_radius * model.scaling_factor_for_scores_.iloc[1], rtol=1e-3)
+        # And it must be strictly tighter than the (wrong) full-model limit.
+        full_radius = np.sqrt(hotellings_t2_limit(0.95, n_components=5, n_rows=50))
+        assert np.max(x_coords) < full_radius * model.scaling_factor_for_scores_.iloc[0]
+
+    def test_rejects_degenerate_n_points(self, model: PCA) -> None:
+        with pytest.raises(ValueError, match="n_points"):
+            model.ellipse_coordinates(1, 2, n_points=1)
+
+    def test_standalone_function_agrees(self, model: PCA) -> None:
+        x_m, y_m = model.ellipse_coordinates(1, 2)
+        x_f, y_f = ellipse_coordinates(
+            score_horiz=1,
+            score_vert=2,
+            n_components=model.n_components,
+            scaling_factor_for_scores=model.scaling_factor_for_scores_,
+            n_rows=model.n_samples_,
+        )
+        np.testing.assert_allclose(x_m, x_f)
+        np.testing.assert_allclose(y_m, y_f)
+
+
+class TestPlotLimits:
+    """spe_plot / t2_plot must draw the limit for the plotted component count."""
+
+    @pytest.fixture
+    def model(self) -> PCA:
+        x = _low_rank_matrix(n=40, k=6, rank=4, noise=0.3, seed=8)
+        frame = pd.DataFrame(MCUVScaler().fit_transform(pd.DataFrame(x)))
+        return PCA(n_components=3).fit(frame)
+
+    def test_t2_plot_limit_matches_sub_model(self, model: PCA) -> None:
+        fig = model.t2_plot(with_a=1)
+        expected = hotellings_t2_limit(0.95, n_components=1, n_rows=model.n_samples_)
+        limit_line = fig.layout.shapes[0]
+        assert np.isclose(limit_line.y0, expected)
+        # y-axis label is the data series name, not the limit legend entry.
+        assert "T2 values" in fig.layout.yaxis.title.text
+
+    def test_spe_plot_limit_matches_sub_model(self, model: PCA) -> None:
+        fig = model.spe_plot(with_a=1)
+        expected = spe_calculation(model.spe_[1], conf_level=0.95)
+        limit_line = fig.layout.shapes[0]
+        assert np.isclose(limit_line.y0, expected)
+        assert "SPE values" in fig.layout.yaxis.title.text
+
+    def test_full_model_plots_unchanged(self, model: PCA) -> None:
+        fig = model.t2_plot()
+        expected = hotellings_t2_limit(0.95, n_components=3, n_rows=model.n_samples_)
+        assert np.isclose(fig.layout.shapes[0].y0, expected)
+
+
+class TestSelectNComponentsScales:
+    """PCA CV: the 1-SE band and the Q2 null model."""
+
+    def test_se_press_is_on_the_press_scale(self) -> None:
+        x = _low_rank_matrix(n=30, k=8, rank=3, noise=0.3, seed=9)
+        n_folds = 5
+        result = PCA.select_n_components(pd.DataFrame(x), max_components=4, cv=n_folds, random_state=0)
+        per_fold = result.per_fold_press.to_numpy()
+        counts = np.maximum(1, np.sum(~np.isnan(per_fold), axis=1))
+        expected_se = np.nanstd(per_fold, axis=1, ddof=1) / np.sqrt(counts) * n_folds
+        np.testing.assert_allclose(result.se_press.to_numpy(), expected_se)
+
+    def test_q2_null_model_is_centred(self) -> None:
+        rng = np.random.default_rng(10)
+        x = _low_rank_matrix(n=30, k=6, rank=2, noise=0.4, seed=11) + 100.0  # large offset
+        x += rng.standard_normal(x.shape) * 0.01
+        result = PCA.select_n_components(pd.DataFrame(x), max_components=3, cv=4, random_state=0)
+        x_arr = np.asarray(x, dtype=float)
+        null_ss = float(np.nansum((x_arr - np.nanmean(x_arr, axis=0)) ** 2))
+        expected_q2 = 1.0 - result.press.to_numpy() / null_ss
+        np.testing.assert_allclose(result.q2.to_numpy(), expected_q2)
+        # With the uncentred sum(x^2) null model the offset made every Q2
+        # indistinguishable from 1; the centred reference must discriminate.
+        assert result.q2.iloc[0] < 0.9999
+
+
+class TestPLSInference:
+    """K-fold beta CIs and the NIPALS non-convergence warning."""
+
+    @staticmethod
+    def _xy(seed: int = 12) -> tuple[pd.DataFrame, pd.DataFrame]:
+        rng = np.random.default_rng(seed)
+        x = pd.DataFrame(rng.standard_normal((40, 5)), columns=[f"x{i}" for i in range(5)])
+        beta = np.array([1.0, -0.5, 0.0, 0.25, 0.0])
+        y = pd.DataFrame({"y": x.values @ beta + 0.1 * rng.standard_normal(40)})
+        return x, y
+
+    def test_kfold_beta_std_uses_delete_a_block_jackknife(self) -> None:
+        x, y = self._xy()
+        model = PLS(n_components=2).fit(x, y)
+        result = model.cross_validate(x, y, cv=5, show_progress=False, random_state=0)
+        k = result.beta_samples.shape[0]
+        deviations_sq = np.sum((result.beta_samples - result.beta_samples.mean(axis=0)) ** 2, axis=0)
+        expected_std = np.sqrt((k - 1) / k * deviations_sq)
+        np.testing.assert_allclose(result.beta_std.to_numpy(), expected_std)
+
+    def test_pls_warns_when_nipals_hits_max_iter(self) -> None:
+        x, y = self._xy(seed=13)
+        with pytest.warns(SpecificationWarning, match="maximum number of iterations"):
+            PLS(n_components=1, max_iter=1).fit(x, y)
+
+    def test_pca_warns_when_nipals_hits_max_iter(self) -> None:
+        x, _ = self._xy(seed=14)
+        with pytest.warns(SpecificationWarning, match="maximum number of iterations"):
+            PCA(n_components=1, algorithm="nipals", missing_data_settings={"md_max_iter": 1}).fit(x)
+
+
+class TestRankDeficiencyGuards:
+    """T2 must stay finite when a trailing component has ~zero variance."""
+
+    def test_pca_full_rank_request_on_centred_data(self) -> None:
+        rng = np.random.default_rng(15)
+        x = rng.standard_normal((6, 10))
+        x -= x.mean(axis=0)  # rank is now at most N - 1 = 5
+        model = PCA(n_components=6).fit(pd.DataFrame(x))
+        assert np.isfinite(model.hotellings_t2_.values).all()
+
+    def test_pca_rejects_zero_components(self) -> None:
+        x = pd.DataFrame(np.random.default_rng(16).standard_normal((10, 4)))
+        with pytest.raises(ValueError, match="n_components"):
+            PCA(n_components=0).fit(x)
+
+    def test_pls_rejects_zero_components(self) -> None:
+        rng = np.random.default_rng(17)
+        x = pd.DataFrame(rng.standard_normal((10, 4)))
+        y = pd.DataFrame(rng.standard_normal((10, 1)))
+        with pytest.raises(ValueError, match="n_components"):
+            PLS(n_components=0).fit(x, y)
+
+
+class TestTargetProjection:
+    """The TP direction must live in the model's internal (scaled) space."""
+
+    def test_raw_and_prescaled_fits_agree(self) -> None:
+        rng = np.random.default_rng(18)
+        n = 60
+        # Columns on wildly different raw scales; y driven by the first two.
+        x_raw = pd.DataFrame(
+            {
+                "a": 1000.0 * rng.standard_normal(n) + 5000.0,
+                "b": 0.001 * rng.standard_normal(n),
+                "c": rng.standard_normal(n),
+                "d": 10.0 * rng.standard_normal(n),
+            }
+        )
+        y_raw = pd.DataFrame({"y": 0.002 * x_raw["a"] + 800.0 * x_raw["b"] + 0.05 * rng.standard_normal(n)})
+
+        model_raw = PLS(n_components=2).fit(x_raw, y_raw)  # scale=True, raw input
+        tp_raw = model_raw.target_projection(x_raw)
+
+        x_scaled = MCUVScaler().fit_transform(x_raw)
+        y_scaled = MCUVScaler().fit_transform(y_raw)
+        model_pre = PLS(n_components=2).fit(x_scaled, y_scaled)
+        tp_pre = model_pre.target_projection(x_scaled)
+
+        # Same underlying model in two parameterisations: the TP scores must
+        # agree (up to a global sign). Pre-fix, the raw-units beta was used as
+        # a direction in scaled space and the two disagreed wildly.
+        corr = np.corrcoef(tp_raw.scores.to_numpy(), tp_pre.scores.to_numpy())[0, 1]
+        assert abs(corr) > 0.999
+
+    def test_tp_scores_track_the_response(self) -> None:
+        rng = np.random.default_rng(19)
+        n = 80
+        x_raw = pd.DataFrame(
+            {
+                "big": 1e4 * rng.standard_normal(n),
+                "small": 1e-3 * rng.standard_normal(n),
+                "noise": rng.standard_normal(n),
+            }
+        )
+        y_raw = pd.DataFrame({"y": 5000.0 * x_raw["small"] + 0.01 * rng.standard_normal(n)})
+        model = PLS(n_components=2).fit(x_raw, y_raw)
+        tp = model.target_projection(x_raw)
+        corr = np.corrcoef(tp.scores.to_numpy(), y_raw["y"].to_numpy())[0, 1]
+        assert abs(corr) > 0.99
+
+
+class TestPreprocessingGuards:
+    """MCUVScaler degenerate columns and center()/scale() axis=1."""
+
+    def test_mcuv_single_observation_column(self) -> None:
+        x = pd.DataFrame({"good": [1.0, 2.0, 3.0], "lonely": [5.0, np.nan, np.nan]})
+        scaler = MCUVScaler().fit(x)
+        assert scaler.scale_["lonely"] == 1.0
+        out = scaler.transform(x)
+        assert np.isfinite(out["lonely"].iloc[0])
+
+    def test_mcuv_all_nan_column(self) -> None:
+        x = pd.DataFrame({"good": [1.0, 2.0, 3.0], "empty": [np.nan, np.nan, np.nan]})
+        scaler = MCUVScaler().fit(x)
+        assert scaler.scale_["empty"] == 1.0
+        assert scaler.center_["empty"] == 0.0
+        out = scaler.transform(x)
+        # The NaN cells pass through; the finite column is untouched.
+        assert out["empty"].isna().all()
+        assert np.isfinite(out["good"]).all()
+
+    def test_center_axis_1(self) -> None:
+        x = np.arange(12, dtype=float).reshape(3, 4)
+        centred = center(x, axis=1)
+        np.testing.assert_allclose(np.asarray(centred).mean(axis=1), 0.0, atol=1e-12)
+
+    def test_scale_axis_1(self) -> None:
+        rng = np.random.default_rng(20)
+        x = rng.standard_normal((3, 5)) * np.array([[1.0], [10.0], [100.0]])
+        scaled = scale(x, axis=1)
+        np.testing.assert_allclose(np.asarray(scaled).std(axis=1), 1.0, atol=1e-12)
+
+
+class TestTPLSDiagnoseMissing:
+    """TPLS.diagnose must neutralise NaN cells like fit() does."""
+
+    @pytest.fixture
+    def fitted(self) -> tuple[TPLS, dict]:
+        rng = np.random.default_rng(21)
+        n, n_materials = 24, 5
+        d = pd.DataFrame(
+            rng.standard_normal((n_materials, 3)),
+            index=[f"m{i}" for i in range(n_materials)],
+            columns=["p1", "p2", "p3"],
+        )
+        f = pd.DataFrame(
+            np.abs(rng.standard_normal((n, n_materials))),
+            columns=d.index,
+            index=[f"obs{i}" for i in range(n)],
+        )
+        f = f.div(f.sum(axis=1), axis=0)  # ratios per observation
+        z = pd.DataFrame(rng.standard_normal((n, 2)), columns=["z1", "z2"], index=f.index)
+        y = pd.DataFrame(
+            {"q1": f.values @ rng.standard_normal(n_materials) + 0.1 * z["z1"].values},
+            index=f.index,
+        )
+        data = {"F": {"G": f}, "Z": {"Cond": z}, "Y": {"Quality": y}}
+        model = TPLS(n_components=2, d_matrix={"G": d}).fit(DataFrameDict(data))
+        return model, data
+
+    def test_single_missing_cell_stays_finite(self, fitted: tuple[TPLS, dict]) -> None:
+        model, data = fitted
+        f_new = data["F"]["G"].iloc[:4].copy()
+        z_new = data["Z"]["Cond"].iloc[:4].copy()
+        f_new.iloc[1, 2] = np.nan  # a single missing formula entry
+        result = model.diagnose(DataFrameDict({"F": {"G": f_new}, "Z": {"Cond": z_new}}))
+        assert np.isfinite(result.t_scores_super.values).all()
+        assert np.isfinite(result.hotellings_t2.values).all()
+        for frame in result.hat.values():
+            assert np.isfinite(frame.values).all()
+
+    def test_rows_without_missing_cells_are_unaffected(self, fitted: tuple[TPLS, dict]) -> None:
+        model, data = fitted
+        f_new = data["F"]["G"].iloc[:4].copy()
+        z_new = data["Z"]["Cond"].iloc[:4].copy()
+        clean = model.diagnose(DataFrameDict({"F": {"G": f_new.copy()}, "Z": {"Cond": z_new.copy()}}))
+        f_new.iloc[1, 2] = np.nan
+        poked = model.diagnose(DataFrameDict({"F": {"G": f_new}, "Z": {"Cond": z_new}}))
+        other_rows = [0, 2, 3]
+        np.testing.assert_allclose(
+            poked.t_scores_super.iloc[other_rows].values,
+            clean.t_scores_super.iloc[other_rows].values,
+        )

--- a/tests/test_audit_regressions_regression_batch.py
+++ b/tests/test_audit_regressions_regression_batch.py
@@ -26,7 +26,7 @@ class TestRobustRegressionDegenerateX:
 class TestDTWDistance:
     def test_distance_is_the_accumulated_cost(self) -> None:
         """The DTW distance must equal D[-1, -1], not a sum of prefix sums."""
-        numba = pytest.importorskip("numba")  # noqa: F841
+        pytest.importorskip("numba")
         from process_improve.batch.alignment_helpers import backtrack_optimal_path, distance_matrix
 
         rng = np.random.default_rng(0)

--- a/tests/test_audit_regressions_regression_batch.py
+++ b/tests/test_audit_regressions_regression_batch.py
@@ -1,0 +1,89 @@
+"""Regression tests for the 2026-08 repo-wide correctness audit: regression + batch.
+
+Each test pins a specific defect found and fixed in the audit.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from process_improve.regression._robust_regression import robust_regression
+
+
+class TestRobustRegressionDegenerateX:
+    def test_constant_x_gives_finite_uniform_leverage(self) -> None:
+        """The degenerate-x branch previously divided ~0 by ~0 for leverage."""
+        x = np.array([2.0, 2.0, 2.0, 2.0, 2.0])
+        y = np.array([1.0, 2.0, 3.0, 2.5, 1.5])
+        out = robust_regression(x, y)
+        leverage = np.asarray(out["leverage"], dtype=float)
+        assert np.isfinite(leverage).all()
+        np.testing.assert_allclose(leverage, 1.0 / len(x))
+
+
+class TestDTWDistance:
+    def test_distance_is_the_accumulated_cost(self) -> None:
+        """The DTW distance must equal D[-1, -1], not a sum of prefix sums."""
+        numba = pytest.importorskip("numba")  # noqa: F841
+        from process_improve.batch.alignment_helpers import backtrack_optimal_path, distance_matrix
+
+        rng = np.random.default_rng(0)
+        test = rng.standard_normal((20, 2)).cumsum(axis=0)
+        ref = rng.standard_normal((25, 2)).cumsum(axis=0)
+        weights = np.eye(2)
+        D = distance_matrix(test, ref, weights)
+        _path, distance = backtrack_optimal_path(D)
+        assert distance == pytest.approx(float(D[-1, -1]))
+
+    def test_identical_batches_have_near_zero_distance(self) -> None:
+        """Aligning a batch against itself must report ~0 distance.
+
+        Pre-fix, the 'distance' summed the cumulative-cost matrix entries
+        along the diagonal path, which is 0 only in exact arithmetic but grows
+        with path length as soon as any cost is non-zero; more importantly the
+        reported value was not comparable across batches of different length.
+        """
+        pytest.importorskip("numba")
+        from process_improve.batch.preprocessing import dtw_core
+
+        rng = np.random.default_rng(1)
+        batch = pd.DataFrame(rng.standard_normal((30, 3)).cumsum(axis=0))
+        result = dtw_core(batch, batch, np.eye(3))
+        assert result.distance == pytest.approx(0.0, abs=1e-10)
+
+
+class TestKassidasWeights:
+    def test_well_aligned_variable_gets_the_largest_weight(self) -> None:
+        """A variable with near-zero deviation SSQ must be up-weighted.
+
+        The previous guard substituted 10000 for a near-zero SSQ, giving the
+        BEST-aligned variable a weight of ~1e-4 (the exact opposite of the
+        Kassidas weighting).
+        """
+        pytest.importorskip("numba")
+        from process_improve.batch.preprocessing import batch_dtw
+
+        rng = np.random.default_rng(2)
+        n_time = 40
+        t = np.linspace(0, 1, n_time)
+        batches = {}
+        for i in range(4):
+            frame = pd.DataFrame(
+                {
+                    # 'clean' has an identical trajectory in every batch.
+                    "clean": np.sin(2 * np.pi * t) * 10,
+                    # 'noisy' differs per batch.
+                    "noisy": np.cos(2 * np.pi * t) * 10 + rng.standard_normal(n_time) * 3,
+                }
+            )
+            batches[f"b{i}"] = frame
+        result = batch_dtw(
+            batches,
+            columns_to_align=["clean", "noisy"],
+            reference_batch="b0",
+            settings={"show_progress": False, "maximum_iterations": 3},
+        )
+        weights = result["weight_history"].iloc[-1]
+        assert weights["clean"] > weights["noisy"]

--- a/tests/test_audit_regressions_univariate_monitoring.py
+++ b/tests/test_audit_regressions_univariate_monitoring.py
@@ -37,7 +37,8 @@ class TestGeneralizedESD:
 
     def test_default_is_classical_statistic(self) -> None:
         """The MAD-scaled variant is anti-conservative against classical
-        critical values, so it must be opt-in, not the default."""
+        critical values, so it must be opt-in, not the default.
+        """
         rng = np.random.default_rng(1)
         clean_sample = rng.normal(10.0, 2.0, size=60)
         outliers, _ = univariate.detect_outliers_esd(clean_sample, max_outliers_detected=6)
@@ -58,9 +59,7 @@ class TestGeneralizedESD:
                 4.64, 5.34, 5.42, 6.01,
             ]
         )  # fmt: skip
-        outliers, details = univariate.detect_outliers_esd(
-            rosner, max_outliers_detected=10, robust_variant=False
-        )
+        outliers, _details = univariate.detect_outliers_esd(rosner, max_outliers_detected=10, robust_variant=False)
         assert len(outliers) == 3
 
 
@@ -159,13 +158,15 @@ class TestHoltWintersChart:
 
     def test_small_sample_grid_search_is_not_degenerate(self) -> None:
         """10 <= N < 20: the training window includes row 0, whose error is
-        unset. Pre-fix, every grid cell was NaN and (0.1, 0.1) always 'won'."""
+        unset. Pre-fix, every grid cell was NaN and (0.1, 0.1) always 'won'.
+        """
         rng = np.random.default_rng(8)
         y = pd.Series(rng.normal(50.0, 3.0, size=15))
         cc = ControlChart(variant="HW")
         cc.calculate_limits(y)
         assert np.isfinite(cc._residuals_HW).all()
-        assert cc.s is not None and np.isfinite(cc.s)
+        assert cc.s is not None
+        assert np.isfinite(cc.s)
 
     def test_explicit_zero_lambda_is_respected(self) -> None:
         rng = np.random.default_rng(9)

--- a/tests/test_audit_regressions_univariate_monitoring.py
+++ b/tests/test_audit_regressions_univariate_monitoring.py
@@ -1,0 +1,202 @@
+"""Regression tests for the 2026-08 repo-wide correctness audit: univariate + monitoring.
+
+Each test pins a specific defect found and fixed in the audit.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from scipy import integrate, stats
+
+from process_improve.monitoring.control_charts import ControlChart, rho
+from process_improve.monitoring.metrics import calculate_cpk
+from process_improve.univariate import metrics as univariate
+
+
+class TestGeneralizedESD:
+    """detect_outliers_esd: last crossing, and the classical default."""
+
+    def test_number_of_outliers_is_largest_crossing(self) -> None:
+        """NIST: the outlier count is the LARGEST i with R_i > lambda_i.
+
+        Build a masking scenario: a tight cluster plus three far points close
+        to one another. R_1 dips (masking), and only at i=3 do the statistics
+        clear the critical values again; the pre-fix code stopped at the
+        first crossing and under-reported.
+        """
+        rng = np.random.default_rng(0)
+        base = rng.normal(0.0, 1.0, size=40)
+        contaminated = np.concatenate([base, [12.0, 12.5, 13.0]])
+        outliers, details = univariate.detect_outliers_esd(contaminated, max_outliers_detected=5)
+        crossings = np.where(np.array(details["R_i"]) >= np.array(details["lambda"]))[0]
+        assert details["cutoff"] == crossings[-1]
+        assert len(outliers) == 3
+        assert set(outliers) == {40, 41, 42}
+
+    def test_default_is_classical_statistic(self) -> None:
+        """The MAD-scaled variant is anti-conservative against classical
+        critical values, so it must be opt-in, not the default."""
+        rng = np.random.default_rng(1)
+        clean_sample = rng.normal(10.0, 2.0, size=60)
+        outliers, _ = univariate.detect_outliers_esd(clean_sample, max_outliers_detected=6)
+        # Clean normal data: a calibrated 5% test should find (almost) nothing.
+        assert len(outliers) <= 1
+
+    def test_nist_rosner_example_still_reproduces(self) -> None:
+        """The classical path must still match the published NIST example."""
+        # https://www.itl.nist.gov/div898/handbook/eda/section3/eda35h3.htm
+        # (Rosner, 1983): 54 observations, 3 outliers at the 5% level.
+        rosner = np.array(
+            [
+                -0.25, 0.68, 0.94, 1.15, 1.20, 1.26, 1.26, 1.34, 1.38, 1.43,
+                1.49, 1.49, 1.55, 1.56, 1.58, 1.65, 1.69, 1.70, 1.76, 1.77,
+                1.81, 1.91, 1.94, 1.96, 1.99, 2.06, 2.09, 2.10, 2.14, 2.15,
+                2.23, 2.24, 2.26, 2.35, 2.37, 2.40, 2.47, 2.54, 2.62, 2.64,
+                2.90, 2.92, 2.92, 2.93, 3.21, 3.26, 3.30, 3.59, 3.68, 4.30,
+                4.64, 5.34, 5.42, 6.01,
+            ]
+        )  # fmt: skip
+        outliers, details = univariate.detect_outliers_esd(
+            rosner, max_outliers_detected=10, robust_variant=False
+        )
+        assert len(outliers) == 3
+
+
+class TestMedianConfidenceInterval:
+    """The robust CI must use the median's standard error, sqrt(pi/2) * sigma / sqrt(n)."""
+
+    def test_robust_interval_carries_median_se_factor(self) -> None:
+        rng = np.random.default_rng(2)
+        data = pd.DataFrame({"v": rng.normal(50.0, 5.0, size=200)})
+        robust = univariate.confidence_interval(data, "v", conflevel=0.95, style="robust")
+        mad = univariate.median_absolute_deviation(data["v"].to_numpy(), nan_policy="omit")
+        n = 200
+        c_t = univariate.t_value(0.975, n - 1)
+        expected_half_width = c_t * mad * np.sqrt(np.pi / 2.0) / np.sqrt(n)
+        observed_half_width = (robust[1] - robust[0]) / 2.0
+        assert observed_half_width == pytest.approx(expected_half_width, rel=1e-12)
+
+    def test_robust_coverage_on_normal_data(self) -> None:
+        """~95% of intervals must contain the true median (was ~87% pre-fix)."""
+        rng = np.random.default_rng(3)
+        hits = 0
+        n_sim = 400
+        for _ in range(n_sim):
+            sample = pd.DataFrame({"v": rng.normal(0.0, 1.0, size=60)})
+            low, high = univariate.confidence_interval(sample, "v", conflevel=0.95, style="robust")
+            hits += low <= 0.0 <= high
+        coverage = hits / n_sim
+        assert coverage > 0.92
+
+
+class TestVarianceDecomposition:
+    def test_between_stddev_is_the_variance_component(self) -> None:
+        df = pd.DataFrame(data={"Result": [101, 102, 94, 95], "Repeat": [1, 1, 2, 2]})
+        out = univariate.variance_decomposition(df, measured="Result", repeat="Repeat")
+        assert out["between_ms"] == pytest.approx(49.0)
+        # sigma_between^2 = (MS_between - MS_within) / n = (49 - 0.5) / 2.
+        assert out["between_stddev"] == pytest.approx(np.sqrt(24.25))
+        assert out["within_stddev"] == pytest.approx(np.sqrt(0.5))
+
+    def test_noise_only_data_reports_zero_between_component(self) -> None:
+        """When groups do not differ, the between component must clip at 0."""
+        rng = np.random.default_rng(4)
+        df = pd.DataFrame({"v": rng.normal(0, 1, size=40), "g": np.repeat(np.arange(8), 5)})
+        out = univariate.variance_decomposition(df, measured="v", repeat="g")
+        assert out["between_stddev"] < out["within_stddev"]
+
+
+class TestBiweightMidvariance:
+    def test_consistent_with_variance_on_normal_data(self) -> None:
+        """With c = 9 the estimator tracks sigma^2 on clean Gaussian data.
+
+        The previous c = 6 (the biweight LOCATION constant) rejected too much
+        of the sample and was biased low.
+        """
+        rng = np.random.default_rng(5)
+        sample = rng.normal(0.0, 2.0, size=5000)
+        bw = univariate.biweight_midvariance(sample)
+        assert bw == pytest.approx(4.0, rel=0.10)
+
+
+class TestHoltWintersChart:
+    def test_rho_is_normalised_for_consistency(self) -> None:
+        """E[rho(Z)] = 1 for standard-normal Z; pre-fix it was ~0.77."""
+        expectation, _ = integrate.quad(lambda z: rho(z) * stats.norm.pdf(z), -12, 12, limit=200)
+        assert expectation == pytest.approx(1.0, abs=1e-3)
+
+    def test_limits_track_sigma_on_clean_data(self) -> None:
+        """+/-3S limits on well-behaved N(mu, sigma) data must be ~3 sigma wide.
+
+        Pre-fix the biweight constant made S ~ 0.88 sigma, i.e. limits at
+        +/-2.6 sigma and a ~3x inflated false-alarm rate.
+        """
+        rng = np.random.default_rng(6)
+        y = pd.Series(rng.normal(100.0, 2.0, size=400))
+        cc = ControlChart(variant="HW")
+        cc.calculate_limits(y)
+        assert cc.s == pytest.approx(2.0, rel=0.15)
+
+    def test_warm_up_residuals_remove_the_trend(self) -> None:
+        """A strong warm-up trend must not inflate sigma_0."""
+        rng = np.random.default_rng(7)
+        n = 400
+        trend = 0.5 * np.arange(n)
+        y = pd.Series(trend + rng.normal(0.0, 1.0, size=n))
+        cc = ControlChart(variant="HW")
+        cc._apply_tuning_kwargs({})
+        cc.df["y"] = y.values
+        cc.N = n
+        cc.warm_up["M"] = cc.warm_up_M = 20
+        cc.train_samples = [int(i) for i in np.arange(20, n)]
+        cc.ld_1 = cc.ld_2 = None
+        cc._holt_winters_parameter_fit()
+        # sigma_0 estimated from de-trended residuals: ~1, nowhere near the
+        # ~ MAD of the raw trending window (~ 2.5+).
+        assert cc.warm_up["sigma_0"] < 2.0
+
+    def test_small_sample_grid_search_is_not_degenerate(self) -> None:
+        """10 <= N < 20: the training window includes row 0, whose error is
+        unset. Pre-fix, every grid cell was NaN and (0.1, 0.1) always 'won'."""
+        rng = np.random.default_rng(8)
+        y = pd.Series(rng.normal(50.0, 3.0, size=15))
+        cc = ControlChart(variant="HW")
+        cc.calculate_limits(y)
+        assert np.isfinite(cc._residuals_HW).all()
+        assert cc.s is not None and np.isfinite(cc.s)
+
+    def test_explicit_zero_lambda_is_respected(self) -> None:
+        rng = np.random.default_rng(9)
+        y = pd.Series(rng.normal(10.0, 1.0, size=60))
+        cc = ControlChart(variant="HW")
+        cc.calculate_limits(y, ld_1=0.0, ld_2=0.5)
+        # 0.0 must survive as the user's choice, not trigger the grid search.
+        assert cc.ld_1 == 0.0
+        assert cc.ld_2 == 0.5
+
+    def test_unknown_variant_rejected_up_front(self) -> None:
+        with pytest.raises(ValueError, match="not implemented"):
+            ControlChart(variant="cusum")
+
+
+class TestCpkTool:
+    def test_rsd_is_of_the_data_not_the_spec_distance(self) -> None:
+        rng = np.random.default_rng(10)
+        values = rng.normal(100.0, 2.0, size=200)
+        df = pd.DataFrame({"v": values})
+        result_a = calculate_cpk(df, "v", specifications=(90.0, 110.0))
+        result_b = calculate_cpk(df, "v", specifications=(50.0, 150.0))
+        # Moving the spec limits must not change the data's RSD.
+        assert result_a.rsd == pytest.approx(result_b.rsd, rel=1e-9)
+        assert result_a.rsd == pytest.approx(2.0, rel=0.25)  # ~ 2/100 * 100%
+
+    def test_nan_cpk_reports_undefined_not_poor(self) -> None:
+        from process_improve.monitoring.tools import ProcessCapabilityInput, process_capability
+
+        rng = np.random.default_rng(11)
+        spec = ProcessCapabilityInput(values=list(rng.normal(10, 1, size=20)))  # no spec limits
+        result = process_capability(spec)
+        assert "error" not in result
+        assert "could not be computed" in result["interpretation"]

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -136,7 +136,12 @@ class TestHoltWintersControlChart:
     cc_missing = ControlChart()
     cc_missing.calculate_limits(with_missing, ld_1=0.4, ld_2=0.7)
     assert cc_missing.target == pytest.approx(100.3, abs=1e-1)
-    assert cc_missing.s == pytest.approx(6, abs=1)
+    # `s` is the robust scale of the one-step-ahead prediction errors. The
+    # earlier pin of ~6.5 was measured with a biweight rho whose consistency
+    # constant was conflated with the cutoff k = 2.52, shrinking every scale
+    # estimate by sqrt(2.52 * 0.30612) = 0.878; the corrected value is the
+    # same estimate divided by that factor.
+    assert cc_missing.s == pytest.approx(7.45, abs=1)
 
     # test_hw_short_length:
     # Ensures that short length sequences are also handled well.
@@ -151,7 +156,9 @@ class TestHoltWintersControlChart:
     cc_medium = ControlChart()
     cc_medium.calculate_limits(medium_length, ld_1=0.2, ld_2=0.5)
     assert cc_medium.target == pytest.approx(93.945, abs=1e-3)
-    assert cc_medium.s == pytest.approx(4.493, abs=1e-3)
+    # 5.116 = the pre-fix pin of 4.493 divided by the removed 0.878 biweight
+    # consistency bias (see the note on cc_missing.s above).
+    assert cc_medium.s == pytest.approx(5.116, abs=1e-3)
     assert len(cc_medium.idx_outside_3S) == 0
 
 
@@ -203,12 +210,13 @@ def test_calculate_limits_rejects_non_positive_s() -> None:
 
 
 def test_unsupported_variant_cannot_estimate_limits() -> None:
-    """A variant with no fitting routine (e.g. cusum) leaves target/s unset and raises."""
-    rng = np.random.default_rng(2)
-    y = 50.0 + rng.standard_normal(100)
-    cc = ControlChart(variant="cusum")
-    with pytest.raises(ValueError, match="could not be estimated"):
-        cc.calculate_limits(y)
+    """A variant with no fitting routine (e.g. cusum) is rejected at construction.
+
+    Previously it slipped through every fit branch and surfaced much later as
+    a misleading "input is likely constant or too short" error.
+    """
+    with pytest.raises(ValueError, match="not implemented"):
+        ControlChart(variant="cusum")
 
 
 def test_unknown_style_for_xbar_no_subgroup_raises() -> None:
@@ -242,13 +250,18 @@ def test_hw_zero_mad_but_nonconstant_warmup_falls_back_to_std() -> None:
 
 
 def test_rho_boundary_values() -> None:
-    """Bi-weight rho: zero at 0, capped at k beyond |x| > k, continuous at k."""
-    from process_improve.monitoring.control_charts import rho
+    """Bi-weight rho: zero at 0, capped at c_k beyond |x| > k, continuous at k.
+
+    The cap is the consistency constant c_k = 3.266736 (E[rho(Z)] = 1 for
+    standard-normal Z), not the cutoff k = 2.52; the two were previously
+    conflated, shrinking every scale estimate built from rho by 12 percent.
+    """
+    from process_improve.monitoring.control_charts import BIWEIGHT_RHO_CONSISTENCY, rho
 
     assert rho(0.0) == pytest.approx(0.0)
-    assert rho(5.0) == pytest.approx(2.52)
-    assert rho(-5.0) == pytest.approx(2.52)
-    assert rho(2.52) == pytest.approx(2.52)
+    assert rho(5.0) == pytest.approx(BIWEIGHT_RHO_CONSISTENCY)
+    assert rho(-5.0) == pytest.approx(BIWEIGHT_RHO_CONSISTENCY)
+    assert rho(2.52) == pytest.approx(BIWEIGHT_RHO_CONSISTENCY)
 
 
 def test_psi_boundary_values() -> None:
@@ -309,13 +322,18 @@ def test_cpk_estimates_specs_from_data_when_none() -> None:
 
 
 def test_cpk_returns_rsd() -> None:
-    """calculate_cpk should report the RSD of the limiting side alongside Cpk."""
+    """calculate_cpk reports the RSD of the DATA alongside Cpk.
+
+    Earlier versions divided the spread by the distance-to-spec centre, which
+    is not an RSD of anything and changed value when the spec limits moved.
+    """
     rng = np.random.default_rng(42)
     data = pd.DataFrame({"value": rng.normal(loc=50, scale=2, size=500)})
     result = calculate_cpk(data, "value", specifications=(40, 60), trim_percentile=0)
     assert set(result.keys()) >= {"cpk", "center", "spread", "rsd"}
     assert np.isfinite(result.rsd)
-    assert result.rsd == pytest.approx((result.spread / result.center) * 100, rel=1e-9)
+    expected_rsd = float(data["value"].std() / data["value"].mean()) * 100
+    assert result.rsd == pytest.approx(expected_rsd, rel=1e-9)
 
 
 def test_metrics_renamed_attribute_raises_helpful_error() -> None:
@@ -365,9 +383,14 @@ class TestHoltWintersControlChartBatchYield:
     y = subgroups.mean(axis=1)
 
     cc = ControlChart()
-    cc.calculate_limits(y)  # ld_1=0.5, ld_2=0.5
+    cc.calculate_limits(y)
     assert cc.target == pytest.approx(75.1, abs=1e-1)
-    assert cc.s == pytest.approx(4.16, abs=1e-3)
+    # `s` is the robust one-step-ahead prediction-error scale. The pre-fix pin
+    # of 4.16 sat BELOW the process's own robust spread (MAD*1.4826 = 4.20)
+    # because the biweight rho conflated the consistency constant with the
+    # cutoff k = 2.52; the corrected estimate (with the NaN-aware lambda grid
+    # search) lands just above the process spread, as a forecast error should.
+    assert cc.s == pytest.approx(4.825, abs=1e-3)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_safety.py
+++ b/tests/test_tool_safety.py
@@ -414,16 +414,13 @@ class TestSafeExecuteToolCall:
         # (audit fix: the shared module pool was not thread-safe), so capture
         # the worker pids at teardown time via _terminate_workers and confirm
         # they are gone afterwards.
-        import process_improve.tool_safety as ts
-
         seen_pids: list[int] = []
-        original_terminate = ts._terminate_workers
 
         def capture_and_terminate(pool) -> None:
             seen_pids.extend(getattr(pool, "_processes", None) or {})
-            original_terminate(pool)
+            _terminate_workers(pool)
 
-        monkeypatch.setattr(ts, "_terminate_workers", capture_and_terminate)
+        monkeypatch.setattr("process_improve.tool_safety._terminate_workers", capture_and_terminate)
 
         with pytest.raises(ToolTimeoutError):
             safe_execute_tool_call("_safety_test_busy_loop", {}, timeout=0.3)
@@ -439,12 +436,12 @@ class TestSafeExecuteToolCall:
         # worker (clean process-global state), and never touches the shared
         # module-level pool, so concurrent calls cannot tear down each
         # other's workers.
-        import process_improve.tool_safety as ts
+        from process_improve import tool_safety as ts
 
         ts.shutdown_pool()
         result = safe_execute_tool_call("_safety_test_echo", {"value": 1}, timeout=10)
         assert result == {"value": 1}
-        assert ts._pool is None
+        assert ts._pool_state is None
 
     def test_error_has_json_serialisable_dict(self) -> None:
         err: ToolSafetyError = ToolTimeoutError("boom", details={"tool_name": "x", "timeout": 1})

--- a/tests/test_tool_safety.py
+++ b/tests/test_tool_safety.py
@@ -408,29 +408,40 @@ class TestSafeExecuteToolCall:
         assert exc_info.value.code == "timeout"
         assert exc_info.value.details["tool_name"] == "_safety_test_sleep"
 
-    def test_timeout_force_terminates_runaway_worker(self) -> None:
+    def test_timeout_force_terminates_runaway_worker(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # SEC-02: a CPU-bound runaway must actually be killed on timeout, not
-        # left spinning. Warm the module pool (workers spawn lazily) so we can
-        # record its worker pids, then run an infinite-loop tool through the same
-        # pool and confirm those workers are gone afterwards.
-        pool = get_pool()
-        pool.submit(_worker_run, "_safety_test_echo", {"value": 0}).result(timeout=10)
-        pids = list(getattr(pool, "_processes", {}).keys())
-        assert pids, "expected at least one worker process"
+        # left spinning. The default path now runs each call in a PRIVATE pool
+        # (audit fix: the shared module pool was not thread-safe), so capture
+        # the worker pids at teardown time via _terminate_workers and confirm
+        # they are gone afterwards.
+        import process_improve.tool_safety as ts
+
+        seen_pids: list[int] = []
+        original_terminate = ts._terminate_workers
+
+        def capture_and_terminate(pool) -> None:
+            seen_pids.extend(getattr(pool, "_processes", None) or {})
+            original_terminate(pool)
+
+        monkeypatch.setattr(ts, "_terminate_workers", capture_and_terminate)
 
         with pytest.raises(ToolTimeoutError):
             safe_execute_tool_call("_safety_test_busy_loop", {}, timeout=0.3)
 
+        assert seen_pids, "expected at least one worker process"
         deadline = time.time() + 5
-        while time.time() < deadline and any(_pid_alive(p) for p in pids):
+        while time.time() < deadline and any(_pid_alive(p) for p in seen_pids):
             time.sleep(0.05)
-        assert not any(_pid_alive(p) for p in pids), "runaway worker still alive after timeout"
+        assert not any(_pid_alive(p) for p in seen_pids), "runaway worker still alive after timeout"
 
-    def test_module_pool_recycled_after_each_call(self) -> None:
-        # SEC-03: the module-managed pool is recycled after every call so each
-        # call runs in a fresh, isolated worker.
+    def test_default_path_uses_a_private_per_call_pool(self) -> None:
+        # SEC-03 + audit fix: each default-path call runs in its own fresh
+        # worker (clean process-global state), and never touches the shared
+        # module-level pool, so concurrent calls cannot tear down each
+        # other's workers.
         import process_improve.tool_safety as ts
 
+        ts.shutdown_pool()
         result = safe_execute_tool_call("_safety_test_echo", {"value": 1}, timeout=10)
         assert result == {"value": 1}
         assert ts._pool is None

--- a/tests/test_tool_spec.py
+++ b/tests/test_tool_spec.py
@@ -94,9 +94,22 @@ class TestToolSpecDecorator:
         assert _plain._tool_spec["description"] == "Plain description."
 
     def test_registered_in_registry(self) -> None:
-        """Verify decorated tools are added to the global registry."""
-        assert "test_dummy_add" in _TOOL_REGISTRY
-        assert "test_dummy_mul" in _TOOL_REGISTRY
+        """Verify decorated tools are added to the global registry.
+
+        Registers its own tool: relying on ``test_dummy_add`` from the sibling
+        tests made this order-dependent, and under pytest-xdist's per-test
+        distribution the sibling may run on a different worker process.
+        """
+
+        @tool_spec(
+            name="test_dummy_registry_probe",
+            description="Registry probe.",
+            input_model=_AddInput,
+        )
+        def _probe(spec: _AddInput) -> dict:
+            return {"result": spec.a + spec.b}
+
+        assert "test_dummy_registry_probe" in _TOOL_REGISTRY
 
     def test_rejects_non_basemodel_input_model(self) -> None:
         """input_model must be a pydantic BaseModel subclass."""
@@ -258,10 +271,17 @@ class TestRobustSummaryStats:
 
 class TestDetectOutliers:
     def test_detects_obvious_outlier(self) -> None:
-        """Verify an obvious outlier is detected."""
-        result = execute_tool_call("detect_outliers", {"values": [1, 2, 2, 3, 2, 100]})
+        """Verify an obvious outlier is detected.
+
+        The sample must be big enough for the ESD critical-value
+        approximation to hold (NIST recommends n >= 15): on a 6-point sample
+        the late-iteration critical values are unreliable, and the corrected
+        largest-crossing rule then legitimately flags extra points.
+        """
+        values = [10.1, 10.3, 10.2, 10.0, 10.4, 10.2, 10.1, 10.3, 9.9, 10.2, 10.0, 10.1, 10.3, 10.2, 100.0]
+        result = execute_tool_call("detect_outliers", {"values": values})
         assert result["n_outliers_found"] == 1
-        assert 5 in result["outlier_indices"]
+        assert 14 in result["outlier_indices"]
         assert 100.0 in result["outlier_values"]
 
     def test_clean_data_no_outliers(self) -> None:
@@ -481,7 +501,11 @@ class TestWithinBetweenVariance:
             {"values": [101, 102, 94, 95], "groups": [1, 1, 2, 2]},
         )
         assert result["within_stddev"] == pytest.approx(0.70711, abs=1e-4)
-        assert result["between_stddev"] == pytest.approx(7.0, abs=1e-4)
+        # between_stddev is the between-group variance COMPONENT:
+        # sqrt((MS_between - MS_within) / n) = sqrt((49 - 0.5) / 2). The raw
+        # ANOVA mean square is still available as between_ms (= 49).
+        assert result["between_ms"] == pytest.approx(49.0, abs=1e-4)
+        assert result["between_stddev"] == pytest.approx(np.sqrt(24.25), abs=1e-4)
 
     def test_output_keys_present(self) -> None:
         """Verify all expected output keys are present."""

--- a/tests/test_univariate.py
+++ b/tests/test_univariate.py
@@ -598,13 +598,24 @@ def outliers_data_measurement() -> list[float]:
 
 
 def test_edge_case_outliers(outliers_data_measurement: list[float]) -> None:
-    """Test an actual edge case that did not return p-values."""
+    """Test an actual edge case that did not return p-values.
+
+    Exercises the (opt-in) robust variant. Note how far the MAD-scaled
+    statistic (R_1 = 7.16) sits above the classical critical value
+    (lambda_1 = 2.02) - the mismatch that makes the robust variant
+    anti-conservative and is the reason it is no longer the default.
+    With the corrected largest-crossing rule both tested points are flagged.
+    """
     max_outliers = len(outliers_data_measurement) - 5
     outliers, reasons = univariate.detect_outliers_esd(
-        outliers_data_measurement, algoritm="esd", max_outliers_detected=max_outliers, alpha=0.05
+        outliers_data_measurement,
+        algorithm="esd",
+        max_outliers_detected=max_outliers,
+        alpha=0.05,
+        robust_variant=True,
     )
 
-    assert len(outliers) == 1
+    assert len(outliers) == 2
     assert reasons["lambda"][0] == pytest.approx(2.0199685076)
     assert reasons["R_i"][0] == pytest.approx(7.16003736)
     assert reasons["p-value"][0] == 0
@@ -776,7 +787,13 @@ def test_rosner_nonrobust_esd(outliers_data: tuple[list[float], list[float]]) ->
 
 
 def test_rosner_esd_kwargs(outliers_data: tuple[list[float], list[float]]) -> None:
-    """In this example it picks up fewer outliers."""
+    """The (opt-in) robust variant over-detects on the Rosner data.
+
+    NIST's answer for this data set is 3 outliers; the MAD-scaled statistic
+    against classical critical values flags 4. This pins the documented
+    anti-conservative behaviour of ``robust_variant=True`` (the reason it is
+    no longer the default), with the corrected largest-crossing rule.
+    """
     rosner, _ = outliers_data
     outliers, _ = univariate.detect_outliers_esd(
         rosner,
@@ -785,7 +802,7 @@ def test_rosner_esd_kwargs(outliers_data: tuple[list[float], list[float]]) -> No
         robust_variant=True,
         alpha=0.05,
     )
-    assert outliers == [53]
+    assert outliers == [53, 52, 51, 50]
 
 
 def test_rosner_esd_no_outliers(outliers_data: tuple[list[float], list[float]]) -> None:


### PR DESCRIPTION
A ruthless correctness audit of the whole package, followed by fixes for every verified critical and major finding. Three deep audit passes covered the multivariate core, the univariate/monitoring/DOE/regression/batch modules, and the infrastructure (config, tool safety, CI, tests). Each fix landed as a batch commit with regression tests that fail on the pre-fix code (`tests/test_audit_regressions_*.py`).

## Statistical correctness fixes

**Multivariate core**
- TSR PCA missing-data fit: the N &lt;= K SVD branch used a wrongly transposed singular-vector matrix (crash for wide matrices, silently wrong imputation for square ones); fitted scores were centred while `transform()` is not, so `scores_`/SPE/R2 disagreed with `transform` on the same data; sign convention now matches the other algorithms.
- Score-plot T2 ellipse now uses the bivariate (2-dof) limit, not the full model's A: the old ellipse was ~42% too wide per axis at A=5, N=50, hiding real outliers. `spe_plot`/`t2_plot` limits are now computed at the plotted component count.
- `PCA.select_n_components`: the 1-SE band was ~n_folds too narrow (total PRESS vs per-fold SE), silently degenerating `"1se"` to `"min"`; the Q2 null model was uncentred. PLS's Q2 SE band had the same scale bug.
- `PLS.cross_validate` K-fold beta CIs now use the delete-a-block jackknife SE (the plain SD was 1.79x too small at K=5, over-declaring significance).
- Target projection / selectivity ratio used the raw-units beta as a direction in scaled space; wrong whenever X columns have different raw scales.
- `TPLS.diagnose`: one missing F/Z cell poisoned that observation's scores, T2, SPE and predictions with NaN.
- NIPALS non-convergence warnings could never fire (PLS) or did not exist (PCA); rank-deficient fits produced inf/NaN T2; `MCUVScaler` emitted all-NaN columns for single-observation columns; `center`/`scale` axis=1 was broken.

**Univariate and monitoring**
- Generalized ESD: the outlier count is the largest crossing (NIST/Rosner), not the first; and the MAD-scaled "robust" variant (previously the default) is anti-conservative against classical critical values, declaring outliers in clean data - flipped to opt-in.
- Robust median CI was missing the sqrt(pi/2) factor: ~87% coverage at nominal 95%.
- Holt-Winters chart: the biweight rho conflated the consistency constant with the cutoff, so every scale estimate was 12% too small (+/-3S was really +/-2.63 sigma, ~3x the false-alarm rate); warm-up residuals subtracted the slope instead of the trend; the lambda grid search NaN-degenerated to (0.1, 0.1) for 10 &lt;= N &lt; 20.
- `variance_decomposition.between_stddev` reported sqrt(MS_between) rather than the variance component; `biweight_midvariance` used the location constant c=6 instead of c=9; `calculate_cpk`'s "RSD" divided by the distance-to-spec centre.

**DOE**
- Clear effects now follow Wu &amp; Hamada (every Res-III design previously reported all main effects "clear").
- Explicit fractional-factorial generators silently swapped factor columns for non-last-factor generators and misparsed multi-character factor names.
- Lack-of-fit could never find replicates on generated designs (grouped on the unique-per-row RunOrder column).
- D-optimal point exchange scored a de-duplicated design and dropped improving swaps onto row label 0; `to_coded(center=0)` was ignored; `gather()` dropped positional args.

**Regression and batch**
- Repeated-median leverage divided 0/0 inside its own degenerate-x guard; the DTW "distance" summed cumulative costs (not a distance - now `D[-1,-1]`); Kassidas alignment weights gave the best-aligned variables near-zero weight (the exact opposite of the intent).

## Robustness and infrastructure fixes
- `Settings` never actually cached (eager `setdefault`), and a typo in `PROCESS_IMPROVE_MCP_SAFE_MODE` silently disabled safe mode (fail-open) - boolean env vars are now strict.
- `clean()` gaps (`np.bool_`, numpy dict keys, sets) that surfaced as generic internal errors at the MCP boundary.
- `discover_tools` swallowed missing first-party modules as "missing dependencies".
- `tool_safety`'s shared worker pool raced under the threaded MCP server (cross-thread teardown SIGKILLed other calls' workers); the default path now uses a private per-call pool.
- The fuzz suite could hang CI for hours by running a test-only infinite-loop tool in-process, depending only on module import order - reproduced live during this audit and fixed.
- CI: removed the no-op `create` trigger, least-privilege workflow token scopes.
- Version 1.68.0 with a full changelog entry.

## Rebased onto current main (2026-08-22)

`main` moved on while this PR sat open, and released its own 1.67.0 on 2026-08-21. Resolving that:

- The audit's changelog section is now **[1.68.0] - 2026-08-22**; main's [1.67.0] section is untouched below it. `pyproject.toml` and `CITATION.cff` follow to 1.68.0 in the same commit.
- The `[1.66.2]` section this branch originally added is **dropped**, not merged: main renamed its own `Unreleased` heading after this branch was cut, so every line of it is already present verbatim inside main's `[1.67.0]`. Re-adding it would have duplicated those entries under two headings.
- Every other file auto-merged. Checked for semantic conflicts with #495 (which corrected docstrings across the same modules this PR changes): the cusum notes in `control_charts.py` agree with this PR's corrected tool error message; #495's `spe_calculation` Notes describe a function this PR does not touch; #495's degenerate-stub docs describe the fewer-than-three-observations early return, not the zero-variance-x branch fixed here; and the `robust_variant` docstring and its default both read `False`.
- Validated on the merged tree: `ruff check`, `ruff format --check`, `mypy src/process_improve`, and the full pytest suite (2670 passed, 6 skipped). The two remote dataset loader tests (`oildoe`, `distillateflow`) fail identically on unmerged main in a sandbox without access to openmv.net; they are network tests, not merge fallout.

## Deliberately not fixed here (filed for follow-up)
`mcp_server._create_mcp_tool` discards every tool's JSON Schema (FastMCP sees `(**kwargs)`); TPLS T2 fit-vs-diagnose use different covariance conventions; MBPLS/MBPCA hardcode `default_rng(0)` against the documented random_state contract; PCA/PLS mutate constructor params in `fit()` (sklearn clone contract); absolute (non-relative) NIPALS convergence tolerances; `publish.yml` workflow_dispatch bypasses the tag/version guard and the SBOM includes build tooling; test tier markers (`slow`/`integration`) are registered but unused; perf "baselines" cannot fail; remote dataset loaders have no timeout.

These are tracked as #502-#512, with the remaining minor findings in #513. All of them were independently re-verified against main at 08df441 on 2026-08-22 and still apply; that verification also re-checked all 63 minor leads in #513 (61 confirmed, 6 partly confirmed, 8 not a bug), posted [there](https://github.com/kgdunn/process-improve/issues/513#issuecomment-5378224627).