### PR TITLE
docs: correct docstrings across batch, multivariate, regression, univariate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,23 @@ those changes.
   present `model_summary` dict; `ControlChart.__init__` marks
   `'cusum'` as an unimplemented future variant.
 
+- Follow-up docstring corrections across `batch`, `multivariate`,
+  `regression`, and `univariate`: `melted_to_wide` now says it returns
+  an empty dict (not yet implemented, pointer to `dict_to_wide`);
+  `wide_to_melted` and `wide_to_dict` docstrings match their new
+  `NotImplementedError` bodies (the previous silent empty returns
+  contradicted the "Not yet implemented" wording); the `PCA` class
+  docstring documents `n_components : int or None` and the
+  `PCA.__init__` signature now defaults `n_components` to `None`
+  (matching `_parameter_constraints` and `fit()`); the `fitting_info_`
+  comment on `PCA` corrects a swapped mapping from algorithm to output
+  shape (arrays are produced by SVD/NIPALS, scalar totals by TSR);
+  `robust_regression.conf_intervals` is described as a single-slope
+  1 x 2 interval, not a K-row block (the single-predictor function
+  never had K); `t_value_cdf` doctests use `float("inf")` /
+  `float("-inf")` instead of `np.inf`, which was previously referenced
+  without an in-doctest numpy import.
+
 ## [1.66.1] - 2026-08-09
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.66.2
-date-released: "2026-08-14"
+version: 1.66.3
+date-released: "2026-08-21"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.66.2"
+version = "1.66.3"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/batch/data_input.py
+++ b/src/process_improve/batch/data_input.py
@@ -172,7 +172,10 @@ def melted_to_dict(in_df: pd.DataFrame, batch_id_col: str) -> dict:
 
 
 def melted_to_wide(in_df: pd.DataFrame, batch_id_col: str) -> dict:
-    """Convert aligned melted data to wide format."""
+    """Convert aligned melted data to wide format.
+
+    Not yet implemented (returns an empty dict); see also ``dict_to_wide``.
+    """
     if batch_id_col not in in_df:
         raise ValueError(f"The `batch_id_col` column {batch_id_col!r} does not exist in the incoming dataframe.")
     return {}
@@ -192,13 +195,14 @@ def melted_to_wide(in_df: pd.DataFrame, batch_id_col: str) -> dict:
 
 
 def wide_to_melted(in_df: pd.DataFrame) -> pd.DataFrame:
-    """Convert wide-format batch data to melted format. Not yet implemented."""
+    """Convert wide-format batch data to melted (long) format. Not yet implemented."""
     # dict_to_melted(dict_to_wide(in_df))
-    return pd.DataFrame()
+    raise NotImplementedError("wide_to_melted is not yet implemented.")
 
 
-def wide_to_dict() -> None:
+def wide_to_dict(in_df: pd.DataFrame) -> dict:
     """Convert wide-format batch data to dict format. Not yet implemented."""
+    raise NotImplementedError("wide_to_dict is not yet implemented.")
 
 
 def melt_df_to_series(in_df: pd.DataFrame, exclude_columns: list | None = None, name: str | None = None) -> pd.Series:

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -218,8 +218,9 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    n_components : int
-        Number of principal components to extract.
+    n_components : int or None
+        Number of principal components to extract. If ``None``, the maximum
+        possible ``min(n_samples, n_features)`` is used.
 
     algorithm : str, default="auto"
         Algorithm to use for fitting the model.
@@ -270,7 +271,7 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
 
     def __init__(
         self,
-        n_components: int,
+        n_components: int | None = None,
         *,
         algorithm: str = "auto",
         missing_data_settings: dict | None = None,
@@ -299,7 +300,7 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
     }
     _RENAME_CONTEXT: typing.ClassVar[str] = "PCA"
 
-    # Fitted diagnostics: per-component arrays (NIPALS/TSR) or scalar totals (SVD).
+    # Fitted diagnostics: per-component arrays (SVD/NIPALS) or scalar totals (TSR).
     fitting_info_: dict[str, np.ndarray | int | float]
 
     # ENG-18: public DataFrame views built lazily from the private ndarrays.

--- a/src/process_improve/regression/_robust_regression.py
+++ b/src/process_improve/regression/_robust_regression.py
@@ -132,7 +132,8 @@ def robust_regression(  # noqa: PLR0913, PLR0915
         residuals:                the N residuals
         t_value:                  the two-sided critical t-value at ``conflevel`` used
                                   to build the confidence and prediction intervals
-        conf_intervals:           K rows x 2 columns (lower, upper) confidence intervals
+        conf_intervals:           1 x 2 (lower, upper) confidence interval for the single
+                                  slope coefficient
         conf_interval_intercept:  (lower, upper) confidence interval for the intercept
         pi_range:                 prediction intervals above and below, over the range of data
         leverage:                 the hat-matrix diagonal (leverage) for each observation

--- a/src/process_improve/univariate/metrics.py
+++ b/src/process_improve/univariate/metrics.py
@@ -62,12 +62,12 @@ def t_value_cdf(z: float, v: float) -> float:
 
     Zero fractional area under the curve is at :math:`-\infty`:
 
-    >>> t_value_cdf(-np.inf, v=10)
+    >>> t_value_cdf(float("-inf"), v=10)
     0.0
 
     100% fractional area is at :math:`+\infty`:
 
-    >>> t_value_cdf(np.inf, v=10)
+    >>> t_value_cdf(float("inf"), v=10)
     1.0
 
     See also

--- a/tests/batch/test_data_input.py
+++ b/tests/batch/test_data_input.py
@@ -9,6 +9,7 @@ from process_improve.batch.data_input import (
     melt_df_to_series,
     melted_to_dict,
     melted_to_wide,
+    wide_to_dict,
     wide_to_melted,
 )
 
@@ -43,14 +44,15 @@ def test_melted_to_wide(nylon_raw_melteddata: pd.DataFrame) -> None:
 
 
 def test_wide_to_melted() -> None:
-    """Test conversion from wide format to melted format."""
-    out = wide_to_melted(pd.DataFrame({"x": [1, 2]}))
-    assert isinstance(out, pd.DataFrame)
-    assert out.empty
+    """wide_to_melted is a stub and should raise NotImplementedError."""
+    with pytest.raises(NotImplementedError):
+        wide_to_melted(pd.DataFrame({"x": [1, 2]}))
 
 
 def test_wide_to_dict() -> None:
-    """Test conversion from wide format to dictionary."""
+    """wide_to_dict is a stub and should raise NotImplementedError."""
+    with pytest.raises(NotImplementedError):
+        wide_to_dict(pd.DataFrame({"x": [1, 2]}))
 
 
 def test_dict_to_melted_default_inserts_batch_id(aligned_batch_dict: dict) -> None:


### PR DESCRIPTION
## Summary

Follow-up docstring audit after #495. Six small drifts between what the docstring says and what the code does, plus one tiny code fix to make two stubs behave the way their docstrings claim.

- **`src/process_improve/batch/data_input.py`** (line 174): `melted_to_wide` unconditionally returned `{}` while its docstring simply said "Convert aligned melted data to wide format." Docstring now says "Not yet implemented (returns an empty dict); see also `dict_to_wide`."
- **`src/process_improve/batch/data_input.py`** (lines 194, 200): `wide_to_melted` and `wide_to_dict` said "Not yet implemented" while silently returning empty structures. `wide_to_dict` also took no arguments, so any caller passing a DataFrame got a `TypeError`. Both now accept the expected input and `raise NotImplementedError` so the behaviour matches the docs. The two stub tests were updated to `pytest.raises(NotImplementedError)`.
- **`src/process_improve/multivariate/_pca.py`** (lines 220-233, 271-280): `PCA` docstring now documents `n_components : int or None`, and `__init__` defaults `n_components` to `None`; this matches `_parameter_constraints` (`[int, None]`) and `fit()`, which already clamped `None` to `min(n_samples, n_features)`.
- **`src/process_improve/multivariate/_pca.py`** (line 302): the `fitting_info_` inline comment had algorithm-to-shape backwards. Corrected to "per-component arrays (SVD/NIPALS) or scalar totals (TSR)."
- **`src/process_improve/regression/_robust_regression.py`** (line 135): the `conf_intervals` entry in `robust_regression`'s Returns block described it as `K rows x 2 columns`, but the function only supports single-predictor regression. Rewritten as `1 x 2 (lower, upper) confidence interval for the single slope coefficient`. The K-row wording on the sibling `multiple_linear_regression` (line 325) was left untouched.
- **`src/process_improve/univariate/metrics.py`** (lines 63-70): `t_value_cdf` doctests used `np.inf` without importing numpy into the doctest namespace. Replaced with `float("inf")` / `float("-inf")`, which needs no import and matches the surrounding style. `t_value` didn't actually use `np.inf` in its doctest code (only in the `:math:` prose), so it was left alone.

Version bumped 1.66.2 -> 1.66.3 (PATCH, docs). `CITATION.cff` synced to the new version and today's date (2026-08-21). New Documentation bullet added under `## [Unreleased]` in `CHANGELOG.md`.

## Test plan

- [x] `uv run ruff check src/process_improve/... tests/batch/test_data_input.py` - passes.
- [x] `uv run ruff format --check src/process_improve/... tests/batch/test_data_input.py` - 5 files already formatted.
- [x] `uv run pytest tests/batch/test_data_input.py --no-cov` - 10 passed.
- [x] `uv run pytest tests/test_multivariate.py tests/test_regression.py tests/test_univariate.py tests/batch/ --no-cov` - 302 passed, 2 skipped. The 4 errors seen are pre-existing `ImportError` for the optional `scikit-fda`/pyDOE3 extras and are unrelated to this change.

## Checklist

- [x] Version bumped in `pyproject.toml` (PATCH, docs-only)
- [x] Tests added or updated where relevant (two stub tests re-pointed at `pytest.raises(NotImplementedError)`)
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated
- [x] `CITATION.cff` version and date synced

---
_Generated by [Claude Code](https://claude.ai/code/session_017eNvkh6WTyBeTt4fTVxmUr)_