### PR TITLE
Batch mid-course correction, step 1: a realistic fed-batch bioreactor simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ those changes.
 
 ## [Unreleased]
 
+## [1.67.0] - 2026-08-21
+
 ### Fixed
 
 - `omars_properties` and `is_omars` now reject a design that leaves a factor at
@@ -34,6 +36,27 @@ those changes.
 
 ### Added
 
+- `simulation.batch`: a deterministic fed-batch bioreactor simulator with
+  tunable disturbance channels, the quantitative baseline for batch trajectory
+  adaptation and, later, mid-course correction. Growth follows the Rosso et
+  al. (1995) cardinal temperature and pH model with Luedeking-Piret
+  production, an oxygen-transfer ceiling with hypoxic death, hypothermic
+  growth arrest and substrate-coupled production, so the optimal schedule
+  genuinely depends on each batch's initial conditions. Public surface:
+  `BioreactorConfig`, `BioreactorSimulator` (single batches, replay /
+  historical / adapted campaigns, the true optimal trajectory for any initial
+  conditions, a golden trajectory, and a `sensitivity_budget` that publishes
+  how the titer responds to input perturbations), `sample_initial_conditions`
+  (an 11-variable upstream Z block with three feed classes),
+  `variance_decomposition` (the split into before-batch, within-batch and
+  noise sources with the interaction residual reported explicitly), and the
+  cardinal functions. Fully reproducible from a `random_state`, including
+  across processes; campaign output uses the standard batch dictionary
+  format so it feeds `dict_to_wide` and the alignment tooling directly.
+- Two agent tools, `simulate_batch_campaign` and
+  `decompose_batch_quality_variance`, plus the `golden_batch_baseline`
+  analysis recipe chaining them into the argument for why replaying a golden
+  batch does not reproduce it.
 - Minimum moment aberration (Xu, 2003) for two-level designs, as
   `process_improve.experiments.moment_aberration` and as a new
   `moment_aberration` metric on `evaluate_design`. Unlike the existing
@@ -3104,7 +3127,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.66.1...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.67.0...HEAD
+[1.67.0]: https://github.com/kgdunn/process-improve/compare/v1.66.1...v1.67.0
 [1.66.1]: https://github.com/kgdunn/process-improve/compare/v1.66.0...v1.66.1
 [1.66.0]: https://github.com/kgdunn/process-improve/compare/v1.65.0...v1.66.0
 [1.65.0]: https://github.com/kgdunn/process-improve/compare/v1.64.0...v1.65.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.66.2
-date-released: "2026-08-14"
+version: 1.67.0
+date-released: "2026-08-21"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -12,3 +12,4 @@ API Reference
    batch
    bivariate
    visualization
+   simulation

--- a/docs/api/simulation.rst
+++ b/docs/api/simulation.rst
@@ -1,0 +1,10 @@
+Simulation
+==========
+
+Bioreactor batch simulator
+--------------------------
+
+.. automodule:: process_improve.simulation.batch
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/user_guide/batch_simulator.rst
+++ b/docs/user_guide/batch_simulator.rst
@@ -1,0 +1,163 @@
+The batch (bioreactor) simulator
+================================
+
+A "golden batch" is the run where everything went right, and batch automation
+commonly responds by replaying its charging recipe and setpoint schedules for
+every future batch. Replaying is open-loop control: it assumes the
+disturbances present during the golden run will recur, and they do not. The
+:mod:`process_improve.simulation.batch` module exists to make the
+consequences of that assumption measurable, with numbers that reproduce
+exactly from a seed:
+
+1. Replaying a golden schedule does not reproduce the golden outcome.
+2. The spread persists even when the measured initial conditions are held
+   identical, because disturbances also arise while the batch runs.
+3. The quality variance under replay therefore splits into a share that
+   adapting the schedule *before* the batch could address, a share observable
+   only *during* the batch (the case for mid-course correction), and a noise
+   floor.
+
+Because the simulator's own kinetics are known, the *true* optimal schedule
+for any batch's initial conditions is computable. That gives later,
+data-driven schemes (latent-variable models, trajectory optimisation,
+mid-course correction) a ceiling to be scored against, which no historical
+dataset can offer.
+
+The process model
+-----------------
+
+A 10-day fed-batch bioreactor, sampled twice daily: biomass, substrate,
+product (titer) and volume, with pH and temperature as the manipulated
+schedule and dissolved oxygen, offgas CO2 and volume as recorded responses.
+Growth follows the gamma-concept cardinal temperature and pH model of Rosso
+et al. (1995); production follows Luedeking and Piret (1959). Three couplings
+give the schedule a real, condition-dependent optimum: an oxygen-transfer
+ceiling with hypoxic death, strong hypothermic growth arrest (the reason the
+industrial biphasic temperature shift works), and substrate consumption by
+production with starvation death. The full equations, parameter meanings and
+citations are in the module docstring
+(:mod:`process_improve.simulation.batch`).
+
+Three disturbance channels can each be scaled or switched off independently:
+measured initial conditions (an 11-variable upstream ``Z`` block with three
+feed classes A, B and C), an unmeasured within-batch disturbance that is
+visible in the gas trajectories, and control-loop plus measurement noise at
+instrument scale. All random draws are made on every call and multiplied by
+their channel scale, so the same seed with one channel switched off is a true
+counterfactual for the same batch.
+
+Realism: the sensitivity budget
+-------------------------------
+
+A simulator whose quality output moves when an input moves by less than an
+instrument can resolve is not believable. The nominal schedule therefore sits
+at stationary points of the response (the pH optimum and the interior optimum
+of the production-phase temperature hold), so instrument-scale deviations are
+second order, while sustained multi-degree deviations cross real mechanisms
+and cost real titer. Measured on the default configuration (nominal titer
+8.01 g/L, 200 noise replicates, seed 0):
+
+===============================================  =================
+Perturbation                                     Effect on titer
+===============================================  =================
+Control-loop noise, sd 0.15 degC and 0.02 pH     sd 0.25%
+Sustained bias of +0.1 / -0.1 degC               -0.22% / -0.20%
+Sustained bias of +0.02 / -0.02 pH               -0.01%
+One 12-hour sample at +0.5 degC                  -0.30%
+Sustained bias of +1.0 / -1.0 degC               -11.5% / -7.1%
+Sustained bias of +2.0 / -2.0 degC               -20.6% / -22.5%
+===============================================  =================
+
+These numbers are enforced as acceptance tests in
+``tests/test_simulation_batch.py``, and
+:meth:`~process_improve.simulation.batch.BioreactorSimulator.sensitivity_budget`
+recomputes the table from the live configuration, so the claim can be checked
+against any parameter changes rather than taken on trust:
+
+.. code-block:: python
+
+    from process_improve.simulation import BioreactorSimulator
+
+    sim = BioreactorSimulator()
+    print(sim.sensitivity_budget(random_state=0))
+
+The three claims, in code
+-------------------------
+
+Replaying the schedule does not reproduce the outcome:
+
+.. code-block:: python
+
+    campaign = sim.simulate_campaign(50, policy="replay", random_state=0)
+    titer = campaign.quality["titer"]
+    print(titer.mean(), titer.std(ddof=1))   # a spread of roughly 14% CV
+
+Holding the measured initial conditions identical does not remove the spread.
+``dataclasses.replace`` derives a configuration with the initial-condition
+channel off; what remains (roughly 8% CV, about twenty-five times the noise
+floor) arose during the batches:
+
+.. code-block:: python
+
+    import dataclasses
+    from process_improve.simulation import BioreactorConfig
+
+    same_z = BioreactorSimulator(
+        dataclasses.replace(BioreactorConfig(), ic_scale=0.0, noise_scale=0.0)
+    )
+    campaign = same_z.simulate_campaign(50, policy="replay", random_state=0)
+
+And the decomposition, which runs the four campaigns and reports the
+interaction residual of the nonlinear model explicitly instead of forcing the
+buckets to sum:
+
+.. code-block:: python
+
+    from process_improve.simulation import variance_decomposition
+
+    print(variance_decomposition(sim, n_batches=200, random_state=0))
+
+The golden batch and the adaptation ceiling
+-------------------------------------------
+
+:meth:`~process_improve.simulation.batch.BioreactorSimulator.golden_trajectory`
+finds the true optimal schedule for the *nominal* initial conditions by
+optimising over the simulator's own kinetics; it recovers the industrial
+biphasic shape (a warm growth phase near 37.5 degC, a smooth downshift into a
+production hold near 29 degC) without being told it. On the defaults it
+reaches 8.54 g/L against 8.01 g/L for the built-in nominal recipe.
+
+:meth:`~process_improve.simulation.batch.BioreactorSimulator.optimal_trajectory`
+does the same for any batch's own initial conditions. The gap between
+replaying the golden schedule and each batch's own optimum is the value a
+perfect feedforward adaptation could recover; on the default configuration it
+ranges from under 1% for a good feed lot to roughly 20% for the poorest.
+The ``"adapted"`` campaign policy runs every batch at its own optimum, as
+that ceiling, and the ``"historical"`` policy adds deliberate setpoint
+variation, since a perfectly consistent history carries no information about
+how the controls affect quality.
+
+.. code-block:: python
+
+    golden = sim.golden_trajectory()
+    adapted = sim.optimal_trajectory(campaign.initial_conditions.iloc[0])
+
+Campaign outputs use the package's standard batch dictionary format
+(``dict[batch_id, DataFrame]``), so they feed directly into
+:func:`process_improve.batch.data_input.dict_to_wide` and the alignment
+tooling for latent-variable modelling.
+
+Agent tools
+-----------
+
+Two registered tools expose the baseline to agent callers:
+``simulate_batch_campaign`` (campaign outcomes with the disturbance-free
+reference titer for comparison) and ``decompose_batch_quality_variance`` (the
+variance split). The ``golden_batch_baseline`` analysis recipe chains them
+into the three-step argument above.
+
+.. note::
+
+   The accompanying book, `Process Improvement using Data
+   <https://learnche.org/pid>`_, develops the golden-batch discussion and the
+   latent-variable methods this baseline is built to support.

--- a/docs/user_guide/batch_simulator.rst
+++ b/docs/user_guide/batch_simulator.rst
@@ -90,11 +90,11 @@ Replaying the schedule does not reproduce the outcome:
 
     campaign = sim.simulate_campaign(50, policy="replay", random_state=0)
     titer = campaign.quality["titer"]
-    print(titer.mean(), titer.std(ddof=1))   # a spread of roughly 14% CV
+    print(titer.mean(), titer.std(ddof=1))   # a spread of roughly 13% CV
 
 Holding the measured initial conditions identical does not remove the spread.
 ``dataclasses.replace`` derives a configuration with the initial-condition
-channel off; what remains (roughly 8% CV, about twenty-five times the noise
+channel off; what remains (close to 7% CV, about thirty times the noise
 floor) arose during the batches:
 
 .. code-block:: python
@@ -105,7 +105,7 @@ floor) arose during the batches:
     same_z = BioreactorSimulator(
         dataclasses.replace(BioreactorConfig(), ic_scale=0.0, noise_scale=0.0)
     )
-    campaign = same_z.simulate_campaign(50, policy="replay", random_state=0)
+    same_z_campaign = same_z.simulate_campaign(50, policy="replay", random_state=0)
 
 And the decomposition, which runs the four campaigns and reports the
 interaction residual of the nonlinear model explicitly instead of forcing the
@@ -131,7 +131,8 @@ reaches 8.54 g/L against 8.01 g/L for the built-in nominal recipe.
 does the same for any batch's own initial conditions. The gap between
 replaying the golden schedule and each batch's own optimum is the value a
 perfect feedforward adaptation could recover; on the default configuration it
-ranges from under 1% for a good feed lot to roughly 20% for the poorest.
+ranges from about 3% at the centre of the good feed class to over 40% at the
+centre of the poorest.
 The ``"adapted"`` campaign policy runs every batch at its own optimum, as
 that ceiling, and the ``"historical"`` policy adds deliberate setpoint
 variation, since a perfectly consistent history carries no information about

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -11,3 +11,4 @@ User Guide
    design_evaluation
    omars_designs
    sensory_panel
+   batch_simulator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.66.2"
+version = "1.67.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -550,11 +550,11 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         Parameters
         ----------
         X : array-like, shape (n_samples, n_features)
-            Training data, where `n_samples` is the number of samples (rows)
-            and `n_features` is the number of features (columns).
+            Training data, where ``n_samples`` is the number of samples (rows)
+            and ``n_features`` is the number of features (columns).
         Y : array-like, shape (n_samples, n_targets)
-            Training data, where `n_samples` is the number of samples (rows)
-            and `n_targets` is the number of target outputs (columns).
+            Training data, where ``n_samples`` is the number of samples (rows)
+            and ``n_targets`` is the number of target outputs (columns).
         sample_weight : array-like of shape (n_samples,), optional
             Non-negative row weights for a weighted PLS fit (#394). NIPALS
             is run on ``sqrt(w)``-rescaled X and Y, which is equivalent to

--- a/src/process_improve/recipes.py
+++ b/src/process_improve/recipes.py
@@ -143,6 +143,7 @@ _recipes_discovered: bool = False
 #: ``process_improve.<subpackage>.recipes`` modules here as they are added.
 _RECIPE_MODULES: list[str] = [
     "process_improve.sensory.recipes",
+    "process_improve.simulation.recipes",
 ]
 
 

--- a/src/process_improve/simulation/__init__.py
+++ b/src/process_improve/simulation/__init__.py
@@ -2,7 +2,7 @@
 
 Fake-data / process-simulator subpackage.
 
-Provides three agent-callable tools used to demonstrate DOE workflows
+Provides agent-callable tools, three of which demonstrate DOE workflows
 against a synthetic (but deterministic) response surface:
 
 - ``create_simulator`` - records a hidden model from a seed + factor

--- a/src/process_improve/simulation/__init__.py
+++ b/src/process_improve/simulation/__init__.py
@@ -15,4 +15,31 @@ against a synthetic (but deterministic) response surface:
 The math itself lives in :mod:`process_improve.simulation.model`; the
 tools in :mod:`process_improve.simulation.tools` are the
 JSON-schema-wrapped entry points registered with ``@tool_spec``.
+
+A second, open simulator lives in :mod:`process_improve.simulation.batch`:
+a deterministic fed-batch bioreactor with tunable disturbance channels,
+the baseline for batch trajectory adaptation and mid-course correction.
+Unlike the DOE simulator above, its parameters are deliberately visible.
 """
+
+from process_improve.simulation.batch import (
+    LATENT_FACTOR_NAMES,
+    UPSTREAM_VARIABLE_NAMES,
+    BioreactorConfig,
+    BioreactorSimulator,
+    cardinal_ph,
+    cardinal_temperature,
+    sample_initial_conditions,
+    variance_decomposition,
+)
+
+__all__ = [
+    "LATENT_FACTOR_NAMES",
+    "UPSTREAM_VARIABLE_NAMES",
+    "BioreactorConfig",
+    "BioreactorSimulator",
+    "cardinal_ph",
+    "cardinal_temperature",
+    "sample_initial_conditions",
+    "variance_decomposition",
+]

--- a/src/process_improve/simulation/batch.py
+++ b/src/process_improve/simulation/batch.py
@@ -333,7 +333,7 @@ class BioreactorConfig:
         Cardinal pH values, shared by growth and productivity.
     batch_days : float
         Batch duration [day].
-    n_samples : int
+    samples_per_batch : int
         Number of recorded samples (and setpoint intervals) per batch.
     steps_per_day : int
         Integration steps per day for the fixed-step RK4 integrator.
@@ -432,7 +432,7 @@ class BioreactorConfig:
     ph_max: float = 7.9
     # Operation
     batch_days: float = 10.0
-    n_samples: int = 20
+    samples_per_batch: int = 20
     steps_per_day: int = 24
     feed_rate: float = 0.055
     feed_substrate: float = 50.0
@@ -532,15 +532,15 @@ class BioreactorConfig:
                 f"Cardinal pH values must satisfy ph_min < ph_opt < ph_max; got "
                 f"({self.ph_min}, {self.ph_opt}, {self.ph_max})."
             )
-        if self.n_samples < 2:
-            raise ValueError(f"n_samples must be at least 2; got {self.n_samples}.")
+        if self.samples_per_batch < 2:
+            raise ValueError(f"samples_per_batch must be at least 2; got {self.samples_per_batch}.")
         if self.steps_per_day < 1:
             raise ValueError(f"steps_per_day must be at least 1; got {self.steps_per_day}.")
         n_steps = self.batch_days * self.steps_per_day
-        if abs(n_steps / self.n_samples - round(n_steps / self.n_samples)) > 1e-9:
+        if abs(n_steps / self.samples_per_batch - round(n_steps / self.samples_per_batch)) > 1e-9:
             raise ValueError(
-                "batch_days * steps_per_day must be an integer multiple of n_samples so every "
-                f"sample falls on an integration step; got {n_steps} steps for {self.n_samples} samples."
+                "batch_days * steps_per_day must be an integer multiple of samples_per_batch so every "
+                f"sample falls on an integration step; got {n_steps} steps for {self.samples_per_batch} samples."
             )
         for name, (low, high) in (("temp_bounds", self.temp_bounds), ("ph_bounds", self.ph_bounds)):
             if not (math.isfinite(low) and math.isfinite(high) and low < high):
@@ -573,17 +573,17 @@ class BioreactorConfig:
     @property
     def interval_days(self) -> float:
         """Duration of one setpoint interval (one recorded sample) [day]."""
-        return self.batch_days / self.n_samples
+        return self.batch_days / self.samples_per_batch
 
     @property
     def sample_days(self) -> np.ndarray:
         """Recording times, the end of each setpoint interval [day]."""
-        return np.linspace(self.interval_days, self.batch_days, self.n_samples)
+        return np.linspace(self.interval_days, self.batch_days, self.samples_per_batch)
 
     @property
     def interval_start_days(self) -> np.ndarray:
         """Setpoint interval start times, the index of a trajectory frame [day]."""
-        return np.linspace(0.0, self.batch_days - self.interval_days, self.n_samples)
+        return np.linspace(0.0, self.batch_days - self.interval_days, self.samples_per_batch)
 
 
 def _latent_effects(config: BioreactorConfig, latent: np.ndarray) -> tuple[float, float, float]:
@@ -760,7 +760,7 @@ class BioreactorSimulator:
         Returns
         -------
         pd.DataFrame
-            ``n_samples`` rows indexed by setpoint interval start time [day],
+            ``samples_per_batch`` rows indexed by setpoint interval start time [day],
             columns ``["pH", "temperature"]``. Each row is the setpoint held
             over the following interval (zero-order hold).
         """
@@ -783,8 +783,10 @@ class BioreactorSimulator:
         missing = [c for c in _TRAJECTORY_COLUMNS if c not in trajectory.columns]
         if missing:
             raise ValueError(f"trajectory is missing columns {missing}; it needs {list(_TRAJECTORY_COLUMNS)}.")
-        if len(trajectory) != cfg.n_samples:
-            raise ValueError(f"trajectory must have n_samples = {cfg.n_samples} rows; got {len(trajectory)}.")
+        if len(trajectory) != cfg.samples_per_batch:
+            raise ValueError(
+                f"trajectory must have samples_per_batch = {cfg.samples_per_batch} rows; got {len(trajectory)}."
+            )
         ph = trajectory["pH"].to_numpy(dtype=float)
         temperature = trajectory["temperature"].to_numpy(dtype=float)
         if not (np.all(np.isfinite(ph)) and np.all(np.isfinite(temperature))):
@@ -803,7 +805,7 @@ class BioreactorSimulator:
         Returns arrays of length ``n_steps + 1``; entry ``i`` is the setpoint
         in force during step ``i`` (the final entry repeats the last setpoint).
         """
-        steps_per_interval = self.config.n_steps // self.config.n_samples
+        steps_per_interval = self.config.n_steps // self.config.samples_per_batch
         ph_hourly = np.repeat(ph, steps_per_interval)
         temp_hourly = np.repeat(temperature, steps_per_interval)
         return (
@@ -856,7 +858,7 @@ class BioreactorSimulator:
         ph_err *= cfg.control_sd_ph * cfg.noise_scale
 
         # 4. Measurement noise on the recorded tags (noise channel).
-        meas = rng.standard_normal((cfg.n_samples, len(_TAG_COLUMNS))) * cfg.noise_scale
+        meas = rng.standard_normal((cfg.samples_per_batch, len(_TAG_COLUMNS))) * cfg.noise_scale
 
         return Bunch(feed_scale=feed_scale, phi=phi, temp_err=temp_err, ph_err=ph_err, meas=meas)
 
@@ -1025,7 +1027,7 @@ class BioreactorSimulator:
             variable names). ``None`` runs the nominal batch (all upstream
             variables at their means).
         trajectory : pd.DataFrame, optional
-            Setpoint schedule with ``n_samples`` rows and columns
+            Setpoint schedule with ``samples_per_batch`` rows and columns
             ``["pH", "temperature"]``; each row is held over its interval
             (zero-order hold). ``None`` uses :meth:`nominal_trajectory`.
         random_state : int, np.random.Generator, or None
@@ -1036,7 +1038,7 @@ class BioreactorSimulator:
         result : sklearn.utils.Bunch
             With keys:
 
-            - ``tags``: DataFrame, ``n_samples`` rows indexed by sample time
+            - ``tags``: DataFrame, ``samples_per_batch`` rows indexed by sample time
               [day], columns ``["pH", "temperature", "dissolved_oxygen",
               "offgas_co2", "volume"]``: what the historian records,
               including measurement noise.
@@ -1333,7 +1335,7 @@ class BioreactorSimulator:
         batches: dict = {}
         trajectories: dict = {}
         titers = np.empty(int(n_batches))
-        interval_fraction = np.linspace(0.0, 1.0, cfg.n_samples)
+        interval_fraction = np.linspace(0.0, 1.0, cfg.samples_per_batch)
 
         for row, (batch_id, child) in enumerate(zip(batch_ids, child_rngs, strict=True)):
             if policy == "adapted":
@@ -1447,7 +1449,7 @@ class BioreactorSimulator:
                 rows.append((f"sustained pH bias {sign * bias:+.2f}", titer, 100.0 * (titer - base) / base))
 
         one_sample = temp_set.copy()
-        mid = cfg.n_samples // 2
+        mid = cfg.samples_per_batch // 2
         one_sample[mid] = min(one_sample[mid] + 0.5, cfg.temp_bounds[1])
         titer = self._deterministic_titer(latent0, ph_set, one_sample)
         rows.append(("single-sample temperature excursion +0.5 degC", titer, 100.0 * (titer - base) / base))

--- a/src/process_improve/simulation/batch.py
+++ b/src/process_improve/simulation/batch.py
@@ -1238,6 +1238,8 @@ class BioreactorSimulator:
         trajectory: pd.DataFrame | None = None,
         initial_conditions: pd.DataFrame | None = None,
         mv_variation: float = 0.0,
+        n_knots: int = 4,
+        n_starts: int = 5,
         random_state: int | np.random.Generator | None = None,
     ) -> Bunch:
         """Simulate a campaign of batches under a named operating policy.
@@ -1272,6 +1274,10 @@ class BioreactorSimulator:
             temperature (standard deviation ``mv_variation`` degC each) and
             for pH (standard deviation ``0.1 * mv_variation`` each), clipped
             to the operating bounds.
+        n_knots, n_starts : int
+            Passed to :meth:`optimal_trajectory` for the ``"adapted"``
+            policy, which runs the optimiser once per batch; lower values
+            trade optimality for speed. Ignored by the other policies.
         random_state : int, np.random.Generator, or None
             Seed or generator; child seeds are spawned per batch, so a
             campaign is reproducible end to end.
@@ -1331,7 +1337,9 @@ class BioreactorSimulator:
 
         for row, (batch_id, child) in enumerate(zip(batch_ids, child_rngs, strict=True)):
             if policy == "adapted":
-                requested = self.optimal_trajectory(z_block.loc[batch_id], random_state=0).trajectory
+                requested = self.optimal_trajectory(
+                    z_block.loc[batch_id], n_knots=n_knots, n_starts=n_starts, random_state=0
+                ).trajectory
             elif policy == "historical" and mv_variation > 0:
                 offsets = rng.standard_normal(4)
                 temp_delta = mv_variation * (offsets[0] + offsets[1] * interval_fraction)

--- a/src/process_improve/simulation/batch.py
+++ b/src/process_improve/simulation/batch.py
@@ -947,21 +947,22 @@ class BioreactorSimulator:
         out = np.empty((n_steps + 1, 4))
         x, s, p, v = x0, s0, 0.0, cfg.volume_initial
         out[0] = (x, s, p, v)
-        half_h = 0.5 * h
+        hh = 0.5 * h
         sixth_h = h / 6.0
         for i in range(n_steps):
-            temp_a, temp_b = temp_hourly[i], temp_hourly[i + 1]
-            ph_a, ph_b = ph_hourly[i], ph_hourly[i + 1]
-            phi_a, phi_b = phi_hourly[i], phi_hourly[i + 1]
-            temp_m = 0.5 * (temp_a + temp_b)
-            ph_m = 0.5 * (ph_a + ph_b)
-            phi_m = 0.5 * (phi_a + phi_b)
+            # Every input (setpoint schedule, control error, phi) is held
+            # constant over its integration step, so setpoint jumps land
+            # exactly on step boundaries and RK4 keeps its full order.
+            # Blending across the boundary instead degrades the whole
+            # integration to first order.
+            temp = temp_hourly[i]
+            ph = ph_hourly[i]
+            phi = phi_hourly[i]
 
-            hh = half_h
-            k1 = rhs(x, s, p, v, temp_a, ph_a, phi_a)
-            k2 = rhs(x + hh * k1[0], s + hh * k1[1], p + hh * k1[2], v + hh * k1[3], temp_m, ph_m, phi_m)
-            k3 = rhs(x + hh * k2[0], s + hh * k2[1], p + hh * k2[2], v + hh * k2[3], temp_m, ph_m, phi_m)
-            k4 = rhs(x + h * k3[0], s + h * k3[1], p + h * k3[2], v + h * k3[3], temp_b, ph_b, phi_b)
+            k1 = rhs(x, s, p, v, temp, ph, phi)
+            k2 = rhs(x + hh * k1[0], s + hh * k1[1], p + hh * k1[2], v + hh * k1[3], temp, ph, phi)
+            k3 = rhs(x + hh * k2[0], s + hh * k2[1], p + hh * k2[2], v + hh * k2[3], temp, ph, phi)
+            k4 = rhs(x + h * k3[0], s + h * k3[1], p + h * k3[2], v + h * k3[3], temp, ph, phi)
 
             x += sixth_h * (k1[0] + 2.0 * k2[0] + 2.0 * k3[0] + k4[0])
             s += sixth_h * (k1[1] + 2.0 * k2[1] + 2.0 * k3[1] + k4[1])

--- a/src/process_improve/simulation/batch.py
+++ b/src/process_improve/simulation/batch.py
@@ -22,25 +22,48 @@ A 10-day fed-batch bioreactor with biomass ``X``, substrate ``S``, product
 gamma-concept model of Rosso et al. (1995): a cardinal temperature model with
 inflection (CTMI) multiplied by a cardinal pH model (CPM), each equal to 1 at
 its optimum and exactly 0 outside its cardinal range, further multiplied by
-Monod substrate limitation, a within-batch disturbance ``phi(t)`` and an
-initial-condition inhibition factor::
+Monod substrate limitation, a within-batch disturbance ``phi(t)``, an
+initial-condition growth-inhibition factor and an oxygen-limitation factor::
 
-    mu = mu_opt * gamma_T(T) * gamma_pH(pH) * S / (K_S + S) * phi * inh
-
-Two additional temperature effects make the industrially standard biphasic
-temperature shift (warm growth phase, mild-hypothermia production phase) a
-genuine trade-off rather than decoration: a thermal death rate that rises
-steeply above ``temp_death``, and a non-growth-associated specific
-productivity whose own cardinal optimum sits *below* the growth optimum.
-Product formation follows Luedeking and Piret (1959)::
+    mu_pot = mu_opt * gamma_T(T) * gamma_pH(pH) * S / (K_S + S) * phi * inh
+    f_O2   = smooth_min(1, our_capacity / ((o2_yield * mu_pot + o2_m) * X))
+    mu     = mu_pot * f_O2
 
     k_d = k_d0 * (1 + exp((T - temp_death) / width_death))
-    q_P = alpha_lp * mu + beta_lp * gamma_q(T) * gamma_pH(pH) * phi * inh
+          + k_d_starv * k_s_starv / (k_s_starv + S)
+          + k_d_hyp * (1 - f_O2)
+    q_P = (alpha_lp * mu + beta_lp * gamma_q(T) * gamma_pH(pH) * phi * f_O2)
+          * S / (k_sp + S)
 
     dX/dt = mu * X - k_d * X - (F/V) * X
-    dS/dt = -(mu / yield_xs + maintenance) * X + (F/V) * (feed_substrate - S)
+    dS/dt = -(mu / yield_xs + maintenance) * X - q_P * X / yield_ps
+            + (F/V) * (feed_substrate - S)
     dP/dt = q_P * X - (F/V) * P
     dV/dt = F
+
+The couplings are chosen so the industrially standard biphasic temperature
+shift (a warm growth phase, then a mild-hypothermia production phase) is a
+genuine optimum rather than decoration, and so the *right* schedule depends
+on the batch's own conditions:
+
+- The oxygen-transfer capacity caps the biomass pile the reactor can sustain,
+  and the cap is temperature-dependent because warmer cells each demand more
+  oxygen. Overshooting the cap is punished by hypoxic death, an irreversible
+  loss, so the optimal pile size is interior.
+- Strong hypothermic growth arrest below about 28 degC (the reason biphasic
+  mammalian-cell culture works) freezes the pile once the batch shifts cold,
+  so the *timing* of the shift decides the production capacity, and the right
+  timing depends on the inoculum and the growth rate the raw-material lot
+  supports.
+- Production consumes substrate (``yield_ps``) and stalls when it runs out
+  (``k_sp``); starvation kills cells (``k_d_starv``). Residual growth at
+  too-warm production temperatures burns the feed that production needs,
+  which is what places the production hold at an interior optimum
+  (``temp_production``) below the isolated productivity optimum
+  ``temp_q_opt``.
+- The growth-inhibition factor ``inh`` (from the raw-material impurity latent
+  factor) acts on growth only, so an inhibited lot needs a longer warm growth
+  phase, not a scaled-down copy of the same batch.
 
 The gamma hypothesis (temperature and pH acting independently on growth) is a
 modelling choice, not an established fact: published work finds the cardinal
@@ -57,19 +80,25 @@ responsive to real ones:
 - Quality is a time integral of bounded, smooth rates over 240 integration
   steps, so high-frequency input noise averages out and only sustained
   deviations accumulate.
-- The cardinal windows are physiological no-growth bounds (18 to 41.5 degC,
-  pH 5.9 to 8.2), not the operating range, so the response surface is gently
-  curved across the operating band.
-- The nominal pH sits at its optimum, where the response is stationary and
-  perturbations are second order.
+- The nominal recipe sits at stationary points of the response: pH is held at
+  its cardinal optimum, and the production-phase temperature hold is the
+  interior optimum of the hold-temperature response. Instrument-scale
+  deviations around a stationary point are second order.
+- Sustained multi-degree deviations, by contrast, cross real mechanisms
+  (hypothermic growth arrest on the cold side, feed-burning residual growth
+  and hypoxia on the warm side), so they cost percent-level titer, as they
+  should.
 
 :meth:`BioreactorSimulator.sensitivity_budget` computes the resulting budget
 from the live configuration, so the realism claim can be checked rather than
 taken on trust. Indicative values for the default configuration: zero-mean
-control-loop noise at instrument scale (sd 0.15 degC, 0.02 pH) moves the titer
-by well under half a percent, while a sustained 2 degC bias costs several
-percent and a sustained 3 degC bias far more. Overheating costs more than the
-same excursion undercooling, because of the thermal death term.
+control-loop noise at instrument scale (sd 0.15 degC, 0.02 pH) moves the
+final titer by under 0.3% (standard deviation), a sustained 0.1 degC bias
+costs about 0.2%, a sustained 0.02 pH bias is invisible (about 0.01%), while
+a sustained 1 degC bias costs 7 to 11% and a sustained 2 degC bias about
+20%. Around the operating point overheating costs more than the same
+excursion undercooling (feed burn plus hypoxia); far from it undercooling
+costs more (full growth arrest).
 
 Disturbance channels
 --------------------
@@ -277,6 +306,18 @@ class BioreactorConfig:
         Luedeking-Piret coefficients: growth-associated product yield
         [g product / g biomass] and non-growth-associated specific
         productivity [g product / g biomass / day].
+    yield_ps : float
+        Product yield on substrate [g product / g substrate]: production
+        consumes substrate, so a large biomass pile competes with its own
+        productivity for feed.
+    k_sp : float
+        Half-saturation substrate concentration for product formation [g/L]:
+        production stalls when the substrate runs out.
+    k_d_starv : float
+        Additional death rate under full starvation [1/day].
+    k_s_starv : float
+        Substrate concentration at which the starvation death rate reaches
+        half its maximum [g/L].
     temp_min, temp_opt, temp_max : float
         Cardinal temperatures for growth [degC].
     k_d0 : float
@@ -310,7 +351,13 @@ class BioreactorConfig:
         realised trajectories are validated or clipped against these.
     shift_start_day, shift_end_day : float
         Start and end [day] of the nominal biphasic temperature ramp from
-        ``temp_opt`` down to ``temp_q_opt``.
+        ``temp_opt`` down to ``temp_production``.
+    temp_production : float
+        The production-phase hold temperature of the nominal recipe [degC].
+        It sits below the isolated productivity optimum ``temp_q_opt``
+        because residual growth at warmer temperatures consumes the feed
+        that production needs; cold enough to arrest growth is what a
+        sensible recipe holds.
     ic_scale : float
         Scale of the measured initial-condition channel; 0 switches it off.
     within_batch_scale : float
@@ -339,7 +386,13 @@ class BioreactorConfig:
         Maintenance oxygen uptake [g O2 / g biomass / day].
     our_capacity : float
         Maximum oxygen transfer the sparger and agitation can supply
-        [g O2 / L / day]; sets how far dissolved oxygen is drawn down.
+        [g O2 / L / day]. This is the binding constraint of the process: it
+        caps the biomass pile the reactor can sustain, and the cap is
+        temperature-dependent because warmer cells demand more oxygen each.
+    k_d_hyp : float
+        Additional death rate under full oxygen limitation [1/day]:
+        overshooting the sustainable biomass pile is an irreversible loss,
+        which is what gives the optimal schedule curvature on both sides.
     rq : float
         Respiratory quotient, the CO2 evolved per O2 consumed [g/g].
     co2_gain : float
@@ -352,11 +405,17 @@ class BioreactorConfig:
     mu_opt: float = 0.80
     k_s: float = 0.20
     yield_xs: float = 0.40
-    maintenance: float = 0.015
+    maintenance: float = 0.02
     alpha_lp: float = 0.30
-    beta_lp: float = 0.40
-    # Cardinal temperatures for growth
-    temp_min: float = 18.0
+    beta_lp: float = 0.35
+    yield_ps: float = 0.90
+    k_sp: float = 0.10
+    k_d_starv: float = 0.08
+    k_s_starv: float = 0.12
+    # Cardinal temperatures for growth. temp_min models the strong hypothermic
+    # growth arrest that biphasic mammalian-cell culture relies on: growth is
+    # essentially zero at 28 degC while productivity remains high.
+    temp_min: float = 27.5
     temp_opt: float = 36.8
     temp_max: float = 41.5
     # Thermal death
@@ -368,15 +427,15 @@ class BioreactorConfig:
     temp_q_opt: float = 31.5
     temp_q_max: float = 40.5
     # Cardinal pH
-    ph_min: float = 5.9
+    ph_min: float = 6.3
     ph_opt: float = 7.10
-    ph_max: float = 8.2
+    ph_max: float = 7.9
     # Operation
     batch_days: float = 10.0
     n_samples: int = 20
     steps_per_day: int = 24
     feed_rate: float = 0.055
-    feed_substrate: float = 26.0
+    feed_substrate: float = 50.0
     volume_initial: float = 1.0
     biomass_initial: float = 0.30
     substrate_initial: float = 5.0
@@ -384,6 +443,7 @@ class BioreactorConfig:
     ph_bounds: tuple[float, float] = (6.6, 7.6)
     shift_start_day: float = 3.0
     shift_end_day: float = 4.5
+    temp_production: float = 29.05
     # Disturbance channel scales
     ic_scale: float = 1.0
     within_batch_scale: float = 1.0
@@ -402,10 +462,11 @@ class BioreactorConfig:
     meas_sd_do: float = 1.0
     meas_sd_co2: float = 0.08
     meas_sd_volume: float = 0.005
-    # Gas-phase model
+    # Oxygen transfer and gas-phase model
     o2_yield: float = 0.55
     o2_maintenance: float = 0.02
-    our_capacity: float = 3.0
+    our_capacity: float = 1.85
+    k_d_hyp: float = 0.40
     rq: float = 1.0
     co2_gain: float = 1.0
     co2_inlet_pct: float = 0.04
@@ -416,6 +477,9 @@ class BioreactorConfig:
             "mu_opt",
             "k_s",
             "yield_xs",
+            "yield_ps",
+            "k_sp",
+            "k_s_starv",
             "batch_days",
             "feed_substrate",
             "volume_initial",
@@ -434,6 +498,8 @@ class BioreactorConfig:
             "alpha_lp",
             "beta_lp",
             "k_d0",
+            "k_d_starv",
+            "k_d_hyp",
             "feed_rate",
             "ic_scale",
             "within_batch_scale",
@@ -494,6 +560,10 @@ class BioreactorConfig:
                 "The nominal temperature shift must satisfy 0 <= shift_start_day <= shift_end_day <= "
                 f"batch_days; got ({self.shift_start_day}, {self.shift_end_day}, {self.batch_days})."
             )
+        if not self.temp_bounds[0] <= self.temp_production <= self.temp_bounds[1]:
+            raise ValueError(
+                f"temp_production must lie within temp_bounds {self.temp_bounds}; got {self.temp_production}."
+            )
 
     @property
     def n_steps(self) -> int:
@@ -532,13 +602,15 @@ def _latent_effects(config: BioreactorConfig, latent: np.ndarray) -> tuple[float
     tuple[float, float, float]
         ``(biomass_initial, substrate_initial, inhibition)`` for this batch:
         the perturbed initial concentrations [g/L] and the multiplicative
-        growth/productivity inhibition factor in (0, 1].
+        growth-inhibition factor in (0, 1]. The inhibition acts on growth
+        only, which is why an inhibited lot calls for a different schedule
+        (a longer warm growth phase) rather than a scaled-down copy.
     """
     scale = config.ic_scale
     viability, richness, inhibitor = (float(v) for v in latent)
     x0 = config.biomass_initial * min(max(1.0 + 0.18 * scale * viability, 0.40), 1.80)
-    s0 = config.substrate_initial * min(max(1.0 + 0.12 * scale * richness, 0.50), 1.60)
-    inhibition = min(max(1.0 - 0.10 * scale * max(inhibitor, 0.0), 0.55), 1.0)
+    s0 = config.substrate_initial * min(max(1.0 + 0.20 * scale * richness, 0.50), 1.60)
+    inhibition = min(max(1.0 - 0.12 * scale * max(inhibitor, 0.0), 0.55), 1.0)
     return x0, s0, inhibition
 
 
@@ -680,10 +752,10 @@ class BioreactorSimulator:
         """Return the nominal (recipe) setpoint schedule: biphasic temperature, pH held.
 
         Temperature holds the growth optimum until ``shift_start_day``, ramps
-        linearly to the productivity optimum by ``shift_end_day``, and holds it
-        for the rest of the batch. pH is held at its cardinal optimum
-        throughout, matching the industrial practice of holding pH and
-        shifting temperature.
+        linearly to the production hold ``temp_production`` by
+        ``shift_end_day``, and holds it for the rest of the batch. pH is held
+        at its cardinal optimum throughout, matching the industrial practice
+        of holding pH and shifting temperature.
 
         Returns
         -------
@@ -698,7 +770,7 @@ class BioreactorSimulator:
             fraction = np.clip((days - cfg.shift_start_day) / (cfg.shift_end_day - cfg.shift_start_day), 0.0, 1.0)
         else:
             fraction = (days >= cfg.shift_start_day).astype(float)
-        temperature = cfg.temp_opt - (cfg.temp_opt - cfg.temp_q_opt) * fraction
+        temperature = cfg.temp_opt - (cfg.temp_opt - cfg.temp_production) * fraction
         temperature = np.clip(temperature, cfg.temp_bounds[0], cfg.temp_bounds[1])
         ph = np.clip(np.full_like(days, cfg.ph_opt), cfg.ph_bounds[0], cfg.ph_bounds[1])
         return pd.DataFrame({"pH": ph, "temperature": temperature}, index=pd.Index(days, name="day"))
@@ -820,9 +892,17 @@ class BioreactorSimulator:
         mu_opt = cfg.mu_opt
         k_s = cfg.k_s
         inv_yield = 1.0 / cfg.yield_xs
+        inv_yield_ps = 1.0 / cfg.yield_ps
         maintenance = cfg.maintenance
         alpha_lp = cfg.alpha_lp
         beta_lp = cfg.beta_lp
+        k_sp = cfg.k_sp
+        k_d_starv = cfg.k_d_starv
+        k_s_starv = cfg.k_s_starv
+        o2_yield = cfg.o2_yield
+        o2_maintenance = cfg.o2_maintenance
+        our_capacity = cfg.our_capacity
+        k_d_hyp = cfg.k_d_hyp
         t_min, t_opt, t_max = cfg.temp_min, cfg.temp_opt, cfg.temp_max
         tq_min, tq_opt, tq_max = cfg.temp_q_min, cfg.temp_q_opt, cfg.temp_q_max
         p_min, p_opt, p_max = cfg.ph_min, cfg.ph_opt, cfg.ph_max
@@ -834,18 +914,32 @@ class BioreactorSimulator:
 
         def rhs(x: float, s: float, p: float, v: float, temp: float, ph: float, phi: float) -> tuple:  # noqa: PLR0913
             gamma_ph = _cardinal_ph_f(ph, p_min, p_opt, p_max)
-            mu = mu_opt * _cardinal_temperature_f(temp, t_min, t_opt, t_max) * gamma_ph
-            mu *= s / (k_s + s) * phi * inhibition
-            k_d = k_d0 * (1.0 + math.exp((temp - temp_death) / width_death))
-            # The non-growth-associated production term carries phi and the
-            # inhibition factor directly; the growth-associated term already
-            # carries them inside mu.
-            q_p = alpha_lp * mu + (
-                beta_lp * _cardinal_temperature_f(temp, tq_min, tq_opt, tq_max) * gamma_ph * phi * inhibition
+            mu_pot = mu_opt * _cardinal_temperature_f(temp, t_min, t_opt, t_max) * gamma_ph
+            # The impurity-driven inhibition factor acts on growth only; the
+            # within-batch disturbance phi acts on the whole metabolism.
+            mu_pot *= s / (k_s + s) * phi * inhibition
+            # Oxygen limitation: the pile's demand against the reactor's
+            # transfer capacity. f is a smooth min(1, supply/demand), so
+            # metabolism throttles as the pile approaches the ceiling, and
+            # hypoxia kills cells beyond it. This mirrors _gas_tags.
+            demand = (o2_yield * mu_pot + o2_maintenance) * x
+            a = our_capacity / max(demand, 1e-12)
+            f_o2 = a / (1.0 + a**6) ** (1.0 / 6.0)
+            mu = mu_pot * f_o2
+            k_d = (
+                k_d0 * (1.0 + math.exp((temp - temp_death) / width_death))
+                + k_d_starv * k_s_starv / (k_s_starv + s)
+                + k_d_hyp * (1.0 - f_o2)
             )
+            # Production consumes substrate and stalls when it runs out; it is
+            # oxygen-limited like growth (the growth-associated term already
+            # carries phi and f_o2 inside mu).
+            q_p = (
+                alpha_lp * mu + beta_lp * _cardinal_temperature_f(temp, tq_min, tq_opt, tq_max) * gamma_ph * phi * f_o2
+            ) * (s / (k_sp + s))
             dilution = feed / v
             dx = mu * x - k_d * x - dilution * x
-            ds = -(mu * inv_yield + maintenance) * x + dilution * (s_feed - s)
+            ds = -(mu * inv_yield + maintenance) * x - q_p * x * inv_yield_ps + dilution * (s_feed - s)
             dp = q_p * x - dilution * p
             dv = feed
             return dx, ds, dp, dv
@@ -885,16 +979,28 @@ class BioreactorSimulator:
             out[i + 1] = (x, s, p, v)
         return out
 
-    def _gas_tags(self, states: np.ndarray, temp: np.ndarray, ph: np.ndarray, phi: np.ndarray) -> Bunch:
-        """Dissolved oxygen [%] and offgas CO2 [%] at every grid point."""
+    def _gas_tags(
+        self, states: np.ndarray, temp: np.ndarray, ph: np.ndarray, phi: np.ndarray, inhibition: float
+    ) -> Bunch:
+        """Dissolved oxygen [%] and offgas CO2 [%] at every grid point.
+
+        Uses the same specific growth rate as the integrator (including the
+        within-batch disturbance and the growth inhibition factor), so the
+        gas trajectories reflect what the cells are actually doing. This is
+        what makes the unmeasured disturbance channel observable.
+        """
         cfg = self.config
         biomass = states[:, 0]
         substrate = states[:, 1]
         gamma_t = cardinal_temperature(temp, cfg.temp_min, cfg.temp_opt, cfg.temp_max)
         gamma_p = cardinal_ph(ph, cfg.ph_min, cfg.ph_opt, cfg.ph_max)
         monod = substrate / (cfg.k_s + substrate)
-        mu = cfg.mu_opt * gamma_t * gamma_p * monod * phi
-        our = (cfg.o2_yield * mu + cfg.o2_maintenance) * biomass
+        # Mirrors the oxygen-limitation calculation in _integrate's rhs.
+        mu_pot = cfg.mu_opt * gamma_t * gamma_p * monod * phi * inhibition
+        demand = (cfg.o2_yield * mu_pot + cfg.o2_maintenance) * biomass
+        a = cfg.our_capacity / np.maximum(demand, 1e-12)
+        f_o2 = a / (1.0 + a**6) ** (1.0 / 6.0)
+        our = (cfg.o2_yield * mu_pot * f_o2 + cfg.o2_maintenance) * biomass
         dissolved_oxygen = 100.0 * np.clip(1.0 - our / cfg.our_capacity, 0.03, 1.0)
         offgas_co2 = cfg.co2_inlet_pct + cfg.co2_gain * cfg.rq * our
         return Bunch(dissolved_oxygen=dissolved_oxygen, offgas_co2=offgas_co2)
@@ -959,7 +1065,7 @@ class BioreactorSimulator:
         ph_real = np.clip(ph_hourly + disturbances.ph_err, cfg.ph_bounds[0], cfg.ph_bounds[1])
 
         states = self._integrate(ph_real, temp_real, disturbances.phi, x0, s0, inhibition, disturbances.feed_scale)
-        gas = self._gas_tags(states, temp_real, ph_real, disturbances.phi)
+        gas = self._gas_tags(states, temp_real, ph_real, disturbances.phi, inhibition)
 
         grid_days = np.linspace(0.0, cfg.batch_days, cfg.n_steps + 1)
         sample_idx = np.round(cfg.sample_days * cfg.steps_per_day).astype(int)

--- a/src/process_improve/simulation/batch.py
+++ b/src/process_improve/simulation/batch.py
@@ -1,0 +1,1428 @@
+# (c) Kevin Dunn, 2010-2026. MIT License.
+"""A deterministic fed-batch bioreactor simulator with tunable disturbance channels.
+
+Purpose
+-------
+This module is the quantitative baseline for batch trajectory adaptation and,
+later, batch mid-course correction. It makes three claims demonstrable, with
+numbers a reader can reproduce exactly from a seed:
+
+1. Replaying a "golden batch" trajectory open-loop does not reproduce the
+   golden outcome, because each batch carries its own disturbances.
+2. The spread persists even when the measured initial conditions are held
+   identical, because disturbances also arise *during* the batch.
+3. The quality variance under replay therefore decomposes into a bucket that
+   pre-batch (feedforward) adaptation can address, a bucket that only
+   mid-course (feedback) correction can address, and a noise floor.
+
+The model
+---------
+A 10-day fed-batch bioreactor with biomass ``X``, substrate ``S``, product
+(titer) ``P`` and working volume ``V``. The specific growth rate follows the
+gamma-concept model of Rosso et al. (1995): a cardinal temperature model with
+inflection (CTMI) multiplied by a cardinal pH model (CPM), each equal to 1 at
+its optimum and exactly 0 outside its cardinal range, further multiplied by
+Monod substrate limitation, a within-batch disturbance ``phi(t)`` and an
+initial-condition inhibition factor::
+
+    mu = mu_opt * gamma_T(T) * gamma_pH(pH) * S / (K_S + S) * phi * inh
+
+Two additional temperature effects make the industrially standard biphasic
+temperature shift (warm growth phase, mild-hypothermia production phase) a
+genuine trade-off rather than decoration: a thermal death rate that rises
+steeply above ``temp_death``, and a non-growth-associated specific
+productivity whose own cardinal optimum sits *below* the growth optimum.
+Product formation follows Luedeking and Piret (1959)::
+
+    k_d = k_d0 * (1 + exp((T - temp_death) / width_death))
+    q_P = alpha_lp * mu + beta_lp * gamma_q(T) * gamma_pH(pH) * phi * inh
+
+    dX/dt = mu * X - k_d * X - (F/V) * X
+    dS/dt = -(mu / yield_xs + maintenance) * X + (F/V) * (feed_substrate - S)
+    dP/dt = q_P * X - (F/V) * P
+    dV/dt = F
+
+The gamma hypothesis (temperature and pH acting independently on growth) is a
+modelling choice, not an established fact: published work finds the cardinal
+temperatures themselves shift with pH. It is adopted here because it keeps the
+true optimum interpretable in closed form.
+
+Sensitivity by construction
+---------------------------
+A simulator whose quality output moves visibly when an input moves by less
+than an instrument can resolve is not believable. Three structural properties
+keep this model insensitive to meaningless input changes while still
+responsive to real ones:
+
+- Quality is a time integral of bounded, smooth rates over 240 integration
+  steps, so high-frequency input noise averages out and only sustained
+  deviations accumulate.
+- The cardinal windows are physiological no-growth bounds (18 to 41.5 degC,
+  pH 5.9 to 8.2), not the operating range, so the response surface is gently
+  curved across the operating band.
+- The nominal pH sits at its optimum, where the response is stationary and
+  perturbations are second order.
+
+:meth:`BioreactorSimulator.sensitivity_budget` computes the resulting budget
+from the live configuration, so the realism claim can be checked rather than
+taken on trust. Indicative values for the default configuration: zero-mean
+control-loop noise at instrument scale (sd 0.15 degC, 0.02 pH) moves the titer
+by well under half a percent, while a sustained 2 degC bias costs several
+percent and a sustained 3 degC bias far more. Overheating costs more than the
+same excursion undercooling, because of the thermal death term.
+
+Disturbance channels
+--------------------
+Three independently tunable channels, each with a scale that can be set to
+zero (``ic_scale``, ``within_batch_scale``, ``noise_scale``):
+
+1. Measured initial conditions: an 11-variable upstream ``Z`` block generated
+   from three latent factors (seed viability, medium richness, inhibitor
+   level) with three cluster centres, the feed classes A, B and C. Only the
+   three latent factors drive the process, so ``Z`` also carries directions
+   that do not matter, as real upstream data do.
+2. Within-batch, unmeasured but observable: an Ornstein-Uhlenbeck process on
+   ``log phi(t)`` with a correlation time comparable to the batch length,
+   plus a per-batch feed-rate drift. It is not predictable from ``Z``, is
+   continuously visible in the oxygen and offgas trajectories, and its
+   present partly predicts its own future, which is exactly why observing
+   the running batch helps.
+3. Control-loop and measurement noise: autocorrelated zero-mean deviation of
+   the realised trajectory from its setpoints, plus independent measurement
+   noise on every recorded tag, at instrument scale.
+
+All random draws are made on every call and multiplied by their channel
+scale, so setting a scale to zero removes that channel without changing the
+draw sequence of the others: the same seed with a channel switched off is a
+true counterfactual for the same batch.
+
+References
+----------
+Rosso, L., Lobry, J. R., Bajard, S. and Flandrois, J. P. (1995), "Convenient
+model to describe the combined effects of temperature and pH on microbial
+growth", *Applied and Environmental Microbiology*, **61** (2), 610-616.
+
+Luedeking, R. and Piret, E. L. (1959), "A kinetic study of the lactic acid
+fermentation", *Journal of Biochemical and Microbiological Technology and
+Engineering*, **1** (4), 393-412.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import math
+
+import numpy as np
+import pandas as pd
+from sklearn.utils import Bunch
+
+from process_improve._random import check_random_state
+
+logger = logging.getLogger(__name__)
+
+# Names of the 11 upstream (initial-condition) variables in the Z block.
+UPSTREAM_VARIABLE_NAMES: tuple[str, ...] = (
+    "seed_viability_pct",
+    "seed_age_h",
+    "inoculum_density_e6_per_ml",
+    "media_glucose_g_L",
+    "media_glutamine_mM",
+    "media_osmolality_mOsm_kg",
+    "media_lot_age_d",
+    "trace_metal_index",
+    "impurity_index",
+    "water_conductivity_uS_cm",
+    "supplier_lot_score",
+)
+
+# Latent factor names, in order: they are the only directions in Z that
+# actually drive the process.
+LATENT_FACTOR_NAMES: tuple[str, ...] = ("seed_viability", "medium_richness", "inhibitor_level")
+
+# Fixed loading matrix (3 latent factors x 11 standardized upstream
+# variables). These are constants, not draws, so the Z-to-process mapping is
+# identical across sessions, platforms and package versions.
+_Z_LOADINGS: np.ndarray = np.array(
+    [
+        # viability: seed quality and inoculum variables
+        [0.90, -0.70, 0.80, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.30],
+        # richness: medium composition variables
+        [0.00, 0.00, 0.00, 0.90, 0.85, 0.50, -0.60, 0.55, 0.00, 0.00, 0.00],
+        # inhibitor: impurity-related variables
+        [0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.35, 0.00, 0.90, 0.60, -0.50],
+    ]
+)
+
+# Means and standard deviations that place the standardized Z variables on
+# plausible physical scales (units are in the variable names).
+_Z_MEANS: np.ndarray = np.array([92.0, 48.0, 2.5, 6.0, 4.0, 300.0, 30.0, 1.0, 1.0, 1.2, 8.0])
+_Z_SDS: np.ndarray = np.array([4.0, 10.0, 0.5, 0.5, 0.5, 15.0, 12.0, 0.2, 0.4, 0.3, 1.0])
+
+# Residual (non-latent) standardized noise on each Z variable.
+_Z_RESIDUAL_SD: float = 0.35
+
+# Cluster centres of the three feed-disturbance classes in latent space, and
+# the within-cluster standard deviation.
+_CLASS_CENTRES: dict[str, tuple[float, float, float]] = {
+    "A": (0.8, 0.6, -0.8),
+    "B": (0.0, 0.0, 0.0),
+    "C": (-0.8, -0.6, 1.0),
+}
+_CLASS_SD: float = 0.55
+
+_DEFAULT_CLASS_PROPORTIONS: dict[str, float] = {"A": 0.40, "B": 0.35, "C": 0.25}
+
+_TAG_COLUMNS: tuple[str, ...] = ("pH", "temperature", "dissolved_oxygen", "offgas_co2", "volume")
+_TRAJECTORY_COLUMNS: tuple[str, ...] = ("pH", "temperature")
+_POLICIES: tuple[str, ...] = ("replay", "historical", "adapted")
+
+
+def cardinal_temperature(temperature: float | np.ndarray, t_min: float, t_opt: float, t_max: float) -> np.ndarray:
+    """Cardinal temperature model with inflection (CTMI) of Rosso et al. (1995).
+
+    Equal to 1 at ``t_opt``, exactly 0 at and beyond the cardinal bounds, and
+    smoothly curved in between with an inflection in the suboptimal range.
+
+    Parameters
+    ----------
+    temperature : float or np.ndarray
+        Temperature(s) [degC].
+    t_min, t_opt, t_max : float
+        Cardinal temperatures [degC]: no growth at or below ``t_min``, maximum
+        growth at ``t_opt``, no growth at or above ``t_max``.
+
+    Returns
+    -------
+    np.ndarray
+        The dimensionless growth factor gamma_T in [0, 1], with the same shape
+        as ``temperature``.
+    """
+    temp = np.asarray(temperature, dtype=float)
+    numerator = (temp - t_max) * (temp - t_min) ** 2
+    denominator = (t_opt - t_min) * ((t_opt - t_min) * (temp - t_opt) - (t_opt - t_max) * (t_opt + t_min - 2.0 * temp))
+    with np.errstate(divide="ignore", invalid="ignore"):
+        gamma = np.where((temp <= t_min) | (temp >= t_max), 0.0, numerator / denominator)
+    return np.clip(gamma, 0.0, 1.0)
+
+
+def cardinal_ph(ph: float | np.ndarray, ph_min: float, ph_opt: float, ph_max: float) -> np.ndarray:
+    """Cardinal pH model (CPM) of Rosso et al. (1995).
+
+    Equal to 1 at ``ph_opt`` and exactly 0 at and beyond the cardinal bounds.
+
+    Parameters
+    ----------
+    ph : float or np.ndarray
+        pH value(s) [-].
+    ph_min, ph_opt, ph_max : float
+        Cardinal pH values: no growth at or below ``ph_min``, maximum growth
+        at ``ph_opt``, no growth at or above ``ph_max``.
+
+    Returns
+    -------
+    np.ndarray
+        The dimensionless growth factor gamma_pH in [0, 1], with the same
+        shape as ``ph``.
+    """
+    ph_arr = np.asarray(ph, dtype=float)
+    numerator = (ph_arr - ph_min) * (ph_arr - ph_max)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        gamma = np.where(
+            (ph_arr <= ph_min) | (ph_arr >= ph_max),
+            0.0,
+            numerator / (numerator - (ph_arr - ph_opt) ** 2),
+        )
+    return np.clip(gamma, 0.0, 1.0)
+
+
+def _cardinal_temperature_f(temp: float, t_min: float, t_opt: float, t_max: float) -> float:
+    """Scalar-float CTMI for the integration hot loop (see :func:`cardinal_temperature`)."""
+    if temp <= t_min or temp >= t_max:
+        return 0.0
+    numerator = (temp - t_max) * (temp - t_min) ** 2
+    denominator = (t_opt - t_min) * ((t_opt - t_min) * (temp - t_opt) - (t_opt - t_max) * (t_opt + t_min - 2.0 * temp))
+    return min(max(numerator / denominator, 0.0), 1.0)
+
+
+def _cardinal_ph_f(ph: float, ph_min: float, ph_opt: float, ph_max: float) -> float:
+    """Scalar-float CPM for the integration hot loop (see :func:`cardinal_ph`)."""
+    if ph <= ph_min or ph >= ph_max:
+        return 0.0
+    numerator = (ph - ph_min) * (ph - ph_max)
+    return min(max(numerator / (numerator - (ph - ph_opt) ** 2), 0.0), 1.0)
+
+
+@dataclasses.dataclass(frozen=True)
+class BioreactorConfig:
+    """Kinetic, operating and disturbance parameters of the simulated bioreactor.
+
+    All parameters have defaults chosen so the nominal batch lands in a
+    physiologically plausible range for a pilot-scale mammalian-cell fed-batch
+    process (peak biomass a few g/L, final titer of order 10 g/L). Units are
+    given per field. The dataclass is frozen; derive variants with
+    :func:`dataclasses.replace`.
+
+    Parameters
+    ----------
+    mu_opt : float
+        Maximum specific growth rate at the cardinal optima [1/day].
+    k_s : float
+        Monod half-saturation constant for the substrate [g/L].
+    yield_xs : float
+        Biomass yield on substrate [g biomass / g substrate].
+    maintenance : float
+        Maintenance substrate consumption [g substrate / g biomass / day].
+    alpha_lp, beta_lp : float
+        Luedeking-Piret coefficients: growth-associated product yield
+        [g product / g biomass] and non-growth-associated specific
+        productivity [g product / g biomass / day].
+    temp_min, temp_opt, temp_max : float
+        Cardinal temperatures for growth [degC].
+    k_d0 : float
+        Baseline first-order death rate [1/day].
+    temp_death, width_death : float
+        Onset temperature [degC] and width [degC] of the exponential rise in
+        the death rate.
+    temp_q_min, temp_q_opt, temp_q_max : float
+        Cardinal temperatures for the non-growth-associated productivity
+        [degC]; ``temp_q_opt`` sits below ``temp_opt``, which is what makes
+        the biphasic temperature shift a real trade-off.
+    ph_min, ph_opt, ph_max : float
+        Cardinal pH values, shared by growth and productivity.
+    batch_days : float
+        Batch duration [day].
+    n_samples : int
+        Number of recorded samples (and setpoint intervals) per batch.
+    steps_per_day : int
+        Integration steps per day for the fixed-step RK4 integrator.
+    feed_rate : float
+        Nominal constant feed rate [L/day].
+    feed_substrate : float
+        Substrate concentration in the feed [g/L].
+    volume_initial : float
+        Working volume at inoculation [L].
+    biomass_initial, substrate_initial : float
+        Nominal initial biomass and substrate concentrations [g/L]; the
+        measured initial-condition channel perturbs these per batch.
+    temp_bounds, ph_bounds : tuple[float, float]
+        Recipe-allowed operating window for the setpoints; requested and
+        realised trajectories are validated or clipped against these.
+    shift_start_day, shift_end_day : float
+        Start and end [day] of the nominal biphasic temperature ramp from
+        ``temp_opt`` down to ``temp_q_opt``.
+    ic_scale : float
+        Scale of the measured initial-condition channel; 0 switches it off.
+    within_batch_scale : float
+        Scale of the unmeasured within-batch channel; 0 switches it off.
+    noise_scale : float
+        Scale of the control-loop and measurement noise channel; 0 switches
+        it off.
+    ou_tau_days : float
+        Correlation time of the Ornstein-Uhlenbeck disturbance on
+        ``log phi(t)`` [day].
+    ou_sd : float
+        Stationary standard deviation of ``log phi(t)`` [-].
+    feed_drift_sd : float
+        Per-batch fractional standard deviation of the realised feed rate [-].
+    control_sd_temp, control_sd_ph : float
+        Stationary standard deviation of the realised-minus-setpoint control
+        error for temperature [degC] and pH [-].
+    control_tau_h : float
+        Correlation time of the control error [hour].
+    meas_sd_temp, meas_sd_ph, meas_sd_do, meas_sd_co2, meas_sd_volume : float
+        Measurement noise standard deviations on the recorded tags
+        [degC, -, % saturation, % offgas, L].
+    o2_yield : float
+        Oxygen demand per unit growth [g O2 / g biomass].
+    o2_maintenance : float
+        Maintenance oxygen uptake [g O2 / g biomass / day].
+    our_capacity : float
+        Maximum oxygen transfer the sparger and agitation can supply
+        [g O2 / L / day]; sets how far dissolved oxygen is drawn down.
+    rq : float
+        Respiratory quotient, the CO2 evolved per O2 consumed [g/g].
+    co2_gain : float
+        Offgas CO2 percentage per unit CO2 evolution rate [% / (g/L/day)].
+    co2_inlet_pct : float
+        CO2 percentage of the inlet gas [%].
+    """
+
+    # Kinetics
+    mu_opt: float = 0.80
+    k_s: float = 0.20
+    yield_xs: float = 0.40
+    maintenance: float = 0.015
+    alpha_lp: float = 0.30
+    beta_lp: float = 0.40
+    # Cardinal temperatures for growth
+    temp_min: float = 18.0
+    temp_opt: float = 36.8
+    temp_max: float = 41.5
+    # Thermal death
+    k_d0: float = 0.015
+    temp_death: float = 39.0
+    width_death: float = 0.9
+    # Cardinal temperatures for non-growth-associated productivity
+    temp_q_min: float = 22.0
+    temp_q_opt: float = 31.5
+    temp_q_max: float = 40.5
+    # Cardinal pH
+    ph_min: float = 5.9
+    ph_opt: float = 7.10
+    ph_max: float = 8.2
+    # Operation
+    batch_days: float = 10.0
+    n_samples: int = 20
+    steps_per_day: int = 24
+    feed_rate: float = 0.055
+    feed_substrate: float = 26.0
+    volume_initial: float = 1.0
+    biomass_initial: float = 0.30
+    substrate_initial: float = 5.0
+    temp_bounds: tuple[float, float] = (28.0, 39.0)
+    ph_bounds: tuple[float, float] = (6.6, 7.6)
+    shift_start_day: float = 3.0
+    shift_end_day: float = 4.5
+    # Disturbance channel scales
+    ic_scale: float = 1.0
+    within_batch_scale: float = 1.0
+    noise_scale: float = 1.0
+    # Within-batch channel
+    ou_tau_days: float = 6.0
+    ou_sd: float = 0.15
+    feed_drift_sd: float = 0.06
+    # Control-loop error
+    control_sd_temp: float = 0.15
+    control_sd_ph: float = 0.02
+    control_tau_h: float = 6.0
+    # Measurement noise
+    meas_sd_temp: float = 0.05
+    meas_sd_ph: float = 0.01
+    meas_sd_do: float = 1.0
+    meas_sd_co2: float = 0.08
+    meas_sd_volume: float = 0.005
+    # Gas-phase model
+    o2_yield: float = 0.55
+    o2_maintenance: float = 0.02
+    our_capacity: float = 3.0
+    rq: float = 1.0
+    co2_gain: float = 1.0
+    co2_inlet_pct: float = 0.04
+
+    def __post_init__(self) -> None:  # noqa: C901, PLR0912
+        """Validate parameter relationships that the model depends on."""
+        for name in (
+            "mu_opt",
+            "k_s",
+            "yield_xs",
+            "batch_days",
+            "feed_substrate",
+            "volume_initial",
+            "biomass_initial",
+            "substrate_initial",
+            "ou_tau_days",
+            "control_tau_h",
+            "our_capacity",
+            "width_death",
+        ):
+            value = getattr(self, name)
+            if not (isinstance(value, (int, float)) and math.isfinite(value) and value > 0):
+                raise ValueError(f"{name} must be a finite positive number; got {value!r}.")
+        for name in (
+            "maintenance",
+            "alpha_lp",
+            "beta_lp",
+            "k_d0",
+            "feed_rate",
+            "ic_scale",
+            "within_batch_scale",
+            "noise_scale",
+            "ou_sd",
+            "feed_drift_sd",
+            "control_sd_temp",
+            "control_sd_ph",
+            "meas_sd_temp",
+            "meas_sd_ph",
+            "meas_sd_do",
+            "meas_sd_co2",
+            "meas_sd_volume",
+        ):
+            value = getattr(self, name)
+            if not (isinstance(value, (int, float)) and math.isfinite(value) and value >= 0):
+                raise ValueError(f"{name} must be a finite non-negative number; got {value!r}.")
+        if not self.temp_min < self.temp_opt < self.temp_max:
+            raise ValueError(
+                "Cardinal temperatures must satisfy temp_min < temp_opt < temp_max; got "
+                f"({self.temp_min}, {self.temp_opt}, {self.temp_max})."
+            )
+        if not self.temp_q_min < self.temp_q_opt < self.temp_q_max:
+            raise ValueError(
+                "Productivity cardinal temperatures must satisfy temp_q_min < temp_q_opt < temp_q_max; got "
+                f"({self.temp_q_min}, {self.temp_q_opt}, {self.temp_q_max})."
+            )
+        if not self.ph_min < self.ph_opt < self.ph_max:
+            raise ValueError(
+                f"Cardinal pH values must satisfy ph_min < ph_opt < ph_max; got "
+                f"({self.ph_min}, {self.ph_opt}, {self.ph_max})."
+            )
+        if self.n_samples < 2:
+            raise ValueError(f"n_samples must be at least 2; got {self.n_samples}.")
+        if self.steps_per_day < 1:
+            raise ValueError(f"steps_per_day must be at least 1; got {self.steps_per_day}.")
+        n_steps = self.batch_days * self.steps_per_day
+        if abs(n_steps / self.n_samples - round(n_steps / self.n_samples)) > 1e-9:
+            raise ValueError(
+                "batch_days * steps_per_day must be an integer multiple of n_samples so every "
+                f"sample falls on an integration step; got {n_steps} steps for {self.n_samples} samples."
+            )
+        for name, (low, high) in (("temp_bounds", self.temp_bounds), ("ph_bounds", self.ph_bounds)):
+            if not (math.isfinite(low) and math.isfinite(high) and low < high):
+                raise ValueError(f"{name} must be a finite (low, high) pair with low < high; got ({low}, {high}).")
+        if not self.temp_min < self.temp_bounds[0] < self.temp_bounds[1] < self.temp_max:
+            raise ValueError(
+                f"temp_bounds {self.temp_bounds} must lie strictly inside the cardinal window "
+                f"({self.temp_min}, {self.temp_max})."
+            )
+        if not self.ph_min < self.ph_bounds[0] < self.ph_bounds[1] < self.ph_max:
+            raise ValueError(
+                f"ph_bounds {self.ph_bounds} must lie strictly inside the cardinal window "
+                f"({self.ph_min}, {self.ph_max})."
+            )
+        if not 0 <= self.shift_start_day <= self.shift_end_day <= self.batch_days:
+            raise ValueError(
+                "The nominal temperature shift must satisfy 0 <= shift_start_day <= shift_end_day <= "
+                f"batch_days; got ({self.shift_start_day}, {self.shift_end_day}, {self.batch_days})."
+            )
+
+    @property
+    def n_steps(self) -> int:
+        """Total number of RK4 integration steps per batch."""
+        return round(self.batch_days * self.steps_per_day)
+
+    @property
+    def interval_days(self) -> float:
+        """Duration of one setpoint interval (one recorded sample) [day]."""
+        return self.batch_days / self.n_samples
+
+    @property
+    def sample_days(self) -> np.ndarray:
+        """Recording times, the end of each setpoint interval [day]."""
+        return np.linspace(self.interval_days, self.batch_days, self.n_samples)
+
+    @property
+    def interval_start_days(self) -> np.ndarray:
+        """Setpoint interval start times, the index of a trajectory frame [day]."""
+        return np.linspace(0.0, self.batch_days - self.interval_days, self.n_samples)
+
+
+def _latent_effects(config: BioreactorConfig, latent: np.ndarray) -> tuple[float, float, float]:
+    """Map the three latent initial-condition factors to their process effects.
+
+    Parameters
+    ----------
+    config : BioreactorConfig
+        Configuration supplying the nominal values and ``ic_scale``.
+    latent : np.ndarray
+        The three latent factor values (seed viability, medium richness,
+        inhibitor level) in standardized units.
+
+    Returns
+    -------
+    tuple[float, float, float]
+        ``(biomass_initial, substrate_initial, inhibition)`` for this batch:
+        the perturbed initial concentrations [g/L] and the multiplicative
+        growth/productivity inhibition factor in (0, 1].
+    """
+    scale = config.ic_scale
+    viability, richness, inhibitor = (float(v) for v in latent)
+    x0 = config.biomass_initial * min(max(1.0 + 0.18 * scale * viability, 0.40), 1.80)
+    s0 = config.substrate_initial * min(max(1.0 + 0.12 * scale * richness, 0.50), 1.60)
+    inhibition = min(max(1.0 - 0.10 * scale * max(inhibitor, 0.0), 0.55), 1.0)
+    return x0, s0, inhibition
+
+
+def _z_to_latent(z_row: np.ndarray) -> np.ndarray:
+    """Recover the three latent factors from an 11-variable Z row.
+
+    The Z block is generated as ``latent @ loadings`` in standardized space
+    plus residual noise, so projecting a standardized row onto the pseudo-
+    inverse of the (fixed, known) loading matrix recovers the latent factors.
+    This makes the simulator a pure function of any user-supplied Z row, not
+    only rows produced by :func:`sample_initial_conditions`.
+    """
+    z_std = (z_row - _Z_MEANS) / _Z_SDS
+    return z_std @ np.linalg.pinv(_Z_LOADINGS)
+
+
+def _coerce_z_row(initial_conditions: pd.Series | None) -> np.ndarray:
+    """Validate a single batch's initial conditions and return the raw Z row.
+
+    ``None`` means the nominal batch: every upstream variable at its mean, so
+    all three latent factors are zero.
+    """
+    if initial_conditions is None:
+        return _Z_MEANS.copy()
+    if not isinstance(initial_conditions, pd.Series):
+        raise TypeError(
+            f"initial_conditions must be a pandas Series with the {len(UPSTREAM_VARIABLE_NAMES)} upstream "
+            f"variables as its index, or None for the nominal batch; got {type(initial_conditions).__name__}."
+        )
+    missing = [name for name in UPSTREAM_VARIABLE_NAMES if name not in initial_conditions.index]
+    if missing:
+        raise ValueError(f"initial_conditions is missing upstream variables {missing}.")
+    values = initial_conditions.reindex(list(UPSTREAM_VARIABLE_NAMES)).to_numpy(dtype=float)
+    if not np.all(np.isfinite(values)):
+        raise ValueError("initial_conditions contains non-finite values; every upstream variable must be a number.")
+    return values
+
+
+def sample_initial_conditions(
+    n_batches: int,
+    *,
+    proportions: dict[str, float] | None = None,
+    ic_scale: float = 1.0,
+    random_state: int | np.random.Generator | None = None,
+) -> Bunch:
+    """Draw upstream (initial-condition) data for a campaign of batches.
+
+    Each batch belongs to one of three feed-disturbance classes, A, B or C,
+    with a cluster centre in the three-dimensional latent space (seed
+    viability, medium richness, inhibitor level). The observed ``Z`` block has
+    11 variables generated from those latent factors through a fixed loading
+    matrix plus residual noise, so a PCA of ``Z`` recovers about three
+    meaningful components and shows the three classes as clusters.
+
+    Parameters
+    ----------
+    n_batches : int
+        Number of batches to draw.
+    proportions : dict[str, float], optional
+        Expected class proportions keyed by ``"A"``, ``"B"``, ``"C"``. They
+        must be non-negative and sum to a positive number (they are
+        normalised). Default ``{"A": 0.40, "B": 0.35, "C": 0.25}``.
+    ic_scale : float, default=1.0
+        Scale of the initial-condition variation. 0 collapses every batch to
+        the nominal upstream values while keeping the class labels.
+    random_state : int, np.random.Generator, or None
+        Seed or generator; see ``process_improve._random.check_random_state``.
+
+    Returns
+    -------
+    result : sklearn.utils.Bunch
+        With keys ``z`` (DataFrame, ``n_batches`` rows by 11 upstream
+        variables, integer batch ids as index), ``classes`` (Series of "A" /
+        "B" / "C" labels, same index) and ``latent`` (DataFrame of the three
+        latent factor values, same index).
+    """
+    if not isinstance(n_batches, (int, np.integer)) or isinstance(n_batches, bool) or n_batches < 1:
+        raise ValueError(f"n_batches must be a positive integer; got {n_batches!r}.")
+    if not (isinstance(ic_scale, (int, float)) and math.isfinite(ic_scale) and ic_scale >= 0):
+        raise ValueError(f"ic_scale must be a finite non-negative number; got {ic_scale!r}.")
+    props = dict(_DEFAULT_CLASS_PROPORTIONS) if proportions is None else dict(proportions)
+    unknown = sorted(set(props) - set(_CLASS_CENTRES))
+    if unknown:
+        raise ValueError(f"proportions has unknown class labels {unknown}; valid labels are ['A', 'B', 'C'].")
+    weights = np.array([float(props.get(label, 0.0)) for label in sorted(_CLASS_CENTRES)])
+    if np.any(weights < 0) or not np.isfinite(weights).all() or weights.sum() <= 0:
+        raise ValueError(f"proportions must be non-negative with a positive sum; got {props!r}.")
+    weights = weights / weights.sum()
+
+    rng = check_random_state(random_state)
+    labels_pool = sorted(_CLASS_CENTRES)
+    labels = rng.choice(labels_pool, size=int(n_batches), p=weights)
+    centres = np.array([_CLASS_CENTRES[label] for label in labels])
+    latent = ic_scale * (centres + _CLASS_SD * rng.standard_normal((int(n_batches), 3)))
+    z_std = latent @ _Z_LOADINGS + _Z_RESIDUAL_SD * ic_scale * rng.standard_normal((int(n_batches), len(_Z_MEANS)))
+    z_values = _Z_MEANS + _Z_SDS * z_std
+
+    index = pd.RangeIndex(1, int(n_batches) + 1, name="batch_id")
+    return Bunch(
+        z=pd.DataFrame(z_values, index=index, columns=list(UPSTREAM_VARIABLE_NAMES)),
+        classes=pd.Series(labels, index=index, name="feed_class"),
+        latent=pd.DataFrame(latent, index=index, columns=list(LATENT_FACTOR_NAMES)),
+    )
+
+
+class BioreactorSimulator:
+    """A deterministic fed-batch bioreactor with tunable disturbance channels.
+
+    See the module docstring for the model, its citations, and the design
+    constraints. Given the same configuration, inputs and ``random_state``,
+    every method reproduces its results exactly.
+
+    Parameters
+    ----------
+    config : BioreactorConfig, optional
+        The full parameter set; defaults to ``BioreactorConfig()``.
+
+    Examples
+    --------
+    >>> from process_improve.simulation import BioreactorSimulator
+    >>> sim = BioreactorSimulator()
+    >>> golden = sim.golden_trajectory()
+    >>> campaign = sim.simulate_campaign(50, policy="replay", trajectory=golden.trajectory, random_state=42)
+    >>> float(campaign.quality["titer"].std()) > 0.0
+    True
+    """
+
+    def __init__(self, config: BioreactorConfig | None = None) -> None:
+        if config is None:
+            config = BioreactorConfig()
+        if not isinstance(config, BioreactorConfig):
+            raise TypeError(f"config must be a BioreactorConfig or None; got {type(config).__name__}.")
+        self.config = config
+
+    # ------------------------------------------------------------------
+    # Trajectories
+    # ------------------------------------------------------------------
+    def nominal_trajectory(self) -> pd.DataFrame:
+        """Return the nominal (recipe) setpoint schedule: biphasic temperature, pH held.
+
+        Temperature holds the growth optimum until ``shift_start_day``, ramps
+        linearly to the productivity optimum by ``shift_end_day``, and holds it
+        for the rest of the batch. pH is held at its cardinal optimum
+        throughout, matching the industrial practice of holding pH and
+        shifting temperature.
+
+        Returns
+        -------
+        pd.DataFrame
+            ``n_samples`` rows indexed by setpoint interval start time [day],
+            columns ``["pH", "temperature"]``. Each row is the setpoint held
+            over the following interval (zero-order hold).
+        """
+        cfg = self.config
+        days = cfg.interval_start_days
+        if cfg.shift_end_day > cfg.shift_start_day:
+            fraction = np.clip((days - cfg.shift_start_day) / (cfg.shift_end_day - cfg.shift_start_day), 0.0, 1.0)
+        else:
+            fraction = (days >= cfg.shift_start_day).astype(float)
+        temperature = cfg.temp_opt - (cfg.temp_opt - cfg.temp_q_opt) * fraction
+        temperature = np.clip(temperature, cfg.temp_bounds[0], cfg.temp_bounds[1])
+        ph = np.clip(np.full_like(days, cfg.ph_opt), cfg.ph_bounds[0], cfg.ph_bounds[1])
+        return pd.DataFrame({"pH": ph, "temperature": temperature}, index=pd.Index(days, name="day"))
+
+    def _validate_trajectory(self, trajectory: pd.DataFrame) -> tuple[np.ndarray, np.ndarray]:
+        """Check a setpoint trajectory and return (ph, temperature) arrays."""
+        cfg = self.config
+        if not isinstance(trajectory, pd.DataFrame):
+            raise TypeError(f"trajectory must be a pandas DataFrame; got {type(trajectory).__name__}.")
+        missing = [c for c in _TRAJECTORY_COLUMNS if c not in trajectory.columns]
+        if missing:
+            raise ValueError(f"trajectory is missing columns {missing}; it needs {list(_TRAJECTORY_COLUMNS)}.")
+        if len(trajectory) != cfg.n_samples:
+            raise ValueError(f"trajectory must have n_samples = {cfg.n_samples} rows; got {len(trajectory)}.")
+        ph = trajectory["pH"].to_numpy(dtype=float)
+        temperature = trajectory["temperature"].to_numpy(dtype=float)
+        if not (np.all(np.isfinite(ph)) and np.all(np.isfinite(temperature))):
+            raise ValueError("trajectory contains non-finite values.")
+        t_lo, t_hi = cfg.temp_bounds
+        p_lo, p_hi = cfg.ph_bounds
+        if np.any(temperature < t_lo - 1e-9) or np.any(temperature > t_hi + 1e-9):
+            raise ValueError(f"trajectory temperature must lie within temp_bounds {cfg.temp_bounds} degC.")
+        if np.any(ph < p_lo - 1e-9) or np.any(ph > p_hi + 1e-9):
+            raise ValueError(f"trajectory pH must lie within ph_bounds {cfg.ph_bounds}.")
+        return ph, temperature
+
+    def _setpoints_hourly(self, ph: np.ndarray, temperature: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Expand per-interval setpoints to the integration grid (zero-order hold).
+
+        Returns arrays of length ``n_steps + 1``; entry ``i`` is the setpoint
+        in force during step ``i`` (the final entry repeats the last setpoint).
+        """
+        steps_per_interval = self.config.n_steps // self.config.n_samples
+        ph_hourly = np.repeat(ph, steps_per_interval)
+        temp_hourly = np.repeat(temperature, steps_per_interval)
+        return (
+            np.append(ph_hourly, ph_hourly[-1]),
+            np.append(temp_hourly, temp_hourly[-1]),
+        )
+
+    # ------------------------------------------------------------------
+    # Disturbance channels
+    # ------------------------------------------------------------------
+    def _draw_disturbances(self, rng: np.random.Generator) -> Bunch:
+        """Draw one batch's worth of disturbance realisations.
+
+        Every random quantity is drawn on every call, in a fixed order, and
+        multiplied by its channel scale afterwards. Setting a scale to zero
+        therefore removes the channel without altering the draws of any other
+        channel: the same seed with one channel off is a true counterfactual.
+        """
+        cfg = self.config
+        n_steps = cfg.n_steps
+
+        # 1. Per-batch feed-rate drift (within-batch channel).
+        feed_shock = float(rng.standard_normal())
+        feed_scale = max(1.0 + cfg.feed_drift_sd * cfg.within_batch_scale * feed_shock, 0.50)
+
+        # 2. Ornstein-Uhlenbeck path for log phi (within-batch channel).
+        ou_draws = rng.standard_normal(n_steps + 1)
+        dt = 1.0 / cfg.steps_per_day
+        rho_ou = math.exp(-dt / cfg.ou_tau_days)
+        innovation_sd = cfg.ou_sd * math.sqrt(1.0 - rho_ou * rho_ou)
+        log_phi = np.empty(n_steps + 1)
+        log_phi[0] = 0.0
+        for i in range(1, n_steps + 1):
+            log_phi[i] = rho_ou * log_phi[i - 1] + innovation_sd * ou_draws[i]
+        phi = np.exp(cfg.within_batch_scale * log_phi)
+
+        # 3. Control-loop error paths for temperature and pH (noise channel).
+        rho_ctrl = math.exp(-1.0 / (cfg.control_tau_h * cfg.steps_per_day / 24.0))
+        ctrl_sd_factor = math.sqrt(1.0 - rho_ctrl * rho_ctrl)
+        temp_draws = rng.standard_normal(n_steps + 1)
+        ph_draws = rng.standard_normal(n_steps + 1)
+        temp_err = np.empty(n_steps + 1)
+        ph_err = np.empty(n_steps + 1)
+        temp_err[0] = 0.0
+        ph_err[0] = 0.0
+        for i in range(1, n_steps + 1):
+            temp_err[i] = rho_ctrl * temp_err[i - 1] + ctrl_sd_factor * temp_draws[i]
+            ph_err[i] = rho_ctrl * ph_err[i - 1] + ctrl_sd_factor * ph_draws[i]
+        temp_err *= cfg.control_sd_temp * cfg.noise_scale
+        ph_err *= cfg.control_sd_ph * cfg.noise_scale
+
+        # 4. Measurement noise on the recorded tags (noise channel).
+        meas = rng.standard_normal((cfg.n_samples, len(_TAG_COLUMNS))) * cfg.noise_scale
+
+        return Bunch(feed_scale=feed_scale, phi=phi, temp_err=temp_err, ph_err=ph_err, meas=meas)
+
+    # ------------------------------------------------------------------
+    # Core integration
+    # ------------------------------------------------------------------
+    def _integrate(  # noqa: PLR0913, PLR0915
+        self,
+        ph_hourly: np.ndarray,
+        temp_hourly: np.ndarray,
+        phi_hourly: np.ndarray,
+        x0: float,
+        s0: float,
+        inhibition: float,
+        feed_scale: float,
+    ) -> np.ndarray:
+        """Fixed-step RK4 integration of the four-state model.
+
+        The inner loop runs on plain Python floats: on states this small that
+        is roughly two orders of magnitude faster than numpy scalar
+        arithmetic, and it keeps results bit-identical across processes.
+
+        Returns
+        -------
+        np.ndarray
+            States at every grid point, shape ``(n_steps + 1, 4)`` with
+            columns biomass, substrate, titer, volume.
+        """
+        cfg = self.config
+        n_steps = cfg.n_steps
+        h = 1.0 / cfg.steps_per_day
+
+        mu_opt = cfg.mu_opt
+        k_s = cfg.k_s
+        inv_yield = 1.0 / cfg.yield_xs
+        maintenance = cfg.maintenance
+        alpha_lp = cfg.alpha_lp
+        beta_lp = cfg.beta_lp
+        t_min, t_opt, t_max = cfg.temp_min, cfg.temp_opt, cfg.temp_max
+        tq_min, tq_opt, tq_max = cfg.temp_q_min, cfg.temp_q_opt, cfg.temp_q_max
+        p_min, p_opt, p_max = cfg.ph_min, cfg.ph_opt, cfg.ph_max
+        k_d0 = cfg.k_d0
+        temp_death = cfg.temp_death
+        width_death = cfg.width_death
+        feed = cfg.feed_rate * feed_scale
+        s_feed = cfg.feed_substrate
+
+        def rhs(x: float, s: float, p: float, v: float, temp: float, ph: float, phi: float) -> tuple:  # noqa: PLR0913
+            gamma_ph = _cardinal_ph_f(ph, p_min, p_opt, p_max)
+            mu = mu_opt * _cardinal_temperature_f(temp, t_min, t_opt, t_max) * gamma_ph
+            mu *= s / (k_s + s) * phi * inhibition
+            k_d = k_d0 * (1.0 + math.exp((temp - temp_death) / width_death))
+            # The non-growth-associated production term carries phi and the
+            # inhibition factor directly; the growth-associated term already
+            # carries them inside mu.
+            q_p = alpha_lp * mu + (
+                beta_lp * _cardinal_temperature_f(temp, tq_min, tq_opt, tq_max) * gamma_ph * phi * inhibition
+            )
+            dilution = feed / v
+            dx = mu * x - k_d * x - dilution * x
+            ds = -(mu * inv_yield + maintenance) * x + dilution * (s_feed - s)
+            dp = q_p * x - dilution * p
+            dv = feed
+            return dx, ds, dp, dv
+
+        out = np.empty((n_steps + 1, 4))
+        x, s, p, v = x0, s0, 0.0, cfg.volume_initial
+        out[0] = (x, s, p, v)
+        half_h = 0.5 * h
+        sixth_h = h / 6.0
+        for i in range(n_steps):
+            temp_a, temp_b = temp_hourly[i], temp_hourly[i + 1]
+            ph_a, ph_b = ph_hourly[i], ph_hourly[i + 1]
+            phi_a, phi_b = phi_hourly[i], phi_hourly[i + 1]
+            temp_m = 0.5 * (temp_a + temp_b)
+            ph_m = 0.5 * (ph_a + ph_b)
+            phi_m = 0.5 * (phi_a + phi_b)
+
+            hh = half_h
+            k1 = rhs(x, s, p, v, temp_a, ph_a, phi_a)
+            k2 = rhs(x + hh * k1[0], s + hh * k1[1], p + hh * k1[2], v + hh * k1[3], temp_m, ph_m, phi_m)
+            k3 = rhs(x + hh * k2[0], s + hh * k2[1], p + hh * k2[2], v + hh * k2[3], temp_m, ph_m, phi_m)
+            k4 = rhs(x + h * k3[0], s + h * k3[1], p + h * k3[2], v + h * k3[3], temp_b, ph_b, phi_b)
+
+            x += sixth_h * (k1[0] + 2.0 * k2[0] + 2.0 * k3[0] + k4[0])
+            s += sixth_h * (k1[1] + 2.0 * k2[1] + 2.0 * k3[1] + k4[1])
+            p += sixth_h * (k1[2] + 2.0 * k2[2] + 2.0 * k3[2] + k4[2])
+            v += sixth_h * (k1[3] + 2.0 * k2[3] + 2.0 * k3[3] + k4[3])
+
+            # Physical floors: concentrations cannot go negative; volume
+            # cannot vanish. The floors only bind in pathological corners of
+            # parameter space (the RK4 step is far smaller than any dynamic
+            # timescale at the defaults).
+            x = max(x, 1e-9)
+            s = max(s, 0.0)
+            p = max(p, 0.0)
+            v = max(v, 1e-9)
+            out[i + 1] = (x, s, p, v)
+        return out
+
+    def _gas_tags(self, states: np.ndarray, temp: np.ndarray, ph: np.ndarray, phi: np.ndarray) -> Bunch:
+        """Dissolved oxygen [%] and offgas CO2 [%] at every grid point."""
+        cfg = self.config
+        biomass = states[:, 0]
+        substrate = states[:, 1]
+        gamma_t = cardinal_temperature(temp, cfg.temp_min, cfg.temp_opt, cfg.temp_max)
+        gamma_p = cardinal_ph(ph, cfg.ph_min, cfg.ph_opt, cfg.ph_max)
+        monod = substrate / (cfg.k_s + substrate)
+        mu = cfg.mu_opt * gamma_t * gamma_p * monod * phi
+        our = (cfg.o2_yield * mu + cfg.o2_maintenance) * biomass
+        dissolved_oxygen = 100.0 * np.clip(1.0 - our / cfg.our_capacity, 0.03, 1.0)
+        offgas_co2 = cfg.co2_inlet_pct + cfg.co2_gain * cfg.rq * our
+        return Bunch(dissolved_oxygen=dissolved_oxygen, offgas_co2=offgas_co2)
+
+    # ------------------------------------------------------------------
+    # Public simulation entry points
+    # ------------------------------------------------------------------
+    def simulate_batch(
+        self,
+        initial_conditions: pd.Series | None = None,
+        trajectory: pd.DataFrame | None = None,
+        *,
+        random_state: int | np.random.Generator | None = None,
+    ) -> Bunch:
+        """Simulate one batch under given initial conditions and setpoints.
+
+        Parameters
+        ----------
+        initial_conditions : pd.Series, optional
+            One row of the upstream ``Z`` block (index: the 11 upstream
+            variable names). ``None`` runs the nominal batch (all upstream
+            variables at their means).
+        trajectory : pd.DataFrame, optional
+            Setpoint schedule with ``n_samples`` rows and columns
+            ``["pH", "temperature"]``; each row is held over its interval
+            (zero-order hold). ``None`` uses :meth:`nominal_trajectory`.
+        random_state : int, np.random.Generator, or None
+            Seed or generator for the disturbance and noise draws.
+
+        Returns
+        -------
+        result : sklearn.utils.Bunch
+            With keys:
+
+            - ``tags``: DataFrame, ``n_samples`` rows indexed by sample time
+              [day], columns ``["pH", "temperature", "dissolved_oxygen",
+              "offgas_co2", "volume"]``: what the historian records,
+              including measurement noise.
+            - ``titer``: float, the final product concentration [g/L].
+            - ``states``: DataFrame on the integration grid (indexed by day)
+              with columns ``["biomass", "substrate", "titer", "volume",
+              "phi", "temperature", "pH"]``: the noise-free god view,
+              including the unmeasured disturbance ``phi``.
+            - ``realised_trajectory``: DataFrame like ``tags`` but only
+              ``["pH", "temperature"]`` and without measurement noise: what
+              the control loops actually delivered.
+            - ``initial_conditions``: Series, the ``Z`` row used.
+        """
+        cfg = self.config
+        z_row = _coerce_z_row(initial_conditions)
+        if trajectory is None:
+            trajectory = self.nominal_trajectory()
+        ph_set, temp_set = self._validate_trajectory(trajectory)
+        rng = check_random_state(random_state)
+
+        latent = _z_to_latent(z_row)
+        x0, s0, inhibition = _latent_effects(cfg, latent)
+        disturbances = self._draw_disturbances(rng)
+
+        ph_hourly, temp_hourly = self._setpoints_hourly(ph_set, temp_set)
+        temp_real = np.clip(temp_hourly + disturbances.temp_err, cfg.temp_bounds[0], cfg.temp_bounds[1])
+        ph_real = np.clip(ph_hourly + disturbances.ph_err, cfg.ph_bounds[0], cfg.ph_bounds[1])
+
+        states = self._integrate(ph_real, temp_real, disturbances.phi, x0, s0, inhibition, disturbances.feed_scale)
+        gas = self._gas_tags(states, temp_real, ph_real, disturbances.phi)
+
+        grid_days = np.linspace(0.0, cfg.batch_days, cfg.n_steps + 1)
+        sample_idx = np.round(cfg.sample_days * cfg.steps_per_day).astype(int)
+
+        realised = pd.DataFrame(
+            {"pH": ph_real[sample_idx], "temperature": temp_real[sample_idx]},
+            index=pd.Index(cfg.sample_days, name="day"),
+        )
+        meas = disturbances.meas
+        tags = pd.DataFrame(
+            {
+                "pH": ph_real[sample_idx] + cfg.meas_sd_ph * meas[:, 0],
+                "temperature": temp_real[sample_idx] + cfg.meas_sd_temp * meas[:, 1],
+                "dissolved_oxygen": gas.dissolved_oxygen[sample_idx] + cfg.meas_sd_do * meas[:, 2],
+                "offgas_co2": gas.offgas_co2[sample_idx] + cfg.meas_sd_co2 * meas[:, 3],
+                "volume": states[sample_idx, 3] + cfg.meas_sd_volume * meas[:, 4],
+            },
+            index=pd.Index(cfg.sample_days, name="day"),
+        )
+        states_frame = pd.DataFrame(
+            {
+                "biomass": states[:, 0],
+                "substrate": states[:, 1],
+                "titer": states[:, 2],
+                "volume": states[:, 3],
+                "phi": disturbances.phi,
+                "temperature": temp_real,
+                "pH": ph_real,
+            },
+            index=pd.Index(grid_days, name="day"),
+        )
+        return Bunch(
+            tags=tags,
+            titer=float(states[-1, 2]),
+            states=states_frame,
+            realised_trajectory=realised,
+            initial_conditions=pd.Series(z_row, index=list(UPSTREAM_VARIABLE_NAMES), name="initial_conditions"),
+        )
+
+    def _deterministic_titer(self, latent: np.ndarray, ph_set: np.ndarray, temp_set: np.ndarray) -> float:
+        """Return the final titer with every disturbance and noise channel off (the god view)."""
+        cfg = self.config
+        x0, s0, inhibition = _latent_effects(cfg, latent)
+        ph_hourly, temp_hourly = self._setpoints_hourly(ph_set, temp_set)
+        phi = np.ones(cfg.n_steps + 1)
+        states = self._integrate(ph_hourly, temp_hourly, phi, x0, s0, inhibition, 1.0)
+        return float(states[-1, 2])
+
+    def optimal_trajectory(
+        self,
+        initial_conditions: pd.Series | None = None,
+        *,
+        n_knots: int = 4,
+        n_starts: int = 5,
+        random_state: int | np.random.Generator | None = 0,
+    ) -> Bunch:
+        """Find the true optimal setpoint schedule for a batch's initial conditions.
+
+        Maximises the deterministic (disturbance-free) final titer over pH and
+        temperature schedules parameterised by ``n_knots`` values each,
+        linearly interpolated across the batch and held per interval. Because
+        the optimiser queries the simulator's own model, the result is the
+        *true* optimum for these initial conditions: the ceiling any
+        data-driven scheme can be scored against.
+
+        Parameters
+        ----------
+        initial_conditions : pd.Series, optional
+            One upstream ``Z`` row; ``None`` for the nominal batch.
+        n_knots : int, default=4
+            Number of knots per manipulated variable.
+        n_starts : int, default=5
+            Multi-start count: the nominal trajectory plus ``n_starts - 1``
+            random starts inside the operating bounds.
+        random_state : int, np.random.Generator, or None, default=0
+            Seed for the random starts; the default makes the search
+            reproducible without an argument.
+
+        Returns
+        -------
+        result : sklearn.utils.Bunch
+            With keys ``trajectory`` (DataFrame in the same layout as
+            :meth:`nominal_trajectory`), ``titer`` (float, the deterministic
+            titer of that trajectory) and ``optimizer_success`` (bool).
+        """
+        from scipy import optimize  # noqa: PLC0415  (scipy is not a declared runtime dependency)
+
+        cfg = self.config
+        if not isinstance(n_knots, (int, np.integer)) or isinstance(n_knots, bool) or n_knots < 2:
+            raise ValueError(f"n_knots must be an integer of at least 2; got {n_knots!r}.")
+        if not isinstance(n_starts, (int, np.integer)) or isinstance(n_starts, bool) or n_starts < 1:
+            raise ValueError(f"n_starts must be a positive integer; got {n_starts!r}.")
+        z_row = _coerce_z_row(initial_conditions)
+        latent = _z_to_latent(z_row)
+        rng = check_random_state(random_state)
+
+        knot_days = np.linspace(0.0, cfg.batch_days, int(n_knots))
+        interval_days = cfg.interval_start_days
+
+        def expand(knots: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+            ph_knots, temp_knots = knots[: int(n_knots)], knots[int(n_knots) :]
+            ph_set = np.interp(interval_days, knot_days, ph_knots)
+            temp_set = np.interp(interval_days, knot_days, temp_knots)
+            return ph_set, temp_set
+
+        def negative_titer(knots: np.ndarray) -> float:
+            ph_set, temp_set = expand(knots)
+            return -self._deterministic_titer(latent, ph_set, temp_set)
+
+        p_lo, p_hi = cfg.ph_bounds
+        t_lo, t_hi = cfg.temp_bounds
+        bounds = [(p_lo, p_hi)] * int(n_knots) + [(t_lo, t_hi)] * int(n_knots)
+
+        nominal = self.nominal_trajectory()
+        start_nominal = np.concatenate(
+            [
+                np.interp(knot_days, interval_days, nominal["pH"].to_numpy()),
+                np.interp(knot_days, interval_days, nominal["temperature"].to_numpy()),
+            ]
+        )
+        starts = [start_nominal]
+        lows = np.array([b[0] for b in bounds])
+        highs = np.array([b[1] for b in bounds])
+        starts.extend(rng.uniform(lows, highs) for _ in range(int(n_starts) - 1))
+
+        best_result = None
+        for start in starts:
+            result = optimize.minimize(negative_titer, start, method="SLSQP", bounds=bounds)
+            if best_result is None or result.fun < best_result.fun:
+                best_result = result
+        if best_result is None:  # pragma: no cover - n_starts >= 1 guarantees a result
+            raise RuntimeError("internal: the optimiser produced no result; this is a bug.")
+
+        ph_set, temp_set = expand(best_result.x)
+        trajectory = pd.DataFrame(
+            {"pH": ph_set, "temperature": temp_set},
+            index=pd.Index(interval_days, name="day"),
+        )
+        logger.debug(
+            "optimal_trajectory: best titer %.4f g/L after %d starts (success=%s)",
+            -best_result.fun,
+            len(starts),
+            best_result.success,
+        )
+        return Bunch(trajectory=trajectory, titer=float(-best_result.fun), optimizer_success=bool(best_result.success))
+
+    def golden_trajectory(
+        self,
+        *,
+        n_knots: int = 4,
+        n_starts: int = 5,
+        random_state: int | np.random.Generator | None = 0,
+    ) -> Bunch:
+        """Find the golden batch: the optimal schedule for the *nominal* initial conditions.
+
+        This is what golden-batch practice enshrines as the recipe. It is the
+        true optimum only for the conditions under which it was found; the
+        whole point of the baseline is what happens when it is replayed under
+        other conditions. Parameters and return value match
+        :meth:`optimal_trajectory` with ``initial_conditions=None``.
+        """
+        return self.optimal_trajectory(None, n_knots=n_knots, n_starts=n_starts, random_state=random_state)
+
+    def simulate_campaign(  # noqa: C901, PLR0913
+        self,
+        n_batches: int,
+        *,
+        policy: str = "replay",
+        trajectory: pd.DataFrame | None = None,
+        initial_conditions: pd.DataFrame | None = None,
+        mv_variation: float = 0.0,
+        random_state: int | np.random.Generator | None = None,
+    ) -> Bunch:
+        """Simulate a campaign of batches under a named operating policy.
+
+        Parameters
+        ----------
+        n_batches : int
+            Number of batches in the campaign.
+        policy : {"replay", "historical", "adapted"}, default="replay"
+            - ``"replay"``: every batch is given the same setpoint schedule,
+              the golden-batch practice.
+            - ``"historical"``: the same schedule plus deliberate per-batch
+              setpoint variation of size ``mv_variation`` (see below). A
+              perfectly consistent history contains no information about how
+              the controls affect quality; this policy produces a history
+              that does.
+            - ``"adapted"``: each batch runs the *true* optimal schedule for
+              its own initial conditions, computed from the simulator's model
+              via :meth:`optimal_trajectory`. This is the ceiling a perfect
+              feedforward scheme could reach, not an implementable policy.
+        trajectory : pd.DataFrame, optional
+            The schedule used by ``"replay"`` and ``"historical"``; defaults
+            to :meth:`nominal_trajectory`. Ignored by ``"adapted"``.
+        initial_conditions : pd.DataFrame, optional
+            The upstream ``Z`` block, one row per batch (the 11 upstream
+            variables as columns). ``None`` draws it with
+            :func:`sample_initial_conditions` using the configuration's
+            ``ic_scale``.
+        mv_variation : float, default=0.0
+            Size of the deliberate variation for ``"historical"``: each batch
+            draws a random constant offset and a random start-to-end ramp for
+            temperature (standard deviation ``mv_variation`` degC each) and
+            for pH (standard deviation ``0.1 * mv_variation`` each), clipped
+            to the operating bounds.
+        random_state : int, np.random.Generator, or None
+            Seed or generator; child seeds are spawned per batch, so a
+            campaign is reproducible end to end.
+
+        Returns
+        -------
+        result : sklearn.utils.Bunch
+            With keys:
+
+            - ``batches``: ``dict[int, pd.DataFrame]``, the recorded tags per
+              batch in the package's standard batch-dictionary format.
+            - ``quality``: DataFrame indexed by batch id with the single
+              column ``titer`` [g/L].
+            - ``initial_conditions``: DataFrame, the ``Z`` block used.
+            - ``classes``: Series of feed-class labels ("A"/"B"/"C"), or
+              ``"?"`` when ``initial_conditions`` was supplied by the caller.
+            - ``trajectories``: ``dict[int, pd.DataFrame]``, the *requested*
+              setpoint schedule per batch.
+        """
+        cfg = self.config
+        if not isinstance(n_batches, (int, np.integer)) or isinstance(n_batches, bool) or n_batches < 1:
+            raise ValueError(f"n_batches must be a positive integer; got {n_batches!r}.")
+        if policy not in _POLICIES:
+            raise ValueError(f"policy must be one of {list(_POLICIES)}; got {policy!r}.")
+        if not (isinstance(mv_variation, (int, float)) and math.isfinite(mv_variation) and mv_variation >= 0):
+            raise ValueError(f"mv_variation must be a finite non-negative number; got {mv_variation!r}.")
+        rng = check_random_state(random_state)
+
+        if initial_conditions is None:
+            drawn = sample_initial_conditions(int(n_batches), ic_scale=cfg.ic_scale, random_state=rng)
+            z_block, classes = drawn.z, drawn.classes
+        else:
+            if not isinstance(initial_conditions, pd.DataFrame):
+                raise TypeError(
+                    f"initial_conditions must be a DataFrame with one row per batch or None; "
+                    f"got {type(initial_conditions).__name__}."
+                )
+            if len(initial_conditions) != int(n_batches):
+                raise ValueError(
+                    f"initial_conditions must have n_batches = {n_batches} rows; got {len(initial_conditions)}."
+                )
+            missing = [name for name in UPSTREAM_VARIABLE_NAMES if name not in initial_conditions.columns]
+            if missing:
+                raise ValueError(f"initial_conditions is missing upstream variables {missing}.")
+            z_block = initial_conditions
+            classes = pd.Series("?", index=z_block.index, name="feed_class")
+
+        base_trajectory = self.nominal_trajectory() if trajectory is None else trajectory
+        self._validate_trajectory(base_trajectory)
+
+        batch_ids = list(z_block.index)
+        child_rngs = rng.spawn(int(n_batches))
+        batches: dict = {}
+        trajectories: dict = {}
+        titers = np.empty(int(n_batches))
+        interval_fraction = np.linspace(0.0, 1.0, cfg.n_samples)
+
+        for row, (batch_id, child) in enumerate(zip(batch_ids, child_rngs, strict=True)):
+            if policy == "adapted":
+                requested = self.optimal_trajectory(z_block.loc[batch_id], random_state=0).trajectory
+            elif policy == "historical" and mv_variation > 0:
+                offsets = rng.standard_normal(4)
+                temp_delta = mv_variation * (offsets[0] + offsets[1] * interval_fraction)
+                ph_delta = 0.1 * mv_variation * (offsets[2] + offsets[3] * interval_fraction)
+                requested = base_trajectory.copy()
+                requested["temperature"] = np.clip(
+                    requested["temperature"].to_numpy() + temp_delta, cfg.temp_bounds[0], cfg.temp_bounds[1]
+                )
+                requested["pH"] = np.clip(requested["pH"].to_numpy() + ph_delta, cfg.ph_bounds[0], cfg.ph_bounds[1])
+            else:
+                requested = base_trajectory
+
+            result = self.simulate_batch(z_block.loc[batch_id], requested, random_state=child)
+            batches[batch_id] = result.tags
+            trajectories[batch_id] = requested
+            titers[row] = result.titer
+
+        quality = pd.DataFrame({"titer": titers}, index=pd.Index(batch_ids, name="batch_id"))
+        logger.debug(
+            "simulate_campaign: %d batches under %r; titer mean %.3f g/L, sd %.3f g/L",
+            n_batches,
+            policy,
+            float(quality["titer"].mean()),
+            float(quality["titer"].std(ddof=1)) if n_batches > 1 else float("nan"),
+        )
+        return Bunch(
+            batches=batches,
+            quality=quality,
+            initial_conditions=z_block,
+            classes=classes,
+            trajectories=trajectories,
+        )
+
+    # ------------------------------------------------------------------
+    # Analyses
+    # ------------------------------------------------------------------
+    def sensitivity_budget(
+        self,
+        *,
+        n_noise_replicates: int = 100,
+        random_state: int | np.random.Generator | None = 0,
+    ) -> pd.DataFrame:
+        """How much the final titer moves under standard input perturbations.
+
+        This is the realism check: a credible process model must not respond
+        visibly to input changes smaller than an instrument can resolve, and
+        must respond clearly to sustained multi-degree deviations. The rows
+        cover zero-mean control-loop noise at instrument scale, sustained
+        setpoint biases of increasing size, and a single-sample excursion.
+        All effects are measured on the deterministic model (disturbance
+        channels off) except the control-noise row, which uses the
+        configured control-error model.
+
+        Parameters
+        ----------
+        n_noise_replicates : int, default=100
+            Number of batches used for the control-loop-noise row.
+        random_state : int, np.random.Generator, or None, default=0
+            Seed for the control-noise replicates.
+
+        Returns
+        -------
+        pd.DataFrame
+            One row per perturbation with columns ``perturbation`` (index),
+            ``titer_g_L`` and ``effect_pct`` (percentage change of the final
+            titer against the unperturbed nominal batch; for the noise row,
+            the standard deviation across replicates).
+        """
+        if not isinstance(n_noise_replicates, (int, np.integer)) or n_noise_replicates < 2:
+            raise ValueError(f"n_noise_replicates must be an integer of at least 2; got {n_noise_replicates!r}.")
+        cfg = self.config
+        rng = check_random_state(random_state)
+        nominal = self.nominal_trajectory()
+        latent0 = np.zeros(3)
+        ph_set = nominal["pH"].to_numpy()
+        temp_set = nominal["temperature"].to_numpy()
+        base = self._deterministic_titer(latent0, ph_set, temp_set)
+
+        rows: list[tuple[str, float, float]] = []
+
+        # Zero-mean control-loop noise at the configured instrument scale.
+        noise_config = dataclasses.replace(cfg, ic_scale=0.0, within_batch_scale=0.0, noise_scale=1.0)
+        noise_sim = BioreactorSimulator(noise_config)
+        children = rng.spawn(int(n_noise_replicates))
+        titers = np.array([noise_sim.simulate_batch(None, nominal, random_state=child).titer for child in children])
+        rows.append(
+            (
+                f"control-loop noise (sd {cfg.control_sd_temp} degC, {cfg.control_sd_ph} pH)",
+                float(titers.mean()),
+                float(100.0 * titers.std(ddof=1) / base),
+            )
+        )
+
+        def clipped(values: np.ndarray, bounds: tuple[float, float]) -> np.ndarray:
+            return np.clip(values, bounds[0], bounds[1])
+
+        for bias in (0.1, 0.5, 1.0, 2.0, 3.0):
+            for sign in (1.0, -1.0):
+                titer = self._deterministic_titer(latent0, ph_set, clipped(temp_set + sign * bias, cfg.temp_bounds))
+                label = f"sustained temperature bias {sign * bias:+.1f} degC"
+                rows.append((label, titer, 100.0 * (titer - base) / base))
+        for bias in (0.02, 0.1, 0.2):
+            for sign in (1.0, -1.0):
+                titer = self._deterministic_titer(latent0, clipped(ph_set + sign * bias, cfg.ph_bounds), temp_set)
+                rows.append((f"sustained pH bias {sign * bias:+.2f}", titer, 100.0 * (titer - base) / base))
+
+        one_sample = temp_set.copy()
+        mid = cfg.n_samples // 2
+        one_sample[mid] = min(one_sample[mid] + 0.5, cfg.temp_bounds[1])
+        titer = self._deterministic_titer(latent0, ph_set, one_sample)
+        rows.append(("single-sample temperature excursion +0.5 degC", titer, 100.0 * (titer - base) / base))
+
+        frame = pd.DataFrame(rows, columns=["perturbation", "titer_g_L", "effect_pct"]).set_index("perturbation")
+        frame.attrs["nominal_titer_g_L"] = base
+        return frame
+
+
+def variance_decomposition(
+    simulator: BioreactorSimulator,
+    n_batches: int = 200,
+    *,
+    trajectory: pd.DataFrame | None = None,
+    random_state: int | np.random.Generator | None = None,
+) -> pd.DataFrame:
+    """Split the replay-policy titer variance into its three sources.
+
+    Runs four replay campaigns with the same size and schedule: all channels
+    on (the total), then each channel alone. The initial-condition bucket is
+    what pre-batch (feedforward) trajectory adaptation could remove; the
+    within-batch bucket is what only mid-course (feedback) correction can
+    reach; the noise bucket is the floor. Because the model is nonlinear the
+    three buckets do not sum exactly to the total; the difference is reported
+    as the interaction residual rather than hidden.
+
+    Parameters
+    ----------
+    simulator : BioreactorSimulator
+        The simulator whose configuration (including channel scales) defines
+        the "all channels on" case.
+    n_batches : int, default=200
+        Batches per campaign.
+    trajectory : pd.DataFrame, optional
+        The replayed schedule; defaults to the simulator's nominal.
+    random_state : int, np.random.Generator, or None
+        Seed or generator; each campaign draws its own child seed.
+
+    Returns
+    -------
+    pd.DataFrame
+        Rows ``["measured initial conditions", "within-batch disturbance",
+        "control and measurement noise", "interaction residual", "total"]``
+        with columns ``variance`` [g^2/L^2], ``sd`` [g/L], ``cv_pct`` (sd as
+        a percentage of the all-channels mean titer) and ``pct_of_total``
+        (share of the total variance; the residual's share can be negative).
+    """
+    if not isinstance(simulator, BioreactorSimulator):
+        raise TypeError(f"simulator must be a BioreactorSimulator; got {type(simulator).__name__}.")
+    if not isinstance(n_batches, (int, np.integer)) or isinstance(n_batches, bool) or n_batches < 2:
+        raise ValueError(f"n_batches must be an integer of at least 2; got {n_batches!r}.")
+    rng = check_random_state(random_state)
+    cfg = simulator.config
+    if trajectory is None:
+        trajectory = simulator.nominal_trajectory()
+
+    channel_configs = {
+        "total": cfg,
+        "measured initial conditions": dataclasses.replace(cfg, within_batch_scale=0.0, noise_scale=0.0),
+        "within-batch disturbance": dataclasses.replace(cfg, ic_scale=0.0, noise_scale=0.0),
+        "control and measurement noise": dataclasses.replace(cfg, ic_scale=0.0, within_batch_scale=0.0),
+    }
+    variances: dict[str, float] = {}
+    mean_total = float("nan")
+    for label, channel_config in channel_configs.items():
+        campaign = BioreactorSimulator(channel_config).simulate_campaign(
+            int(n_batches), policy="replay", trajectory=trajectory, random_state=rng.spawn(1)[0]
+        )
+        titer = campaign.quality["titer"]
+        variances[label] = float(titer.var(ddof=1))
+        if label == "total":
+            mean_total = float(titer.mean())
+
+    residual = variances["total"] - sum(v for k, v in variances.items() if k != "total")
+    order = [
+        "measured initial conditions",
+        "within-batch disturbance",
+        "control and measurement noise",
+        "interaction residual",
+        "total",
+    ]
+    values = {**variances, "interaction residual": residual}
+    frame = pd.DataFrame(
+        {
+            "variance": [values[k] for k in order],
+            "sd": [math.sqrt(values[k]) if values[k] >= 0 else float("nan") for k in order],
+        },
+        index=pd.Index(order, name="source"),
+    )
+    frame["cv_pct"] = 100.0 * frame["sd"] / mean_total
+    frame["pct_of_total"] = 100.0 * frame["variance"] / values["total"]
+    frame.attrs["mean_titer_g_L"] = mean_total
+    return frame

--- a/src/process_improve/simulation/batch.py
+++ b/src/process_improve/simulation/batch.py
@@ -121,9 +121,12 @@ zero (``ic_scale``, ``within_batch_scale``, ``noise_scale``):
    noise on every recorded tag, at instrument scale.
 
 All random draws are made on every call and multiplied by their channel
-scale, so setting a scale to zero removes that channel without changing the
-draw sequence of the others: the same seed with a channel switched off is a
-true counterfactual for the same batch.
+scale exactly once, so setting a scale to zero removes that channel without
+changing the draw sequence of the others: the same seed with a channel
+switched off is a true counterfactual for the same batch. The
+initial-condition scale acts where upstream data are *drawn*
+(:func:`sample_initial_conditions`); a caller-supplied ``Z`` block is
+measured data and is used at face value.
 
 References
 ----------
@@ -207,6 +210,27 @@ _TRAJECTORY_COLUMNS: tuple[str, ...] = ("pH", "temperature")
 _POLICIES: tuple[str, ...] = ("replay", "historical", "adapted")
 
 
+def _validate_ctmi_cardinals(where: str, t_min: float, t_opt: float, t_max: float) -> None:
+    """Reject cardinal temperature triples for which the CTMI is ill posed.
+
+    The CTMI denominator is linear in temperature and changes sign strictly
+    inside the cardinal window whenever ``t_opt < (t_min + t_max) / 2``,
+    producing a pole where the formula returns nonsense. Rosso et al. (1995)
+    derive the model under the opposite condition, which every organism they
+    fit satisfies (the optimum sits closer to ``t_max`` than to ``t_min``).
+    """
+    if not t_min < t_opt < t_max:
+        raise ValueError(
+            f"{where}: cardinal temperatures must satisfy t_min < t_opt < t_max; got ({t_min}, {t_opt}, {t_max})."
+        )
+    midpoint = (t_min + t_max) / 2.0
+    if t_opt < midpoint:
+        raise ValueError(
+            f"{where}: the CTMI requires t_opt >= (t_min + t_max) / 2 so its denominator has no root inside "
+            f"the cardinal window; got t_opt = {t_opt} with midpoint {midpoint}."
+        )
+
+
 def cardinal_temperature(temperature: float | np.ndarray, t_min: float, t_opt: float, t_max: float) -> np.ndarray:
     """Cardinal temperature model with inflection (CTMI) of Rosso et al. (1995).
 
@@ -219,7 +243,10 @@ def cardinal_temperature(temperature: float | np.ndarray, t_min: float, t_opt: f
         Temperature(s) [degC].
     t_min, t_opt, t_max : float
         Cardinal temperatures [degC]: no growth at or below ``t_min``, maximum
-        growth at ``t_opt``, no growth at or above ``t_max``.
+        growth at ``t_opt``, no growth at or above ``t_max``. The CTMI is
+        well posed only for ``t_opt >= (t_min + t_max) / 2``; below that the
+        denominator has a root strictly inside the cardinal window and the
+        formula is meaningless there, so such triples are rejected.
 
     Returns
     -------
@@ -227,6 +254,7 @@ def cardinal_temperature(temperature: float | np.ndarray, t_min: float, t_opt: f
         The dimensionless growth factor gamma_T in [0, 1], with the same shape
         as ``temperature``.
     """
+    _validate_ctmi_cardinals("cardinal_temperature", t_min, t_opt, t_max)
     temp = np.asarray(temperature, dtype=float)
     numerator = (temp - t_max) * (temp - t_min) ** 2
     denominator = (t_opt - t_min) * ((t_opt - t_min) * (temp - t_opt) - (t_opt - t_max) * (t_opt + t_min - 2.0 * temp))
@@ -359,7 +387,12 @@ class BioreactorConfig:
         that production needs; cold enough to arrest growth is what a
         sensible recipe holds.
     ic_scale : float
-        Scale of the measured initial-condition channel; 0 switches it off.
+        Scale of the upstream variation put into *drawn* initial conditions
+        (campaigns that draw their own ``Z`` block, and
+        :func:`sample_initial_conditions` when called through them); 0
+        collapses drawn batches to the nominal upstream values. A
+        caller-supplied ``Z`` block is measured data and is always used at
+        face value, independent of this scale.
     within_batch_scale : float
         Scale of the unmeasured within-batch channel; 0 switches it off.
     noise_scale : float
@@ -522,11 +555,23 @@ class BioreactorConfig:
                 "Cardinal temperatures must satisfy temp_min < temp_opt < temp_max; got "
                 f"({self.temp_min}, {self.temp_opt}, {self.temp_max})."
             )
+        _validate_ctmi_cardinals(
+            "BioreactorConfig growth cardinals (temp_min, temp_opt, temp_max)",
+            self.temp_min,
+            self.temp_opt,
+            self.temp_max,
+        )
         if not self.temp_q_min < self.temp_q_opt < self.temp_q_max:
             raise ValueError(
                 "Productivity cardinal temperatures must satisfy temp_q_min < temp_q_opt < temp_q_max; got "
                 f"({self.temp_q_min}, {self.temp_q_opt}, {self.temp_q_max})."
             )
+        _validate_ctmi_cardinals(
+            "BioreactorConfig productivity cardinals (temp_q_min, temp_q_opt, temp_q_max)",
+            self.temp_q_min,
+            self.temp_q_opt,
+            self.temp_q_max,
+        )
         if not self.ph_min < self.ph_opt < self.ph_max:
             raise ValueError(
                 f"Cardinal pH values must satisfy ph_min < ph_opt < ph_max; got "
@@ -589,10 +634,17 @@ class BioreactorConfig:
 def _latent_effects(config: BioreactorConfig, latent: np.ndarray) -> tuple[float, float, float]:
     """Map the three latent initial-condition factors to their process effects.
 
+    A ``Z`` row is measured data, so the mapping is fixed: it does not depend
+    on ``ic_scale``, which governs only how much variation
+    :func:`sample_initial_conditions` puts *into* drawn upstream data. (An
+    earlier draft applied ``ic_scale`` here as well, which made the channel
+    scale quadratically on the drawn path and inconsistently between drawn
+    and caller-supplied ``Z`` blocks.)
+
     Parameters
     ----------
     config : BioreactorConfig
-        Configuration supplying the nominal values and ``ic_scale``.
+        Configuration supplying the nominal initial concentrations.
     latent : np.ndarray
         The three latent factor values (seed viability, medium richness,
         inhibitor level) in standardized units.
@@ -606,11 +658,10 @@ def _latent_effects(config: BioreactorConfig, latent: np.ndarray) -> tuple[float
         only, which is why an inhibited lot calls for a different schedule
         (a longer warm growth phase) rather than a scaled-down copy.
     """
-    scale = config.ic_scale
     viability, richness, inhibitor = (float(v) for v in latent)
-    x0 = config.biomass_initial * min(max(1.0 + 0.18 * scale * viability, 0.40), 1.80)
-    s0 = config.substrate_initial * min(max(1.0 + 0.20 * scale * richness, 0.50), 1.60)
-    inhibition = min(max(1.0 - 0.12 * scale * max(inhibitor, 0.0), 0.55), 1.0)
+    x0 = config.biomass_initial * min(max(1.0 + 0.18 * viability, 0.40), 1.80)
+    s0 = config.substrate_initial * min(max(1.0 + 0.20 * richness, 0.50), 1.60)
+    inhibition = min(max(1.0 - 0.12 * max(inhibitor, 0.0), 0.55), 1.0)
     return x0, s0, inhibition
 
 
@@ -644,8 +695,12 @@ def _coerce_z_row(initial_conditions: pd.Series | None) -> np.ndarray:
     if missing:
         raise ValueError(f"initial_conditions is missing upstream variables {missing}.")
     values = initial_conditions.reindex(list(UPSTREAM_VARIABLE_NAMES)).to_numpy(dtype=float)
-    if not np.all(np.isfinite(values)):
-        raise ValueError("initial_conditions contains non-finite values; every upstream variable must be a number.")
+    finite = np.isfinite(values)
+    if not finite.all():
+        bad = [name for name, ok in zip(UPSTREAM_VARIABLE_NAMES, finite, strict=True) if not ok]
+        raise ValueError(
+            f"initial_conditions contains non-finite values for {bad}; every upstream variable must be a number."
+        )
     return values
 
 
@@ -790,13 +845,20 @@ class BioreactorSimulator:
         ph = trajectory["pH"].to_numpy(dtype=float)
         temperature = trajectory["temperature"].to_numpy(dtype=float)
         if not (np.all(np.isfinite(ph)) and np.all(np.isfinite(temperature))):
-            raise ValueError("trajectory contains non-finite values.")
+            bad_columns = [col for col, arr in (("pH", ph), ("temperature", temperature)) if not np.isfinite(arr).all()]
+            raise ValueError(f"trajectory contains non-finite values in columns {bad_columns}.")
         t_lo, t_hi = cfg.temp_bounds
         p_lo, p_hi = cfg.ph_bounds
         if np.any(temperature < t_lo - 1e-9) or np.any(temperature > t_hi + 1e-9):
-            raise ValueError(f"trajectory temperature must lie within temp_bounds {cfg.temp_bounds} degC.")
+            raise ValueError(
+                f"trajectory temperature must lie within temp_bounds {cfg.temp_bounds} degC; got values in "
+                f"[{temperature.min():.6g}, {temperature.max():.6g}]."
+            )
         if np.any(ph < p_lo - 1e-9) or np.any(ph > p_hi + 1e-9):
-            raise ValueError(f"trajectory pH must lie within ph_bounds {cfg.ph_bounds}.")
+            raise ValueError(
+                f"trajectory pH must lie within ph_bounds {cfg.ph_bounds}; got values in "
+                f"[{ph.min():.6g}, {ph.max():.6g}]."
+            )
         return ph, temperature
 
     def _setpoints_hourly(self, ph: np.ndarray, temperature: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
@@ -1041,16 +1103,22 @@ class BioreactorSimulator:
             - ``tags``: DataFrame, ``samples_per_batch`` rows indexed by sample time
               [day], columns ``["pH", "temperature", "dissolved_oxygen",
               "offgas_co2", "volume"]``: what the historian records,
-              including measurement noise.
+              including measurement noise. Each row reads at the end of its
+              interval: states at that instant, inputs as delivered over the
+              interval that ends there.
             - ``titer``: float, the final product concentration [g/L].
             - ``states``: DataFrame on the integration grid (indexed by day)
               with columns ``["biomass", "substrate", "titer", "volume",
               "phi", "temperature", "pH"]``: the noise-free god view,
-              including the unmeasured disturbance ``phi``.
+              including the unmeasured disturbance ``phi``. The input columns
+              (``phi``, ``temperature``, ``pH``) hold the value in force
+              during the step *starting* at each grid instant.
             - ``realised_trajectory``: DataFrame like ``tags`` but only
               ``["pH", "temperature"]`` and without measurement noise: what
-              the control loops actually delivered.
-            - ``initial_conditions``: Series, the ``Z`` row used.
+              the control loops delivered over the interval ending at each
+              sample time.
+            - ``initial_conditions``: Series, the ``Z`` row used, taken at
+              face value (see ``ic_scale`` in :class:`BioreactorConfig`).
         """
         cfg = self.config
         z_row = _coerce_z_row(initial_conditions)
@@ -1068,22 +1136,34 @@ class BioreactorSimulator:
         ph_real = np.clip(ph_hourly + disturbances.ph_err, cfg.ph_bounds[0], cfg.ph_bounds[1])
 
         states = self._integrate(ph_real, temp_real, disturbances.phi, x0, s0, inhibition, disturbances.feed_scale)
-        gas = self._gas_tags(states, temp_real, ph_real, disturbances.phi, inhibition)
 
         grid_days = np.linspace(0.0, cfg.batch_days, cfg.n_steps + 1)
         sample_idx = np.round(cfg.sample_days * cfg.steps_per_day).astype(int)
+        # Each sample instant is an interval boundary, where grid entry i of
+        # the input arrays already holds the *next* interval's setpoint (the
+        # input in force during the step starting at i). A reading taken at
+        # the end of an interval reports what the loops delivered during that
+        # interval, so the inputs are sampled one step back.
+        input_idx = sample_idx - 1
+        gas = self._gas_tags(
+            states[sample_idx],
+            temp_real[input_idx],
+            ph_real[input_idx],
+            disturbances.phi[input_idx],
+            inhibition,
+        )
 
         realised = pd.DataFrame(
-            {"pH": ph_real[sample_idx], "temperature": temp_real[sample_idx]},
+            {"pH": ph_real[input_idx], "temperature": temp_real[input_idx]},
             index=pd.Index(cfg.sample_days, name="day"),
         )
         meas = disturbances.meas
         tags = pd.DataFrame(
             {
-                "pH": ph_real[sample_idx] + cfg.meas_sd_ph * meas[:, 0],
-                "temperature": temp_real[sample_idx] + cfg.meas_sd_temp * meas[:, 1],
-                "dissolved_oxygen": gas.dissolved_oxygen[sample_idx] + cfg.meas_sd_do * meas[:, 2],
-                "offgas_co2": gas.offgas_co2[sample_idx] + cfg.meas_sd_co2 * meas[:, 3],
+                "pH": ph_real[input_idx] + cfg.meas_sd_ph * meas[:, 0],
+                "temperature": temp_real[input_idx] + cfg.meas_sd_temp * meas[:, 1],
+                "dissolved_oxygen": gas.dissolved_oxygen + cfg.meas_sd_do * meas[:, 2],
+                "offgas_co2": gas.offgas_co2 + cfg.meas_sd_co2 * meas[:, 3],
                 "volume": states[sample_idx, 3] + cfg.meas_sd_volume * meas[:, 4],
             },
             index=pd.Index(cfg.sample_days, name="day"),
@@ -1232,7 +1312,7 @@ class BioreactorSimulator:
         """
         return self.optimal_trajectory(None, n_knots=n_knots, n_starts=n_starts, random_state=random_state)
 
-    def simulate_campaign(  # noqa: C901, PLR0913
+    def simulate_campaign(  # noqa: C901, PLR0912, PLR0913
         self,
         n_batches: int,
         *,
@@ -1324,6 +1404,11 @@ class BioreactorSimulator:
             missing = [name for name in UPSTREAM_VARIABLE_NAMES if name not in initial_conditions.columns]
             if missing:
                 raise ValueError(f"initial_conditions is missing upstream variables {missing}.")
+            if not initial_conditions.index.is_unique:
+                duplicated = initial_conditions.index[initial_conditions.index.duplicated()].unique().tolist()
+                raise ValueError(
+                    f"initial_conditions must have unique batch ids as its index; duplicated ids: {duplicated}."
+                )
             z_block = initial_conditions
             classes = pd.Series("?", index=z_block.index, name="feed_class")
 

--- a/src/process_improve/simulation/recipes.py
+++ b/src/process_improve/simulation/recipes.py
@@ -1,0 +1,88 @@
+"""(c) Kevin Dunn, 2010-2026. MIT License.
+
+Analysis recipes for the batch (bioreactor) simulator.
+
+One guided workflow: establish, quantitatively, why replaying a golden
+batch's schedule does not reproduce its outcome, and how the remaining
+variance splits between what can be addressed before a batch and what can
+only be addressed while it runs. Registered into the package-wide catalog
+on import; see :mod:`process_improve.recipes` for the framework.
+"""
+
+from __future__ import annotations
+
+from process_improve.recipes import AnalysisRecipe, RecipeStep, register_recipe
+
+_DOMAIN = "simulation"
+
+
+_GOLDEN_BATCH_BASELINE = AnalysisRecipe(
+    key="golden_batch_baseline",
+    title="Golden batch baseline: why replaying the best batch does not repeat it",
+    summary=(
+        "Quantify what happens when a batch process replays its best (golden) batch schedule open-loop. "
+        "Simulate a replay campaign to measure the outcome spread, hold the measured initial conditions "
+        "identical to show the spread that remains, then decompose the variance into the share addressable "
+        "before the batch (feedforward adaptation), the share observable only while the batch runs "
+        "(mid-course correction), and the noise floor. Use this to ground a discussion of batch trajectory "
+        "adaptation in numbers rather than assertion."
+    ),
+    domain=_DOMAIN,
+    cue_phrases=[
+        "golden batch",
+        "best batch",
+        "replicate our best run",
+        "replay the recipe",
+        "batches do not repeat",
+        "batches don't repeat",
+        "batch to batch variation",
+        "batch-to-batch variability",
+        "same recipe different result",
+        "why do batches differ",
+        "mid-course correction",
+        "trajectory adaptation",
+        "batch consistency",
+    ],
+    inputs_needed=[
+        "nothing external: the workflow runs on the package's bioreactor simulator with its default "
+        "configuration, so every number is reproducible from the stated seed",
+        "optionally, disturbance channel scales to match a scenario (for example ic_scale=0 for perfectly "
+        "consistent raw materials)",
+    ],
+    stages=[
+        RecipeStep(
+            order=1,
+            directive=(
+                "Run a replay campaign with all disturbance channels at their defaults: "
+                "simulate_batch_campaign(n_batches=50, policy='replay', random_state=0). Report the titer "
+                "mean, standard deviation and coefficient of variation, and compare the spread against the "
+                "disturbance-free reference titer the tool returns: the schedule is identical for every "
+                "batch, yet the outcomes are not."
+            ),
+            tools=["simulate_batch_campaign"],
+        ),
+        RecipeStep(
+            order=2,
+            directive=(
+                "Repeat the campaign with identical measured initial conditions for every batch: "
+                "simulate_batch_campaign(n_batches=50, policy='replay', ic_scale=0.0, random_state=0). The "
+                "spread that remains cannot be removed by characterising incoming materials better; it "
+                "arises during the batch."
+            ),
+            tools=["simulate_batch_campaign"],
+        ),
+        RecipeStep(
+            order=3,
+            directive=(
+                "Decompose the variance: decompose_batch_quality_variance(random_state=0). Present the four "
+                "sources (measured initial conditions, within-batch disturbance, noise, interaction "
+                "residual) with their shares, and state which intervention reaches which share: schedule "
+                "adaptation before the batch for the first, mid-course correction at decision points for "
+                "the second, neither for the floor."
+            ),
+            tools=["decompose_batch_quality_variance"],
+        ),
+    ],
+)
+
+register_recipe(_GOLDEN_BATCH_BASELINE)

--- a/src/process_improve/simulation/recipes.py
+++ b/src/process_improve/simulation/recipes.py
@@ -15,6 +15,18 @@ from process_improve.recipes import AnalysisRecipe, RecipeStep, register_recipe
 
 _DOMAIN = "simulation"
 
+# Hoisted so the list elements below are single names: implicit string
+# concatenation directly inside a list looks like a missing comma to static
+# analysis (CodeQL py/implicit-string-concatenation-in-list).
+_INPUT_SIMULATOR = (
+    "nothing external: the workflow runs on the package's bioreactor simulator with its default "
+    "configuration, so every number is reproducible from the stated seed"
+)
+_INPUT_SCALES = (
+    "optionally, disturbance channel scales to match a scenario (for example ic_scale=0 for perfectly "
+    "consistent raw materials)"
+)
+
 
 _GOLDEN_BATCH_BASELINE = AnalysisRecipe(
     key="golden_batch_baseline",
@@ -43,12 +55,7 @@ _GOLDEN_BATCH_BASELINE = AnalysisRecipe(
         "trajectory adaptation",
         "batch consistency",
     ],
-    inputs_needed=[
-        "nothing external: the workflow runs on the package's bioreactor simulator with its default "
-        "configuration, so every number is reproducible from the stated seed",
-        "optionally, disturbance channel scales to match a scenario (for example ic_scale=0 for perfectly "
-        "consistent raw materials)",
-    ],
+    inputs_needed=[_INPUT_SIMULATOR, _INPUT_SCALES],
     stages=[
         RecipeStep(
             order=1,

--- a/src/process_improve/simulation/tools.py
+++ b/src/process_improve/simulation/tools.py
@@ -392,6 +392,248 @@ _register("reveal_simulator")
 
 
 # ---------------------------------------------------------------------------
+# Bioreactor (golden batch) tools
+# ---------------------------------------------------------------------------
+
+
+class SimulateBatchCampaignInput(BaseModel):
+    """Input contract for ``simulate_batch_campaign``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    n_batches: int = Field(..., ge=2, le=500, description="Number of batches to simulate in the campaign.")
+    policy: Literal["replay", "historical"] = Field(
+        "replay",
+        description=(
+            "Operating policy. 'replay' gives every batch the same nominal setpoint schedule (the "
+            "golden-batch practice). 'historical' adds deliberate per-batch setpoint variation of size "
+            "mv_variation, producing a history that carries information about how the controls affect quality."
+        ),
+    )
+    mv_variation: float = Field(
+        0.0,
+        ge=0.0,
+        le=3.0,
+        description=(
+            "Size of the deliberate setpoint variation for the 'historical' policy: the standard deviation "
+            "in degC of each batch's random temperature offset and ramp (pH varies at one tenth of this)."
+        ),
+    )
+    ic_scale: float = Field(
+        1.0,
+        ge=0.0,
+        le=3.0,
+        description=(
+            "Scale of the measured initial-condition (upstream Z block) disturbance channel; 0 gives every "
+            "batch identical initial conditions."
+        ),
+    )
+    within_batch_scale: float = Field(
+        1.0,
+        ge=0.0,
+        le=3.0,
+        description=(
+            "Scale of the unmeasured within-batch disturbance channel (slow metabolic drift and feed-rate "
+            "drift); 0 switches it off."
+        ),
+    )
+    noise_scale: float = Field(
+        1.0,
+        ge=0.0,
+        le=3.0,
+        description="Scale of the control-loop and measurement noise channel; 0 switches it off.",
+    )
+    random_state: int = Field(0, ge=0, le=2**31 - 1, description="Seed; the same seed reproduces the campaign exactly.")
+
+
+@tool_spec(
+    name="simulate_batch_campaign",
+    description=(
+        "Simulate a campaign of fed-batch bioreactor runs under a named operating policy and report the "
+        "final-titer outcomes. The simulator is a deterministic mechanistic model (Rosso cardinal "
+        "temperature/pH growth kinetics, Luedeking-Piret production, an oxygen-transfer ceiling) with three "
+        "independently tunable disturbance channels: measured initial conditions, an unmeasured within-batch "
+        "disturbance, and instrument-scale noise. Use it to demonstrate that replaying a fixed 'golden batch' "
+        "schedule does not reproduce its outcome, and to generate batch data for latent-variable modelling. "
+        "Returns the per-batch titers with feed-class labels, summary statistics, and the disturbance-free "
+        "reference titer of the same schedule for comparison."
+    ),
+    input_model=SimulateBatchCampaignInput,
+    examples="""
+    # "Replay our best batch's recipe 50 times and show me the spread"
+        -> ``simulate_batch_campaign(n_batches=50, policy="replay", random_state=0)``
+    # "Give me a historical campaign with deliberate setpoint variation for model building"
+        -> ``simulate_batch_campaign(n_batches=80, policy="historical", mv_variation=1.0)``
+    # "Same initial conditions for every batch; how much spread remains?"
+        -> ``simulate_batch_campaign(n_batches=50, ic_scale=0.0)``
+    """,
+    category="simulation",
+    rng={"uses_rng": True, "seed_param": "random_state", "default_seed": 0},
+)
+def simulate_batch_campaign(spec: SimulateBatchCampaignInput) -> dict[str, Any]:
+    """Simulate a bioreactor campaign and summarise the final-quality outcomes."""
+    import dataclasses  # noqa: PLC0415
+
+    import numpy as np  # noqa: PLC0415
+
+    from process_improve.simulation.batch import BioreactorConfig, BioreactorSimulator  # noqa: PLC0415
+
+    try:
+        config = dataclasses.replace(
+            BioreactorConfig(),
+            ic_scale=spec.ic_scale,
+            within_batch_scale=spec.within_batch_scale,
+            noise_scale=spec.noise_scale,
+        )
+        simulator = BioreactorSimulator(config)
+        campaign = simulator.simulate_campaign(
+            spec.n_batches,
+            policy=spec.policy,
+            mv_variation=spec.mv_variation,
+            random_state=spec.random_state,
+        )
+        nominal = simulator.nominal_trajectory()
+        reference = BioreactorSimulator(
+            dataclasses.replace(config, ic_scale=0.0, within_batch_scale=0.0, noise_scale=0.0)
+        ).simulate_batch(None, nominal)
+        titer = campaign.quality["titer"]
+        by_class = titer.groupby(campaign.classes).agg(["count", "mean", "std"])
+        return clean(
+            {
+                "n_batches": spec.n_batches,
+                "policy": spec.policy,
+                "titer_g_L": {
+                    "mean": float(titer.mean()),
+                    "sd": float(titer.std(ddof=1)),
+                    "cv_pct": float(100.0 * titer.std(ddof=1) / titer.mean()),
+                    "min": float(titer.min()),
+                    "max": float(titer.max()),
+                },
+                "reference_titer_g_L": {
+                    "value": float(reference.titer),
+                    "meaning": "the same nominal schedule with every disturbance channel switched off",
+                    "fraction_of_batches_below": float(np.mean(titer.to_numpy() < reference.titer)),
+                },
+                "by_feed_class": {
+                    str(label): {
+                        "count": int(row["count"]),
+                        "mean": float(row["mean"]),
+                        "sd": float(row["std"]),
+                    }
+                    for label, row in by_class.iterrows()
+                },
+                "batches": [
+                    {
+                        "batch_id": int(batch_id),
+                        "feed_class": str(campaign.classes.loc[batch_id]),
+                        "titer_g_L": round(float(value), 4),
+                    }
+                    for batch_id, value in titer.items()
+                ],
+            }
+        )
+    except (ValueError, TypeError, KeyError) as exc:
+        return {"error": str(exc)}
+
+
+_register("simulate_batch_campaign")
+
+
+class DecomposeBatchQualityVarianceInput(BaseModel):
+    """Input contract for ``decompose_batch_quality_variance``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    n_batches: int = Field(
+        150,
+        ge=10,
+        le=400,
+        description="Batches per campaign; four campaigns are run (all channels on, then each channel alone).",
+    )
+    ic_scale: float = Field(
+        1.0, ge=0.0, le=3.0, description="Scale of the measured initial-condition disturbance channel."
+    )
+    within_batch_scale: float = Field(
+        1.0, ge=0.0, le=3.0, description="Scale of the unmeasured within-batch disturbance channel."
+    )
+    noise_scale: float = Field(
+        1.0, ge=0.0, le=3.0, description="Scale of the control-loop and measurement noise channel."
+    )
+    random_state: int = Field(0, ge=0, le=2**31 - 1, description="Seed; the same seed reproduces the decomposition.")
+
+
+@tool_spec(
+    name="decompose_batch_quality_variance",
+    description=(
+        "Split the batch-to-batch final-quality variance of a replayed (golden batch) schedule into its "
+        "sources: measured initial conditions, an unmeasured within-batch disturbance, and control plus "
+        "measurement noise, with the interaction residual reported separately. This answers the question "
+        "'we replicate our best batch's recipe exactly, why do the outcomes still differ?'. The "
+        "initial-condition share is the part that adapting the schedule before the batch could address; "
+        "the within-batch share is observable only while the batch runs, so it is the part a mid-course "
+        "correction at decision points could address; the noise share is the floor."
+    ),
+    input_model=DecomposeBatchQualityVarianceInput,
+    examples="""
+    # "Why do our batches differ when we run the same recipe every time?"
+        -> ``decompose_batch_quality_variance()``
+    # "How much of the spread is left if incoming materials were perfectly consistent?"
+        -> ``decompose_batch_quality_variance(ic_scale=0.0)``
+    """,
+    category="simulation",
+    rng={"uses_rng": True, "seed_param": "random_state", "default_seed": 0},
+)
+def decompose_batch_quality_variance(spec: DecomposeBatchQualityVarianceInput) -> dict[str, Any]:
+    """Decompose replay-campaign titer variance into its disturbance sources."""
+    import dataclasses  # noqa: PLC0415
+
+    from process_improve.simulation.batch import (  # noqa: PLC0415
+        BioreactorConfig,
+        BioreactorSimulator,
+        variance_decomposition,
+    )
+
+    try:
+        config = dataclasses.replace(
+            BioreactorConfig(),
+            ic_scale=spec.ic_scale,
+            within_batch_scale=spec.within_batch_scale,
+            noise_scale=spec.noise_scale,
+        )
+        simulator = BioreactorSimulator(config)
+        frame = variance_decomposition(simulator, n_batches=spec.n_batches, random_state=spec.random_state)
+        return clean(
+            {
+                "n_batches_per_campaign": spec.n_batches,
+                "mean_titer_g_L": float(frame.attrs["mean_titer_g_L"]),
+                "sources": [
+                    {
+                        "source": str(source),
+                        "variance": float(row["variance"]),
+                        "sd_g_L": float(row["sd"]),
+                        "cv_pct": float(row["cv_pct"]),
+                        "pct_of_total": float(row["pct_of_total"]),
+                    }
+                    for source, row in frame.iterrows()
+                ],
+                "reading_the_result": (
+                    "'measured initial conditions' is addressable before the batch starts (feedforward "
+                    "adaptation of the schedule); 'within-batch disturbance' is observable only through the "
+                    "trajectories while the batch runs, so only a mid-course correction can address it; "
+                    "'control and measurement noise' is the irreducible floor. The buckets need not sum to "
+                    "the total because the process model is nonlinear; the difference is the interaction "
+                    "residual."
+                ),
+            }
+        )
+    except (ValueError, TypeError, KeyError) as exc:
+        return {"error": str(exc)}
+
+
+_register("decompose_batch_quality_variance")
+
+
+# ---------------------------------------------------------------------------
 # Module-level convenience
 # ---------------------------------------------------------------------------
 

--- a/src/process_improve/simulation/tools.py
+++ b/src/process_improve/simulation/tools.py
@@ -1,6 +1,6 @@
 """(c) Kevin Dunn, 2010-2026. MIT License.
 
-Agent-callable tool wrappers for the fake-data simulator.
+Agent-callable tool wrappers for the simulation subpackage.
 
 The tools exposed here:
 
@@ -9,6 +9,16 @@ The tools exposed here:
   settings, with fresh Gaussian noise each call.
 - ``reveal_simulator`` - returns the underlying coefficients, gated
   behind a ``confirmed`` flag enforced by the host.
+- ``simulate_batch_campaign`` - runs a fed-batch bioreactor campaign
+  under a named operating policy and reports the titer outcomes.
+- ``decompose_batch_quality_variance`` - splits the replay-campaign
+  titer variance into its disturbance sources.
+
+The three DOE tools above are stateless in the ``private_state`` sense
+described below; the two bioreactor tools have no hidden state at all
+(their model is deliberately open, see
+:mod:`process_improve.simulation.batch`) and are reproducible from
+their ``random_state`` field alone.
 
 The tools are intentionally stateless: the hidden model lives in a
 ``private_state`` dict that the host (e.g. the factorial web app)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -475,14 +475,16 @@ class TestRegistryIntegration:
         names = {s["name"] for s in get_tool_specs()}
         assert {"create_simulator", "simulate_process", "reveal_simulator"} <= names
 
-    def test_simulation_helper_lists_all_three(self):
+    def test_simulation_helper_lists_all_registered(self):
         specs = get_simulation_tool_specs()
         assert {s["name"] for s in specs} == {
             "create_simulator",
             "simulate_process",
             "reveal_simulator",
+            "simulate_batch_campaign",
+            "decompose_batch_quality_variance",
         }
-        assert len(specs) == 3
+        assert len(specs) == 5
 
     def test_dispatch_via_execute_tool_call(self):
         out = execute_tool_call(

--- a/tests/test_simulation_batch.py
+++ b/tests/test_simulation_batch.py
@@ -595,3 +595,67 @@ def test_campaign_output_feeds_the_alignment_tooling(sim: BioreactorSimulator) -
         campaign.batches, columns_to_align=tags, reference_batch=first_id, settings={"show_progress": False}
     )
     assert set(aligned.keys()) == set(campaign.batches.keys())
+
+
+# ---------------------------------------------------------------------------
+# Agent tools and recipe
+# ---------------------------------------------------------------------------
+
+
+def test_batch_tool_schemas_and_rng_metadata() -> None:
+    from process_improve.tool_spec import get_tool_specs
+
+    specs = {s["name"]: s for s in get_tool_specs(category="simulation")}
+    for name in ("simulate_batch_campaign", "decompose_batch_quality_variance"):
+        assert name in specs
+        assert specs[name]["input_schema"]["additionalProperties"] is False
+        assert specs[name]["rng"] == {"uses_rng": True, "seed_param": "random_state", "default_seed": 0}
+
+
+def test_simulate_batch_campaign_tool_runs_and_reproduces() -> None:
+    from process_improve.tool_spec import execute_tool_call
+
+    payload = {"n_batches": 10, "policy": "replay", "random_state": 0}
+    one = execute_tool_call("simulate_batch_campaign", payload)
+    two = execute_tool_call("simulate_batch_campaign", payload)
+    assert "error" not in one
+    assert one == two
+    assert len(one["batches"]) == 10
+    assert one["titer_g_L"]["sd"] > 0.0
+    assert one["reference_titer_g_L"]["value"] > 0.0
+
+
+def test_simulate_batch_campaign_tool_rejects_bad_input() -> None:
+    from process_improve.tool_safety import ToolInputInvalidError
+    from process_improve.tool_spec import execute_tool_call
+
+    with pytest.raises(ToolInputInvalidError):
+        execute_tool_call("simulate_batch_campaign", {"n_batches": 1})
+    with pytest.raises(ToolInputInvalidError):
+        execute_tool_call("simulate_batch_campaign", {"n_batches": 10, "unexpected": True})
+
+
+def test_decompose_batch_quality_variance_tool_runs() -> None:
+    from process_improve.tool_spec import execute_tool_call
+
+    out = execute_tool_call("decompose_batch_quality_variance", {"n_batches": 20, "random_state": 0})
+    assert "error" not in out
+    sources = {row["source"]: row for row in out["sources"]}
+    assert set(sources) == {
+        "measured initial conditions",
+        "within-batch disturbance",
+        "control and measurement noise",
+        "interaction residual",
+        "total",
+    }
+    assert sources["control and measurement noise"]["cv_pct"] < 1.0
+
+
+def test_golden_batch_recipe_is_registered_and_matches() -> None:
+    from process_improve.recipes import discover_recipes, get_recipe, select_recipe
+
+    discover_recipes()
+    assert get_recipe("golden_batch_baseline") is not None
+    match = select_recipe("our golden batch does not repeat; batches differ with the same recipe")
+    assert match is not None
+    assert match.key == "golden_batch_baseline"

--- a/tests/test_simulation_batch.py
+++ b/tests/test_simulation_batch.py
@@ -667,3 +667,71 @@ def test_adapted_policy_runs_and_differs_per_batch(sim: BioreactorSimulator) -> 
     ids = list(campaign.trajectories)
     assert not campaign.trajectories[ids[0]].equals(campaign.trajectories[ids[1]])
     assert (campaign.quality["titer"] > 0).all()
+
+
+# ---------------------------------------------------------------------------
+# Regression tests from the adversarial review
+# ---------------------------------------------------------------------------
+
+
+def test_ic_scale_acts_linearly_and_only_at_the_draw() -> None:
+    """The initial-condition channel scales linearly (it was once applied twice,
+    making it quadratic), and a caller-supplied Z row is used at face value,
+    independent of ic_scale.
+    """
+    from process_improve.simulation.batch import _coerce_z_row, _latent_effects, _z_to_latent
+
+    full = sample_initial_conditions(60, ic_scale=1.0, random_state=9)
+    half = sample_initial_conditions(60, ic_scale=0.5, random_state=9)
+    np.testing.assert_allclose(half.latent.to_numpy(), 0.5 * full.latent.to_numpy())
+
+    cfg = BioreactorConfig()
+    x0_full = np.array([_latent_effects(cfg, _z_to_latent(_coerce_z_row(row)))[0] for _, row in full.z.iterrows()])
+    x0_half = np.array([_latent_effects(cfg, _z_to_latent(_coerce_z_row(row)))[0] for _, row in half.z.iterrows()])
+    deviation_full = x0_full / cfg.biomass_initial - 1.0
+    deviation_half = x0_half / cfg.biomass_initial - 1.0
+    unclipped = (np.abs(deviation_full) < 0.35) & (np.abs(deviation_half) < 0.35)
+    assert unclipped.sum() > 30
+    np.testing.assert_allclose(deviation_half[unclipped], 0.5 * deviation_full[unclipped], rtol=1e-9)
+
+    z_row = full.z.iloc[0]
+    quiet = dict(within_batch_scale=0.0, noise_scale=0.0)
+    titer_a = BioreactorSimulator(_config(ic_scale=0.25, **quiet)).simulate_batch(z_row).titer
+    titer_b = BioreactorSimulator(_config(ic_scale=1.0, **quiet)).simulate_batch(z_row).titer
+    assert titer_a == titer_b, "a supplied Z row must mean the same thing at every ic_scale"
+
+
+def test_ctmi_rejects_ill_posed_cardinals() -> None:
+    """t_opt below the window midpoint puts a pole inside the cardinal window."""
+    with pytest.raises(ValueError, match="t_opt >= \\(t_min \\+ t_max\\) / 2"):
+        cardinal_temperature(30.0, 27.5, 33.0, 41.5)
+    with pytest.raises(ValueError, match="t_opt >= \\(t_min \\+ t_max\\) / 2"):
+        BioreactorConfig(temp_opt=33.0)
+    with pytest.raises(ValueError, match="t_opt >= \\(t_min \\+ t_max\\) / 2"):
+        BioreactorConfig(temp_q_opt=31.0)
+
+
+def test_realised_trajectory_matches_requested_when_noise_off(nominal: pd.DataFrame) -> None:
+    """With control noise off, each realised row equals the requested setpoint of
+    the interval that ends at its timestamp (it was once shifted one interval
+    ahead, reporting the next interval's setpoint).
+    """
+    quiet = BioreactorSimulator(_config(ic_scale=0.0, within_batch_scale=0.0, noise_scale=0.0))
+    result = quiet.simulate_batch(None, nominal)
+    np.testing.assert_allclose(result.realised_trajectory["temperature"].to_numpy(), nominal["temperature"].to_numpy())
+    np.testing.assert_allclose(result.realised_trajectory["pH"].to_numpy(), nominal["pH"].to_numpy())
+    np.testing.assert_allclose(result.tags["temperature"].to_numpy(), nominal["temperature"].to_numpy())
+
+
+def test_duplicate_batch_ids_are_rejected(sim: BioreactorSimulator) -> None:
+    z = sample_initial_conditions(2, random_state=0).z
+    doubled = pd.concat([z, z])
+    with pytest.raises(ValueError, match="unique batch ids"):
+        sim.simulate_campaign(4, initial_conditions=doubled)
+
+
+def test_supplied_z_block_happy_path(sim: BioreactorSimulator) -> None:
+    z = sample_initial_conditions(3, random_state=1).z
+    campaign = sim.simulate_campaign(3, initial_conditions=z, random_state=2)
+    assert list(campaign.quality.index) == list(z.index)
+    assert (campaign.classes == "?").all()

--- a/tests/test_simulation_batch.py
+++ b/tests/test_simulation_batch.py
@@ -1,0 +1,597 @@
+"""Tests for the fed-batch bioreactor simulator (``process_improve.simulation.batch``).
+
+Grouped by intent:
+
+- Realism acceptance tests: the sensitivity budget must show instrument-scale
+  input noise to be immaterial and sustained multi-degree deviations to be
+  material. These pin the property the simulator was designed around.
+- Determinism: bitwise reproducibility from a seed, including across
+  processes.
+- Channel isolation: each disturbance channel can be switched off without
+  altering the draws of the others, and the within-batch channel alone
+  spreads the titer (the load-bearing claim for mid-course correction).
+- Physical invariants (property-based, hypothesis).
+- Optimiser behaviour and the variance decomposition (slow tier).
+- Round-trips into the package's batch tooling (integration tier).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import subprocess
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from process_improve.batch.data_input import check_valid_batch_dict, dict_to_wide
+from process_improve.batch.preprocessing import resample_to_reference
+from process_improve.multivariate import PCA, MCUVScaler
+from process_improve.simulation import (
+    UPSTREAM_VARIABLE_NAMES,
+    BioreactorConfig,
+    BioreactorSimulator,
+    cardinal_ph,
+    cardinal_temperature,
+    sample_initial_conditions,
+    variance_decomposition,
+)
+
+
+@pytest.fixture(scope="module")
+def sim() -> BioreactorSimulator:
+    """Return a simulator on the default configuration (stateless, safe to share)."""
+    return BioreactorSimulator()
+
+
+@pytest.fixture(scope="module")
+def nominal(sim: BioreactorSimulator) -> pd.DataFrame:
+    return sim.nominal_trajectory()
+
+
+@pytest.fixture(scope="module")
+def budget(sim: BioreactorSimulator) -> pd.DataFrame:
+    """Compute the sensitivity budget once for all realism tests."""
+    return sim.sensitivity_budget(n_noise_replicates=80, random_state=0)
+
+
+def _effect(budget: pd.DataFrame, label_fragment: str) -> float:
+    rows = [label for label in budget.index if label_fragment in label]
+    assert len(rows) == 1, f"expected exactly one budget row matching {label_fragment!r}, found {rows}"
+    return float(budget.loc[rows[0], "effect_pct"])
+
+
+# ---------------------------------------------------------------------------
+# Realism acceptance tests
+# ---------------------------------------------------------------------------
+
+
+def test_control_loop_noise_is_immaterial(budget: pd.DataFrame) -> None:
+    """Zero-mean control noise at instrument scale moves titer by well under 1%."""
+    assert 0.0 < _effect(budget, "control-loop noise") < 0.5
+
+
+def test_instrument_resolution_bias_is_immaterial(budget: pd.DataFrame) -> None:
+    """A sustained bias at instrument resolution (0.1 degC, 0.02 pH) is second order."""
+    assert abs(_effect(budget, "temperature bias +0.1")) < 0.30
+    assert abs(_effect(budget, "temperature bias -0.1")) < 0.30
+    assert abs(_effect(budget, "pH bias +0.02")) < 0.05
+    assert abs(_effect(budget, "pH bias -0.02")) < 0.05
+
+
+def test_single_sample_excursion_is_immaterial(budget: pd.DataFrame) -> None:
+    """One 12-hour 0.5 degC excursion costs well under 1%."""
+    assert abs(_effect(budget, "single-sample temperature excursion")) < 0.5
+
+
+def test_two_degree_bias_is_material(budget: pd.DataFrame) -> None:
+    """A sustained 2 degC bias costs real titer, so the model is not inert."""
+    assert _effect(budget, "temperature bias +2.0") < -5.0
+    assert _effect(budget, "temperature bias -2.0") < -5.0
+
+
+def test_ph_bias_is_material(budget: pd.DataFrame) -> None:
+    """A sustained 0.2 pH bias is visible even though 0.02 is not."""
+    assert _effect(budget, "pH bias +0.20") < -0.3
+    assert _effect(budget, "pH bias -0.20") < -0.3
+
+
+def test_overheating_costs_more_than_undercooling(budget: pd.DataFrame) -> None:
+    """Near the operating point a warm bias costs more than the same cool bias.
+
+    Warm burns feed through residual growth and approaches hypoxia; cool at
+    this scale only slows the ramp. (Far from the operating point the
+    asymmetry reverses: full growth arrest is catastrophic.)
+    """
+    assert _effect(budget, "temperature bias +1.0") < _effect(budget, "temperature bias -1.0") < 0.0
+
+
+def test_perturbations_never_beat_the_stationary_nominal(budget: pd.DataFrame) -> None:
+    """The nominal recipe sits at a stationary maximum: every probed deterministic
+    perturbation should cost titer, not gain it.
+    """
+    deterministic = budget.drop(index=[label for label in budget.index if "noise" in label])
+    assert (deterministic["effect_pct"] < 0.05).all()
+
+
+# ---------------------------------------------------------------------------
+# Cardinal functions
+# ---------------------------------------------------------------------------
+
+
+def test_cardinal_functions_peak_at_one_and_vanish_at_bounds() -> None:
+    assert cardinal_temperature(36.8, 27.5, 36.8, 41.5) == pytest.approx(1.0)
+    assert cardinal_temperature(27.5, 27.5, 36.8, 41.5) == 0.0
+    assert cardinal_temperature(41.5, 27.5, 36.8, 41.5) == 0.0
+    assert cardinal_temperature(20.0, 27.5, 36.8, 41.5) == 0.0
+    assert cardinal_ph(7.10, 6.3, 7.10, 7.9) == pytest.approx(1.0)
+    assert cardinal_ph(6.3, 6.3, 7.10, 7.9) == 0.0
+    assert cardinal_ph(8.5, 6.3, 7.10, 7.9) == 0.0
+    grid = np.linspace(20.0, 45.0, 301)
+    values = cardinal_temperature(grid, 27.5, 36.8, 41.5)
+    assert np.all(values >= 0.0)
+    assert np.all(values <= 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_same_seed_is_bitwise_identical(sim: BioreactorSimulator) -> None:
+    one = sim.simulate_batch(random_state=42)
+    two = sim.simulate_batch(random_state=42)
+    assert one.titer == two.titer
+    pd.testing.assert_frame_equal(one.tags, two.tags, check_exact=True)
+    pd.testing.assert_frame_equal(one.states, two.states, check_exact=True)
+
+
+def test_different_seeds_differ(sim: BioreactorSimulator) -> None:
+    assert sim.simulate_batch(random_state=1).titer != sim.simulate_batch(random_state=2).titer
+
+
+def test_campaign_is_reproducible(sim: BioreactorSimulator) -> None:
+    one = sim.simulate_campaign(8, policy="replay", random_state=5)
+    two = sim.simulate_campaign(8, policy="replay", random_state=5)
+    pd.testing.assert_frame_equal(one.quality, two.quality, check_exact=True)
+    pd.testing.assert_frame_equal(one.initial_conditions, two.initial_conditions, check_exact=True)
+
+
+@pytest.mark.slow
+def test_cross_process_determinism(sim: BioreactorSimulator) -> None:
+    """A separate interpreter process reproduces the same titer bit for bit."""
+    code = (
+        "from process_improve.simulation import BioreactorSimulator; "
+        "print(repr(BioreactorSimulator().simulate_batch(random_state=42).titer))"
+    )
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True, timeout=300
+    )
+    assert float(result.stdout.strip()) == sim.simulate_batch(random_state=42).titer
+
+
+# ---------------------------------------------------------------------------
+# Channel isolation
+# ---------------------------------------------------------------------------
+
+
+def _config(**overrides: float) -> BioreactorConfig:
+    return dataclasses.replace(BioreactorConfig(), **overrides)
+
+
+def test_all_channels_zero_gives_identical_batches() -> None:
+    quiet = BioreactorSimulator(_config(ic_scale=0.0, within_batch_scale=0.0, noise_scale=0.0))
+    one = quiet.simulate_batch(random_state=1)
+    two = quiet.simulate_batch(random_state=999)
+    assert one.titer == two.titer
+    pd.testing.assert_frame_equal(one.tags, two.tags, check_exact=True)
+
+
+def test_replay_repeats_requested_but_not_realised(sim: BioreactorSimulator, nominal: pd.DataFrame) -> None:
+    campaign = sim.simulate_campaign(4, policy="replay", trajectory=nominal, random_state=3)
+    requested = list(campaign.trajectories.values())
+    for other in requested[1:]:
+        pd.testing.assert_frame_equal(requested[0], other, check_exact=True)
+    realised_temp = np.array([campaign.batches[b]["temperature"].to_numpy() for b in campaign.batches])
+    assert np.ptp(realised_temp, axis=0).max() > 0.0
+
+
+def test_within_batch_channel_alone_spreads_titer() -> None:
+    """The load-bearing claim: identical measured initial conditions for every
+    batch, no measurement or control noise, and the titer still spreads far
+    beyond the noise floor. This is the part of the variance only mid-course
+    correction can reach.
+    """
+    wb_only = BioreactorSimulator(_config(ic_scale=0.0, noise_scale=0.0))
+    campaign = wb_only.simulate_campaign(40, policy="replay", random_state=11)
+    z = campaign.initial_conditions
+    assert (z == z.iloc[0]).all().all(), "every batch must have identical initial conditions"
+    titer = campaign.quality["titer"]
+    assert 100.0 * titer.std(ddof=1) / titer.mean() > 3.0
+
+
+def test_noise_channel_alone_is_the_floor() -> None:
+    noise_only = BioreactorSimulator(_config(ic_scale=0.0, within_batch_scale=0.0))
+    campaign = noise_only.simulate_campaign(40, policy="replay", random_state=11)
+    titer = campaign.quality["titer"]
+    assert 100.0 * titer.std(ddof=1) / titer.mean() < 1.0
+
+
+def test_replay_spread_exceeds_zero_disturbance_spread(sim: BioreactorSimulator) -> None:
+    campaign = sim.simulate_campaign(40, policy="replay", random_state=11)
+    titer = campaign.quality["titer"]
+    assert 100.0 * titer.std(ddof=1) / titer.mean() > 5.0
+
+
+def test_channel_toggle_is_a_true_counterfactual() -> None:
+    """Switching one channel off must not change the draws of the others: the
+    same seed with within-batch off keeps the identical realised trajectory.
+    """
+    with_wb = BioreactorSimulator(_config(ic_scale=0.0, noise_scale=1.0, within_batch_scale=1.0))
+    without_wb = BioreactorSimulator(_config(ic_scale=0.0, noise_scale=1.0, within_batch_scale=0.0))
+    one = with_wb.simulate_batch(random_state=7)
+    two = without_wb.simulate_batch(random_state=7)
+    pd.testing.assert_frame_equal(one.realised_trajectory, two.realised_trajectory, check_exact=True)
+    assert one.titer != two.titer
+
+
+def test_unmeasured_disturbance_is_observable_in_the_gas_tags() -> None:
+    """The within-batch disturbance must show up in the oxygen trajectory even
+    though it is not a recorded variable: that observability is the premise of
+    mid-course correction.
+    """
+    with_wb = BioreactorSimulator(_config(ic_scale=0.0, noise_scale=0.0, within_batch_scale=1.0))
+    without_wb = BioreactorSimulator(_config(ic_scale=0.0, noise_scale=0.0, within_batch_scale=0.0))
+    one = with_wb.simulate_batch(random_state=7)
+    two = without_wb.simulate_batch(random_state=7)
+    assert not np.allclose(one.tags["dissolved_oxygen"], two.tags["dissolved_oxygen"])
+
+
+def test_historical_policy_varies_the_requested_trajectories(sim: BioreactorSimulator) -> None:
+    campaign = sim.simulate_campaign(5, policy="historical", mv_variation=1.0, random_state=3)
+    temps = np.array([t["temperature"].to_numpy() for t in campaign.trajectories.values()])
+    assert np.ptp(temps, axis=0).max() > 0.1
+    cfg = sim.config
+    assert temps.min() >= cfg.temp_bounds[0]
+    assert temps.max() <= cfg.temp_bounds[1]
+
+
+# ---------------------------------------------------------------------------
+# The upstream Z block
+# ---------------------------------------------------------------------------
+
+
+def test_z_block_layout() -> None:
+    drawn = sample_initial_conditions(12, random_state=1)
+    assert drawn.z.shape == (12, len(UPSTREAM_VARIABLE_NAMES))
+    assert list(drawn.z.columns) == list(UPSTREAM_VARIABLE_NAMES)
+    assert drawn.classes.isin(["A", "B", "C"]).all()
+    assert drawn.latent.shape == (12, 3)
+    assert (drawn.z.index == drawn.classes.index).all()
+
+
+def test_pca_of_z_recovers_about_three_components() -> None:
+    drawn = sample_initial_conditions(200, random_state=2)
+    scaled = MCUVScaler().fit_transform(drawn.z)
+    model = PCA(n_components=5).fit(scaled)
+    r2 = model.r2_cumulative_.to_numpy().ravel()
+    assert r2[2] > 0.55, "three components should capture the bulk of the upstream variation"
+    assert r2[3] - r2[2] < 0.10, "a fourth component should add little"
+
+
+def test_feed_classes_separate_in_z() -> None:
+    drawn = sample_initial_conditions(300, random_state=3)
+    grouped = drawn.z.groupby(drawn.classes)
+    assert grouped["seed_viability_pct"].mean()["A"] > grouped["seed_viability_pct"].mean()["C"]
+    assert grouped["impurity_index"].mean()["C"] > grouped["impurity_index"].mean()["A"]
+
+
+def test_class_proportions_are_respected() -> None:
+    drawn = sample_initial_conditions(50, proportions={"A": 1.0, "B": 0.0, "C": 0.0}, random_state=4)
+    assert (drawn.classes == "A").all()
+
+
+def test_ic_scale_zero_collapses_z_to_nominal() -> None:
+    drawn = sample_initial_conditions(6, ic_scale=0.0, random_state=5)
+    assert (drawn.z == drawn.z.iloc[0]).all().all()
+    assert np.allclose(drawn.latent.to_numpy(), 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Structure and physical plausibility
+# ---------------------------------------------------------------------------
+
+
+def test_output_shapes_and_layout(sim: BioreactorSimulator) -> None:
+    result = sim.simulate_batch(random_state=0)
+    cfg = sim.config
+    assert result.tags.shape == (cfg.n_samples, 5)
+    assert list(result.tags.columns) == ["pH", "temperature", "dissolved_oxygen", "offgas_co2", "volume"]
+    assert result.tags.index.name == "day"
+    assert result.tags.index[-1] == pytest.approx(cfg.batch_days)
+    assert result.states.shape[0] == cfg.n_steps + 1
+    assert list(result.realised_trajectory.columns) == ["pH", "temperature"]
+    assert list(result.initial_conditions.index) == list(UPSTREAM_VARIABLE_NAMES)
+
+
+def test_nominal_batch_is_physiologically_plausible(sim: BioreactorSimulator, nominal: pd.DataFrame) -> None:
+    quiet = BioreactorSimulator(_config(ic_scale=0.0, within_batch_scale=0.0, noise_scale=0.0))
+    result = quiet.simulate_batch(None, nominal)
+    assert 4.0 < result.titer < 12.0, "final titer should sit in a modern fed-batch range [g/L]"
+    assert 2.0 < result.states["biomass"].max() < 8.0, "peak biomass [g/L]"
+    assert (result.tags["dissolved_oxygen"] > 3.0).all()
+    assert (result.tags["dissolved_oxygen"] <= 100.0).all()
+    expected_volume = sim.config.volume_initial + sim.config.feed_rate * sim.config.batch_days
+    assert result.states["volume"].iloc[-1] == pytest.approx(expected_volume)
+
+
+def test_oxygen_falls_as_the_pile_grows() -> None:
+    quiet = BioreactorSimulator(_config(ic_scale=0.0, within_batch_scale=0.0, noise_scale=0.0))
+    tags = quiet.simulate_batch(None).tags
+    assert tags["dissolved_oxygen"].iloc[5] < tags["dissolved_oxygen"].iloc[0]
+
+
+def test_rk4_step_halving_changes_little() -> None:
+    coarse = BioreactorSimulator(_config(ic_scale=0.0, within_batch_scale=0.0, noise_scale=0.0))
+    fine = BioreactorSimulator(_config(ic_scale=0.0, within_batch_scale=0.0, noise_scale=0.0, steps_per_day=48))
+    t_coarse = coarse.simulate_batch(None).titer
+    t_fine = fine.simulate_batch(None).titer
+    assert abs(t_fine - t_coarse) / t_coarse < 1e-5  # inputs are held per step, so RK4 keeps its order
+
+
+def test_nominal_trajectory_is_biphasic(sim: BioreactorSimulator, nominal: pd.DataFrame) -> None:
+    cfg = sim.config
+    assert nominal["temperature"].iloc[0] == pytest.approx(cfg.temp_opt)
+    assert nominal["temperature"].iloc[-1] == pytest.approx(cfg.temp_production)
+    assert np.allclose(nominal["pH"], cfg.ph_opt)
+    assert nominal["temperature"].is_monotonic_decreasing
+
+
+# ---------------------------------------------------------------------------
+# Physical invariants (property-based)
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=15, deadline=None)
+@given(
+    seed=st.integers(min_value=0, max_value=2**31 - 1),
+    ic_scale=st.floats(min_value=0.0, max_value=2.0),
+    within_batch_scale=st.floats(min_value=0.0, max_value=2.0),
+    noise_scale=st.floats(min_value=0.0, max_value=2.0),
+)
+def test_physical_invariants_hold_for_any_input(
+    seed: int, ic_scale: float, within_batch_scale: float, noise_scale: float
+) -> None:
+    """States stay finite and non-negative, the realised trajectory stays inside
+    the actuator bounds, volume grows linearly, and the product mass never
+    exceeds what the substrate fed in can support.
+    """
+    cfg = _config(ic_scale=ic_scale, within_batch_scale=within_batch_scale, noise_scale=noise_scale)
+    simulator = BioreactorSimulator(cfg)
+    rng = np.random.default_rng(seed)
+    trajectory = pd.DataFrame(
+        {
+            "pH": rng.uniform(cfg.ph_bounds[0], cfg.ph_bounds[1], cfg.n_samples),
+            "temperature": rng.uniform(cfg.temp_bounds[0], cfg.temp_bounds[1], cfg.n_samples),
+        }
+    )
+    z = pd.Series(rng.normal(0.0, 3.0, len(UPSTREAM_VARIABLE_NAMES)), index=list(UPSTREAM_VARIABLE_NAMES))
+    z = z * 10.0 + 50.0  # arbitrary but finite user-supplied upstream values
+    result = simulator.simulate_batch(z, trajectory, random_state=seed)
+
+    states = result.states
+    assert np.isfinite(states.to_numpy()).all()
+    assert (states["biomass"] >= 0.0).all()
+    assert (states["substrate"] >= 0.0).all()
+    assert (states["titer"] >= 0.0).all()
+    assert (states["volume"] > 0.0).all()
+
+    assert (result.realised_trajectory["temperature"] >= cfg.temp_bounds[0]).all()
+    assert (result.realised_trajectory["temperature"] <= cfg.temp_bounds[1]).all()
+    assert (result.realised_trajectory["pH"] >= cfg.ph_bounds[0]).all()
+    assert (result.realised_trajectory["pH"] <= cfg.ph_bounds[1]).all()
+
+    volume = states["volume"].to_numpy()
+    increments = np.diff(volume)
+    assert increments.min() > 0.0
+    assert np.allclose(increments, increments[0], rtol=1e-9)
+
+    # Mass balance: product mass cannot exceed the yield on all substrate
+    # that entered the reactor (initial charge plus feed).
+    feed_rate = (volume[-1] - volume[0]) / cfg.batch_days
+    substrate_in = states["substrate"].iloc[0] * volume[0] + feed_rate * cfg.batch_days * cfg.feed_substrate
+    product_mass = states["titer"].iloc[-1] * volume[-1]
+    assert product_mass <= cfg.yield_ps * substrate_in * 1.001
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+def test_config_rejects_bad_cardinal_order() -> None:
+    with pytest.raises(ValueError, match="temp_min < temp_opt < temp_max"):
+        BioreactorConfig(temp_min=40.0, temp_opt=36.8, temp_max=41.5)
+
+
+def test_config_rejects_bad_sampling_grid() -> None:
+    with pytest.raises(ValueError, match="integer multiple of n_samples"):
+        BioreactorConfig(n_samples=7)
+
+
+def test_config_rejects_negative_kinetics() -> None:
+    with pytest.raises(ValueError, match="mu_opt"):
+        BioreactorConfig(mu_opt=-1.0)
+
+
+def test_config_rejects_bounds_outside_cardinal_window() -> None:
+    with pytest.raises(ValueError, match="temp_bounds"):
+        BioreactorConfig(temp_bounds=(20.0, 39.0))
+
+
+def test_config_rejects_hold_outside_bounds() -> None:
+    with pytest.raises(ValueError, match="temp_production"):
+        BioreactorConfig(temp_production=45.0)
+
+
+def test_simulator_rejects_wrong_config_type() -> None:
+    with pytest.raises(TypeError, match="BioreactorConfig"):
+        BioreactorSimulator(config="not a config")  # type: ignore[arg-type]
+
+
+def test_simulate_batch_rejects_bad_trajectory(sim: BioreactorSimulator, nominal: pd.DataFrame) -> None:
+    with pytest.raises(ValueError, match="missing columns"):
+        sim.simulate_batch(None, nominal[["pH"]])
+    with pytest.raises(ValueError, match="rows"):
+        sim.simulate_batch(None, nominal.iloc[:5])
+    too_hot = nominal.copy()
+    too_hot["temperature"] = 45.0
+    with pytest.raises(ValueError, match="temp_bounds"):
+        sim.simulate_batch(None, too_hot)
+    not_finite = nominal.copy()
+    not_finite.iloc[0, 0] = np.nan
+    with pytest.raises(ValueError, match="non-finite"):
+        sim.simulate_batch(None, not_finite)
+    with pytest.raises(TypeError, match="DataFrame"):
+        sim.simulate_batch(None, "not a frame")  # type: ignore[arg-type]
+
+
+def test_simulate_batch_rejects_bad_initial_conditions(sim: BioreactorSimulator) -> None:
+    with pytest.raises(TypeError, match="Series"):
+        sim.simulate_batch({"a": 1.0})  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="missing upstream variables"):
+        sim.simulate_batch(pd.Series({"seed_viability_pct": 90.0}))
+    bad = pd.Series(np.nan, index=list(UPSTREAM_VARIABLE_NAMES))
+    with pytest.raises(ValueError, match="non-finite"):
+        sim.simulate_batch(bad)
+
+
+def test_campaign_rejects_bad_arguments(sim: BioreactorSimulator) -> None:
+    with pytest.raises(ValueError, match="n_batches"):
+        sim.simulate_campaign(0)
+    with pytest.raises(ValueError, match="policy"):
+        sim.simulate_campaign(3, policy="whatever")
+    with pytest.raises(ValueError, match="mv_variation"):
+        sim.simulate_campaign(3, policy="historical", mv_variation=-1.0)
+    with pytest.raises(TypeError, match="DataFrame"):
+        sim.simulate_campaign(3, initial_conditions="nope")  # type: ignore[arg-type]
+    z = sample_initial_conditions(2, random_state=0).z
+    with pytest.raises(ValueError, match="rows"):
+        sim.simulate_campaign(3, initial_conditions=z)
+    with pytest.raises(ValueError, match="missing upstream variables"):
+        sim.simulate_campaign(2, initial_conditions=z[["seed_viability_pct"]])
+
+
+def test_sample_initial_conditions_rejects_bad_arguments() -> None:
+    with pytest.raises(ValueError, match="n_batches"):
+        sample_initial_conditions(0)
+    with pytest.raises(ValueError, match="ic_scale"):
+        sample_initial_conditions(3, ic_scale=-1.0)
+    with pytest.raises(ValueError, match="unknown class labels"):
+        sample_initial_conditions(3, proportions={"D": 1.0})
+    with pytest.raises(ValueError, match="positive sum"):
+        sample_initial_conditions(3, proportions={"A": 0.0, "B": 0.0, "C": 0.0})
+
+
+def test_optimal_trajectory_rejects_bad_arguments(sim: BioreactorSimulator) -> None:
+    with pytest.raises(ValueError, match="n_knots"):
+        sim.optimal_trajectory(n_knots=1)
+    with pytest.raises(ValueError, match="n_starts"):
+        sim.optimal_trajectory(n_starts=0)
+
+
+def test_sensitivity_budget_rejects_bad_arguments(sim: BioreactorSimulator) -> None:
+    with pytest.raises(ValueError, match="n_noise_replicates"):
+        sim.sensitivity_budget(n_noise_replicates=1)
+
+
+def test_variance_decomposition_rejects_bad_arguments(sim: BioreactorSimulator) -> None:
+    with pytest.raises(TypeError, match="BioreactorSimulator"):
+        variance_decomposition("not a simulator")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="n_batches"):
+        variance_decomposition(sim, n_batches=1)
+
+
+# ---------------------------------------------------------------------------
+# Optimiser and variance decomposition (slow tier)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_golden_trajectory_is_biphasic_and_beats_the_recipe(sim: BioreactorSimulator, nominal: pd.DataFrame) -> None:
+    golden = sim.golden_trajectory(n_knots=3, n_starts=2)
+    assert golden.optimizer_success
+    temperature = golden.trajectory["temperature"].to_numpy()
+    assert temperature[0] > 34.0, "the growth phase should be warm"
+    assert temperature[-1] < 31.0, "the production phase should be cool"
+    nominal_titer = sim._deterministic_titer(np.zeros(3), nominal["pH"].to_numpy(), nominal["temperature"].to_numpy())
+    assert golden.titer > nominal_titer
+
+
+@pytest.mark.slow
+def test_adaptation_beats_replaying_the_golden_batch(sim: BioreactorSimulator) -> None:
+    """For a poor feed lot, the true optimum for its own conditions beats
+    replaying the golden trajectory by a material margin.
+    """
+    from process_improve.simulation.batch import _coerce_z_row, _z_to_latent
+
+    golden = sim.golden_trajectory(n_knots=3, n_starts=2)
+    drawn = sample_initial_conditions(30, random_state=3)
+    # The batch with the strongest inhibitor level is the worst lot.
+    worst = drawn.latent["inhibitor_level"].idxmax()
+    z_row = drawn.z.loc[worst]
+    latent = _z_to_latent(_coerce_z_row(z_row))
+    replay_titer = sim._deterministic_titer(
+        latent, golden.trajectory["pH"].to_numpy(), golden.trajectory["temperature"].to_numpy()
+    )
+    adapted = sim.optimal_trajectory(z_row, n_knots=3, n_starts=2)
+    assert adapted.titer > replay_titer * 1.01, "adaptation should recover at least 1% for a poor lot"
+
+
+@pytest.mark.slow
+def test_variance_decomposition_buckets(sim: BioreactorSimulator) -> None:
+    frame = variance_decomposition(sim, n_batches=60, random_state=11)
+    assert list(frame.index) == [
+        "measured initial conditions",
+        "within-batch disturbance",
+        "control and measurement noise",
+        "interaction residual",
+        "total",
+    ]
+    noise = frame.loc["control and measurement noise"]
+    assert noise["cv_pct"] < 1.0
+    assert frame.loc["measured initial conditions", "cv_pct"] > 3.0
+    assert frame.loc["within-batch disturbance", "cv_pct"] > 3.0
+    assert frame.loc["total", "cv_pct"] > 8.0
+    parts = frame.loc[
+        ["measured initial conditions", "within-batch disturbance", "control and measurement noise"], "variance"
+    ].sum()
+    residual = frame.loc["interaction residual", "variance"]
+    assert frame.loc["total", "variance"] == pytest.approx(parts + residual)
+
+
+# ---------------------------------------------------------------------------
+# Integration with the batch tooling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_campaign_output_is_a_valid_batch_dict(sim: BioreactorSimulator) -> None:
+    campaign = sim.simulate_campaign(6, policy="replay", random_state=1)
+    assert check_valid_batch_dict(campaign.batches)
+    wide = dict_to_wide(campaign.batches)
+    assert wide.shape == (6, sim.config.n_samples * 5)
+
+
+@pytest.mark.integration
+def test_campaign_output_feeds_the_alignment_tooling(sim: BioreactorSimulator) -> None:
+    campaign = sim.simulate_campaign(4, policy="replay", random_state=2)
+    tags = list(next(iter(campaign.batches.values())).columns)
+    first_id = next(iter(campaign.batches))
+    aligned = resample_to_reference(
+        campaign.batches, columns_to_align=tags, reference_batch=first_id, settings={"show_progress": False}
+    )
+    assert set(aligned.keys()) == set(campaign.batches.keys())

--- a/tests/test_simulation_batch.py
+++ b/tests/test_simulation_batch.py
@@ -659,3 +659,11 @@ def test_golden_batch_recipe_is_registered_and_matches() -> None:
     match = select_recipe("our golden batch does not repeat; batches differ with the same recipe")
     assert match is not None
     assert match.key == "golden_batch_baseline"
+
+
+@pytest.mark.slow
+def test_adapted_policy_runs_and_differs_per_batch(sim: BioreactorSimulator) -> None:
+    campaign = sim.simulate_campaign(2, policy="adapted", n_knots=3, n_starts=1, random_state=4)
+    ids = list(campaign.trajectories)
+    assert not campaign.trajectories[ids[0]].equals(campaign.trajectories[ids[1]])
+    assert (campaign.quality["titer"] > 0).all()

--- a/tests/test_simulation_batch.py
+++ b/tests/test_simulation_batch.py
@@ -308,7 +308,7 @@ def test_ic_scale_zero_collapses_z_to_nominal() -> None:
 def test_output_shapes_and_layout(sim: BioreactorSimulator) -> None:
     result = sim.simulate_batch(random_state=0)
     cfg = sim.config
-    assert result.tags.shape == (cfg.n_samples, 5)
+    assert result.tags.shape == (cfg.samples_per_batch, 5)
     assert list(result.tags.columns) == ["pH", "temperature", "dissolved_oxygen", "offgas_co2", "volume"]
     assert result.tags.index.name == "day"
     assert result.tags.index[-1] == pytest.approx(cfg.batch_days)
@@ -374,8 +374,8 @@ def test_physical_invariants_hold_for_any_input(
     rng = np.random.default_rng(seed)
     trajectory = pd.DataFrame(
         {
-            "pH": rng.uniform(cfg.ph_bounds[0], cfg.ph_bounds[1], cfg.n_samples),
-            "temperature": rng.uniform(cfg.temp_bounds[0], cfg.temp_bounds[1], cfg.n_samples),
+            "pH": rng.uniform(cfg.ph_bounds[0], cfg.ph_bounds[1], cfg.samples_per_batch),
+            "temperature": rng.uniform(cfg.temp_bounds[0], cfg.temp_bounds[1], cfg.samples_per_batch),
         }
     )
     z = pd.Series(rng.normal(0.0, 3.0, len(UPSTREAM_VARIABLE_NAMES)), index=list(UPSTREAM_VARIABLE_NAMES))
@@ -418,8 +418,8 @@ def test_config_rejects_bad_cardinal_order() -> None:
 
 
 def test_config_rejects_bad_sampling_grid() -> None:
-    with pytest.raises(ValueError, match="integer multiple of n_samples"):
-        BioreactorConfig(n_samples=7)
+    with pytest.raises(ValueError, match="integer multiple of samples_per_batch"):
+        BioreactorConfig(samples_per_batch=7)
 
 
 def test_config_rejects_negative_kinetics() -> None:
@@ -583,7 +583,7 @@ def test_campaign_output_is_a_valid_batch_dict(sim: BioreactorSimulator) -> None
     campaign = sim.simulate_campaign(6, policy="replay", random_state=1)
     assert check_valid_batch_dict(campaign.batches)
     wide = dict_to_wide(campaign.batches)
-    assert wide.shape == (6, sim.config.n_samples * 5)
+    assert wide.shape == (6, sim.config.samples_per_batch * 5)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

- Adds `simulation.batch`: a deterministic fed-batch bioreactor simulator (biomass, substrate, titer, volume; growth from the Rosso et al. 1995 cardinal temperature and pH model; Luedeking-Piret production; an oxygen-transfer ceiling with hypoxic death; hypothermic growth arrest; substrate-coupled production) with three independently tunable disturbance channels: measured initial conditions (an 11-variable Z block with three feed classes A/B/C), a within-batch disturbance that is unmeasured but observable in the gas trajectories, and control-loop plus measurement noise.
- Purpose: the quantitative baseline for later batch mid-course-correction tools. Three claims become demonstrable and reproducible from a seed: replaying a golden batch's schedule does not reproduce its outcome (about 13% titer CV under replay); the spread persists with identical measured initial conditions (about 7% CV, roughly thirty times the noise floor); and the variance decomposes into a before-batch share, a during-batch share, and a noise floor (with the nonlinear interaction residual reported explicitly).
- Realism is enforced, not asserted: instrument-scale input noise must not visibly move the titer (control-loop noise sd 0.25%, a sustained 0.1 degC bias about 0.2%, 0.02 pH invisible) while sustained deviations must (1 degC costs 7 to 11%, 2 degC about 21%). The budget ships as a public `sensitivity_budget()` method and as acceptance tests.
- The true optimal schedule for any initial conditions is computable from the model, so later latent-variable schemes have a ceiling to score against. The optimiser independently recovers the industrial biphasic downshift (golden schedule 8.54 g/L vs 8.01 g/L for the nominal recipe); per-lot adaptation gaps range from about 3% (good feed class centre) to over 40% (poorest class centre).
- Campaign policies (`replay`, `historical`, `adapted`), `variance_decomposition`, two agent tools (`simulate_batch_campaign`, `decompose_batch_quality_variance`) and the `golden_batch_baseline` analysis recipe. Campaign output uses the standard batch dictionary format, feeding `dict_to_wide` and the alignment tooling directly.
- An independent multi-lens adversarial review (27 agents, findings verified by dedicated refuters) ran before finalising; its 10 confirmed findings, including a quadratic-scaling bug in the initial-condition channel and an off-by-one-interval defect in the recorded tags, are fixed in the last commit with regression tests.

Note: the stale batch-modelling stack #459-#462 is untouched here and needs rebasing onto current `main` before the mid-course-correction phase builds on it.

## Test plan

- [x] `tests/test_simulation_batch.py` (60 tests): sensitivity acceptance tests, bitwise determinism (including cross-process), channel isolation (the same-Z spread test), hypothesis property invariants, round-trips through `dict_to_wide` and `resample_to_reference`, optimum-beats-replay, RK4 step-halving convergence, and regression tests for every confirmed review finding
- [x] `uv run ruff check .` and `uv run ruff format --check .`
- [x] `uv run mypy src/process_improve`
- [x] Full suite under the 92% coverage gate (2593 passed locally; the only 2 local failures are openmv.net downloads blocked by the sandbox proxy, and they pass in CI), and the new tests under `python -O`
- [x] Docs build green in CI (a cross-reference collision was fixed by renaming the config field to `samples_per_batch`)

## Checklist

- [x] Version bumped in `pyproject.toml` (MINOR: 1.66.2 to 1.67.0, new module and tools)
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZAyiPT8xURSdi24yFKCra