### PR TITLE
fix(lint): restore the ruff gate under 0.16, and fix what it caught

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ those changes.
 
 ## [Unreleased]
 
+## [1.67.1] - 2026-08-22
+
+### Fixed
+
+- The lint gate is green again under ruff 0.16, which the dependency bump in
+  #492 allowed in without adjusting the configuration. Three preview or changed
+  rules fired repo-wide: `PLR0917` (too many positional arguments) is now
+  ignored, because it reports the same wide scientific signatures that
+  `PLR0913` already covers case by case; `S310` is scoped off for `tests/**`,
+  because 0.15 reports it for `urllib.request.Request` and 0.16 only for
+  `urlopen`, so an inline directive is required by one version and reported as
+  unused (`RUF100`) by the other; and Markdown is excluded from the formatter,
+  which began reflowing Python snippets inside fenced code blocks in 0.16 and
+  stripped the deliberate comment alignment from the README and CONTRIBUTING
+  examples. Both gates now give identical results on ruff 0.15 and 0.16.
+- Three genuine findings from the same ruff upgrade: `TPLS.score` annotated
+  `sample_weight` as `None | np.ndarray` (`RUF036`, `None` belongs last);
+  `_serialise_tool_error` called `logger.exception()` outside an exception
+  handler (`LOG004`) and now logs the exception it is passed explicitly via
+  `exc_info`, which also puts its previously unused `exc` argument to work; and
+  a recipe in `sensory/recipes.py` relied on unparenthesised implicit string
+  concatenation inside a list (`ISC004`), the classic missing-comma trap.
+
 ## [1.67.0] - 2026-08-21
 
 ### Fixed
@@ -3127,7 +3150,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.67.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.67.1...HEAD
+[1.67.1]: https://github.com/kgdunn/process-improve/compare/v1.67.0...v1.67.1
 [1.67.0]: https://github.com/kgdunn/process-improve/compare/v1.66.1...v1.67.0
 [1.66.1]: https://github.com/kgdunn/process-improve/compare/v1.66.0...v1.66.1
 [1.66.0]: https://github.com/kgdunn/process-improve/compare/v1.65.0...v1.66.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.67.0
-date-released: "2026-08-21"
+version: 1.67.1
+date-released: "2026-08-22"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.67.0"
+version = "1.67.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"
@@ -203,6 +203,14 @@ exclude = [
     "__pypackages__",
 ]
 
+[tool.ruff.format]
+# ruff 0.16 began formatting Python snippets inside Markdown fenced code blocks.
+# The examples in README.md / CONTRIBUTING.md / CHANGELOG.md align their trailing
+# comments deliberately, and the formatter strips that alignment. Markdown was
+# never formatted before 0.16, so keep it that way rather than reflow the docs
+# and have the gate depend on the installed ruff version (see CPY001 above).
+exclude = ["*.md"]
+
 [tool.ruff.lint]
 
 # Enable ALL Pyflakes codes by default.
@@ -269,6 +277,13 @@ ignore = [
     # Refactoring
     "PLR2004", # Don't agree that this is a bad style. It leads to overly verbose code in many cases.
 
+    # PLR0917 is the preview sibling of PLR0913 (too many ARGUMENTS), which this
+    # repo already accepts case by case via `# noqa: PLR0913` on the wide
+    # scientific signatures. ruff 0.16 began reporting PLR0917 on every one of
+    # those same functions, so the two rules must be handled the same way or the
+    # lint gate would depend on the installed ruff version (see CPY001 above).
+    "PLR0917", # Too many positional arguments: same signatures PLR0913 already covers.
+
     # Stop it with the trailing commas.
     "COM812", # Trailing comma is not always needed - doesn't lead to more readable code.
 
@@ -310,6 +325,12 @@ convention = "numpy"
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = [
     "ANN001",  # Type annotations not needed in tests
+    # ruff 0.15 reports S310 for urllib.request.Request(), ruff 0.16 only for
+    # urlopen(), so an inline `# noqa: S310` is required by one version and
+    # reported as an unused directive (RUF100) by the other. The URLs here are
+    # hard-coded https literals in network-gated tests, so scope the rule off
+    # for tests rather than let the lint gate depend on the ruff version.
+    "S310",    # Audit URL open: test URLs are hard-coded https literals
     "ANN201",  # Return type annotations not needed in tests
     "ANN202",  # Return type annotations not needed in tests
     "D102",    # Docstrings not needed in test methods

--- a/src/process_improve/mcp_server.py
+++ b/src/process_improve/mcp_server.py
@@ -70,7 +70,7 @@ def _serialise_tool_error(exc: Exception, tool_name: str) -> str:
     :class:`ToolSafetyError`s, which have a curated payload, are handled by the
     caller before reaching here.)
     """
-    logger.exception("Tool %r raised an unexpected error", tool_name)
+    logger.error("Tool %r raised an unexpected error", tool_name, exc_info=exc)
     return json.dumps({"error": "internal error while executing tool", "tool": tool_name})
 
 

--- a/src/process_improve/multivariate/_tpls.py
+++ b/src/process_improve/multivariate/_tpls.py
@@ -857,7 +857,7 @@ class TPLS(RegressorMixin, BaseEstimator):
 
         return output
 
-    def score(self, X: DataFrameDict, y: None = None, sample_weight: None | np.ndarray = None) -> float:  # noqa: ARG002
+    def score(self, X: DataFrameDict, y: None = None, sample_weight: np.ndarray | None = None) -> float:  # noqa: ARG002
         """Return r2_score` on test data.
 
         See RegressorMixin.score for more details.

--- a/src/process_improve/sensory/recipes.py
+++ b/src/process_improve/sensory/recipes.py
@@ -47,8 +47,10 @@ _INTAKE = AnalysisRecipe(
         "descriptive panel",
     ],
     inputs_needed=[
-        "the parsed spreadsheet as rows (the front end or a code sandbox reads the file first; these "
-        "recipes do not read files themselves)",
+        (
+            "the parsed spreadsheet as rows (the front end or a code sandbox reads the file first; these "
+            "recipes do not read files themselves)"
+        ),
         "which columns hold the panelist, product, attribute, replicate, session and score",
         "the layout: one column per attribute, one column per product, or already one row per score",
         "the valid score range if known (for example 0 to 10)",

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -156,9 +156,9 @@ def test_pca_foods() -> None:
     """Arrays with no variance should not be able to have variance extracted."""
 
     url = "https://openmv.net/file/food-texture.csv"
-    req = urllib.request.Request(url, headers={"User-Agent": "Python/process-improve-tests"})  # noqa: S310
+    req = urllib.request.Request(url, headers={"User-Agent": "Python/process-improve-tests"})
     try:
-        with urllib.request.urlopen(req, timeout=10) as response:  # noqa: S310
+        with urllib.request.urlopen(req, timeout=10) as response:
             foods = pd.read_csv(io.StringIO(response.read().decode())).drop(
                 [
                     "Unnamed: 0",


### PR DESCRIPTION
## Summary

- **main's lint job is currently red.** The ruff bump in #492 raised the pin to `<0.17` without adjusting the configuration, so CI now resolves ruff 0.16, which reports 42 errors that 0.15 did not. None of them are new code: the same 42 reproduce on unmodified `main`, and they turn every open PR red too (a PR is linted merged with its base).
- **Three configuration changes**, so `ruff check` and `ruff format --check` give identical results on 0.15 and 0.16: ignore `PLR0917` (38 of the 42; it is the preview sibling of `PLR0913` and fires on exactly the wide scientific signatures this repo already accepts case by case with `# noqa: PLR0913`); scope `S310` off for `tests/**` (0.15 reports it for `urllib.request.Request`, 0.16 only for `urlopen`, so an inline directive is *required* by one version and reported as *unused* by the other); and exclude Markdown from the formatter (0.16 began reformatting Python inside fenced code blocks, stripping the deliberate trailing-comment alignment from the README/CONTRIBUTING examples). Each follows the reasoning already recorded in `pyproject.toml` for `CPY001`: keep the gate from depending on which ruff version happens to be installed.
- **Three genuine findings fixed rather than suppressed**: `TPLS.score` annotated `sample_weight` as `None | np.ndarray` (`RUF036`); `_serialise_tool_error` called `logger.exception()` outside an exception handler (`LOG004`), and now logs the exception it is handed explicitly via `exc_info`, which also puts its previously unused `exc` argument to work instead of relying on ambient exception state; and a recipe in `sensory/recipes.py` relied on unparenthesised implicit string concatenation inside a list (`ISC004`), the classic missing-comma trap.

## Test plan

- [x] `ruff check .` clean under **both** ruff 0.15 and 0.16 (verified with isolated `--with "ruff>=0.16,<0.17"` and `"ruff>=0.15,<0.16"` runs)
- [x] `ruff format --check .` clean under both, and back to formatting the same 274 files as before 0.16
- [x] `mypy src/process_improve` clean (148 source files)
- [x] Full suite: 2598 passed, 6 skipped. The two failures (`test_oildoe_loads`, `test_distillateflow_loads`) are network tests that fail identically on unmodified `main` in a sandbox without access to openmv.net
- [x] Confirmed the 42 errors reproduce on `main` at d6d86ff, establishing this as pre-existing breakage rather than PR fallout

## Checklist

- [x] Version bumped in `pyproject.toml` (PATCH: 1.67.0 to 1.67.1, config/lint fix), with `CITATION.cff` set to the same version and today's date in the same commit
- [x] Tests added or updated where relevant (no new behaviour; the two stale `# noqa: S310` directives in `tests/test_multivariate.py` are removed as part of the S310 scoping)
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated (new `[1.67.1]` section, fresh empty `[Unreleased]`, link footer updated)

---

Found while reviving #500, which is blocked on this: that PR is green on every check except lint, where it inherits these same 42 errors from the base branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPuM5PJdHnpvpKpAsc6uDM)_