### PR TITLE
fix(multivariate, regression): correct the score limit quantile and populate t_value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,51 @@ those changes.
 
 ## [Unreleased]
 
+## [1.69.0] - 2026-08-22
+
+### Changed
+
+- `score_limit` now uses the Student-t quantile on `N - 1` degrees of freedom
+  instead of the standard-normal `z`. The score standard deviation `s_a` is
+  estimated from the same `N` observations, so `z` is only its large-`N`
+  limit: at `N = 10` the old limit was 15 percent too tight (1.96 against
+  2.26), still 2.5 percent at `N = 50`, and negligible past `N = 100`. This
+  makes the function agree with its own documented identity, that
+  `(t_a / s_a) ** 2` follows `F(1, N - 1)`, since `sqrt(F(1, N - 1))` is
+  exactly the two-sided `t_{N - 1}` quantile; the docstring previously
+  asserted that identity while computing `z`, which contradicted it.
+  **Score limits are wider than before, most noticeably on small data sets.**
+
+### Fixed
+
+- `robust_regression` now populates the `t_value` key it documents. It was
+  only ever initialised to `NaN`: the critical value was computed into a local
+  variable, used to build the intervals, and never assigned back. The key now
+  holds the t-statistic per coefficient (coefficient divided by its standard
+  error), which is what the sibling `multiple_linear_regression` has always
+  returned under that name, so the two agree on what `t_value` means. It stays
+  `NaN` on the degenerate paths, where the standard error is undefined.
+
+### Documentation
+
+- Record the API-consistency rules in `CONTRIBUTING.md`: one name means one
+  quantity across sibling functions, a documented key must be populated,
+  sibling methods return the same shape, and a convention chosen once applies
+  everywhere.
+- Remove references to discontinued software that can no longer be used to
+  re-validate anything (ProSensus Multivariate / ProMV, and the legacy
+  ConnectMV MATLAB code). The numerical values recorded from them are kept
+  unchanged and are now described for what they are: regression pins that lock
+  in behaviour that was correct when recorded, distinguished in the reference
+  test suite from values that can still be re-derived from the published Wold,
+  Esbensen & Geladi (1987) paper.
+- `tests/test_multiblock_reference.py::test_score_limit_at_95pct` now asserts
+  against `PCA.score_limit` itself instead of re-deriving the formula inside
+  the test. It previously had to reconstruct the limit by hand because the
+  shipped function used a different convention from the reference value it was
+  checking; with `score_limit` corrected, the public API reproduces that value
+  (7.8432) directly.
+
 ## [1.68.0] - 2026-08-22
 
 A repo-wide correctness audit. Most entries below change numerical results
@@ -3289,7 +3334,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.68.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.69.0...HEAD
+[1.69.0]: https://github.com/kgdunn/process-improve/compare/v1.68.0...v1.69.0
 [1.68.0]: https://github.com/kgdunn/process-improve/compare/v1.67.1...v1.68.0
 [1.67.1]: https://github.com/kgdunn/process-improve/compare/v1.67.0...v1.67.1
 [1.67.0]: https://github.com/kgdunn/process-improve/compare/v1.66.1...v1.67.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.68.0
+version: 1.69.0
 date-released: "2026-08-22"
 keywords:
   - chemometrics

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,30 @@ still be rejected by CI.
 - **Prose:** do not use em-dashes in code, comments, docstrings, or commit
   messages; use a hyphen, a semicolon, or split the sentence.
 
+### API consistency
+
+Functions and estimators that do the same job must present the same API.
+Concretely, across a family of siblings (`PCA` / `PLS` / `TPLS` / `MBPLS` /
+`MBPCA`, or `robust_regression` / `multiple_linear_regression`):
+
+- **The same key or attribute name means the same quantity everywhere.** If
+  one function returns `t_value`, every sibling that can compute it returns
+  `t_value`, holding the same statistic. Reusing a name for a different
+  quantity is worse than not providing it at all.
+- **A key that is documented must be populated.** Do not document a return
+  value the code never assigns; either compute it or remove it from the
+  docstring. Where a value is genuinely undefined (a degenerate fit, for
+  example), return `NaN` and say so in the docstring.
+- **Sibling methods return the same shape of thing.** A method that returns a
+  `DataFrame` on one estimator should not return a `Series` on its sibling.
+- **A convention chosen once applies everywhere.** Degrees of freedom,
+  permutation-test corrections, centred versus uncentred moments, and similar
+  choices should not vary between neighbouring functions. If two conventions
+  are genuinely both needed, name the difference in both docstrings.
+
+When a fix makes one member of a family better, check the others in the same
+change; a divergence introduced quietly is expensive to find later.
+
 ### Naming conventions
 
 - **`pi_` prefix on attributes** stands for **"process-improve"** and marks

--- a/docs/user_guide/case_studies/latent-variable-modelling/mbpls-ldpe-missing-data.ipynb
+++ b/docs/user_guide/case_studies/latent-variable-modelling/mbpls-ldpe-missing-data.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "A small but realistic multi-block PLS case study on the LDPE tubular polymer reactor dataset shipped with this package. We use the **natural 4-block split** of the LDPE columns, fit MBPLS on the complete data, then inject MCAR noise into the X-blocks and Y to see how the mask-aware NIPALS path degrades. The whole workflow is one parameter change (`algorithm=\"auto\"`) different from the complete-data version.\n",
     "\n",
-    "**Data.** `LDPE.csv` shipped under `process_improve/datasets/multivariate/LDPE/` (ported from ConnectMV, originally based on the tubular high-pressure polyethylene reactor described in MacGregor *et al.*).\n",
+    "**Data.** `LDPE.csv` shipped under `process_improve/datasets/multivariate/LDPE/` (based on the tubular high-pressure polyethylene reactor described in MacGregor *et al.*).\n",
     "\n",
     "**Blocks.**\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.68.0"
+version = "1.69.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_limits.py
+++ b/src/process_improve/multivariate/_limits.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
-from scipy.stats import chi2, f, norm
+from scipy.stats import chi2, f
+from scipy.stats import t as t_dist
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_is_fitted
 
@@ -126,10 +127,16 @@ def spe_calculation(spe_values: np.ndarray, conf_level: float = 0.95) -> float:
 def score_limit(model: BaseEstimator, conf_level: float = 0.95) -> np.ndarray:
     """Return two-sided confidence limits for each score component.
 
-    The scores of component ``a`` have mean zero and are normally distributed,
-    so the symmetric limit at the requested confidence level is
-    ``z * std(score_a)``, with ``z`` the standard-normal quantile. A score
-    outside ``[-limit, +limit]`` is unusual at that confidence level.
+    The scores of component ``a`` have mean zero, and their standard deviation
+    is *estimated* from the same ``N`` observations, so the symmetric limit at
+    the requested confidence level is ``t_{N - 1} * std(score_a)`` with
+    ``t_{N - 1}`` the Student-t quantile on ``N - 1`` degrees of freedom. A
+    score outside ``[-limit, +limit]`` is unusual at that confidence level.
+
+    The Student-t quantile is used rather than the standard-normal ``z``
+    because ``s_a`` is an estimate: ``z`` is only its large-``N`` limit and is
+    too narrow otherwise (1.96 against 2.26 at ``N = 10``, a limit 15 percent
+    too tight; the gap falls below 3 percent by ``N = 50``).
 
     Parameters
     ----------
@@ -146,17 +153,18 @@ def score_limit(model: BaseEstimator, conf_level: float = 0.95) -> np.ndarray:
 
     References
     ----------
-    Score limits: the score ``t_a`` is normally distributed, so the limit is
-    ``z_{(1 + conf_level) / 2} * s_a``. Equivalently ``(t_a / s_a) ** 2``
-    follows an ``F(1, N - 1)`` distribution.
+    Score limits: the limit is ``t_{(1 + conf_level) / 2, N - 1} * s_a``.
+    Equivalently ``(t_a / s_a) ** 2`` follows an ``F(1, N - 1)`` distribution,
+    since ``sqrt(F(1, N - 1))`` is exactly the two-sided ``t_{N - 1}``
+    quantile.
     """
     assert 0.0 < conf_level < 1.0, "conf_level must be a value between (0.0, 1.0)"
     check_is_fitted(model, "scores_")
 
     scores = np.asarray(model.scores_, dtype=float)
     std_per_component = scores.std(axis=0, ddof=1)
-    z = norm.ppf(1 - (1 - conf_level) / 2)
-    return z * std_per_component
+    critical_value = t_dist.ppf(1 - (1 - conf_level) / 2, scores.shape[0] - 1)
+    return critical_value * std_per_component
 
 
 def ellipse_coordinates(  # noqa: PLR0913
@@ -234,10 +242,10 @@ def ellipse_coordinates(  # noqa: PLR0913
     s_v = scaling_factor_for_scores.iloc[score_vert - 1]
     # The ellipse is the joint confidence region for the TWO plotted scores,
     # so the T2 limit is computed with 2 degrees of freedom:
-    # 2 (N^2 - 1) / (N (N - 2)) * F(alpha; 2, N - 2), the convention used by
-    # SIMCA / ProMV and in Wold's texts. Using the full model's A here (the
-    # previous behaviour) draws a strictly larger ellipse (~42% too wide per
-    # axis at A=5, N=50; ~2x the area), silently hiding genuine outliers.
+    # 2 (N^2 - 1) / (N (N - 2)) * F(alpha; 2, N - 2), the convention used in
+    # Wold's texts. Using the full model's A here (the previous behaviour)
+    # draws a strictly larger ellipse (~42% too wide per axis at A=5, N=50;
+    # ~2x the area), silently hiding genuine outliers.
     # ``n_components`` is still used above to bound the score indices.
     t2_limit_specific = np.sqrt(hotellings_t2_limit(conf_level, n_components=2, n_rows=n_rows))
     dt = 2 * np.pi / (n_points - 1)

--- a/src/process_improve/multivariate/_mbpca.py
+++ b/src/process_improve/multivariate/_mbpca.py
@@ -135,10 +135,10 @@ class MBPCA(_HotellingsT2LimitMixin, TransformerMixin, BaseEstimator):
     -----
     The deflation step is :math:`X_b \leftarrow X_b - t_{\rm super}\,
     (p_b\,p_s[b]\,\sqrt{K_b})^\top`, derived in Westerhuis et al. 1998.
-    The legacy MATLAB ``mbpca.m`` had this step marked as broken by the
-    original author; this implementation re-derives it directly from the
-    paper and is independently validated against the pure-numpy reference
-    oracles in the test suite.
+    An earlier implementation of this method had this step marked as broken
+    by its author; this implementation re-derives it directly from the paper
+    and is independently validated against the pure-numpy reference oracles
+    in the test suite.
 
     Missing data
     ------------

--- a/src/process_improve/multivariate/_mbpls.py
+++ b/src/process_improve/multivariate/_mbpls.py
@@ -1014,8 +1014,7 @@ def randomization_test_mbpls(
     permutations whose statistic equals or exceeds the original model's.
 
     Statistic: per-component absolute correlation between the super X-score
-    and the super Y-score, ``|t_super(:,a)' u_super(:,a)| / (||t|| * ||u||)``,
-    matching the legacy ConnectMV randomization-objective for PLS.
+    and the super Y-score, ``|t_super(:,a)' u_super(:,a)| / (||t|| * ||u||)``.
 
     Parameters
     ----------

--- a/src/process_improve/regression/_robust_regression.py
+++ b/src/process_improve/regression/_robust_regression.py
@@ -130,8 +130,9 @@ def robust_regression(  # noqa: PLR0913, PLR0915
         k:                        the number of model parameters (2 if fit_intercept else 1)
         fitted_values:            the N predicted values, one per row in y
         residuals:                the N residuals
-        t_value:                  the two-sided critical t-value at ``conflevel`` used
-                                  to build the confidence and prediction intervals
+        t_value:                  the t-values for the standard errors, one per
+                                  coefficient (same meaning as in
+                                  ``multiple_linear_regression``)
         conf_intervals:           K rows x 2 columns (lower, upper) confidence intervals
         conf_interval_intercept:  (lower, upper) confidence interval for the intercept
         pi_range:                 prediction intervals above and below, over the range of data
@@ -259,6 +260,13 @@ def robust_regression(  # noqa: PLR0913, PLR0915
         lower = pi_y_pred - c_t * std_y
         upper = pi_y_pred + c_t * std_y
         out["pi_range"] = np.vstack([pi_range, lower, upper]).T
+
+    # The t-statistic per coefficient: coefficient / standard error. This
+    # matches `multiple_linear_regression`, so the two functions agree on what
+    # the "t_value" key means. It is NaN on the degenerate-x path, where the
+    # standard error is itself undefined. Note `c_t` is a different quantity:
+    # the critical value used to set the interval widths.
+    out["t_value"] = np.array([out["coefficients"][0] / out["standard_errors"][0]])
 
     out["conf_intervals"] = np.array(
         [

--- a/tests/_multiblock_oracles.py
+++ b/tests/_multiblock_oracles.py
@@ -38,8 +38,8 @@ References
 - Wold, S., Esbensen, K. & Geladi, P. "Principal Component Analysis."
   Chemometrics and Intelligent Laboratory Systems, 2 (1987), 37-52.
 
-Ported from the legacy ConnectMV ``unit_tests.m`` MBPCA_tests / MBPLS_tests
-self-consistency blocks.
+Derived from the self-consistency relationships the multi-block algorithms
+must satisfy, as recorded from an earlier implementation of these methods.
 """
 
 from __future__ import annotations
@@ -101,7 +101,7 @@ def mbpca_merged_then_recover(blocks: list[np.ndarray], n_components: int) -> MB
 
     For each latent variable, the per-block recovery operates on the
     *currently-deflated* merged matrix, not on the original. This matches the
-    legacy MATLAB ``MBPCA_tests`` self-consistency reference.
+    recorded MBPCA self-consistency reference.
     """
     n_blocks = len(blocks)
     n_rows = blocks[0].shape[0]
@@ -186,7 +186,7 @@ def mbpca_full_multiblock(blocks: list[np.ndarray], n_components: int) -> MBPCAR
     for a in range(n_components):
         t_super = rng.standard_normal(n_rows)
         prev = t_super * 2
-        # Tightened tolerance per the legacy MATLAB MBPCA self-consistency block.
+        # Tightened tolerance per the recorded MBPCA self-consistency reference.
         while np.linalg.norm(prev - t_super) > np.finfo(float).eps ** (9 / 10):
             prev = t_super
             t_b_summary = np.zeros((n_rows, n_blocks))
@@ -275,7 +275,7 @@ def mbpls_merged_then_recover(  # noqa: PLR0915
         p_a = x_def.T @ t_a / (t_a @ t_a)
 
         # Recover per-block quantities from the SAME deflated matrix BEFORE
-        # the next deflation step, matching legacy MATLAB MBPLS_tests.
+        # the next deflation step, matching the recorded MBPLS reference.
         start = 0
         for b in range(n_blocks):
             stop = start + block_widths[b]

--- a/tests/test_multiblock_oracles.py
+++ b/tests/test_multiblock_oracles.py
@@ -8,10 +8,10 @@ synthetic problem.
 
 If both reference paths agree, we have a trustworthy Python oracle that the
 production :class:`MBPCA` and :class:`MBPLS` classes can be validated against
-when they land in PR3 / PR6 - without ever needing to run MATLAB.
+when they land in PR3 / PR6, with no dependency on any external package.
 
-The MATLAB ``unit_tests.m`` MBPCA_tests / MBPLS_tests blocks structure their
-self-consistency checks the same way; this module is the Python equivalent.
+The recorded MBPCA / MBPLS references structure their self-consistency checks
+the same way; this module is the Python equivalent.
 """
 
 from __future__ import annotations

--- a/tests/test_multiblock_reference.py
+++ b/tests/test_multiblock_reference.py
@@ -1,15 +1,15 @@
 """
 Reference numerical tests for multivariate and (eventually) multi-block methods.
 
-These tests are ported from a legacy MATLAB multi-block latent-variable methods
-codebase (ConnectMV, 2010-2012). The MATLAB codebase contained a large
-``unit_tests.m`` suite that locked in expected numerical values both from the
-chemometrics literature and from cross-checks against commercial packages
-(ProSensus Multivariate / ProMV, Simca-P).
+The expected values are pinned numerical oracles. Those marked with a page
+number come from the published Wold, Esbensen & Geladi (1987) PCA paper and
+can be re-derived from it. The remainder were captured from an earlier
+implementation of these methods; the software that produced them is no longer
+available, so they cannot be re-derived and are kept purely as regression
+pins: they lock in behaviour that was correct when recorded, and a change to
+any of them needs justifying on the mathematics, not by appeal to a source.
 
-Phase 1 of the multi-block port to ``process-improve`` lifts as many of those
-numerical assertions into Python as possible *without needing a MATLAB
-session*. The strategy is:
+The strategy is:
 
 1. Tests that assert against published literature values (Wold, Esbensen &
    Geladi, 1987) run today against the existing single-block :class:`PCA`
@@ -21,19 +21,18 @@ session*. The strategy is:
    split into two blocks. They will turn green when the corresponding
    classes land in the planned PRs.
 
-3. Tests that need real reference datasets (LDPE, FMC, kamyr-digester) or a
-   ProSensus / Simca-P numerical comparison are marked ``pytest.mark.skip``
-   with a reason. They become runnable once the datasets land in
-   ``process_improve.datasets`` (planned in PR2).
+3. Tests that need real reference datasets (LDPE, FMC, kamyr-digester) are
+   marked ``pytest.mark.skip`` with a reason. They become runnable once the
+   datasets land in ``process_improve.datasets`` (planned in PR2).
 
 Conventions
 -----------
-- The legacy MATLAB code defines SPE as :math:`e'e` (raw row sum of squares).
+- The recorded SPE values are :math:`e'e` (raw row sum of squares), while
   ``process_improve.PCA`` stores ``spe_`` as ``sqrt(e'e)``. Every assertion
-  against a MATLAB / ProMV SPE value compares against ``spe_ ** 2``.
-- The legacy MATLAB code stores the *inverse* standard deviation as the
-  scaling vector. :class:`MCUVScaler` stores the standard deviation itself.
-  Hence ``[1, 1, 0.5, 1]`` in MATLAB corresponds to ``[1, 1, 2, 1]`` here.
+  against a recorded SPE value therefore compares against ``spe_ ** 2``.
+- The recorded scaling vector is the *inverse* standard deviation, while
+  :class:`MCUVScaler` stores the standard deviation itself. Hence a recorded
+  ``[1, 1, 0.5, 1]`` corresponds to ``[1, 1, 2, 1]`` here.
 - Sign convention: largest-magnitude element of every loading vector is
   positive (Wold, Esbensen & Geladi, 1987, p 42). Both implementations follow
   this, so loading and score signs should agree without manual flipping.
@@ -50,6 +49,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 import pytest
+from scipy import stats
 
 from process_improve.multivariate.methods import (
     PCA,
@@ -59,10 +59,9 @@ from process_improve.multivariate.methods import (
 # ---------------------------------------------------------------------------
 # Wold/Esbensen/Geladi 1987 reference data and expectations
 # ---------------------------------------------------------------------------
-# The 3x4 worked example used throughout the 1987 PCA paper. All expected
-# values below come straight from that paper's pages 40-43, plus a small
-# number of cross-checks from ProSensus Multivariate (2010, Revision 302)
-# captured in the legacy ``unit_tests.m``.
+# The 3x4 worked example used throughout the 1987 PCA paper. Values marked
+# with a page number come straight from that paper's pages 40-43; the rest are
+# regression pins recorded from an earlier implementation (see module docstring).
 
 WOLD_X = np.array(
     [
@@ -75,7 +74,7 @@ WOLD_X = np.array(
 # Page 40: column means of WOLD_X
 WOLD_CENTER = np.array([4.0, 4.0, 4.0, 3.0])
 
-# Page 40: standard deviations (ddof=1) of WOLD_X. Note that the MATLAB code
+# Page 40: standard deviations (ddof=1) of WOLD_X. The recorded reference
 # stores the *inverse* of this: [1, 1, 0.5, 1].
 WOLD_SCALE = np.array([1.0, 1.0, 2.0, 1.0])
 
@@ -91,18 +90,18 @@ WOLD_R2_PER_COMPONENT = np.array([0.831, 0.169])
 # Page 43, residual sum of squares per column after PC1
 WOLD_RESIDUAL_SSQ_AFTER_PC1 = np.array([0.0551, 1.189, 0.0551, 0.0551])
 
-# ProMV cross-check: SPE = e'e per row, after PC1
-PROMV_SPE_AFTER_PC1 = np.array([0.366107, 0.877964, 0.110178])
+# Regression pin: SPE = e'e per row, after PC1
+REF_SPE_AFTER_PC1 = np.array([0.366107, 0.877964, 0.110178])
 
-# ProMV cross-check: VIP per variable after PC1 and after PC2
-PROMV_VIP_AFTER_PC1 = np.array([1.082, 0.6987, 1.082, 1.082])
-PROMV_VIP_AFTER_PC2 = np.array([1.0, 1.0, 1.0, 1.0])
+# Regression pin: VIP per variable after PC1 and after PC2
+REF_VIP_AFTER_PC1 = np.array([1.082, 0.6987, 1.082, 1.082])
+REF_VIP_AFTER_PC2 = np.array([1.0, 1.0, 1.0, 1.0])
 
-# Statistical limits at 95% confidence (legacy ``unit_tests.m`` lines 210-212)
+# Regression pins: statistical limits at 95% confidence
 WOLD_T2_LIMIT_PC1 = 24.684
 WOLD_SPE_LIMIT_PC1 = 1.2236
-# Score limit uses t.ppf(0.975, N-1) * std(scores, ddof=1); not exposed
-# directly by process_improve.PCA, so it is reconstructed inside the test.
+# Score limit: t.ppf(0.975, N-1) * std(scores, ddof=1), which is what
+# ``PCA.score_limit`` now computes, so the test calls it directly.
 WOLD_SCORE_LIMIT_PC1 = 7.8432
 
 # Two new observations whose projection onto the model is checked.
@@ -140,8 +139,8 @@ class TestWold1987PCA:
 
     The 3x4 worked example from that paper is the smallest non-trivial PCA
     that exercises preprocessing, NIPALS/SVD, sign convention, R² and SPE
-    bookkeeping. Every assertion below comes from the published values or
-    from the legacy ``unit_tests.m`` cross-checks against ProMV.
+    bookkeeping. Every assertion below is either a published value or a
+    recorded regression pin (see the module docstring).
     """
 
     def test_preprocessing_center(self) -> None:
@@ -189,10 +188,10 @@ class TestWold1987PCA:
         np.testing.assert_array_almost_equal(residual_ssq_per_col, np.zeros(4), decimal=6)
 
     def test_spe_per_observation_after_one_pc(self) -> None:
-        # process_improve stores spe_ as sqrt(e'e); ProMV / MATLAB store e'e.
+        # process_improve stores spe_ as sqrt(e'e); the pinned values are e'e.
         model, _, _ = _fit_pca_on_wold(n_components=1)
         spe_squared = model.spe_.iloc[:, 0].values ** 2
-        np.testing.assert_array_almost_equal(spe_squared, PROMV_SPE_AFTER_PC1, decimal=4)
+        np.testing.assert_array_almost_equal(spe_squared, REF_SPE_AFTER_PC1, decimal=4)
 
     def test_spe_per_observation_after_two_pc_is_zero(self) -> None:
         model, _, _ = _fit_pca_on_wold(n_components=2)
@@ -202,12 +201,12 @@ class TestWold1987PCA:
     def test_vip_after_one_pc(self) -> None:
         model, _, _ = _fit_pca_on_wold(n_components=2)
         vip_pc1 = model.vip(n_components=1).values
-        np.testing.assert_array_almost_equal(vip_pc1, PROMV_VIP_AFTER_PC1, decimal=3)
+        np.testing.assert_array_almost_equal(vip_pc1, REF_VIP_AFTER_PC1, decimal=3)
 
     def test_vip_after_two_pc(self) -> None:
         model, _, _ = _fit_pca_on_wold(n_components=2)
         vip_pc2 = model.vip(n_components=2).values
-        np.testing.assert_array_almost_equal(vip_pc2, PROMV_VIP_AFTER_PC2, decimal=3)
+        np.testing.assert_array_almost_equal(vip_pc2, REF_VIP_AFTER_PC2, decimal=3)
 
     def test_t2_limit_at_95pct(self) -> None:
         model, _, _ = _fit_pca_on_wold(n_components=1)
@@ -216,24 +215,28 @@ class TestWold1987PCA:
     def test_spe_limit_at_95pct(self) -> None:
         # process_improve.spe_limit consumes the model's spe_ values
         # (which are stored as sqrt(e'e)) and returns a limit on the same
-        # scale. The MATLAB / ProMV limit is on the e'e scale, so we square
-        # the Python limit to compare.
+        # scale. The pinned limit is on the e'e scale, so we square the
+        # Python limit to compare.
         model, _, _ = _fit_pca_on_wold(n_components=1)
         spe_limit_squared = model.spe_limit(conf_level=0.95) ** 2
         assert spe_limit_squared == pytest.approx(WOLD_SPE_LIMIT_PC1, abs=5e-3)
 
     def test_score_limit_at_95pct(self) -> None:
-        # Score limit per component using the t-distribution:
-        # lim.t = t.ppf(0.975, N-1) * std(scores, ddof=1)
-        # The MATLAB code uses this form; process_improve does not expose
-        # the limit directly but exposes the score scaling factor.
-        from scipy import stats
-
+        # The score limit is t.ppf(0.975, N-1) * std(scores, ddof=1). This is
+        # exactly what PCA.score_limit computes, so assert against the public
+        # API rather than reconstructing the formula in the test: the point is
+        # to test the shipped limit, not a private re-derivation of it.
         model, _, _ = _fit_pca_on_wold(n_components=1)
-        score_std_ddof1 = model.scaling_factor_for_scores_.iloc[0]
-        n_rows = WOLD_X.shape[0]
-        score_limit = stats.t.ppf(0.975, n_rows - 1) * score_std_ddof1
-        assert score_limit == pytest.approx(WOLD_SCORE_LIMIT_PC1, abs=5e-3)
+        limits = model.score_limit(conf_level=0.95)
+        assert limits.shape == (1,)
+        assert limits[0] == pytest.approx(WOLD_SCORE_LIMIT_PC1, abs=5e-3)
+
+        # The score scaling factor is the standard deviation the limit is
+        # built from, so the two must stay consistent.
+        assert limits[0] == pytest.approx(
+            stats.t.ppf(0.975, WOLD_X.shape[0] - 1) * model.scaling_factor_for_scores_.iloc[0],
+            rel=1e-12,
+        )
 
     def test_predict_new_observations_one_pc(self) -> None:
         model, scaler, _ = _fit_pca_on_wold(n_components=1)
@@ -259,7 +262,7 @@ class TestWold1987PCA:
     def test_predict_training_spe_matches_fit_spe(self) -> None:
         model, _, df_pp = _fit_pca_on_wold(n_components=1)
         result = model.predict(df_pp)
-        np.testing.assert_array_almost_equal(result.spe.values**2, PROMV_SPE_AFTER_PC1, decimal=4)
+        np.testing.assert_array_almost_equal(result.spe.values**2, REF_SPE_AFTER_PC1, decimal=4)
 
 
 # ---------------------------------------------------------------------------
@@ -1056,8 +1059,8 @@ class TestMBPLSOnLDPE:
     - Y (5 vars): Conv, Mn, Mw, LCB, SCB. Quality block; used as Y in
       MBPLS or as a fourth X-block in MBPCA.
 
-    The legacy ConnectMV ``test_mbpls.m`` used a 2-block zone split
-    purely to make a single-block-PLS oracle assertion convenient.
+    The earlier implementation used a 2-block zone split purely to make a
+    single-block-PLS oracle assertion convenient.
     The 4-block split here is the chemometrically meaningful one.
     """
 

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -10,6 +10,8 @@ import plotly.graph_objects as go
 import plotly.io as pio
 import pytest
 from scipy.sparse import csr_matrix
+from scipy.stats import f as f_dist
+from scipy.stats import t as t_dist
 from sklearn import config_context
 from sklearn.base import clone
 from sklearn.cross_decomposition import PLSRegression
@@ -1803,7 +1805,7 @@ def test_pls_compare_api(fixture_pls_simca_2_components: dict) -> None:
 
 
 def test_score_limit_pca() -> None:
-    """score_limit returns per-component z * std limits for the PCA scores."""
+    """score_limit returns per-component t_(N-1) * std limits for the PCA scores."""
     rng = np.random.default_rng(0)
     X = pd.DataFrame(rng.normal(size=(60, 5)))
     X_scaled = MCUVScaler().fit_transform(X)
@@ -1813,9 +1815,17 @@ def test_score_limit_pca() -> None:
     assert limits.shape == (3,)
     assert np.all(limits > 0)
 
-    z_95 = 1.959963984540054
-    expected = z_95 * np.asarray(model.scores_).std(axis=0, ddof=1)
+    # The score standard deviation is estimated from the same N observations,
+    # so the quantile is Student-t on N-1 degrees of freedom, not standard
+    # normal. At N=60 that is 2.0010 rather than 1.9600.
+    t_95 = 2.0009953770482318
+    expected = t_95 * np.asarray(model.scores_).std(axis=0, ddof=1)
     np.testing.assert_allclose(limits, expected, rtol=1e-9)
+
+    # The docstring's equivalence: sqrt(F(1, N-1)) IS the two-sided t_(N-1)
+    # quantile. Checked against scipy directly so it validates the identity
+    # rather than the precision of the literal above.
+    np.testing.assert_allclose(t_dist.ppf(0.975, 59), np.sqrt(f_dist.isf(0.05, 1, 59)), rtol=1e-12)
 
     # A higher confidence level widens the limits.
     assert np.all(model.score_limit(conf_level=0.99) > limits)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -339,6 +339,47 @@ def test_regression_simple_robust(simple_robust_regression_data: tuple[np.ndarra
     assert out["residuals"][0:5] == pytest.approx([0.0, 0.000118863, 0.005006413, -0.0035648, -0.000326859], abs=1e-9)
 
 
+def test_robust_regression_t_value_is_populated(
+    simple_robust_regression_data: tuple[np.ndarray, np.ndarray],
+) -> None:
+    """`t_value` holds the per-coefficient t-statistic, as in the OLS sibling.
+
+    Regression test: the key was documented but only ever initialised to NaN,
+    because the critical value was computed into a local variable, used for the
+    interval widths, and never assigned back. This fails on the pre-fix code.
+    """
+    X, y = simple_robust_regression_data
+    out = robust_regression(X, y)
+
+    assert np.all(np.isfinite(out["t_value"])), "t_value must be populated, not left as NaN"
+    assert len(out["t_value"]) == len(out["coefficients"])
+
+    # The documented meaning: coefficient divided by its standard error.
+    assert out["t_value"][0] == pytest.approx(out["coefficients"][0] / out["standard_errors"][0], rel=1e-12)
+
+    # It is NOT the critical value used to build the intervals: the interval
+    # half-width divided by the standard error is that separate quantity.
+    critical = (out["conf_intervals"][0][1] - out["coefficients"][0]) / out["standard_errors"][0]
+    assert out["t_value"][0] != pytest.approx(critical, rel=1e-6)
+
+    # The sibling function reports the same statistic under the same key, so
+    # both are finite, one per coefficient, and consistent with coef / SE.
+    ols_out = multiple_linear_regression(X.reshape(-1, 1), y)
+    assert len(ols_out["t_value"]) == len(ols_out["coefficients"])
+    assert ols_out["t_value"][0] == pytest.approx(ols_out["coefficients"][0] / ols_out["standard_errors"][0], rel=1e-6)
+
+
+def test_robust_regression_t_value_nan_when_undefined() -> None:
+    """`t_value` is NaN exactly where the standard error is undefined."""
+    # No variation in x: the standard error cannot be formed.
+    out = robust_regression(np.array([4.0, 4, 4, 4, 4]), np.array([1.0, 2, 3, 4, 5]))
+    assert np.isnan(out["t_value"]).all()
+
+    # Fewer than three usable observations: the degenerate early-return stub.
+    stub = robust_regression(np.array([1.0, 2]), np.array([1.0, 2]))
+    assert np.isnan(stub["t_value"]).all()
+
+
 def test_simple_robust_regression_corner_case() -> None:
     """Tests some corner cases."""
     # No variation in x-space


### PR DESCRIPTION
## Summary

- **`score_limit` now uses `t_(N-1)` instead of `z`.** The docstring's References section claimed `(t_a / s_a)**2` follows `F(1, N-1)` while the code computed the standard-normal quantile. Those contradict each other: `sqrt(F(1, N-1))` *is* the two-sided `t_(N-1)` quantile. Since `s_a` is estimated from the same `N` observations, `t` is correct and `z` is only its large-`N` limit. The old limit was 15% too tight at `N=10`, 2.5% at `N=50`, negligible past `N=100`. **Score limits are now wider, most noticeably on small data sets.** Closes the first Multivariate item in #513.
- **`robust_regression` now populates the `t_value` key it documents.** It was only ever initialised to `NaN`: the critical value was computed into a local, used for the interval widths, and never assigned back. It now holds the t-statistic per coefficient, the same quantity `multiple_linear_regression` has always returned under that name.
- **`CONTRIBUTING.md` records the API-consistency rules** this was an instance of: one name means one quantity across siblings, a documented key must be populated, siblings return the same shape, and a convention chosen once applies everywhere.
- **References to discontinued software are removed** (ProSensus Multivariate / ProMV, legacy ConnectMV MATLAB). Every recorded number is unchanged.

## The reference test could not call the API

`test_score_limit_at_95pct` previously reconstructed `t.ppf(0.975, N-1) * std` by hand, with a comment saying the shipped function "does not expose the limit directly". That was not the real reason: `score_limit` used a *different convention* from the reference value the test was checking. On the Wold 3x4 example the recorded value is `7.8432`; the `z` convention gives `3.5728`.

With `score_limit` corrected, the test now asserts against `PCA.score_limit` directly and matches `7.8432`, so the shipped function is what gets tested rather than a re-derivation of it.

## On the removed references

ProMV and the ConnectMV MATLAB code are discontinued, so a reader cannot re-run them to check anything, and citing them implied a validation route that no longer exists. The values captured from them are kept **unchanged** and are now described for what they are: regression pins that lock in behaviour that was correct when recorded, and that need justifying on the mathematics rather than by appeal to a source. The reference test module now distinguishes those from values that can still be re-derived from the published Wold, Esbensen & Geladi (1987) paper. The `PROMV_*` oracle constants are renamed `REF_*`.

Two deliberate exclusions:
- **Simca-P references are left alone.** That is a different, still-extant vendor, and renaming the ~15 fixtures and tests carrying the name is invasive with no correctness gain. Happy to do it separately if you want it.
- One `MATLAB` mention survives in `examples/least-squares-modelling/Misguided-reliance-on-R2-alone.ipynb`, where it lists tools a reader might use ("Python, Excel, R, MATLAB"). That is not a validation claim.

## Test plan

- [x] Both fixes carry regression tests that **fail on the pre-fix code**, verified by reverting each change and re-running: `test_robust_regression_t_value_is_populated`, `test_score_limit_pca`, and `TestWold1987PCA::test_score_limit_at_95pct` all fail against the old code and pass against the new
- [x] New `test_robust_regression_t_value_nan_when_undefined` covers both undefined paths (no variation in x; the fewer-than-three-observations stub)
- [x] `test_score_limit_pca` now pins `t` and additionally asserts the `sqrt(F(1, N-1)) == t_(N-1)` identity against scipy, so the docstring claim itself is tested
- [x] Full suite: **2672 passed, 6 skipped**. The two failures (`test_oildoe_loads`, `test_distillateflow_loads`) are network tests that fail identically on unmodified `main` where openmv.net is unreachable
- [x] `ruff check .`, `ruff format --check .`, and `mypy src/process_improve` all clean
- [x] Verified no other consumer of `score_limit` exists in `src/` (no plotting code depends on it)

## Checklist

- [x] Version bumped in `pyproject.toml` (MINOR: 1.68.0 to 1.69.0, a meaningful behavioural change), with `CITATION.cff` matching in the same commit
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated (new `[1.69.0]` section with the score-limit change called out prominently, fresh empty `[Unreleased]`, footer links)

Classified MINOR rather than breaking: `CONTRIBUTING.md` lists "a documented bug is fixed" as explicitly not breaking, and the change is announced rather than silent. This follows the precedent of #500, which also changed numerical results and shipped as MINOR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPuM5PJdHnpvpKpAsc6uDM)_