### PR TITLE
fix(univariate): the audit's univariate cluster, from Sn to the ESD guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,83 @@ those changes.
 
 ## [Unreleased]
 
+## [1.70.0] - 2026-08-22
+
+The univariate cluster from the 2026-08 audit triage (#513). Several entries
+change numerical results, because the previous values were wrong.
+
+### Changed
+
+- `Sn` now follows the Rousseeuw-Croux definition exactly, taking the HIGH
+  median inside and the LOW median outside. These are order statistics that
+  differ from the averaging median precisely when the sample size is even, so
+  using `np.median` for both understated every even-`n` estimate: 0.443 in
+  place of 0.886 at `n = 2`, 1.422 against 1.138 at `n = 4`, and still 0.5
+  percent low at `n = 1500`. A Monte Carlo check put the old estimator 4 to 23
+  percent below sigma at even `n` on standard-normal data. **Sn values change
+  for every even-sized sample**, and now reproduce `robustbase::Sn` for both
+  parities; the test file's claim that R "does not follow the formula presented
+  in the original paper" was backwards and has been removed.
+- `detect_outliers_esd` raises `ValueError` when `max_outliers_detected`
+  exceeds the sample size minus two. The statistic for the i-th suspected
+  outlier uses `t` on `N - i - 1` degrees of freedom, so beyond that the
+  critical value is NaN, every later iteration is silently inert, and the empty
+  result read as "no outliers" rather than "this sample cannot be tested". The
+  `detect_outliers` tool's own cap moves from `N - 1` to `N - 2` for the same
+  reason.
+
+### Fixed
+
+- `detect_outliers_esd` rejects `alpha <= 0`, which was previously accepted and
+  silently produced NaN critical values; only the upper bound was checked.
+- `detect_outliers_esd` computes the Grubbs p-value from the sample actually in
+  hand at each iteration. The sample size was captured once and never
+  refreshed, so from the second iteration onwards the reported p-value belonged
+  to a larger sample than the statistic came from. The ESD critical values are
+  unaffected: those are defined against the original N (NIST / Rosner) and
+  still use it.
+- `detect_outliers_esd` no longer raises `KeyError` when the data contain an
+  infinity. A NaN p-value set the row index to the sentinel `-1`, which is not
+  a label in the reset index, so the subsequent drop failed. There is now no
+  sentinel: an iteration with no usable candidate records `None` and drops
+  nothing.
+- `ttest_independent_from_df` and `ttest_paired_from_df` take their group list
+  from the cleaned data rather than the raw frame. A group whose values are all
+  missing, or a NaN group label, previously survived and was compared against
+  an empty sample, yielding a silent all-NaN row (or an opaque length-mismatch
+  error in the paired case).
+- `summary_stats` returns NaN for `rsd` and `rsd_classical` when the centre is
+  zero, instead of `inf` plus a `RuntimeWarning` raised through the public API
+  and the agent-facing `robust_summary_stats` tool. Relative spread is
+  undefined at a zero centre, which is a natural input here since mean-centred
+  process variables are common.
+
+### Added
+
+- `ttest_independent_from_df` and `ttest_paired_from_df` accept
+  `correction="holm"` or `correction="bh"` to adjust the family of pairwise
+  p-values, using the `holm_bonferroni` and `benjamini_hochberg` functions that
+  already lived in this module. The default is unchanged and uncorrected, and
+  the raw `p value` column is always kept; when a correction is requested,
+  `p value (adjusted)`, `reject` and `correction` columns are added. Both
+  docstrings now state that the default p-values are uncorrected across
+  `k(k-1)/2` comparisons.
+- `ttest_independent` returns correctly named `"t value"`, `"Std error of
+  difference"` and `"Pooled std dev"` entries, and the `ttest_two_samples` tool
+  gains `t_value`, `std_error_of_difference` and `pooled_std_dev`.
+
+### Deprecated
+
+- `"z value"` and `"Pooled standard deviation"` from `ttest_independent`, and
+  `z_value` and `pooled_std` from the `ttest_two_samples` tool. The statistic
+  is a t-statistic, not a z-statistic: its p-value is computed from the t
+  distribution on the reported degrees of freedom. `"Pooled standard
+  deviation"` holds the standard *error* of the difference in means,
+  `sqrt(svar * (1/nA + 1/nB))`, which is smaller than the pooled standard
+  deviation `sqrt(svar)` by a factor of `sqrt(nA*nB/(nA+nB))`. Deprecated since
+  1.70.0; both will be removed in 2.0. Use `"t value"` / `t_value` and
+  `"Std error of difference"` / `std_error_of_difference`.
+
 ## [1.68.0] - 2026-08-22
 
 A repo-wide correctness audit. Most entries below change numerical results
@@ -3289,7 +3366,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.68.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.70.0...HEAD
+[1.70.0]: https://github.com/kgdunn/process-improve/compare/v1.69.0...v1.70.0
 [1.68.0]: https://github.com/kgdunn/process-improve/compare/v1.67.1...v1.68.0
 [1.67.1]: https://github.com/kgdunn/process-improve/compare/v1.67.0...v1.67.1
 [1.67.0]: https://github.com/kgdunn/process-improve/compare/v1.66.1...v1.67.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.68.0
+version: 1.70.0
 date-released: "2026-08-22"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.68.0"
+version = "1.70.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/univariate/metrics.py
+++ b/src/process_improve/univariate/metrics.py
@@ -121,8 +121,9 @@ def Sn(x: np.ndarray | pd.Series, constant: float = 1.1926) -> np.floating:  # n
 
     Notes
     -----
-    Tested against once of the most reliable open-source packages, written by some of the
-    most respected names in the area of robust methods: [1]_ and [2]_.
+    Follows the Rousseeuw-Croux definition [2]_ exactly, including the high median
+    inside and the low median outside, and reproduces ``robustbase::Sn`` [1]_ (with
+    ``finite.corr=TRUE``) for both odd and even sample sizes.
 
     Disadvantages of MAD:
 
@@ -151,7 +152,16 @@ def Sn(x: np.ndarray | pd.Series, constant: float = 1.1926) -> np.floating:  # n
     # Remove NaNs and compute all pairwise absolute differences via broadcasting
     clean = arr[~np.isnan(arr)]
     diffs = np.abs(clean[:, None] - clean[None, :])
-    medians = np.median(diffs, axis=1)
+
+    # Rousseeuw-Croux define Sn = c * lomed_i { himed_j |x_i - x_j| }, using the
+    # HIGH median inside and the LOW median outside. These are order statistics,
+    # not the averaging median numpy provides: himed is element floor(n/2) + 1
+    # and lomed is element floor((n + 1) / 2), one-based, of the sorted values.
+    # They coincide with np.median only for odd n, so using np.median for both
+    # (the previous behaviour) biased every even-n estimate downward: 0.443 in
+    # place of 0.886 at n = 2, and still 0.5 percent low at n = 1500.
+    inner_high_median = np.sort(diffs, axis=1)[:, n // 2]
+    outer_low_median = np.sort(inner_high_median)[(n + 1) // 2 - 1]
 
     if n <= 9:
         # Correction factors for n = 2 to 9:
@@ -161,7 +171,7 @@ def Sn(x: np.ndarray | pd.Series, constant: float = 1.1926) -> np.floating:  # n
     else:
         correction = 1.0
 
-    return constant * np.median(medians) * correction
+    return constant * outer_low_median * correction
 
 
 def _contains_nan(a: np.ndarray, nan_policy: str = "propagate") -> tuple[bool, str]:
@@ -213,7 +223,20 @@ def ttest_independent(sample_A: pd.Series, sample_B: pd.Series, conflevel: float
     Returns
     -------
     dict
-        Outcomes from the statistical test.
+        Outcomes from the statistical test. The keys of interest are
+        ``"t value"`` (the test statistic; its ``"p value"`` is computed from
+        the t distribution on ``"Degrees of freedom"``), ``"Std error of
+        difference"`` (the denominator of that statistic, and the half-width
+        unit of the confidence interval), and ``"Pooled std dev"``.
+
+        .. deprecated:: 1.70.0
+            ``"z value"`` and ``"Pooled standard deviation"`` are misleading
+            names kept as aliases, and will be removed in 2.0. The statistic
+            is a t-statistic, not a z-statistic, and ``"Pooled standard
+            deviation"`` holds the standard *error* of the difference in
+            means, ``sqrt(svar * (1/nA + 1/nB))``, not the pooled standard
+            deviation ``sqrt(svar)``. Use ``"t value"`` and ``"Std error of
+            difference"`` instead.
     """
     axis: Literal[0] = 0
     v1, v2 = sample_A.var(axis=axis, ddof=1), sample_B.var(axis=axis, ddof=1)
@@ -242,7 +265,40 @@ def ttest_independent(sample_A: pd.Series, sample_B: pd.Series, conflevel: float
         "p value": 2 * t_value_cdf(-np.abs(z_variate), df),
         "Degrees of freedom": df,
         "Pooled standard deviation": sd_z_variate,
+        # Correctly named entries for the two mislabelled ones above, which are
+        # kept as deprecated aliases. "z value" is a t-statistic: its p value is
+        # computed from the t distribution on `df` degrees of freedom. "Pooled
+        # standard deviation" is the standard ERROR of the difference in means,
+        # sqrt(svar * (1/nA + 1/nB)); the pooled standard deviation is sqrt(svar).
+        "t value": z_variate,
+        "Std error of difference": sd_z_variate,
+        "Pooled std dev": np.sqrt(svar),
     }
+
+
+def _apply_multiplicity_correction(output: pd.DataFrame, correction: str | None) -> pd.DataFrame:
+    """Add corrected p-values to a table of pairwise comparisons.
+
+    A family of pairwise comparisons inflates the family-wise error rate: with
+    k groups there are k(k-1)/2 tests, so at k=5 ten raw p-values are compared
+    against 0.05 and the chance of at least one false positive is far above 5
+    percent. The raw ``p value`` column is always kept as-is; the corrected
+    values are added alongside so both are visible.
+    """
+    if correction is None or output.empty:
+        return output
+
+    known = {"holm": holm_bonferroni, "bh": benjamini_hochberg, "benjamini-hochberg": benjamini_hochberg}
+    key = correction.strip().lower()
+    if key not in known:
+        raise ValueError(f"correction must be one of 'holm', 'bh', or None; got {correction!r}.")
+
+    adjusted = known[key](output["p value"].to_numpy())
+    output = output.copy()
+    output["p value (adjusted)"] = adjusted.p_adjusted
+    output["reject"] = adjusted.reject
+    output["correction"] = key
+    return output
 
 
 def ttest_independent_from_df(
@@ -250,6 +306,7 @@ def ttest_independent_from_df(
     grouper_column: str,
     values_column: str,
     conflevel: float = 0.995,
+    correction: str | None = None,
 ) -> pd.DataFrame:
     """
     Calculate the t-test for differences between two or more groups and returns a confidence
@@ -264,6 +321,13 @@ def ttest_independent_from_df(
         grouper_column (str): Indicates which column will be grouped on.
         values_column (str): Which column contains the numeric values to calculate the test on.
         conflevel (float, optional): [description]. Defaults to 0.995.
+        correction (str | None, optional): multiplicity correction to apply across the
+            family of pairwise comparisons: ``"holm"`` (family-wise error rate, see
+            :func:`holm_bonferroni`) or ``"bh"`` (false discovery rate, see
+            :func:`benjamini_hochberg`). Defaults to None, which leaves the p-values
+            UNCORRECTED: with k groups there are k(k-1)/2 tests, so read the raw
+            ``p value`` column with that in mind. When set, ``p value (adjusted)``,
+            ``reject`` and ``correction`` columns are added and the raw column is kept.
 
     Output: Dataframe with columns containing the statistical outputs of the t-test, including:
         1. Group "A" name
@@ -288,7 +352,11 @@ def ttest_independent_from_df(
     data_subset = df[[grouper_column, values_column]].copy()
     data_subset = data_subset.dropna()
     output = pd.DataFrame()
-    groups = list(df[grouper_column].unique())
+    # Enumerate the groups from the CLEANED data. Taking them from `df` (the
+    # previous behaviour) kept groups whose values are all missing, and NaN
+    # group labels, each of which then produced a silent all-NaN comparison
+    # row against an empty sample.
+    groups = list(data_subset[grouper_column].unique())
     while len(groups) > 0:
         groupA_name = groups.pop(0)
         for groupB_name in groups:
@@ -305,7 +373,7 @@ def ttest_independent_from_df(
             )
             output = pd.concat([output, pd.DataFrame(basic_stats, index=[0])])
 
-    return output
+    return _apply_multiplicity_correction(output, correction)
 
 
 def ttest_paired(differences: pd.Series, conflevel: float = 0.995) -> dict:
@@ -370,6 +438,7 @@ def ttest_paired_from_df(
     grouper_column: str,
     values_column: str,
     conflevel: float = 0.995,
+    correction: str | None = None,
 ) -> pd.DataFrame:
     """
     Calculate the t-test for paired differences between two or more groups and returns a
@@ -387,6 +456,13 @@ def ttest_paired_from_df(
         grouper_column (str): Indicates which column will be grouped on.
         values_column (str): Which column contains the numeric values to calculate the test on.
         conflevel (float, optional): [description]. Defaults to 0.995.
+        correction (str | None, optional): multiplicity correction to apply across the
+            family of pairwise comparisons: ``"holm"`` (family-wise error rate, see
+            :func:`holm_bonferroni`) or ``"bh"`` (false discovery rate, see
+            :func:`benjamini_hochberg`). Defaults to None, which leaves the p-values
+            UNCORRECTED: with k groups there are k(k-1)/2 tests, so read the raw
+            ``p value`` column with that in mind. When set, ``p value (adjusted)``,
+            ``reject`` and ``correction`` columns are added and the raw column is kept.
 
     Output: Dataframe with columns containing the statistical outputs of the t-test, including:
 
@@ -405,7 +481,11 @@ def ttest_paired_from_df(
     data_subset = df[[grouper_column, values_column]].copy()
     data_subset = data_subset.dropna()
     output = pd.DataFrame()
-    groups = list(df[grouper_column].unique())
+    # Enumerate the groups from the CLEANED data. Taking them from `df` (the
+    # previous behaviour) kept groups whose values are all missing, and NaN
+    # group labels, each of which then produced a silent all-NaN comparison
+    # row against an empty sample.
+    groups = list(data_subset[grouper_column].unique())
     while len(groups) > 0:
         groupA_name = groups.pop(0)
         for groupB_name in groups:
@@ -432,7 +512,7 @@ def ttest_paired_from_df(
             )
             output = pd.concat([output, pd.DataFrame(basic_stats, index=[0])])
 
-    return output
+    return _apply_multiplicity_correction(output, correction)
 
 
 def confidence_interval(df: pd.DataFrame, column_name: str, conflevel: float = 0.95, style: str = "robust") -> tuple:
@@ -806,6 +886,19 @@ def benjamini_hochberg(p_values: np.ndarray | pd.Series | list, alpha: float = 0
     return Bunch(p_adjusted=p_adjusted, reject=p_adjusted <= alpha, alpha=alpha)
 
 
+def _relative_spread(spread: float, center: float) -> float:
+    """Return ``spread / center``, or NaN when the centre is (near) zero.
+
+    A relative standard deviation is undefined at a zero centre: the division
+    gives ``inf`` (or NaN for 0/0) and emits a RuntimeWarning through the
+    public API and the agent-facing tools. Report NaN instead, which is what
+    "undefined" means to every downstream consumer.
+    """
+    if not np.isfinite(center) or abs(center) <= __eps:
+        return float("nan")
+    return float(spread / center)
+
+
 def summary_stats(x: np.ndarray | pd.Series, method: str = "robust") -> dict:
     """
     Return summary statistics of the numeric values in vector ``x``.
@@ -839,7 +932,7 @@ def summary_stats(x: np.ndarray | pd.Series, method: str = "robust") -> dict:
     out["mean"] = np.nanmean(x)
     out["std_ddof0"] = np.nanstd(x, ddof=0)
     out["std_ddof1"] = np.nanstd(x, ddof=1)
-    out["rsd_classical"] = out["std_ddof1"] / out["mean"]
+    out["rsd_classical"] = _relative_spread(out["std_ddof1"], out["mean"])
     (
         out["percentile_05"],
         out["percentile_25"],
@@ -864,7 +957,7 @@ def summary_stats(x: np.ndarray | pd.Series, method: str = "robust") -> dict:
     else:
         out["center"], out["spread"] = out["mean"], out["std_ddof1"]
 
-    out["rsd"] = out["spread"] / out["center"]
+    out["rsd"] = _relative_spread(out["spread"], out["center"])
     return out
 
 
@@ -932,31 +1025,44 @@ def detect_outliers_esd(
         robust_variant = bool(kwargs.get("robust_variant", False))
         alpha = float(kwargs.get("alpha", 0.05))
 
-        if alpha > 1.0:
-            raise ValueError(f"alpha must be <= 1.0, got {alpha}.")
-        if max_outliers_detected > len(x):
+        if not 0.0 < alpha <= 1.0:
+            raise ValueError(f"alpha must lie in (0.0, 1.0], got {alpha}.")
+
+        n_observed = int(pd.Series(x).notna().sum())
+        # The ESD statistic for the i-th suspected outlier uses t on
+        # dof = N - i - 1 degrees of freedom, so testing r outliers needs
+        # r <= N - 2. Beyond that the critical value is undefined (t.ppf on
+        # dof <= 0 is NaN), every later iteration is silently inert, and an
+        # empty result would read as "no outliers" rather than "not testable".
+        if max_outliers_detected > 0 and max_outliers_detected > n_observed - 2:
             raise ValueError(
-                f"max_outliers_detected ({max_outliers_detected}) cannot exceed the sample size ({len(x)})."
+                f"max_outliers_detected ({max_outliers_detected}) cannot exceed the sample size minus 2 "
+                f"({n_observed - 2}); the generalized ESD test needs at least two observations beyond "
+                f"the outliers it tests for. The sample has {n_observed} non-missing observations."
             )
 
         # 1. Run K-S test first to check normality
 
         # 2. https://www.itl.nist.gov/div898/handbook/eda/section3/eda35h3.htm
-        x = x.copy(deep=True)
+        # `sample` shrinks by one point per iteration; keep it separate from
+        # the `x` parameter so its type stays a Series throughout.
+        sample: pd.Series = pd.Series(x).copy(deep=True)
         extra_out: defaultdict[str, list[Any]] = defaultdict(list)
-        N = x.shape[0] - pd.isna(x).sum()
+        N = sample.shape[0] - pd.isna(sample).sum()
 
         for k in range(max_outliers_detected):
             i = k + 1
             extra_out["i"].append(i)
 
             if robust_variant:
-                variation = median_absolute_deviation(x.to_numpy())
-                R = ((x - x.median()) / variation).abs()
+                variation = median_absolute_deviation(sample.to_numpy())
+                R = ((sample - sample.median()) / variation).abs()
             else:
-                variation = x.std()
-                R = ((x - x.mean()) / variation).abs()
+                variation = sample.std()
+                R = ((sample - sample.mean()) / variation).abs()
 
+            # The ESD critical value is defined against the ORIGINAL sample
+            # size N (NIST / Rosner), so N is deliberately not refreshed here.
             dof = N - i - 1
             p = 1 - alpha / (2 * (N - i + 1))
             t_s = t_value(p, dof)
@@ -964,16 +1070,27 @@ def detect_outliers_esd(
             extra_out["lambda"].append(lambda_i)
 
             g = R.max()
-            s = g**2 * N * (2 - N) / (g**2 * N - (N - 1) ** 2)  # Formula from R-function for the Grubb's calculation
-            p_value = 0 if s <= 0 else min(N * (1 - t_value_cdf(np.sqrt(s), N - 2)), 1)
-            R_i_idx = -1 if pd.isna(p_value) else R.idxmax()
+            # The Grubbs p-value, by contrast, describes the sample actually in
+            # hand this iteration, which has shrunk by every point dropped so
+            # far. Using the original N here (the previous behaviour) reported
+            # a p-value for a larger sample than the statistic came from.
+            n_i = int(sample.notna().sum())
+            s = g**2 * n_i * (2 - n_i) / (g**2 * n_i - (n_i - 1) ** 2)  # R-function Grubbs formula
+            p_value = 0 if s <= 0 else min(n_i * (1 - t_value_cdf(np.sqrt(s), n_i - 2)), 1)
+
+            # R is all-NaN when the spread is zero, so there is no candidate to
+            # drop. Record None rather than the -1 sentinel used before, which
+            # is not a label in the reset RangeIndex and raised KeyError from
+            # the drop below whenever the spread was non-zero (an infinity in
+            # the data reaches exactly that state).
+            R_i_idx: Any | None = None if pd.isna(g) else R.idxmax()
             extra_out["R_i_idx"].append(R_i_idx)
-            extra_out["R_i"].append(R.max())
+            extra_out["R_i"].append(g)
             extra_out["p-value"].append(p_value)
 
-            if variation > __eps:
+            if R_i_idx is not None and variation > __eps:
                 # The variation, if zero or small, will fail to drop this index
-                x = x.drop(R_i_idx)
+                sample = sample.drop(R_i_idx)
 
         try:
             # NIST / Rosner: "the number of outliers is determined by finding
@@ -991,7 +1108,7 @@ def detect_outliers_esd(
         # in the list.
         extra_out["cutoff"] = cutoff_i
 
-        outlier_index = extra_out["R_i_idx"][0 : (cutoff_i + 1)]
+        outlier_index = [idx for idx in extra_out["R_i_idx"][0 : (cutoff_i + 1)] if idx is not None]
         return outlier_index, extra_out
     else:
         return [], defaultdict(dict)

--- a/src/process_improve/univariate/metrics.py
+++ b/src/process_improve/univariate/metrics.py
@@ -321,13 +321,14 @@ def ttest_independent_from_df(
         grouper_column (str): Indicates which column will be grouped on.
         values_column (str): Which column contains the numeric values to calculate the test on.
         conflevel (float, optional): [description]. Defaults to 0.995.
-        correction (str | None, optional): multiplicity correction to apply across the
-            family of pairwise comparisons: ``"holm"`` (family-wise error rate, see
-            :func:`holm_bonferroni`) or ``"bh"`` (false discovery rate, see
-            :func:`benjamini_hochberg`). Defaults to None, which leaves the p-values
-            UNCORRECTED: with k groups there are k(k-1)/2 tests, so read the raw
-            ``p value`` column with that in mind. When set, ``p value (adjusted)``,
-            ``reject`` and ``correction`` columns are added and the raw column is kept.
+        correction (str | None, optional): "holm", "bh", or None. Defaults to None. See below.
+
+    Multiplicity: by default the returned p-values are UNCORRECTED. With k groups this
+    runs k(k-1)/2 tests, so the chance of at least one false positive is well above the
+    per-test level. Pass ``correction="holm"`` to control the family-wise error rate (see
+    :func:`holm_bonferroni`) or ``correction="bh"`` to control the false discovery rate
+    (see :func:`benjamini_hochberg`). Either adds ``p value (adjusted)``, ``reject`` and
+    ``correction`` columns; the raw ``p value`` column is always kept.
 
     Output: Dataframe with columns containing the statistical outputs of the t-test, including:
         1. Group "A" name
@@ -456,13 +457,14 @@ def ttest_paired_from_df(
         grouper_column (str): Indicates which column will be grouped on.
         values_column (str): Which column contains the numeric values to calculate the test on.
         conflevel (float, optional): [description]. Defaults to 0.995.
-        correction (str | None, optional): multiplicity correction to apply across the
-            family of pairwise comparisons: ``"holm"`` (family-wise error rate, see
-            :func:`holm_bonferroni`) or ``"bh"`` (false discovery rate, see
-            :func:`benjamini_hochberg`). Defaults to None, which leaves the p-values
-            UNCORRECTED: with k groups there are k(k-1)/2 tests, so read the raw
-            ``p value`` column with that in mind. When set, ``p value (adjusted)``,
-            ``reject`` and ``correction`` columns are added and the raw column is kept.
+        correction (str | None, optional): "holm", "bh", or None. Defaults to None. See below.
+
+    Multiplicity: by default the returned p-values are UNCORRECTED. With k groups this
+    runs k(k-1)/2 tests, so the chance of at least one false positive is well above the
+    per-test level. Pass ``correction="holm"`` to control the family-wise error rate (see
+    :func:`holm_bonferroni`) or ``correction="bh"`` to control the false discovery rate
+    (see :func:`benjamini_hochberg`). Either adds ``p value (adjusted)``, ``reject`` and
+    ``correction`` columns; the raw ``p value`` column is always kept.
 
     Output: Dataframe with columns containing the statistical outputs of the t-test, including:
 

--- a/src/process_improve/univariate/tools.py
+++ b/src/process_improve/univariate/tools.py
@@ -182,7 +182,12 @@ class DetectOutliersInput(BaseModel):
 def detect_outliers(spec: DetectOutliersInput) -> dict:
     """Detect outliers using the Generalised ESD test; see tool spec for details."""
     arr = np.asarray(spec.values, dtype=float)
-    max_k = min(spec.max_outliers_to_detect, len(arr) - 1)
+    # The ESD statistic for the i-th suspected outlier uses t on N - i - 1
+    # degrees of freedom, so at most N - 2 outliers can be tested. The previous
+    # cap of N - 1 allowed a final iteration with zero degrees of freedom,
+    # whose critical value is NaN and can never flag anything.
+    n_observed = int((~np.isnan(arr)).sum())
+    max_k = max(0, min(spec.max_outliers_to_detect, n_observed - 2))
     outlier_indices, _details = detect_outliers_esd(
         arr,
         algorithm="esd",
@@ -488,8 +493,11 @@ class TtestTwoSamplesInput(BaseModel):
     description=(
         "Perform an unpaired (independent samples) two-sided t-test to determine whether the "
         "means of two groups differ significantly. "
-        "Returns the t statistic, p-value, confidence interval for the difference "
+        "Returns `t_value` (the t statistic), `p_value`, `std_error_of_difference`, "
+        "`pooled_std_dev`, the confidence interval for the difference "
         "(group_b_mean - group_a_mean), and degrees of freedom. "
+        "`z_value` and `pooled_std` are deprecated aliases of `t_value` and "
+        "`std_error_of_difference`; prefer the new names. "
         "The groups must be independent (different subjects/items). "
         "Use ttest_paired_samples instead when each observation in group A is matched to one in B."
     ),
@@ -515,6 +523,14 @@ def ttest_two_samples(spec: TtestTwoSamplesInput) -> dict:
         "group_b_n": raw["Group B number"],
         "group_a_mean": raw["Group A average"],
         "group_b_mean": raw["Group B average"],
+        # `t_value` and `std_error_of_difference` are the correctly named
+        # fields. `z_value` and `pooled_std` are kept as deprecated aliases:
+        # the statistic is a t-statistic, not a z, and `pooled_std` held the
+        # standard ERROR of the difference rather than the pooled standard
+        # deviation. Both aliases are scheduled for removal in 2.0.
+        "t_value": raw["t value"],
+        "std_error_of_difference": raw["Std error of difference"],
+        "pooled_std_dev": raw["Pooled std dev"],
         "z_value": raw["z value"],
         "conf_int_lower": raw["ConfInt: Lo"],
         "conf_int_upper": raw["ConfInt: Hi"],

--- a/tests/test_univariate.py
+++ b/tests/test_univariate.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -96,16 +98,16 @@ def test_univariate_robust_scale() -> None:
     Testing against R code [R version 3.6.0 (2019-04-26)]
     > library(robustbase)
     # All code has the default argument: "finite.corr=TRUE"
-    > robustbase::Sn(c(0, 1))                   # 0.8861018: FAILS in our implementation
+    > robustbase::Sn(c(0, 1))                   # 0.8861018
     > robustbase::Sn(c(0, 1, 2))                # 2.207503
-    > robustbase::Sn(c(0, 1, 2, 3))             # 1.13774: FAILS in our implementation
+    > robustbase::Sn(c(0, 1, 2, 3))             # 1.13774
     > robustbase::Sn(c(0, 1, 2, 3, 4))          # 1.611203
-    > robustbase::Sn(c(0, 1, 2, 3, 4, 5))       # 2.368504: FAILS in our implementation
+    > robustbase::Sn(c(0, 1, 2, 3, 4, 5))       # 2.368504
     > robustbase::Sn(c(0, 1, 2, 3, 4, 5, 6))    # 2.85747
     > robustbase::Sn(c(0, 1, 2, 3, 4, 50, 6))   # 2.85747
-    > robustbase::Sn(c(0, 1, 20, 3, 4, 50, 6))  # 5.714939: FAILS in our implementation
+    > robustbase::Sn(c(0, 1, 20, 3, 4, 50, 6))  # 5.714939
     > robustbase::Sn(c(0, 10, 20, 3, 4, 50, 6)) # 8.572409
-    > robustbase::Sn(seq(1, 10))                # 3.5778: FAILS in our implementation
+    > robustbase::Sn(seq(1, 10))                # 3.5778
     > robustbase::Sn(seq(1, 11))                # 3.896614
     > robustbase::Sn(seq(1, 19))                # 6.259503
     > robustbase::Sn(seq(1, 1500))              # 447.225
@@ -115,18 +117,28 @@ def test_univariate_robust_scale() -> None:
     How to make it robust to this weird situation?
     """
 
-    # Tests with an even number of samples, and small sample sizes do not agree with R.
-    # This is because the R implementation aims for efficiency of calculation, and does not
-    # follow the formula presented in the original paper.
-    # Since we aim to be using this on medium/larger data sets, it should not matter.
+    # Every value above is reproduced, at both odd and even n. Sn uses the high
+    # median inside and the low median outside (Rousseeuw-Croux); these are order
+    # statistics that differ from the averaging median exactly when n is even, so
+    # using np.median for both (the behaviour before this was fixed) understated
+    # every even-n estimate: 0.443 against 0.886 at n = 2.
 
+    # Odd n
     assert univariate.Sn(list(range(3))) == pytest.approx(2.207503, rel=1e-6)
     assert univariate.Sn(list(range(5))) == pytest.approx(1.611203, rel=1e-6)
     assert univariate.Sn(list(range(7))) == pytest.approx(2.85747, rel=1e-6)
+    assert univariate.Sn([0, 1, 2, 3, 4, 50, 6]) == pytest.approx(2.85747, rel=1e-6)
+    assert univariate.Sn([0, 1, 20, 3, 4, 50, 6]) == pytest.approx(5.714939, rel=1e-6)
     assert univariate.Sn([0, 10, 20, 3, 4, 50, 6]) == pytest.approx(8.572409, rel=1e-7)
     assert univariate.Sn(list(range(1, 12))) == pytest.approx(3.896614, rel=1e-6)
-    assert univariate.Sn(list(range(1, 19))) == pytest.approx(5.3667, rel=1e-6)
     assert univariate.Sn(list(range(1, 20))) == pytest.approx(6.259503, rel=1e-6)
+
+    # Even n: these are the cases the previous implementation got wrong.
+    assert univariate.Sn([0, 1]) == pytest.approx(0.8861018, rel=1e-6)
+    assert univariate.Sn(list(range(4))) == pytest.approx(1.13774, rel=1e-6)
+    assert univariate.Sn(list(range(6))) == pytest.approx(2.368504, rel=1e-6)
+    assert univariate.Sn(list(range(1, 11))) == pytest.approx(3.5778, rel=1e-6)
+    assert univariate.Sn(list(range(1, 1501))) == pytest.approx(447.225, rel=1e-6)
     # Corner cases:
     assert np.isnan(univariate.Sn([]))
     assert univariate.Sn([13]) == 0.0
@@ -819,33 +831,191 @@ def test_rosner_esd_no_outliers(outliers_data: tuple[list[float], list[float]]) 
     assert outliers == []
 
 
-def test_rosner_esd_corner_case() -> None:
-    """
-    In this example it picks up no outliers. Ensures that the test can also return an empty
-    list.
-    """
-    outliers, extra_out = univariate.detect_outliers_esd([1, 2], algorithm="esd", max_outliers_detected=1)
-    assert extra_out["p-value"][0] == 0
+def test_ttest_independent_correctly_named_fields() -> None:
+    """The correctly named fields hold what their names say.
 
-    # If the values are all the same:
+    Regression test: `z value` is a t-statistic (its p value comes from the t
+    distribution) and `Pooled standard deviation` held the standard ERROR of
+    the difference, not the pooled standard deviation. Both are kept as
+    deprecated aliases alongside correctly named entries.
+    """
+    a = pd.Series([102.0, 98, 100, 101, 97])
+    b = pd.Series([110.0, 112, 108, 109])
+    out = univariate.ttest_independent(a, b)
+
+    n_a, n_b = len(a), len(b)
+    dof = n_a + n_b - 2
+    svar = ((n_a - 1) * a.var(ddof=1) + (n_b - 1) * b.var(ddof=1)) / dof
+    se_difference = np.sqrt(svar * (1 / n_a + 1 / n_b))
+
+    # The new names are accurate.
+    assert out["Std error of difference"] == pytest.approx(se_difference, rel=1e-12)
+    assert out["Pooled std dev"] == pytest.approx(np.sqrt(svar), rel=1e-12)
+    assert out["t value"] == pytest.approx((b.mean() - a.mean()) / se_difference, rel=1e-12)
+
+    # The statistic really is a t-statistic: it matches scipy's t-test, and the
+    # pooled standard deviation is a genuinely different number from the
+    # standard error that the old key held.
+    assert out["t value"] == pytest.approx(stats.ttest_ind(b, a).statistic, rel=1e-10)
+    assert out["Pooled std dev"] != pytest.approx(out["Std error of difference"], rel=1e-3)
+
+    # Deprecated aliases still resolve to the same values, for one more cycle.
+    assert out["z value"] == out["t value"]
+    assert out["Pooled standard deviation"] == out["Std error of difference"]
+
+
+def test_ttest_from_df_skips_groups_with_no_usable_data() -> None:
+    """An all-NaN group is dropped instead of yielding a silent NaN row.
+
+    Regression test: the group list came from the un-dropna-ed frame, so a
+    group whose values are all missing (or a NaN group label) survived and was
+    compared against an empty sample, producing NaN statistics with no warning.
+    """
+    df = pd.DataFrame({"g": ["A"] * 3 + ["B"] * 3 + ["C"] * 3, "v": [1.0, 2, 3] + [np.nan] * 3 + [7.0, 8, 9]})
+    out = univariate.ttest_independent_from_df(df, "g", "v")
+    assert list(zip(out["Group A name"], out["Group B name"], strict=True)) == [("A", "C")]
+    assert not out["p value"].isna().any()
+
+    # A NaN group label is likewise not a group.
+    df_nan_label = pd.DataFrame(
+        {"g": ["A", "A", "A", np.nan, np.nan, np.nan, "C", "C", "C"], "v": [1.0, 2, 3, 4, 5, 6, 7, 8, 9]}
+    )
+    out2 = univariate.ttest_independent_from_df(df_nan_label, "g", "v")
+    assert list(zip(out2["Group A name"], out2["Group B name"], strict=True)) == [("A", "C")]
+
+
+def test_ttest_from_df_multiplicity_correction() -> None:
+    """The pairwise family can be corrected for multiplicity on request."""
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(
+        {
+            "g": ["A"] * 6 + ["B"] * 6 + ["C"] * 6 + ["D"] * 6,
+            "v": np.concatenate(
+                [rng.normal(0, 1, 6), rng.normal(0.5, 1, 6), rng.normal(3, 1, 6), rng.normal(0.2, 1, 6)]
+            ),
+        }
+    )
+
+    # Default is unchanged: raw, uncorrected p-values and no extra columns.
+    raw = univariate.ttest_independent_from_df(df, "g", "v")
+    assert "p value (adjusted)" not in raw.columns
+
+    holm = univariate.ttest_independent_from_df(df, "g", "v", correction="holm")
+    assert len(holm) == 6  # 4 groups -> 4*3/2 pairwise tests
+    # Holm adjustment never decreases a p-value, and the raw column is kept.
+    assert np.all(holm["p value (adjusted)"].to_numpy() >= holm["p value"].to_numpy() - 1e-12)
+    assert holm["p value"].to_numpy() == pytest.approx(raw["p value"].to_numpy(), rel=1e-12)
+    assert holm["reject"].dtype == bool
+
+    # Benjamini-Hochberg controls the FDR, so it is no more conservative than Holm.
+    bh = univariate.ttest_independent_from_df(df, "g", "v", correction="bh")
+    assert np.all(bh["p value (adjusted)"].to_numpy() <= holm["p value (adjusted)"].to_numpy() + 1e-12)
+
+    with pytest.raises(ValueError, match="correction must be one of"):
+        univariate.ttest_independent_from_df(df, "g", "v", correction="bogus")
+
+
+def test_summary_stats_rsd_with_zero_centre() -> None:
+    """A zero centre gives NaN rather than inf plus a RuntimeWarning.
+
+    Regression test: both relative-spread divisions were unguarded, so a
+    mean-centred variable produced inf and a RuntimeWarning through the public
+    API and the agent-facing tool.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        out = univariate.summary_stats(np.array([-1.0, 0.0, 1.0]))
+        assert np.isnan(out["rsd"])
+        assert np.isnan(out["rsd_classical"])
+
+        all_zero = univariate.summary_stats(np.array([0.0, 0.0, 0.0]))
+        assert np.isnan(all_zero["rsd"])
+        assert np.isnan(all_zero["rsd_classical"])
+
+    # A non-zero centre is unaffected.
+    normal = univariate.summary_stats(np.array([10.0, 11.0, 12.0]))
+    assert normal["rsd_classical"] == pytest.approx(np.std([10.0, 11, 12], ddof=1) / 11.0, rel=1e-12)
+
+
+def test_rosner_esd_corner_case() -> None:
+    """Degenerate inputs return an empty list rather than a spurious outlier."""
+    # All values identical: the spread is zero, so there is no candidate.
     outliers, extra_out = univariate.detect_outliers_esd([3, 3, 3], algorithm="esd", max_outliers_detected=1)
     assert np.isnan(extra_out["p-value"])
     assert extra_out["cutoff"] == -1
     assert len(outliers) == 0
 
-    outliers, extra_out = univariate.detect_outliers_esd([2, 2], algorithm="esd", max_outliers_detected=1)
-    assert np.isnan(extra_out["p-value"])
-    assert extra_out["cutoff"] == -1
-    assert len(outliers) == 0
-
-    outliers, extra_out = univariate.detect_outliers_esd([1], algorithm="esd", max_outliers_detected=1)
-    assert np.isnan(extra_out["p-value"])
+    # A clean sample large enough to test: nothing is flagged.
+    outliers, extra_out = univariate.detect_outliers_esd([1, 2, 3, 4], algorithm="esd", max_outliers_detected=1)
     assert extra_out["cutoff"] == -1
     assert len(outliers) == 0
 
     outliers, extra_out = univariate.detect_outliers_esd([1, 2, 3], algorithm="something-else", max_outliers_detected=1)
     assert len(extra_out) == 0
     assert len(outliers) == 0
+
+
+def test_rosner_esd_rejects_samples_too_small_to_test() -> None:
+    """Testing r outliers needs N >= r + 2, since the ESD dof is N - i - 1.
+
+    Regression test: these previously ran with dof <= 0, so `t.ppf` returned
+    NaN, every critical value was NaN, no crossing could ever be found, and the
+    empty result read as "no outliers" rather than "not testable".
+    """
+    for sample in ([1, 2], [2, 2], [1]):
+        with pytest.raises(ValueError, match="cannot exceed the sample size minus 2"):
+            univariate.detect_outliers_esd(sample, algorithm="esd", max_outliers_detected=1)
+
+    # NaN entries do not count towards the usable sample size.
+    with pytest.raises(ValueError, match="cannot exceed the sample size minus 2"):
+        univariate.detect_outliers_esd([1.0, 2.0, np.nan, np.nan], algorithm="esd", max_outliers_detected=2)
+
+    # Asking for zero outliers is always allowed.
+    outliers, _ = univariate.detect_outliers_esd([1, 2], algorithm="esd", max_outliers_detected=0)
+    assert outliers == []
+
+
+def test_rosner_esd_rejects_non_positive_alpha() -> None:
+    """The alpha level must lie in (0, 1]; only the upper bound was checked before."""
+    for bad_alpha in (0.0, -0.5):
+        with pytest.raises(ValueError, match="alpha must lie in"):
+            univariate.detect_outliers_esd([1, 2, 3, 4, 50], algorithm="esd", max_outliers_detected=1, alpha=bad_alpha)
+    with pytest.raises(ValueError, match="alpha must lie in"):
+        univariate.detect_outliers_esd([1, 2, 3, 4, 50], algorithm="esd", max_outliers_detected=1, alpha=1.5)
+
+
+def test_rosner_esd_handles_infinite_values() -> None:
+    """An infinity no longer raises KeyError from the -1 index sentinel.
+
+    Regression test: a NaN p-value set `R_i_idx = -1`, which is not a label in
+    the reset RangeIndex, so the subsequent drop raised KeyError whenever the
+    spread was non-zero.
+    """
+    for sample in ([1.0, 2.0, 3.0, np.inf], [1.0, 2.0, np.inf, 4.0, 5.0]):
+        outliers, extra_out = univariate.detect_outliers_esd(sample, algorithm="esd", max_outliers_detected=1)
+        assert isinstance(outliers, list)
+        assert -1 not in extra_out["R_i_idx"]
+
+
+def test_rosner_esd_pvalue_uses_the_current_sample_size() -> None:
+    """The Grubbs p-value describes the sample in hand, not the original one.
+
+    Regression test: N was computed once and never refreshed, so from the
+    second iteration onwards the reported p-value was computed for a larger
+    sample than the statistic actually came from.
+    """
+    rng = np.random.default_rng(0)
+    sample = [*rng.normal(size=20).tolist(), 12.0, 15.0]
+    _, reasons = univariate.detect_outliers_esd(sample, algorithm="esd", max_outliers_detected=4, alpha=0.05)
+
+    # Recompute iteration 2 by hand on the sample that remains after the first
+    # point is dropped, and confirm the reported value matches it.
+    remaining = pd.Series(sample).drop(pd.Series(sample).sub(np.mean(sample)).abs().idxmax()).reset_index(drop=True)
+    n_2 = len(remaining)
+    g_2 = ((remaining - remaining.mean()) / remaining.std()).abs().max()
+    s_2 = g_2**2 * n_2 * (2 - n_2) / (g_2**2 * n_2 - (n_2 - 1) ** 2)
+    expected = 0 if s_2 <= 0 else min(n_2 * (1 - univariate.t_value_cdf(np.sqrt(s_2), n_2 - 2)), 1)
+    assert reasons["p-value"][1] == pytest.approx(expected, rel=1e-10)
 
 
 def test_sequence_compare_r(outliers_data: tuple[list[float], list[float]]) -> None:


### PR DESCRIPTION
## Summary

All five **Univariate and monitoring** items from the #513 triage list, in one change. (Every item in that section is in `univariate/metrics.py`; there were no monitoring items under it.) Three of them change numerical results or raise where they previously did not.

- **`Sn` was biased low at every even sample size.** It used the averaging median for both the inner and outer medians; Rousseeuw-Croux take the **high** median inside and the **low** median outside, which are order statistics that differ from `np.median` exactly when `n` is even. The old value was 0.443 against a true 0.886 at `n=2`, 1.422 against 1.138 at `n=4`, and still 0.5% low at `n=1500`. A Monte Carlo check put the old estimator 4 to 23 percent below sigma at even `n` on standard-normal data. The corrected version reproduces **all 13** `robustbase::Sn` reference values in the test file, at both parities.
- **`detect_outliers_esd` gets its four missing guards**: rejects `max_outliers_detected > N - 2` (beyond that the critical value is NaN and an empty result reads as "no outliers" rather than "not testable"); rejects `alpha <= 0`; computes the Grubbs p-value from the sample actually in hand rather than the stale original `N`; and drops the `-1` index sentinel that raised `KeyError` on data containing an infinity.
- **The `_from_df` helpers no longer emit silent all-NaN rows** for a group whose values are all missing, and gain an optional multiplicity correction.
- **`summary_stats` returns NaN, not `inf` plus a `RuntimeWarning`,** for `rsd` at a zero centre.
- **`ttest_independent`'s mislabelled fields get correct names**, with the old ones kept as deprecated aliases.

## The Sn test comment was backwards

The test file rationalised the even-`n` mismatches with:

> This is because the R implementation aims for efficiency of calculation, and does not follow the formula presented in the original paper.

The opposite is true: `robustbase` follows Rousseeuw-Croux exactly and this package did not. A high/low-median implementation reproduces every value the file lists, **including all six marked "FAILS in our implementation"**. Those expectations are now asserted rather than excused, and one stale comment (an odd-`n` case marked failing that actually passed) is gone.

## On the mislabelled fields

`"z value"` is a t-statistic (its p-value is computed from the t distribution on the reported degrees of freedom), and `"Pooled standard deviation"` holds the standard **error** of the difference, `sqrt(svar * (1/nA + 1/nB))` - smaller than the pooled standard deviation `sqrt(svar)` by `sqrt(nA*nB/(nA+nB))`, which is 1.49x in the test case. Both are agent-facing through `ttest_two_samples`.

Renaming dict keys is breaking, so this is the **Announce** phase of `docs/development/deprecation_policy.rst`: correctly named entries are added (`"t value"`, `"Std error of difference"`, `"Pooled std dev"`, and `t_value` / `std_error_of_difference` / `pooled_std_dev` on the tool), the old names keep working, and the docstring carries a `.. deprecated:: 1.70.0` note naming the replacement and the 2.0 removal.

**One deliberate deviation from the policy, worth your call:** it specifies a runtime `DeprecationWarning` from the old API. These are plain dict keys, and the `_from_df` helpers feed the same dict straight into `pd.DataFrame(...)`, so warning on key access would fire spuriously on internal use. I documented the deprecation instead of emitting a warning. If you want the warning, the way to get it is a small dict subclass plus reworking the `_from_df` construction, which I kept out of this PR.

## Test plan

- [x] **Eight of the nine new/updated tests fail on the pre-fix code**, verified by stashing `metrics.py` / `tools.py` and re-running. The ninth is the newly added correction feature, which has no pre-fix behaviour to fail
- [x] The pinned NIST reference values for the Rosner data (`lambda`, `R_i`, outlier indices) are **unchanged**: the ESD critical values still use the original `N` per NIST/Rosner, and only the diagnostic Grubbs p-value moved to the current sample size
- [x] Full suite: **2678 passed, 6 skipped**. The two failures (`test_oildoe_loads`, `test_distillateflow_loads`) are network tests failing identically on unmodified `main` where openmv.net is unreachable
- [x] `ruff check .`, `ruff format --check .` and `mypy src/process_improve` all clean
- [x] Verified the `rsd` guard with `RuntimeWarning` escalated to an error, so the fix is proven rather than merely quieter

## Checklist

- [x] Version bumped in `pyproject.toml` (MINOR: to 1.70.0, meaningful behavioural changes), with `CITATION.cff` matching in the same commit
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated, with the Sn and ESD behaviour changes called out under **Changed** and the alias retirement under **Deprecated**

**Sequencing note:** this takes 1.70.0 and leaves 1.69.0 to #518, which is still open. If #518 merges first this rebases cleanly on the changelog; if it is dropped, tell me and I will re-bump this to 1.69.0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPuM5PJdHnpvpKpAsc6uDM)_