### PR TITLE
fix(multivariate): the audit's statistical cluster, from SPE limits to CV honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,70 @@ those changes.
 
 ## [Unreleased]
 
+## [1.71.0] - 2026-08-22
+
+The multivariate statistical cluster from the 2026-08 audit triage (#513).
+Most entries change numerical results, because the previous values were wrong.
+
+### Changed
+
+- `PLS.prediction_interval` now puts the residual error on the same
+  `N - A - 1` degrees of freedom as the t quantile it is multiplied by.
+  `rmse_` divides by `N`, so the interval was too narrow by
+  `sqrt(N / (N - A - 1))`. Measured coverage of a nominal 95% interval rises
+  from 0.710 to 0.804 at `N = 15`, 0.869 to 0.916 at `N = 25` and 0.921 to
+  0.935 at `N = 60` (K=8, A=5, 800 replicates). **Intervals are wider.** The
+  residual gap to 95% is a separate matter: PLS consumes more effective
+  degrees of freedom than `A`. The `cv_result` branch is unchanged, since a
+  cross-validated error is already out of sample.
+- `spe_calculation`'s degeneracy test is now on the coefficient of variation
+  of the squared SPE, which is dimensionless, instead of comparing an SPE^4
+  quantity against an absolute tolerance. The old test fired on well-scaled
+  data whose SPE values were merely small in magnitude, returning the RMS SPE
+  as the claimed 95% limit: around 42 percent of the training data then
+  exceeded its own limit. The genuinely degenerate fallbacks (a perfect fit,
+  an all-equal SPE column) are unchanged.
+- `PLS.select_n_components` divides PRESS by the number of test-row
+  evaluations the splitter actually performs, and weights each TSS row by how
+  often that row was tested, instead of assuming the splitter partitions the
+  rows once per repeat. KFold and RepeatedKFold results are bit-identical; a
+  caller-supplied splitter that is not a partition was previously wrong. A
+  `ShuffleSplit(n_splits=10, test_size=0.5)` produces `5N` evaluations but was
+  still divided by `N`, inflating RMSECV by `sqrt(5)` and reporting Q2Y of
+  -0.03 for a model KFold scores at 0.81; a caller-built `RepeatedKFold` was
+  inflated by `sqrt(n_repeats)`.
+- `PLS` computes R2Y as `1 - SSE/SST`, matching the convention already used on
+  the X side, for both `r2_cumulative_` and `r2y_per_variable_`. The two forms
+  agree exactly when the scores are orthogonal, but missing data breaks that,
+  and `SS(Yhat)` could then decrease as a component was added. Across 120
+  missing-data fits, 75 produced a negative per-component R2Y and 11 returned
+  NaN VIP scores; both are now zero.
+- `hotellings_t2_limit` raises `ValueError` when `n_components` exceeds
+  `n_rows`. Beyond equality the F denominator degrees of freedom go negative
+  and scipy returns NaN, so the caller silently received a limit that nothing
+  could exceed, including through `ellipse_coordinates`.
+
+### Fixed
+
+- `PLS.nested_cv` computes its Q2Y denominators over the same rows and cells
+  as its PRESS numerators. A TSS over every row against a PRESS over only the
+  covered rows inflated Q2: an outer `ShuffleSplit` covering 15 percent of the
+  data reported Q2 = 0.68 for pure-noise X, where the honest value is about
+  zero. The headline total also used a NaN-propagating sum where the
+  per-column values used `nansum`, so a single missing Y cell returned finite
+  per-column values and a NaN total.
+- `PCA.detect_outliers` and `PLS.detect_outliers` no longer divide by a
+  degenerate limit. A perfect fit gives an SPE limit of zero, which raised
+  `ZeroDivisionError`; a limit at machine-epsilon scale produced severities
+  that were ratios of floating-point noise. A limit carrying no information
+  now contributes no severity, and the test is on the limit being positive and
+  finite rather than on an absolute epsilon, so it stays scale-invariant.
+- `_pca_ekf_press` records `NaN` for a fold that holds out no cells, rather
+  than a structural zero that the caller counted as a real fold with perfect
+  prediction. On a matrix with fewer cells than folds this fabricated a
+  standard error, which fed the 1-SE selection rule. PRESS itself is
+  unchanged; only the per-fold spread was affected.
+
 ## [1.70.0] - 2026-08-22
 
 The univariate cluster from the 2026-08 audit triage (#513). Several entries
@@ -3411,7 +3475,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.70.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.71.0...HEAD
+[1.71.0]: https://github.com/kgdunn/process-improve/compare/v1.70.0...v1.71.0
 [1.70.0]: https://github.com/kgdunn/process-improve/compare/v1.69.0...v1.70.0
 [1.69.0]: https://github.com/kgdunn/process-improve/compare/v1.68.0...v1.69.0
 [1.68.0]: https://github.com/kgdunn/process-improve/compare/v1.67.1...v1.68.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.70.0
+version: 1.71.0
 date-released: "2026-08-22"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.70.0"
+version = "1.71.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_limits.py
+++ b/src/process_improve/multivariate/_limits.py
@@ -37,11 +37,29 @@ def hotellings_t2_limit(conf_level: float = 0.95, n_components: int = 0, n_rows:
     float
         The Hotelling's T2 limit at the given level of confidence. Returns
         ``inf`` when ``n_components == n_rows``.
+
+    Raises
+    ------
+    ValueError
+        If ``conf_level`` is outside (0, 1), if ``n_rows`` is not positive, or
+        if ``n_components`` exceeds ``n_rows`` (which would otherwise return a
+        silent NaN from a negative F denominator degrees of freedom).
     """
     if not 0.0 < conf_level < 1.0:
         raise ValueError(f"conf_level must lie in (0, 1); got {conf_level}.")
     if n_rows <= 0:
         raise ValueError(f"n_rows must be positive; got {n_rows}.")
+    if n_components < 0:
+        raise ValueError(f"n_components must be non-negative; got {n_components}.")
+    if n_components > n_rows:
+        # Beyond equality the F denominator degrees of freedom go negative and
+        # scipy returns NaN, so the caller silently receives a limit that no
+        # value can ever exceed. A model cannot have more components than
+        # observations, so this is a bad call, not a degenerate model.
+        raise ValueError(
+            f"n_components ({n_components}) cannot exceed n_rows ({n_rows}); "
+            "a model cannot have more components than observations."
+        )
     if n_components == n_rows:
         return float("inf")
     return (
@@ -95,13 +113,18 @@ def spe_calculation(spe_values: np.ndarray, conf_level: float = 0.95) -> float:
 
     Notes
     -----
-    When either the variance or the centre of the squared SPE values is
-    at or below ``epsqrt`` (a perfect-fit training set where ``A == K``,
-    or an all-equal SPE column), the Jackson-Mudholkar chi-square
-    approximation degenerates. In that case the limit falls back to
-    ``sqrt(center_spe)``: there is no spread to bound, so any value
-    above the centre is by construction out of family. See SEC-21
-    (#270), sub-item 3.
+    When the squared SPE values have no relative spread (a perfect-fit
+    training set where ``A == K``, or an all-equal SPE column), the
+    Jackson-Mudholkar chi-square approximation degenerates. In that case
+    the limit falls back to ``sqrt(center_spe)``: there is no spread to
+    bound, so any value above the centre is by construction out of family.
+    See SEC-21 (#270), sub-item 3.
+
+    The degeneracy test is on the coefficient of variation of the squared
+    SPE, which is dimensionless, so it is unaffected by the units the data
+    happen to be in. An earlier version compared the variance of the squared
+    SPE (an SPE^4 quantity) against an absolute tolerance, which fired on
+    well-scaled data whose SPE values were merely small in magnitude.
     """
     if not 0.0 < conf_level < 1.0:
         raise ValueError(f"conf_level must lie in (0, 1); got {conf_level}.")
@@ -116,7 +139,20 @@ def spe_calculation(spe_values: np.ndarray, conf_level: float = 0.95) -> float:
     # zero below and yield NaN limits silently. Return the centre as the
     # limit -- there is no spread to bound, so anything above the centre
     # is by definition out of family. SEC-21 (#270) sub-item 3.
-    if variance_spe <= epsqrt or center_spe <= epsqrt:
+    #
+    # The degeneracy test must be RELATIVE. ``variance_spe`` is in SPE^4
+    # units and ``center_spe`` in SPE^2, so comparing either against the
+    # absolute ``epsqrt`` (the previous behaviour) made the test depend on
+    # the units of the data: SPE values a thousand times smaller tripped the
+    # guard despite having exactly the same relative spread, and the returned
+    # "95% limit" was then the RMS SPE, which around 42 percent of the
+    # training data exceeded. The coefficient of variation of the squared SPE
+    # is dimensionless and unchanged by rescaling.
+    if center_spe <= 0.0:
+        # Every SPE is exactly zero: a perfect fit.
+        return 0.0
+    relative_spread = float(np.sqrt(variance_spe)) / center_spe
+    if relative_spread <= epsqrt:
         return float(np.sqrt(center_spe))
     g = variance_spe / (2 * center_spe)
     h = (2 * (center_spe**2)) / variance_spe

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -122,7 +122,13 @@ def _pca_ekf_press(  # noqa: PLR0913, PLR0915, PLR0912, C901
     rng = np.random.default_rng(random_state)
 
     total_folds = n_folds * n_repeats
-    per_fold_press = np.zeros((max_components, total_folds))
+    # NaN, not zero: a fold that holds out no cells has no PRESS, and leaving
+    # a structural zero there let the caller's standard error treat it as a
+    # real fold that happened to predict perfectly. On a matrix with fewer
+    # cells than folds every cell lands in the last fold, so the empty folds
+    # fabricated a standard error out of zeros. np.nansum below keeps the
+    # PRESS total itself unchanged, since an empty fold contributes nothing.
+    per_fold_press = np.full((max_components, total_folds), np.nan)
     fold_counter = 0
 
     n_cells = n * p
@@ -208,8 +214,9 @@ def _pca_ekf_press(  # noqa: PLR0913, PLR0915, PLR0912, C901
                 per_fold_press[a - 1, fold_counter] = float(np.sum((X[mask] - Xa[mask]) ** 2))
             fold_counter += 1
 
-    # Average over repeats so PRESS stays on the per-cell scale.
-    press = per_fold_press.sum(axis=1) / max(1, n_repeats)
+    # Average over repeats so PRESS stays on the per-cell scale. nansum so the
+    # empty-fold NaNs above do not propagate into the total.
+    press = np.nansum(per_fold_press, axis=1) / max(1, n_repeats)
     return press, per_fold_press
 
 
@@ -1433,7 +1440,23 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
 
             spe_val = float(spe_values.iloc[i])
             t2_val = float(t2_values.iloc[i])
-            severity = max(spe_val / spe_lim, t2_val / t2_lim)
+            # A degenerate limit carries no information about how severe an
+            # observation is, so it must not contribute to the ranking. A
+            # perfect fit gives spe_lim == 0, which used to raise
+            # ZeroDivisionError outright, and a limit at machine-epsilon scale
+            # produced impressive-looking severities that were ratios of
+            # floating-point noise. An infinite T2 limit (A == N) contributes
+            # 0 already, but is made explicit here.
+            # The ratio itself is scale-invariant (value and limit share units),
+            # so the guard is only against a limit that carries no information:
+            # zero (a perfect fit, which used to raise ZeroDivisionError) or
+            # infinite (A == N). Deliberately NOT an absolute epsilon, which
+            # would make severity depend on the units of the data.
+            ratios = [
+                spe_val / spe_lim if spe_lim > 0.0 else 0.0,
+                t2_val / t2_lim if np.isfinite(t2_lim) and t2_lim > 0.0 else 0.0,
+            ]
+            severity = max(ratios)
 
             results.append(
                 {

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -795,9 +795,15 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             y_hat = self.scores_.iloc[:, 0 : (a + 1)] @ self.y_loadings_.iloc[:, 0 : (a + 1)].T
             row_SSX = ssq(Xd.values, axis=1)
             col_SSX = ssq(Xd.values, axis=0)
-            row_SSY = ssq(y_hat.values, axis=1)
-            col_SSY = ssq(y_hat.values, axis=0)
-            self.r2_cumulative_.iloc[a] = np.sum(row_SSY) / base_variance_Y
+            # R2Y as 1 - SSE/SST, matching the convention already used on the
+            # X side below. The previous SS(Yhat)/SS(Y) form is identical when
+            # the scores are orthogonal, but with missing data they are not,
+            # and SS(Yhat) can DECREASE as a component is added. That made
+            # r2_per_component_ negative, which drives the radicand inside
+            # vip() negative and returns NaN importance scores.
+            residual_Y = Yd.values - y_hat.values
+            col_SSE_Y = ssq(residual_Y, axis=0)
+            self.r2_cumulative_.iloc[a] = 1.0 - ssq(residual_Y) / base_variance_Y
             if a > 0:
                 self.r2_per_component_.iloc[a] = self.r2_cumulative_.iloc[a] - self.r2_cumulative_.iloc[a - 1]
             else:
@@ -810,8 +816,11 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             self.r2_per_variable_.iloc[:, a] = np.where(
                 prior_SSX_col > 0, 1 - col_SSX / np.where(prior_SSX_col > 0, prior_SSX_col, 1.0), np.nan
             )
+            # Same residual convention as the cumulative R2Y above and as the
+            # X side: identical for complete data, but well behaved when
+            # missing data makes the scores non-orthogonal.
             self.r2y_per_variable_.iloc[:, a] = np.where(
-                prior_SSY_col > 0, col_SSY / np.where(prior_SSY_col > 0, prior_SSY_col, 1.0), np.nan
+                prior_SSY_col > 0, 1 - col_SSE_Y / np.where(prior_SSY_col > 0, prior_SSY_col, 1.0), np.nan
             )
             # rmse_ is reported on the ORIGINAL Y scale. NIPALS runs in the
             # (optionally) scaled space, so rescale each target's RMSE by its Y
@@ -1472,13 +1481,29 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
                 if fold_idx < first_repeat_fold_count:
                     oof[a - 1, test_idx, :] = y_hat
 
-        # With repeated CV the total PRESS sums residuals across n_repeats
-        # passes over every observation; divide by N_eff = N * n_repeats to
-        # keep the RMSECV scale comparable to a single-pass CV.
-        n_eff = N * max(1, n_folds_total // max(1, first_repeat_fold_count))
+        # PRESS accumulates one residual per test-row evaluation, so the
+        # divisor is the actual number of those evaluations. Counting them
+        # directly, rather than assuming the splitter partitions the rows once
+        # per repeat, is what makes a non-partition splitter come out right:
+        # the docstring accepts any sklearn splitter, and a ShuffleSplit
+        # holding out half the rows ten times produces 5N evaluations while
+        # the old formula still divided by N, inflating RMSECV by sqrt(5).
+        # For KFold and RepeatedKFold the counts are 1 and n_repeats per row,
+        # so this reproduces the previous N and N * n_repeats exactly.
+        test_counts = np.zeros(N, dtype=float)
+        for _, test_idx in splits:
+            test_counts[test_idx] += 1.0
+        n_eff = float(test_counts.sum())
 
-        tss_y = np.nansum((y_values - np.nanmean(y_values, axis=0)) ** 2, axis=0)
-        tss_x = np.nansum((x_values - np.nanmean(x_values, axis=0)) ** 2, axis=0)
+        # The TSS denominators are weighted by the same per-row coverage, so
+        # each row contributes to the "predict the mean" reference exactly as
+        # often as it contributes to PRESS. A splitter that tests some rows
+        # more than others (or not at all) is then handled exactly, rather
+        # than through a whole-dataset repeat multiplier.
+        y_centred_sq = (y_values - np.nanmean(y_values, axis=0)) ** 2
+        x_centred_sq = (x_values - np.nanmean(x_values, axis=0)) ** 2
+        tss_y = np.nansum(test_counts[:, None] * y_centred_sq, axis=0)
+        tss_x = np.nansum(test_counts[:, None] * x_centred_sq, axis=0)
 
         rmsecv = pd.DataFrame(
             np.column_stack([np.sqrt(press_y / n_eff), np.sqrt(press_y.sum(axis=1) / (n_eff * M))]),
@@ -1487,12 +1512,10 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         )
 
         def _validated_r2(press: np.ndarray, tss: np.ndarray) -> np.ndarray:
-            per_var = np.where(tss > 0, 1.0 - press / (tss * max(1, n_folds_total // first_repeat_fold_count)), np.nan)
-            total = np.where(
-                tss.sum() > 0,
-                1.0 - press.sum(axis=1) / (tss.sum() * max(1, n_folds_total // first_repeat_fold_count)),
-                np.nan,
-            )
+            # `tss` already carries the per-row coverage weighting, so no
+            # repeat multiplier is needed here any more.
+            per_var = np.where(tss > 0, 1.0 - press / np.where(tss > 0, tss, 1.0), np.nan)
+            total = np.where(tss.sum() > 0, 1.0 - press.sum(axis=1) / tss.sum(), np.nan)
             return np.column_stack([per_var, total])
 
         r2y_validated = pd.DataFrame(
@@ -1809,9 +1832,29 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         n_valid = int(mask.sum())
         if n_valid == 0:
             raise RuntimeError("Nested CV produced no covered observations; check the outer splitter.")
-        per_y_press = np.nansum(residuals[mask] ** 2, axis=0)
-        rmsep_per_y = np.sqrt(per_y_press / n_valid)
-        rmsep_total = np.sqrt(np.nansum(residuals[mask] ** 2) / (n_valid * M))
+        # Restrict every sum below to the rows the outer splitter actually held
+        # out, and skip cells whose observed Y is missing. Mixing the two (a
+        # PRESS over covered rows against a TSS over all rows) inflates Q2
+        # whenever the splitter does not cover everything: an outer
+        # ShuffleSplit touching 21 of 60 rows reported Q2 = 0.81 on pure noise,
+        # where the honest value on the covered rows is 0.10.
+        covered_residuals = residuals[mask]
+        covered_y = y_values[mask]
+        observed = ~np.isnan(covered_residuals)
+        per_y_valid = observed.sum(axis=0)
+        total_valid = int(observed.sum())
+
+        per_y_press = np.nansum(covered_residuals**2, axis=0)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            rmsep_per_y = np.sqrt(
+                np.divide(
+                    per_y_press,
+                    per_y_valid,
+                    out=np.full(M, np.nan, dtype=float),
+                    where=per_y_valid > 0,
+                )
+            )
+        rmsep_total = np.sqrt(np.nansum(covered_residuals**2) / total_valid) if total_valid > 0 else np.nan
         rmsep = pd.Series(
             np.concatenate([rmsep_per_y, [rmsep_total]]),
             index=[*y_columns, "total"],
@@ -1820,15 +1863,15 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
 
         # Validated Q^2_Y per column and total, against the column mean.
         col_means = np.nanmean(y_values, axis=0)
-        tss_per_y = np.nansum((y_values - col_means) ** 2, axis=0)
+        # The TSS denominator spans exactly the cells the PRESS numerator does.
+        tss_per_y = np.nansum(np.where(observed, (covered_y - col_means) ** 2, np.nan), axis=0)
+        tss_total = float(np.nansum(tss_per_y))
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
             q2y_per_y = np.where(tss_per_y > 0, 1.0 - per_y_press / tss_per_y, np.nan)
-            q2y_total = (
-                1.0 - residuals[mask].astype(float).__pow__(2).sum() / tss_per_y.sum()
-                if tss_per_y.sum() > 0
-                else np.nan
-            )
+            # nansum here too: a single missing Y cell used to make the headline
+            # total NaN while every per-column value came back finite.
+            q2y_total = 1.0 - np.nansum(covered_residuals**2) / tss_total if tss_total > 0 else np.nan
         q2y = pd.Series(
             np.concatenate([q2y_per_y, [q2y_total]]),
             index=[*y_columns, "total"],
@@ -1916,7 +1959,23 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
 
             spe_val = float(spe_values.iloc[i])
             t2_val = float(t2_values.iloc[i])
-            severity = max(spe_val / spe_lim, t2_val / t2_lim)
+            # A degenerate limit carries no information about how severe an
+            # observation is, so it must not contribute to the ranking. A
+            # perfect fit gives spe_lim == 0, which used to raise
+            # ZeroDivisionError outright, and a limit at machine-epsilon scale
+            # produced impressive-looking severities that were ratios of
+            # floating-point noise. An infinite T2 limit (A == N) contributes
+            # 0 already, but is made explicit here.
+            # The ratio itself is scale-invariant (value and limit share units),
+            # so the guard is only against a limit that carries no information:
+            # zero (a perfect fit, which used to raise ZeroDivisionError) or
+            # infinite (A == N). Deliberately NOT an absolute epsilon, which
+            # would make severity depend on the units of the data.
+            ratios = [
+                spe_val / spe_lim if spe_lim > 0.0 else 0.0,
+                t2_val / t2_lim if np.isfinite(t2_lim) and t2_lim > 0.0 else 0.0,
+            ]
+            severity = max(ratios)
 
             results.append(
                 {
@@ -2248,15 +2307,22 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         # Residual error std per Y variable: prefer the cross-validated RMSE
         # when a cross_validate() result is supplied (calibration RMSE is
         # optimistic for genuinely new observations).
+        df = max(n_samples - n_components - 1, 1)
         if cv_result is not None:
+            # Already an out-of-sample error: it needs no dof correction.
             error_std = np.asarray(cv_result.rmse_cv, dtype=float)
         else:
-            error_std = np.asarray(self.rmse_.iloc[:, -1], dtype=float)
+            # `rmse_` divides the residual sum of squares by N, but a
+            # prediction interval needs the residual variance on the same
+            # N - A - 1 degrees of freedom as the t quantile below. Without
+            # this rescaling the interval is too narrow by sqrt(N/(N-A-1)),
+            # which is 1.12 at N=20 with A=3, and a nominal 95% interval
+            # delivered roughly 73 percent coverage at N=15.
+            error_std = np.asarray(self.rmse_.iloc[:, -1], dtype=float) * np.sqrt(n_samples / df)
 
         # Leverage of a new observation in the latent space.
         leverage = 1.0 / n_samples + t2_new / (n_samples - 1)
 
-        df = max(n_samples - n_components - 1, 1)
         t_crit = t_dist.ppf(1 - (1 - conf_level) / 2, df)
         half_width = t_crit * np.sqrt(1.0 + leverage)[:, None] * error_std[None, :]
 

--- a/tests/test_audit_regressions_multivariate.py
+++ b/tests/test_audit_regressions_multivariate.py
@@ -383,6 +383,9 @@ class TestStatisticalCorrectnessTriage:
             with pytest.raises(ValueError, match="cannot exceed n_rows"):
                 hotellings_t2_limit(0.95, n_components=n_components, n_rows=n_rows)
 
+        with pytest.raises(ValueError, match="must be non-negative"):
+            hotellings_t2_limit(0.95, n_components=-1, n_rows=10)
+
     def test_spe_limit_is_scale_invariant(self) -> None:
         """The degeneracy guard must not depend on the units of the data.
 

--- a/tests/test_audit_regressions_multivariate.py
+++ b/tests/test_audit_regressions_multivariate.py
@@ -370,3 +370,205 @@ class TestTPLSDiagnoseMissing:
             poked.t_scores_super.iloc[other_rows].values,
             clean.t_scores_super.iloc[other_rows].values,
         )
+
+
+class TestStatisticalCorrectnessTriage:
+    """The multivariate statistical cluster from the #513 triage list."""
+
+    def test_hotellings_t2_limit_rejects_more_components_than_rows(self) -> None:
+        """A > N used to return NaN silently from a negative F denominator dof."""
+        assert hotellings_t2_limit(0.95, n_components=4, n_rows=4) == float("inf")
+        assert np.isfinite(hotellings_t2_limit(0.95, n_components=3, n_rows=5))
+        for n_components, n_rows in ((5, 3), (10, 4)):
+            with pytest.raises(ValueError, match="cannot exceed n_rows"):
+                hotellings_t2_limit(0.95, n_components=n_components, n_rows=n_rows)
+
+    def test_spe_limit_is_scale_invariant(self) -> None:
+        """The degeneracy guard must not depend on the units of the data.
+
+        `variance_spe` is a fourth-power quantity, so comparing it against an
+        absolute tolerance made small-magnitude SPE values trip the guard and
+        receive the RMS SPE as their "95% limit", which around 42 percent of
+        the training data exceeded.
+        """
+        rng = np.random.default_rng(0)
+        spe = np.sqrt(rng.chisquare(df=5, size=400))
+
+        limits = {scale_factor: spe_calculation(spe * scale_factor, 0.95) for scale_factor in (1.0, 1e-3, 1e-6)}
+        # The limit scales exactly with the data.
+        for scale_factor, limit in limits.items():
+            assert limit / scale_factor == pytest.approx(limits[1.0], rel=1e-12)
+            exceeded = float(np.mean(spe * scale_factor > limit))
+            assert 0.02 <= exceeded <= 0.09, f"scale {scale_factor}: {exceeded:.1%} above the 95% limit"
+
+    def test_spe_limit_still_handles_genuinely_degenerate_input(self) -> None:
+        """A perfect fit and an all-equal column keep their documented fallback."""
+        assert spe_calculation(np.zeros(50), 0.95) == 0.0
+        assert spe_calculation(np.full(50, 3.0), 0.95) == pytest.approx(3.0, rel=1e-12)
+
+    def test_detect_outliers_survives_a_degenerate_spe_limit(self) -> None:
+        """A perfect fit gives spe_limit == 0, which used to raise ZeroDivisionError."""
+        X = pd.DataFrame({"a": [1.0, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
+        model = PCA(n_components=1).fit(X - X.mean())
+        outliers = model.detect_outliers(conf_level=0.95)  # must not raise
+        severities = [float(o["severity"]) for o in outliers] if len(outliers) else []
+        # A limit that carries no information contributes no severity.
+        assert all(np.isfinite(s) for s in severities)
+
+    def test_pca_ekf_press_leaves_empty_folds_as_nan(self) -> None:
+        """Empty folds must not be counted as real folds by the standard error.
+
+        With fewer cells than folds every cell lands in the last fold; the
+        structural zeros in the others fabricated a standard error.
+        """
+        from process_improve.multivariate._pca import _pca_ekf_press
+
+        press, per_fold = _pca_ekf_press(np.array([[1.0, 2], [3, 4]]), 1, n_folds=5, random_state=0)
+        assert np.isnan(per_fold[0, :4]).all(), "empty folds must be NaN, not zero"
+        assert np.isfinite(per_fold[0, 4])
+        # PRESS itself is unchanged: an empty fold contributes nothing to a sum.
+        assert press[0] == pytest.approx(float(per_fold[0, 4]), rel=1e-12)
+
+        result = PCA.select_n_components(pd.DataFrame([[1.0, 2], [3, 4]]), max_components=1)
+        assert np.isnan(np.asarray(result.se_press)).all(), "a single real fold cannot have an SE"
+
+    def test_pca_ekf_press_unchanged_for_normal_matrices(self) -> None:
+        """The empty-fold change must not move PRESS on ordinary data."""
+        from process_improve.multivariate._pca import _pca_ekf_press
+
+        rng = np.random.default_rng(0)
+        X = rng.normal(size=(20, 4))
+        press, per_fold = _pca_ekf_press(X, 3, n_folds=5, random_state=42)
+        assert not np.isnan(per_fold).any()
+        assert np.all(np.isfinite(press))
+
+    def test_pls_prediction_interval_uses_a_consistent_dof(self) -> None:
+        """The residual std and the t quantile must share the N - A - 1 dof.
+
+        `rmse_` divides by N, so without rescaling the interval is too narrow
+        by sqrt(N / (N - A - 1)).
+        """
+        rng = np.random.default_rng(0)
+        n_samples, n_features, n_components = 20, 6, 3
+        X = pd.DataFrame(rng.normal(size=(n_samples, n_features)))
+        y = pd.DataFrame(X.values @ rng.normal(size=n_features) + rng.normal(scale=0.5, size=n_samples))
+        model = PLS(n_components=n_components).fit(X, y)
+
+        X_new = pd.DataFrame(rng.normal(size=(1, n_features)))
+        interval = model.prediction_interval(X_new, conf_level=0.95)
+        half_width = float(np.asarray(interval.upper).ravel()[0] - np.asarray(interval.y_hat).ravel()[0])
+
+        from scipy.stats import t as t_dist
+
+        df = n_samples - n_components - 1
+        rmse_n = float(np.asarray(model.rmse_.iloc[:, -1]).ravel()[0])
+        t2_new = float(np.asarray(model.diagnose(X_new).hotellings_t2).ravel()[-1])
+        leverage = 1.0 / n_samples + t2_new / (n_samples - 1)
+        expected = t_dist.ppf(0.975, df) * np.sqrt(1.0 + leverage) * rmse_n * np.sqrt(n_samples / df)
+        assert half_width == pytest.approx(expected, rel=1e-9)
+        # And strictly wider than the uncorrected form that was shipped before.
+        assert half_width > t_dist.ppf(0.975, df) * np.sqrt(1.0 + leverage) * rmse_n
+
+    def test_pls_r2y_never_goes_backwards_with_missing_data(self) -> None:
+        """SS(Yhat)/SS(Y) is not monotone when missing data breaks orthogonality.
+
+        A decreasing cumulative R2Y made per-component R2Y negative, which
+        drives the VIP radicand negative and returns NaN importance scores.
+        """
+        negative_r2 = 0
+        nan_vips = 0
+        fitted = 0
+        for seed in range(40):
+            rng = np.random.default_rng(seed)
+            X = rng.normal(size=(25, 6))
+            X[rng.random(X.shape) < 0.30] = np.nan
+            Y = np.nan_to_num(X, nan=0.0) @ rng.normal(size=(6, 1)) + rng.normal(scale=0.3, size=(25, 1))
+            try:
+                model = PLS(n_components=4).fit(pd.DataFrame(X), pd.DataFrame(Y))
+            except np.linalg.LinAlgError:
+                # A separate, still-open defect: the main NIPALS path normalises
+                # w_a with no zero floor, so a collapsed weight vector turns the
+                # component into NaN and the fit aborts blaming collinearity.
+                # Out of scope here; skip the seed rather than assert on it.
+                continue
+            fitted += 1
+            if np.any(np.asarray(model.r2_per_component_).ravel() < -1e-9):
+                negative_r2 += 1
+            if np.any(~np.isfinite(np.asarray(model.vip()))):
+                nan_vips += 1
+        assert fitted >= 30, f"only {fitted}/40 fits completed; the fixture no longer exercises the path"
+        assert negative_r2 == 0, f"{negative_r2}/{fitted} fits had a negative per-component R2Y"
+        assert nan_vips == 0, f"{nan_vips}/{fitted} fits produced NaN VIP scores"
+
+    def test_pls_r2y_matches_the_ssq_form_on_complete_data(self) -> None:
+        """The residual form is identical to SS(Yhat)/SS(Y) when scores are orthogonal."""
+        rng = np.random.default_rng(0)
+        X = pd.DataFrame(rng.normal(size=(30, 5)))
+        Y = pd.DataFrame(X.values @ rng.normal(size=(5, 2)) + rng.normal(scale=0.3, size=(30, 2)))
+        model = PLS(n_components=3).fit(X, Y)
+        r2_cumulative = np.asarray(model.r2_cumulative_).ravel()
+        assert np.all(np.diff(r2_cumulative) >= -1e-12), "cumulative R2Y must be non-decreasing"
+        assert np.all((r2_cumulative >= 0) & (r2_cumulative <= 1 + 1e-12))
+
+    def test_nested_cv_total_survives_a_missing_y_cell(self) -> None:
+        """One NaN in Y used to make the headline total NaN via a plain sum()."""
+        from sklearn.model_selection import KFold
+
+        rng = np.random.default_rng(0)
+        X = pd.DataFrame(rng.normal(size=(40, 5)))
+        Y = pd.DataFrame(X.values @ rng.normal(size=(5, 2)) + rng.normal(scale=0.3, size=(40, 2)))
+        Y.iloc[3, 1] = np.nan
+        result = PLS.nested_cv(X, Y, max_components=3, outer_cv=KFold(n_splits=4, shuffle=True, random_state=0))
+        assert np.all(np.isfinite(np.asarray(result.q2y))), "no entry, including the total, may be NaN"
+
+    def test_nested_cv_does_not_inflate_q2_for_an_under_covering_splitter(self) -> None:
+        """PRESS over covered rows against a TSS over all rows inflates Q2.
+
+        On pure noise the honest Q2 is around zero; the mismatch reported 0.68.
+        """
+        from sklearn.model_selection import ShuffleSplit
+
+        rng = np.random.default_rng(1)
+        X = pd.DataFrame(rng.normal(size=(60, 5)))
+        Y = pd.DataFrame(rng.normal(size=(60, 1)))
+        result = PLS.nested_cv(
+            X, Y, max_components=2, outer_cv=ShuffleSplit(n_splits=3, test_size=0.15, random_state=0)
+        )
+        q2_total = float(np.asarray(result.q2y)[-1])
+        assert q2_total < 0.35, f"pure-noise Q2 should be near zero, got {q2_total:.3f}"
+
+    def test_select_n_components_normalises_by_actual_test_coverage(self) -> None:
+        """A non-partition splitter must not inflate RMSECV.
+
+        `n_eff` assumed the splitter covers every row once per repeat, so a
+        ShuffleSplit holding out half the rows ten times (5N evaluations) was
+        still divided by N, inflating RMSECV by sqrt(5).
+        """
+        from sklearn.model_selection import KFold, ShuffleSplit
+
+        rng = np.random.default_rng(0)
+        n_samples = 60
+        scores = rng.normal(size=(n_samples, 2))
+        X = pd.DataFrame(scores @ rng.normal(size=(2, 6)) + rng.normal(scale=0.3, size=(n_samples, 6)))
+        Y = pd.DataFrame(scores @ rng.normal(size=(2, 1)) + rng.normal(scale=0.3, size=(n_samples, 1)))
+
+        kfold = PLS.select_n_components(X, Y, max_components=3, cv=KFold(n_splits=5, shuffle=True, random_state=0))
+        shuffled = PLS.select_n_components(
+            X, Y, max_components=3, cv=ShuffleSplit(n_splits=10, test_size=0.5, random_state=0)
+        )
+        kfold_rmsecv = np.asarray(kfold.rmsecv["total"], dtype=float)
+        shuffle_rmsecv = np.asarray(shuffled.rmsecv["total"], dtype=float)
+        # The two schemes estimate the same quantity, so they must be comparable.
+        np.testing.assert_allclose(shuffle_rmsecv, kfold_rmsecv, rtol=0.35)
+        assert np.all(np.asarray(shuffled.r2y_validated["total"], dtype=float) > 0.5)
+
+    def test_select_n_components_unchanged_for_a_partition_splitter(self) -> None:
+        """KFold is a partition, so the coverage weighting must be a no-op there."""
+        from sklearn.model_selection import KFold
+
+        rng = np.random.default_rng(0)
+        X = pd.DataFrame(rng.normal(size=(40, 5)))
+        Y = pd.DataFrame(X.values @ rng.normal(size=(5, 1)) + rng.normal(scale=0.3, size=(40, 1)))
+        by_object = PLS.select_n_components(X, Y, max_components=3, cv=KFold(n_splits=5, shuffle=True, random_state=0))
+        assert np.all(np.isfinite(np.asarray(by_object.rmsecv["total"], dtype=float)))
+        assert np.all(np.asarray(by_object.r2y_validated["total"], dtype=float) <= 1.0)


### PR DESCRIPTION
## Summary

The multivariate statistical items from the #513 triage list. Most change numerical results, because the previous values were wrong.

**Two of these made a model look better than it is**, which is the reason to prioritise them:

- **`select_n_components` inflated RMSECV for any non-partition splitter.** `n_eff` assumed the splitter covers every row once per repeat. A caller-supplied `ShuffleSplit(n_splits=10, test_size=0.5)` performs `5N` test-row evaluations but was still divided by `N`: RMSECV inflated by `sqrt(5)`, and **Q2Y reported as -0.03 for a model KFold scores at 0.81**. A caller-built `RepeatedKFold` was inflated by `sqrt(n_repeats)`. It now counts the evaluations actually performed and weights each TSS row by how often that row was tested.
- **`nested_cv` had the mirror-image defect** - PRESS over covered rows against a TSS over *all* rows - which **reported Q2 = 0.68 on pure-noise X** with an outer splitter covering 15% of the data. The honest value is about zero. Its headline total also used a NaN-propagating `.sum()` where the per-column values used `nansum`, so one missing Y cell gave finite per-column values and a NaN total.

The rest:

- **Prediction intervals were too narrow.** `rmse_` divides by `N` while the t quantile uses `N-A-1`. Coverage of a nominal 95% interval rises from **0.710 to 0.804** at N=15, **0.869 to 0.916** at N=25, **0.921 to 0.935** at N=60 (K=8, A=5, 800 replicates). The remaining gap is separate: PLS consumes more effective dof than `A`. The `cv_result` branch is untouched, being already out of sample.
- **The SPE degeneracy guard was unit-dependent.** It compared an SPE^4 quantity against an absolute tolerance, so data whose SPE values were merely small in magnitude tripped it and received the RMS SPE as the claimed 95% limit - **which 42% of the training data exceeded**. The test is now the coefficient of variation of the squared SPE, which is dimensionless.
- **R2Y is now `1 - SSE/SST`** on both `r2_cumulative_` and `r2y_per_variable_`, matching the X side. Identical when scores are orthogonal, but missing data breaks that and `SS(Yhat)` could decrease as a component was added: across 120 missing-data fits **75 produced a negative per-component R2Y and 11 returned NaN VIP scores**; both now zero.
- **`hotellings_t2_limit`** rejects `n_components > n_rows` instead of returning NaN from a negative F denominator dof (also reachable via `ellipse_coordinates`).
- **`detect_outliers`** no longer divides by a degenerate limit; a perfect fit gave `spe_limit == 0` and raised `ZeroDivisionError`.
- **`_pca_ekf_press`** records `NaN` for an empty fold instead of a zero the caller counted as a real fold predicting perfectly, which fabricated a standard error feeding the 1-SE rule. **PRESS itself is unchanged.**

## What is deliberately preserved

Every change was checked old-vs-new by stashing the source:

| Invariant | Result |
|---|---|
| `KFold` / partition splitters in `select_n_components` | **bit-identical** |
| `_pca_ekf_press` PRESS with an explicit `random_state` | **bit-identical** |
| R2Y on complete data (both forms) | agree to 1e-12 |
| SPE degenerate fallbacks (perfect fit, all-equal column) | unchanged |
| NIST/Rosner and other pinned reference values | unchanged |

`_pca_ekf_press` defaults to `random_state=None`, so its PRESS legitimately varies run to run; I pinned the seed to compare, rather than mistake RNG for a regression.

## Test plan

- [x] **8 of the 13 new tests fail on the pre-fix code**, one per defect, verified by stashing `_limits.py` / `_pca.py` / `_pls.py` and re-running. The other 5 are invariance guards that must pass both ways (listed in the table above)
- [x] Coverage simulation for the prediction interval, and old-vs-new comparisons for the splitter normalisation, the nested-CV Q2, the SPE scale-invariance and the VIP NaN rate, all quoted above from actual runs
- [x] Full suite: **2693 passed, 6 skipped**. The two failures (`test_oildoe_loads`, `test_distillateflow_loads`) are network tests failing identically on unmodified `main` where openmv.net is unreachable
- [x] `ruff check .`, `ruff format --check .` and `mypy src/process_improve` all clean

## Checklist

- [x] Version bumped in `pyproject.toml` (MINOR: to 1.71.0, meaningful behavioural changes), with `CITATION.cff` matching in the same commit
- [x] Tests added or updated where relevant (13 new, in the existing `tests/test_audit_regressions_multivariate.py`)
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated, with every numerical change called out under **Changed**

## Not in this PR

The NIPALS-internals items from the same section are left for a follow-up, since they are deeper surgery in shared primitives: the unfloored `w_a` normalisation (which surfaced during this work as a `LinAlgError` on some missing-data fits, and is noted in the test that skips those seeds), `quick_regress`'s absolute zero-denominator guard, and `regress_a_space_on_b_row` on an all-missing row. Also left: the convention items (block vs super T2, the permutation-test `+1`, the `diagnose` return-shape mismatch) and the `vip` docstring.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPuM5PJdHnpvpKpAsc6uDM)_