### PR TITLE
fix(experiments): guarantee D-optimal designs are estimable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ asked for.
   model's from three: `dispatch_d_optimal(factors)` with four factors and the
   default `model_type="interactions"` used to fail outright, and now returns
   the 11 runs that model needs.
+- `point_exchange` raises `ValueError` when `x` has a duplicated index. The
+  search tracks the chosen rows by index label, so a repeated label made the
+  `.loc` lookup return every row carrying it: a request for 4 runs from a
+  6-row candidate set with one repeated label came back with all 6. Rows that
+  are duplicated by value are still fine, and dropped as before.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,67 @@ those changes.
 
 ## [Unreleased]
 
+## [1.72.0] - 2026-08-22
+
+D-optimal designs are now guaranteed estimable: every design these functions
+return has enough runs, and a full-rank model matrix, for the model that was
+asked for.
+
+### Fixed
+
+- `optimization_function` (`experiments/optimal.py`) no longer prefers designs
+  the model cannot be fitted to. It scored a design by inverting `X'X` and
+  taking `slogdet` of the inverse, treating a `LinAlgError` as "singular".
+  `numpy.linalg.inv` raises only when the LU factorisation hits an exactly-zero
+  pivot, which a rank-deficient design over +-1 levels routinely slips past; the
+  inverse then came back as numerical noise whose log-determinant is a large
+  *negative* number, i.e. the best possible score for a search that minimises
+  it. Inestimable designs were therefore actively selected, not merely tolerated.
+  The score is now `-log|det(X'X)|` from `slogdet` directly, guarded by an
+  explicit rank check that returns `+inf` for any design with fewer runs than
+  parameters or a rank-deficient model matrix. Over 500 draws of a 3-factor
+  D-optimal design at the minimum budget, rank-deficient results fell from
+  36 in 200 to 0 in 500.
+- The D-criterion is now computed on the model matrix `[1 | factors]` rather
+  than on the raw factor settings. Without the intercept column, a design
+  holding a factor at a single level scored perfectly well even though that
+  factor was completely aliased with the intercept.
+- `point_exchange` returns exactly `number_points` runs. It used to seed the
+  design with one row per factor and grow it only through additions that
+  improved D-optimality, so when no addition improved it the caller silently
+  received a shorter design than requested (measured: 3 in 400 at 4 points, and
+  designs of 10 or 11 rows when 12 were requested). The design size is a
+  constraint, not something the search may trade away; the search now seeds at
+  the requested size and only ever swaps one row for another.
+- `dispatch_d_optimal`, `dispatch_i_optimal` and `dispatch_a_optimal` raise the
+  budget to the declared model's coefficient count, logging a warning when they
+  do. Previously `dispatch_d_optimal`'s point-exchange fallback clamped to
+  `n_factors + 1`, the size of a main-effects model only, so an `interactions`
+  or `quadratic` request got a design far too small to fit it; and the pyoptex
+  path had no floor at all, failing with an upstream `ValueError` about "rank
+  collinearity" between model components that names neither the budget nor the
+  model. This also repairs the `budget = 2 * n_factors + 1` default, which is
+  below an interactions model's size from four factors up and a quadratic
+  model's from three: `dispatch_d_optimal(factors)` with four factors and the
+  default `model_type="interactions"` used to fail outright, and now returns
+  the 11 runs that model needs.
+
+### Changed
+
+- `point_exchange` requires `number_points` to be at least `x.shape[1] + 1`,
+  one run per column plus the intercept. The bound was `x.shape[1]`, one short
+  of the model being scored, so a request for exactly that many runs was
+  accepted and then spent 1000 attempts failing to find a non-singular start,
+  reported as a problem with the candidate set.
+- `point_exchange` raises when `number_points` exceeds the number of *unique*
+  candidate rows, instead of silently clamping the design down to that number.
+  The upper bound is also now checked after de-duplication, since the search
+  selects distinct rows and duplicates cannot make up a shortfall.
+- The D-optimality value returned by `point_exchange` (and reported as
+  `meta["d_optimality"]`) is `-log|det(X'X)|` on the model matrix. It was
+  `log|det((X'X)^-1)|` on the factor settings alone. Values are not comparable
+  across this release.
+
 ## [1.71.0] - 2026-08-22
 
 The multivariate statistical cluster from the 2026-08 audit triage (#513).
@@ -3475,7 +3536,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.71.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.72.0...HEAD
+[1.72.0]: https://github.com/kgdunn/process-improve/compare/v1.71.0...v1.72.0
 [1.71.0]: https://github.com/kgdunn/process-improve/compare/v1.70.0...v1.71.0
 [1.70.0]: https://github.com/kgdunn/process-improve/compare/v1.69.0...v1.70.0
 [1.69.0]: https://github.com/kgdunn/process-improve/compare/v1.68.0...v1.69.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.71.0
+version: 1.72.0
 date-released: "2026-08-22"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.71.0"
+version = "1.72.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/experiments/designs_optimal.py
+++ b/src/process_improve/experiments/designs_optimal.py
@@ -79,6 +79,72 @@ _PYOPTEX_MODEL_MAP = {
     "quadratic": "quad",
 }
 
+
+def _n_model_parameters(factors: list[Factor], model_type: str) -> int:
+    """Return the number of coefficients in the model an optimal design is asked for.
+
+    A design with fewer runs than this cannot estimate the model at all: the
+    model matrix is rank deficient no matter which points are chosen. The count
+    is the estimability floor every backend is held to.
+
+    Each factor contributes one encoded column, except a categorical factor with
+    ``L`` levels, which contributes ``L - 1``. The model then has an intercept,
+    the main effects, the two-factor interactions (for ``"interactions"`` and
+    ``"quadratic"``), and one pure-quadratic term per non-categorical factor
+    (for ``"quadratic"`` only; a categorical factor has no square, which is why
+    ``_run_pyoptex`` drops it to a ``"tfi"`` model per factor).
+
+    Parameters
+    ----------
+    factors : list[Factor]
+        Factor specifications.
+    model_type : str
+        ``"main_effects"``, ``"interactions"`` or ``"quadratic"``. An unknown
+        value is treated as ``"interactions"``, matching ``_run_pyoptex``.
+
+    Returns
+    -------
+    int
+        The number of model coefficients.
+    """
+    from process_improve.experiments.factor import FactorType  # noqa: PLC0415
+
+    widths = [len(f.levels) - 1 if f.type == FactorType.categorical and f.levels else 1 for f in factors]
+    n_parameters = 1 + sum(widths)  # intercept + main effects
+    rsm_key = _PYOPTEX_MODEL_MAP.get(model_type, "tfi")
+    if rsm_key in {"tfi", "quad"}:
+        n_parameters += sum(widths[i] * widths[j] for i in range(len(widths)) for j in range(i + 1, len(widths)))
+    if rsm_key == "quad":
+        n_parameters += sum(1 for f in factors if f.type != FactorType.categorical)
+    return n_parameters
+
+
+def _floor_budget_at_model_size(factors: list[Factor], budget: int, model_type: str) -> int:
+    """Raise ``budget`` to the model's parameter count, warning when it does.
+
+    Both backends need this floor and neither imposed it consistently. pyoptex
+    failed with an upstream message about "rank collinearity" between model
+    components, which names neither the budget nor the model; the point-exchange
+    fallback clamped to one run per factor, one short of the intercept, and even
+    the default ``budget = 2 * n_factors + 1`` falls below the parameter count
+    of an interactions model from five factors up.
+    """
+    n_parameters = _n_model_parameters(factors, model_type)
+    if budget < n_parameters:
+        logger.warning(
+            "A budget of %d run(s) cannot estimate a '%s' model over %d factor(s), which has %d "
+            "coefficients; raising the budget to %d. Reduce the model or the number of factors to "
+            "run fewer experiments.",
+            budget,
+            model_type,
+            len(factors),
+            n_parameters,
+            n_parameters,
+        )
+        return n_parameters
+    return budget
+
+
 #: Map our optimality-criterion strings to pyoptex metric constructors.
 _PYOPTEX_METRIC_MAP: dict = {}
 if _PYOPTEX_AVAILABLE:  # pragma: no branch - false only in env-without-pyoptex
@@ -347,8 +413,12 @@ def _run_point_exchange_fallback(
     candidates = candidates_raw - 1.0
 
     candidates_df = pd.DataFrame(candidates, columns=[f.name for f in factors])
-    n_points = min(budget, candidates_df.shape[0])
-    n_points = max(n_points, k + 1)
+    # `dispatch_d_optimal` has already floored the budget at the model's
+    # parameter count; ``k + 1`` is the floor for the first-order model that
+    # `point_exchange` itself scores, kept here for a direct internal call.
+    # The candidate set caps the size from above: the search picks distinct
+    # rows, so it cannot return more runs than there are candidates.
+    n_points = max(min(budget, candidates_df.shape[0]), k + 1)
 
     design_df, d_opt = point_exchange(candidates_df, number_points=n_points)
     return design_df.values, {"d_optimality": float(d_opt), "backend": "point_exchange_fallback"}
@@ -393,6 +463,7 @@ def dispatch_d_optimal(  # noqa: PLR0913
     k = len(factors)
     if budget is None:
         budget = 2 * k + 1
+    budget = _floor_budget_at_model_size(factors, budget, model_type)
 
     if fixed_runs is not None and not _PYOPTEX_AVAILABLE:
         raise ImportError(f"fixed_runs (design augmentation) requires pyoptex. {_PYOPTEX_INSTALL_HINT}")
@@ -472,6 +543,7 @@ def dispatch_i_optimal(  # noqa: PLR0913
     k = len(factors)
     if budget is None:
         budget = 2 * k + 1
+    budget = _floor_budget_at_model_size(factors, budget, model_type)
 
     matrix, meta = _run_pyoptex(
         factors,
@@ -524,6 +596,7 @@ def dispatch_a_optimal(  # noqa: PLR0913
     k = len(factors)
     if budget is None:
         budget = 2 * k + 1
+    budget = _floor_budget_at_model_size(factors, budget, model_type)
 
     matrix, meta = _run_pyoptex(
         factors,

--- a/src/process_improve/experiments/optimal.py
+++ b/src/process_improve/experiments/optimal.py
@@ -4,25 +4,53 @@ import numpy as np
 import pandas as pd
 
 
+def _model_matrix(x: pd.DataFrame) -> np.ndarray:
+    """Return the model matrix ``[1 | X]`` for a first-order model with intercept.
+
+    The D-criterion is defined on the model matrix, not on the raw factor
+    settings. Scoring ``X`` alone (the previous behaviour) leaves the intercept
+    out of the design's information matrix, so a candidate that holds a factor
+    at a single level scores perfectly well even though that factor is then
+    completely aliased with the intercept and its effect cannot be estimated.
+    """
+    values = np.asarray(pd.DataFrame(x), dtype=float)
+    return np.column_stack([np.ones(values.shape[0]), values])
+
+
 def optimization_function(x: pd.DataFrame) -> float:
     """Score a design for the point-exchange D-optimal search (lower is better).
 
-    Returns ``log|det((X'X)^-1)|`` which is equivalent to the negative
-    log of the standard D-criterion ``log|det(X'X)|``. The point-exchange
-    routine in this module uses this convention and selects swaps that
-    decrease the returned value, i.e. that increase ``|det(X'X)|``.
+    Returns ``-log|det(X'X)|``, the negative log of the standard D-criterion,
+    where ``X`` is the model matrix ``[1 | factors]`` for a first-order model
+    with an intercept, which is what this package fits. The point-exchange
+    routine in this module uses this convention and selects swaps that decrease
+    the returned value, i.e. that increase ``|det(X'X)|``.
 
-    Returns ``+inf`` when ``X'X`` is singular (no improvement possible).
+    Returns ``+inf`` for any design the model cannot be fitted to: fewer runs
+    than parameters, or a model matrix that is rank deficient. That covers a
+    design holding a factor at a constant level (aliased with the intercept)
+    and one whose factor columns are linearly dependent.
+
+    The score is computed from ``slogdet(X'X)`` and guarded by an explicit rank
+    check, never by inverting ``X'X``. Inversion cannot be used to detect
+    singularity here: ``np.linalg.inv`` raises only when the LU factorisation
+    hits an exactly-zero pivot, which a rank-deficient design of +-1 levels
+    frequently avoids. The inverse then comes back as numerical noise and its
+    log-determinant is a large *negative* number, so a search minimising this
+    value treated inestimable designs as the best available and actively
+    selected them.
     """
-    try:
-        # Do NOT de-duplicate here: replicated runs carry real information
-        # (|X'X| for n copies of a point differs from one copy), so dropping
-        # them would score a different design from the one being evaluated.
-        x = pd.DataFrame(x)
-        xtx_i = np.linalg.inv(np.dot(np.transpose(x), x))
-    except np.linalg.LinAlgError:
+    # Do NOT de-duplicate here: replicated runs carry real information
+    # (|X'X| for n copies of a point differs from one copy), so dropping
+    # them would score a different design from the one being evaluated.
+    model_matrix = _model_matrix(x)
+    n_runs, n_parameters = model_matrix.shape
+    if n_runs < n_parameters or np.linalg.matrix_rank(model_matrix) < n_parameters:
         return float(np.inf)
-    return float(np.linalg.slogdet(xtx_i)[1])
+    sign, log_abs_det = np.linalg.slogdet(np.dot(np.transpose(model_matrix), model_matrix))
+    if sign <= 0 or not np.isfinite(log_abs_det):
+        return float(np.inf)
+    return float(-log_abs_det)
 
 
 def index_to_replace_in_design_row(
@@ -79,29 +107,50 @@ def point_exchange(
     -------
     tuple[pd.DataFrame, float]
         The selected design (sorted by the original row index) and its
-        D-optimality value (log-determinant of ``(X'X)^-1``).
+        D-optimality value, ``-log|det(X'X)|`` on the model matrix
+        ``[1 | factors]``.
     """
-    if number_points < x.shape[1]:
-        raise ValueError(f"`number_points` must be at least {x.shape[1]} (the number of columns in `x`).")
-    if number_points > x.shape[0]:
-        raise ValueError(f"`number_points` must be at most {x.shape[0]} (the number of rows in `x`).")
     x = pd.DataFrame(x).drop_duplicates()
+    # Intercept plus one coefficient per factor. Asking for fewer runs than
+    # that cannot produce an estimable design, so it is rejected here rather
+    # than left to fail later as an exhausted search for a non-singular start.
+    # The bound used to be ``x.shape[1]``, one short of the model it scores.
+    n_parameters = x.shape[1] + 1
+    if number_points < n_parameters:
+        raise ValueError(
+            f"`number_points` must be at least {n_parameters} (an intercept plus "
+            f"one coefficient per column of `x`); {number_points} were requested."
+        )
+    if number_points > x.shape[0]:
+        # Checked after de-duplication: the search picks distinct candidate
+        # rows, so duplicates in `x` cannot make up the shortfall. This used to
+        # silently clamp the size down to the number of candidates available.
+        raise ValueError(f"`number_points` must be at most {x.shape[0]} (the number of unique rows in `x`).")
 
-    number_points = min(number_points, x.shape[0])
     # Continually try to pick rows from x, until it is not singular.
     # A seedable Generator (rather than the global numpy RNG) makes the
     # point-exchange result reproducible; see docs/development/reproducibility.rst.
     rng = np.random.default_rng(random_state)
     max_attempts = 1000
-    xtx_i = None
+    d_optimality_i = float(np.inf)
     for _attempt in range(max_attempts):
-        try:
-            x = x.sample(frac=1, random_state=rng)
-            design = x.iloc[0 : x.shape[1]]
-            xtx_i = np.linalg.inv(np.dot(np.transpose(design), design))
+        x = x.sample(frac=1, random_state=rng)
+        # Seed the design at the REQUESTED size. It used to start with
+        # only ``x.shape[1]`` (one row per factor) and grow towards
+        # `number_points` through the addition branch below, which
+        # accepted a row only when it improved D-optimality. When no
+        # addition improved it the design was returned short: callers
+        # asking for `number_points` runs silently received fewer, and a
+        # design with fewer runs than model parameters cannot be fitted
+        # at all. The size is a constraint, not something to optimise.
+        design = x.iloc[0:number_points]
+        # Score the seed with the SAME criterion used for every comparison
+        # below, so the search cannot be misled by an inconsistent start, and
+        # so that a rank-deficient seed is rejected here rather than carried
+        # through to the returned design.
+        d_optimality_i = optimization_function(design)
+        if np.isfinite(d_optimality_i):
             break
-        except np.linalg.LinAlgError:
-            pass
     else:
         msg = (
             f"Could not find a non-singular starting design after {max_attempts} "
@@ -109,9 +158,7 @@ def point_exchange(
         )
         raise ValueError(msg)
 
-    _, d_optimality_i = np.linalg.slogdet(xtx_i)
-
-    for i in range(x.shape[1], x.shape[0]):  # we've already considered the first `x.shape[1]` rows to start
+    for i in range(number_points, x.shape[0]):  # the first `number_points` rows are the starting design
         candidate_point = x.iloc[[i]]
 
         # Try to replace the candidate point with each row in the current design
@@ -130,13 +177,11 @@ def point_exchange(
             # print(f"New D-optimality at {i=} (replc): {d_optimality_i}")
             continue
 
-        # Now do the additionsm if there is room.
-        if design.shape[0] < number_points:
-            potential_design = pd.concat([design, candidate_point])
-            d_optimality_i_potential = optimization_function(potential_design)
-            if d_optimality_i > d_optimality_i_potential:
-                design = potential_design
-                d_optimality_i = d_optimality_i_potential
-                # print(f"New D-optimality at {i=} (merge): {d_optimality_i}")
+    # Every exchange above swaps one row for another, and only ever onto a
+    # design that scores better than the (finite, full-rank) current one, so
+    # the returned design keeps both the size and the estimability it was
+    # seeded with.
+    if design.shape[0] != number_points:  # pragma: no cover - defensive
+        raise AssertionError(f"point_exchange produced {design.shape[0]} rows; {number_points} were requested.")
 
     return design.sort_index(), d_optimality_i

--- a/src/process_improve/experiments/optimal.py
+++ b/src/process_improve/experiments/optimal.py
@@ -45,10 +45,19 @@ def optimization_function(x: pd.DataFrame) -> float:
     # them would score a different design from the one being evaluated.
     model_matrix = _model_matrix(x)
     n_runs, n_parameters = model_matrix.shape
-    if n_runs < n_parameters or np.linalg.matrix_rank(model_matrix) < n_parameters:
-        return float(np.inf)
     sign, log_abs_det = np.linalg.slogdet(np.dot(np.transpose(model_matrix), model_matrix))
-    if sign <= 0 or not np.isfinite(log_abs_det):
+    # Both tests are needed. ``slogdet`` reports an exactly singular ``X'X``
+    # (sign 0, log -inf), which catches a factor held at a constant level; a
+    # design whose columns are only linearly dependent in exact arithmetic
+    # slips past it with a finite, very negative log, and is caught by the rank
+    # check. Without the second test that design would score as the best one
+    # available, since the search minimises this value.
+    if (
+        n_runs < n_parameters
+        or sign <= 0
+        or not np.isfinite(log_abs_det)
+        or np.linalg.matrix_rank(model_matrix) < n_parameters
+    ):
         return float(np.inf)
     return float(-log_abs_det)
 
@@ -126,13 +135,21 @@ def point_exchange(
         # rows, so duplicates in `x` cannot make up the shortfall. This used to
         # silently clamp the size down to the number of candidates available.
         raise ValueError(f"`number_points` must be at most {x.shape[0]} (the number of unique rows in `x`).")
+    if not x.index.is_unique:
+        # The search tracks the chosen rows by index LABEL, so a repeated label
+        # makes the `.loc` lookup below return every row carrying it: asking for
+        # 4 runs from a 6-row candidate set with one repeated label returned all
+        # 6. Rows that are duplicated by VALUE are fine, and dropped above.
+        raise ValueError("`x` must have a unique index; the point-exchange search selects rows by index label.")
 
     # Continually try to pick rows from x, until it is not singular.
     # A seedable Generator (rather than the global numpy RNG) makes the
     # point-exchange result reproducible; see docs/development/reproducibility.rst.
     rng = np.random.default_rng(random_state)
     max_attempts = 1000
-    d_optimality_i = float(np.inf)
+    # `d_optimality_i` is deliberately NOT pre-initialised: the loop below runs
+    # at least once and always assigns it, and its `else` raises, so a seed
+    # value would only be dead (CodeQL flags it as such).
     for _attempt in range(max_attempts):
         x = x.sample(frac=1, random_state=rng)
         # Seed the design at the REQUESTED size. It used to start with
@@ -177,11 +194,8 @@ def point_exchange(
             # print(f"New D-optimality at {i=} (replc): {d_optimality_i}")
             continue
 
-    # Every exchange above swaps one row for another, and only ever onto a
-    # design that scores better than the (finite, full-rank) current one, so
-    # the returned design keeps both the size and the estimability it was
-    # seeded with.
-    if design.shape[0] != number_points:  # pragma: no cover - defensive
-        raise AssertionError(f"point_exchange produced {design.shape[0]} rows; {number_points} were requested.")
-
+    # Every exchange above swaps one row for another, onto a unique index and
+    # only ever onto a design scoring better than the (finite, full-rank)
+    # current one, so the returned design keeps both the size and the
+    # estimability it was seeded with.
     return design.sort_index(), d_optimality_i

--- a/tests/test_audit_regressions_experiments.py
+++ b/tests/test_audit_regressions_experiments.py
@@ -270,6 +270,27 @@ class TestDOptimal:
         # + a square for each of the two continuous factors only, so 12
         assert _n_model_parameters(factors, "quadratic") == 12
 
+    def test_point_exchange_rejects_a_duplicated_index(self) -> None:
+        """A repeated index label made `.loc` return every row carrying it.
+
+        These six candidate rows are all distinct by value, so de-duplication
+        leaves them alone; the repeated label 0 made a request for 4 runs come
+        back with all 6.
+        """
+        candidates = pd.DataFrame(
+            [[-1.0, -1.0], [1.0, -1.0], [-1.0, 1.0], [1.0, 1.0], [0.0, 0.0], [0.0, 1.0]],
+            index=[0, 0, 1, 2, 3, 4],
+        )
+        with pytest.raises(ValueError, match="unique index"):
+            point_exchange(candidates, number_points=4, random_state=0)
+
+    def test_point_exchange_reports_a_candidate_set_it_cannot_start_from(self) -> None:
+        """Collinear candidate columns make every subset singular, whatever the size."""
+        repeated = [-1.0, -1.0, 1.0, 1.0, 0.0, 0.0]
+        candidates = pd.DataFrame({"a": repeated, "b": [-1.0, 1.0, -1.0, 1.0, -1.0, 1.0], "c": repeated})
+        with pytest.raises(ValueError, match="non-singular starting design"):
+            point_exchange(candidates, number_points=4, random_state=0)
+
     def test_point_exchange_is_reproducible_with_random_state(self) -> None:
         rng = np.random.default_rng(0)
         candidates = pd.DataFrame(rng.choice([-1.0, 0.0, 1.0], size=(40, 3)))

--- a/tests/test_audit_regressions_experiments.py
+++ b/tests/test_audit_regressions_experiments.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 import pytest
+from pyDOE3 import fullfact
 
 from process_improve.experiments.analysis import analyze_experiment
 from process_improve.experiments.designs import generate_design
+from process_improve.experiments.designs_optimal import _n_model_parameters, dispatch_d_optimal
 from process_improve.experiments.evaluate import evaluate_design
 from process_improve.experiments.factor import Factor
 from process_improve.experiments.optimal import (
@@ -140,20 +142,133 @@ class TestDOptimal:
         """The scorer must NOT de-duplicate: n copies of a point carry more
         information than one copy.
         """
-        base = pd.DataFrame([[1.0, 1.0], [1.0, -1.0]])
-        replicated = pd.DataFrame([[1.0, 1.0], [1.0, -1.0], [1.0, 1.0]])
+        base = pd.DataFrame([[-1.0, -1.0], [1.0, -1.0], [-1.0, 1.0]])
+        replicated = pd.DataFrame([[-1.0, -1.0], [1.0, -1.0], [-1.0, 1.0], [-1.0, -1.0]])
         assert optimization_function(replicated) < optimization_function(base)  # lower = better
+
+    def test_rank_deficient_designs_are_rejected_not_preferred(self) -> None:
+        """A design the model cannot be fitted to must score ``+inf``.
+
+        The scorer used to invert ``X'X``. ``np.linalg.inv`` raises only on an
+        exactly-zero LU pivot, which these rank-deficient +-1 designs slip past;
+        the log-determinant of the resulting numerical noise came back as a
+        large NEGATIVE number, so the minimising search treated an inestimable
+        design as the best one available and actively selected it.
+        """
+        constant_factor = pd.DataFrame([[1.0, -1.0, -1.0], [1.0, 1.0, -1.0], [1.0, -1.0, 1.0], [1.0, 1.0, 1.0]])
+        aliased = pd.DataFrame([[1.0, 0.0, -1.0], [0.0, 1.0, -1.0], [1.0, -1.0, 1.0], [-1.0, 1.0, 1.0]])
+        too_few_runs = pd.DataFrame([[1.0, 1.0], [1.0, -1.0]])
+        for degenerate in (constant_factor, aliased, too_few_runs):
+            model_matrix = np.column_stack([np.ones(degenerate.shape[0]), degenerate])
+            assert np.linalg.matrix_rank(model_matrix) < model_matrix.shape[1]
+            assert optimization_function(degenerate) == float(np.inf)
 
     def test_swap_onto_row_label_zero_is_not_discarded(self) -> None:
         """A best-swap row with index LABEL 0 is falsy; the caller previously
         skipped the improving swap entirely.
         """
-        design = pd.DataFrame([[1.0, 0.05], [1.0, -1.0]], index=[0, 1])
-        candidate = pd.DataFrame([[1.0, 1.0]], index=[99])
+        design = pd.DataFrame([[-1.0, 0.05], [1.0, -1.0], [-1.0, 1.0]], index=[0, 1, 2])
+        candidate = pd.DataFrame([[-1.0, -1.0]], index=[99])
         current = optimization_function(design)
         chosen = index_to_replace_in_design_row(design, candidate, current, optimization_function)
         assert chosen == 0
         assert chosen is not None
+
+    def test_point_exchange_returns_the_requested_number_of_points(self) -> None:
+        """The design size is a constraint, not something the search may trade away.
+
+        The design used to be seeded with one row per factor and grown towards
+        `number_points` only by additions that improved D-optimality, so when no
+        addition improved it the caller silently received a short design. A
+        design with fewer runs than model parameters cannot be fitted at all.
+        """
+        candidates = pd.DataFrame(fullfact([3] * 3) - 1.0, columns=["X1", "X2", "X3"])
+        for number_points in (4, 5, 8, 12):
+            sizes = {
+                point_exchange(candidates, number_points=number_points, random_state=seed)[0].shape[0]
+                for seed in range(25)
+            }
+            assert sizes == {number_points}, f"requested {number_points}, got sizes {sorted(sizes)}"
+
+    def test_d_optimal_below_minimum_budget_is_estimable(self) -> None:
+        """A budget below the model size yields a design the model can be fitted to."""
+        from process_improve.experiments import designs_optimal as _designs_optimal
+
+        original = _designs_optimal._PYOPTEX_AVAILABLE
+        _designs_optimal._PYOPTEX_AVAILABLE = False
+        try:
+            factors = [Factor(name=f"X{i + 1}", low=0, high=10) for i in range(3)]
+            for _ in range(25):
+                design, _meta = dispatch_d_optimal(factors, budget=2)
+                assert design.shape[0] >= 4, "intercept plus 3 main effects needs at least 4 runs"
+                # Estimability is the point: the model matrix must have full rank.
+                model_matrix = np.column_stack([np.ones(design.shape[0]), design])
+                assert np.linalg.matrix_rank(model_matrix) == 4
+        finally:
+            _designs_optimal._PYOPTEX_AVAILABLE = original
+
+    def test_point_exchange_minimum_size_counts_the_intercept(self) -> None:
+        """One run per factor is one short: the model this scores has an intercept.
+
+        The bound used to be ``x.shape[1]``, so a request for exactly that many
+        runs was accepted and then spent 1000 attempts failing to find a
+        non-singular start, reported as a candidate-set problem.
+        """
+        candidates = pd.DataFrame(fullfact([3] * 3) - 1.0, columns=["X1", "X2", "X3"])
+        with pytest.raises(ValueError, match="at least 4"):
+            point_exchange(candidates, number_points=3, random_state=0)
+
+    def test_point_exchange_will_not_silently_shrink_to_the_candidate_count(self) -> None:
+        """More runs than unique candidates is an error, not a quiet clamp."""
+        candidates = pd.DataFrame([[-1.0, -1.0], [1.0, -1.0], [-1.0, 1.0], [1.0, 1.0], [1.0, 1.0]])
+        with pytest.raises(ValueError, match="at most 4"):
+            point_exchange(candidates, number_points=5, random_state=0)
+
+    @pytest.mark.parametrize(
+        ("model_type", "n_parameters"),
+        [("main_effects", 4), ("interactions", 7), ("quadratic", 10)],
+    )
+    def test_budget_floor_matches_the_declared_model(
+        self, model_type: str, n_parameters: int, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An under-budget request is raised to the DECLARED model's size, not to one run per factor.
+
+        The floor used to be ``n_factors + 1`` regardless of `model_type`, which
+        is the size of a main-effects model only; an interactions or quadratic
+        model was handed a design far too small to fit it.
+        """
+        from process_improve.experiments import designs_optimal as _designs_optimal
+
+        monkeypatch.setattr(_designs_optimal, "_PYOPTEX_AVAILABLE", False)
+        factors = [Factor(name=f"X{i + 1}", low=0, high=10) for i in range(3)]
+        assert _n_model_parameters(factors, model_type) == n_parameters
+        with caplog.at_level("WARNING", logger="process_improve.experiments.designs_optimal"):
+            design, _meta = dispatch_d_optimal(factors, budget=2, model_type=model_type)
+        assert design.shape[0] == n_parameters
+        assert "raising the budget" in caplog.text  # the clamp is announced, not silent
+
+    def test_default_budget_supports_the_declared_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The ``2 * n_factors + 1`` default is itself below an interactions model from k=4 up."""
+        from process_improve.experiments import designs_optimal as _designs_optimal
+
+        monkeypatch.setattr(_designs_optimal, "_PYOPTEX_AVAILABLE", False)
+        factors = [Factor(name=f"X{i + 1}", low=0, high=10) for i in range(4)]
+        design, _meta = dispatch_d_optimal(factors, model_type="interactions")  # default budget = 9
+        assert design.shape[0] == _n_model_parameters(factors, "interactions") == 11
+
+    def test_n_model_parameters_counts_categorical_levels(self) -> None:
+        """A categorical factor with L levels is L - 1 columns, and has no square."""
+        factors = [
+            Factor(name="X1", low=0, high=10),
+            Factor(name="X2", low=0, high=10),
+            Factor(name="C", type="categorical", levels=["A", "B", "C"]),
+        ]
+        # 1 + (1 + 1 + 2) main effects = 5
+        assert _n_model_parameters(factors, "main_effects") == 5
+        # + interactions 1*1 + 1*2 + 1*2 = 5, so 10
+        assert _n_model_parameters(factors, "interactions") == 10
+        # + a square for each of the two continuous factors only, so 12
+        assert _n_model_parameters(factors, "quadratic") == 12
 
     def test_point_exchange_is_reproducible_with_random_state(self) -> None:
         rng = np.random.default_rng(0)

--- a/tests/test_designs_optimal_pyoptex.py
+++ b/tests/test_designs_optimal_pyoptex.py
@@ -256,10 +256,25 @@ class TestFixedRuns:
             generate_design(_mixed_factors(), design_type="i_optimal", budget=14, fixed_runs=pd.DataFrame(frame))
 
     def test_fixed_runs_must_leave_room_to_optimize(self) -> None:
-
-        centre = pd.DataFrame([{"cat": "A", "x1": 0.0, "x2": 0.0}])
+        # A main-effects model over these factors has 5 coefficients (intercept,
+        # two columns for the 3-level categorical, x1, x2), which is the floor
+        # the budget is raised to. Fixing all 5 runs leaves nothing to optimise.
+        # This used to be written as `budget=1` with a single fixed run, which
+        # no longer reaches the check: a budget of 1 cannot estimate any model,
+        # so it is now raised to the model size before `fixed_runs` is examined.
+        fixed = pd.DataFrame(
+            [
+                {"cat": "A", "x1": 0.0, "x2": 0.0},
+                {"cat": "B", "x1": 1.0, "x2": -1.0},
+                {"cat": "C", "x1": -1.0, "x2": 1.0},
+                {"cat": "A", "x1": 1.0, "x2": 1.0},
+                {"cat": "B", "x1": -1.0, "x2": -1.0},
+            ]
+        )
         with pytest.raises(ValueError, match="budget must exceed"):
-            generate_design(_mixed_factors(), design_type="i_optimal", budget=1, fixed_runs=centre)
+            generate_design(
+                _mixed_factors(), design_type="i_optimal", budget=5, model_type="main_effects", fixed_runs=fixed
+            )
 
     def test_fixed_runs_must_be_a_dataframe(self) -> None:
         with pytest.raises(TypeError, match="must be a pandas DataFrame"):

--- a/tests/test_designs_screening_optimal.py
+++ b/tests/test_designs_screening_optimal.py
@@ -6,6 +6,7 @@ paths that the high-level ``generate_design`` API does not reach.
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 from process_improve.experiments import designs_optimal
@@ -131,9 +132,15 @@ class TestDOptimalDispatch:
             dispatch_d_optimal(_continuous(16), budget=40)
 
     def test_budget_clamped_to_minimum_model_size(self) -> None:
-        """A budget below k + 1 is raised to k + 1 so the model is estimable."""
+        """A budget below the model size is raised to it, so the model is estimable.
+
+        The floor used to be ``k + 1``, the size of a main-effects model, even
+        for the default ``model_type="interactions"``: three factors give
+        1 + 3 + 3 = 7 coefficients, not 4.
+        """
         design, _meta = dispatch_d_optimal(_continuous(3), budget=2)
-        assert design.shape[0] >= 4
+        assert design.shape[0] == 7
+        assert np.linalg.matrix_rank(np.column_stack([np.ones(design.shape[0]), design])) == 4
 
     def test_budget_capped_to_candidate_set(self) -> None:
         """A budget above the 3**k candidate set is capped to its size."""
@@ -141,11 +148,17 @@ class TestDOptimalDispatch:
         assert design.shape[1] == 2
         assert design.shape[0] <= 9  # 3**2 candidate rows
 
-    @pytest.mark.parametrize("model_type", ["main_effects", "interactions", "quadratic"])
-    def test_model_type_accepted_on_fallback_path(self, model_type: str) -> None:
-        """model_type is accepted (though unused) by the point-exchange fallback."""
+    @pytest.mark.parametrize(("model_type", "n_runs"), [("main_effects", 8), ("interactions", 8), ("quadratic", 10)])
+    def test_model_type_sets_the_budget_floor_on_the_fallback_path(self, model_type: str, n_runs: int) -> None:
+        """model_type is no longer inert on this path: it sets the estimability floor.
+
+        A quadratic model over three factors has 10 coefficients, so a budget of
+        8 is raised to 10; the other two models fit inside 8 and are left alone.
+        The point-exchange criterion itself is still first-order.
+        """
         design, meta = dispatch_d_optimal(_continuous(3), budget=8, model_type=model_type)
         assert design.shape[1] == 3
+        assert design.shape[0] == n_runs
         assert meta["backend"] == "point_exchange_fallback"
 
 

--- a/tests/test_doe.py
+++ b/tests/test_doe.py
@@ -564,7 +564,7 @@ def test_expt_repr() -> None:
 
 
 def test_optimization_function_basic() -> None:
-    """optimization_function should return log determinant of (X'X)^-1."""
+    """optimization_function should return the negative log determinant of X'X."""
     X = pd.DataFrame([[-1, -1], [1, -1], [-1, 1], [1, 1]])
     result = optimization_function(X)
     assert np.isfinite(result)


### PR DESCRIPTION
## Summary

Closes the DOE estimability defect from the 2026-08 audit triage (#513): `dispatch_d_optimal` could return a design the requested model cannot be fitted to at all, e.g. a 3-run design for a 4-parameter model.

- **The scorer actively preferred inestimable designs.** `optimization_function` inverted `X'X` and took `slogdet` of the inverse, treating a `LinAlgError` as "singular". `numpy.linalg.inv` raises only when the LU factorisation hits an exactly-zero pivot, which a rank-deficient design over +-1 levels routinely slips past; the inverse then came back as numerical noise whose log-determinant is a large **negative** number, i.e. the best possible score for a search that minimises it. Inestimable designs were selected on purpose, not merely tolerated. The score is now `-log|det(X'X)|` from `slogdet` directly, guarded by an explicit rank check. It is also now computed on the model matrix `[1 | factors]`: without the intercept column, a design holding a factor at a single level scored perfectly well even though that factor is completely aliased with the intercept.
- **`point_exchange` returned fewer runs than requested.** It seeded at one row per factor and grew towards `number_points` only through additions that improved D-optimality, so when none did, the caller silently received a shorter design. The size is a constraint, not something the search may trade away; it now seeds at the requested size and only ever swaps one row for another.
- **Neither backend enforced a consistent estimability floor.** `dispatch_d_optimal` / `dispatch_i_optimal` / `dispatch_a_optimal` now raise the budget to the declared model's coefficient count, logging a warning. The point-exchange fallback clamped to `n_factors + 1`, the size of a main-effects model only, so an `interactions` or `quadratic` request got a design far too small; the pyoptex path had no floor at all and failed with an upstream `ValueError` about "rank collinearity" between model components, naming neither the budget nor the model. This also repairs the `budget = 2 * n_factors + 1` default, which is below an interactions model's size from four factors up and a quadratic model's from three: `dispatch_d_optimal(factors)` with four factors and the default `model_type="interactions"` used to fail outright, and now returns the 11 runs that model needs.

## Test plan

- [x] **Rank deficiency measured before and after.** Over draws of a 3-factor D-optimal design at the minimum budget on the fallback backend: 36 rank-deficient in 200 before, **0 in 500** after. Broken down by fix: 29/60 originally, 19/60 after the size fix alone, 8/60 after the intercept-aware criterion, 0/500 after the rank guard replaced the inversion.
- [x] **Size contract measured.** `point_exchange` returned short designs 3 times in 400 at 4 points, and 10 or 11 rows when 12 were requested. After: exact size in 400/400, across `number_points` of 4, 5, 8, 12 and 20 over 100 seeds each, every one full rank with an intercept. Design quality is unchanged at n=4 and n=8 and slightly better at n=12.
- [x] **The parameter-count formula is calibrated against pyoptex, not assumed.** Its predictions were compared against pyoptex's own minimum feasible budget over six factor configurations (2 to 5 continuous factors; 2 continuous plus a categorical at 2 and 3 levels) and all three model types: exact agreement in every cell. The categorical rules it encodes (a factor with `L` levels is `L - 1` columns; a categorical factor has no square) were then confirmed on a 4-level categorical that was not in the calibration set.
- [x] **Both backends now agree.** Every `(k, model_type)` combination for `k` in 1..5 returns the same run count from the pyoptex and point-exchange paths, and every fallback design is full rank.
- [x] **The new tests were verified to fail on the pre-fix source.** Reverting only `experiments/optimal.py` fails 5 of them; they pass on the fix.
- [x] Full suite: 2702 passed. Two `test_experiments_datasets.py` failures are the sandbox proxy returning 403 for a remote dataset host and reproduce on unmodified `main`.
- [x] `ruff check .`, `ruff format --check .`, and `mypy src/process_improve` all clean.

One existing test needed updating rather than fixing: `test_fixed_runs_must_leave_room_to_optimize` used `budget=1` with one fixed run, which no longer reaches the check because a budget of 1 cannot estimate any model and is raised to the model size first. It now fixes all 5 runs of a 5-coefficient model, which still leaves nothing to optimise, so the guard is exercised as intended.

## Checklist

- [x] Version bumped in `pyproject.toml` (MINOR, 1.71.0 -> 1.72.0: designs change per seed, run counts change for under-budget and defaulted requests, and two `point_exchange` bounds tightened). `CITATION.cff` synced in the same commit.
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPuM5PJdHnpvpKpAsc6uDM)_