### PR TITLE
docs: five docstrings that had drifted from the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ those changes.
 
 ## [Unreleased]
 
+## [1.71.1] - 2026-08-28
+
+### Fixed
+
+- Docstring accuracy pass: five docstrings had drifted from the code.
+  - `univariate/tools.py` (`confidence_interval` tool): the "robust" method
+    formula in the input schema had lost its `sqrt(pi/2)` factor. The actual
+    formula the code computes is
+    `median +/- t * MAD * sqrt(pi/2) / sqrt(n)` (MAD estimates sigma; the
+    sqrt(pi/2) is the asymptotic standard error of the median).
+  - `multivariate/_pls.py` (`PLS.select_n_components`): `n_repeats` said
+    "Default 10" but the signature default is `None`, which the function
+    resolves to 10 internally. Docstring updated to say so.
+  - `batch/preprocessing.py` (`determine_scaling`): the Returns section
+    described the "typical minimum" column as "robustly calculated". The
+    per-batch minimum is the raw `batch.min(axis=0)`; only the cross-batch
+    aggregation is median (robust) or mean (non-robust).
+  - `multivariate/plots.py` (`score_plot`): the default `"title"` in the
+    `settings` block was documented as `"Score plot of ..."`, but the true
+    default is the empty string on the 2D path and a "Score plot of
+    component ..." sentence only on the 3D path (`pc_depth > 0`).
+  - `regression/_robust_regression.py` (`robust_regression`): the
+    Returns block said `intercept` is "returned if fit_intercept==True,
+    otherwise 0". The full-fit path honours that; the degenerate
+    early-return stub sets `intercept` to `np.nan` regardless of
+    `fit_intercept`. The docstring now spells out both paths.
+
 ## [1.71.0] - 2026-08-22
 
 The multivariate statistical cluster from the 2026-08 audit triage (#513).
@@ -3475,7 +3502,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.71.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.71.1...HEAD
+[1.71.1]: https://github.com/kgdunn/process-improve/compare/v1.71.0...v1.71.1
 [1.71.0]: https://github.com/kgdunn/process-improve/compare/v1.70.0...v1.71.0
 [1.70.0]: https://github.com/kgdunn/process-improve/compare/v1.69.0...v1.70.0
 [1.69.0]: https://github.com/kgdunn/process-improve/compare/v1.68.0...v1.69.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.71.0
-date-released: "2026-08-22"
+version: 1.71.1
+date-released: "2026-08-28"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.71.0"
+version = "1.71.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/batch/preprocessing.py
+++ b/src/process_improve/batch/preprocessing.py
@@ -47,8 +47,12 @@ def determine_scaling(
     Returns
     -------
     range_scalers: DataFrame
-        J rows, 2 columns: column 1 = range of each tag (approx. q98 - q02),
-        column 2 = typical minimum of each tag (robustly calculated).
+        J rows, 2 columns: column 1 = the per-tag range (approximately
+        ``q98 - q02`` when ``settings["robust"]`` is True, else raw
+        ``max - min``); column 2 = the per-tag minimum. Both columns are
+        aggregated across batches with the median when ``robust=True`` and
+        the mean otherwise, but the per-batch minimum itself is always the
+        raw ``batch.min(axis=0)``, not a quantile.
 
     TODO: put this in a scikit-learn style: .fit() and .apply() style
     """

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -1239,12 +1239,13 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
             and is used as-is (``n_repeats`` is then ignored).
         n_repeats : int, optional
             Number of times the K-fold split is repeated with a fresh shuffle,
-            used only when ``cv`` is an integer. Default ``10`` (giving a
-            ``cv * 10`` per-fold sample for the 1-SE rule); pass ``1`` to
-            disable repeats. Repeated K-fold's standard errors are slightly
-            optimistic because test folds overlap across repeats; that is fine
-            for the 1-SE *selection* rule but should not be reported as an
-            unbiased generalisation variance.
+            used only when ``cv`` is an integer. The signature default is
+            ``None``, which is resolved to ``10`` inside the function
+            (giving a ``cv * 10`` per-fold sample for the 1-SE rule); pass
+            ``1`` to disable repeats. Repeated K-fold's standard errors are
+            slightly optimistic because test folds overlap across repeats;
+            that is fine for the 1-SE *selection* rule but should not be
+            reported as an unbiased generalisation variance.
         random_state : int, optional
             Seed forwarded to ``KFold`` / ``RepeatedKFold`` for reproducible
             shuffling. Ignored when ``cv`` is a pre-built splitter.

--- a/src/process_improve/multivariate/plots.py
+++ b/src/process_improve/multivariate/plots.py
@@ -103,7 +103,12 @@ def score_plot(  # noqa: C901, PLR0913
             {
                 "show_ellipse": True,          # bool: show the Hotelling's T2 ellipse
                 "ellipse_conf_level": 0.95,    # float: ellipse confidence level (< 1.00)
-                "title": "Score plot of ...",  # str: overall plot title
+                "title": "",                   # str: overall plot title. The
+                                               # default is the empty string on
+                                               # the 2D path (pc_depth <= 0) and
+                                               # a "Score plot of component ..."
+                                               # sentence on the 3D path
+                                               # (pc_depth > 0).
                 "show_labels": False,          # bool: add a label for each observation
                 "show_legend": True,           # bool: show clickable legend
                 "html_image_height": 500,      # int: image height in pixels

--- a/src/process_improve/regression/_robust_regression.py
+++ b/src/process_improve/regression/_robust_regression.py
@@ -121,7 +121,10 @@ def robust_regression(  # noqa: PLR0913, PLR0915
 
         N:                        the number of observations used to fit the model
         coefficients:             a length-1 list containing the regression slope
-        intercept:                returned if fit_intercept==True, otherwise 0
+        intercept:                the fitted intercept on the full-fit path
+                                  (0 when ``fit_intercept=False``); ``np.nan``
+                                  on the degenerate early-return path (see
+                                  below), regardless of ``fit_intercept``
         standard_errors:          a length-1 list containing the standard error of the slope
         standard_error_intercept: standard error for the intercept (np.nan if fit_intercept=False)
         R2:                       the R^2 value

--- a/src/process_improve/univariate/tools.py
+++ b/src/process_improve/univariate/tools.py
@@ -404,7 +404,9 @@ class ConfidenceIntervalInput(BaseModel):
     method: Literal["robust", "classical"] = Field(
         "robust",
         description=(
-            "'robust' (default): use median +/- t * MAD / sqrt(n). 'classical': use mean +/- t * std / sqrt(n)."
+            "'robust' (default): median +/- t * MAD * sqrt(pi/2) / sqrt(n); MAD estimates sigma, "
+            "and sqrt(pi/2) is the asymptotic standard error factor of the median. "
+            "'classical': mean +/- t * std / sqrt(n)."
         ),
     )
 


### PR DESCRIPTION
## Summary

A docstring-accuracy pass across the computational surface. No behaviour changes; only what the docs claim about the code they sit on.

### The five drifts

1. **`src/process_improve/univariate/tools.py`, `confidence_interval` tool schema** (line 407)
   The `"robust"` method description said `median +/- t * MAD / sqrt(n)`, but the code multiplies MAD by `sqrt(pi/2)` first (MAD estimates sigma; `sqrt(pi/2)` is the asymptotic standard-error factor of the median). Mirrors `univariate.metrics.confidence_interval`, whose docstring already carried this factor.

2. **`src/process_improve/multivariate/_pls.py`, `PLS.select_n_components`** (line ~1240)
   `n_repeats` was documented as *"Default `10`"* but the signature default is `None`, resolved to 10 in the function body.

3. **`src/process_improve/batch/preprocessing.py`, `determine_scaling`** (line 49)
   The Returns block called the "typical minimum" column "robustly calculated". Per-batch minima are the raw `batch.min(axis=0)`; only the cross-batch aggregation switches between median (`robust=True`) and mean (`robust=False`).

4. **`src/process_improve/multivariate/plots.py`, `score_plot`** (line 100)
   The `settings` block's default `"title"` was documented as `"Score plot of ..."`; the true default is the empty string on the 2D path (`pc_depth <= 0`) and a `"Score plot of component ..."` sentence only on the 3D path.

5. **`src/process_improve/regression/_robust_regression.py`, `robust_regression`** (line 120)
   The Returns block said `intercept` is "returned if `fit_intercept==True`, otherwise 0". The full-fit path honours that; the degenerate early-return stub sets `intercept` to `np.nan` regardless of `fit_intercept`.

## Version

`1.71.0` → `1.71.1` (PATCH — docs only). `CITATION.cff` and `CHANGELOG.md` (and its link-reference footer) updated in the same commit.

## Test plan

- [ ] `uv run pytest` — no behavioural change, existing tests should stay green.
- [ ] `uv run ruff check .` and `uv run ruff format --check .` — no formatting drift.
- [ ] Read each of the five docstrings against the referenced code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgPoMwwVj8AdyNUTJWfyVe

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgPoMwwVj8AdyNUTJWfyVe)_