### PR TITLE
OMARS generator: n_runs means the returned run count, and selection criteria search the design class (#496-#499)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,41 @@ those changes.
 
 ## [Unreleased]
 
+## [1.72.0] - 2026-08-29
+
+The OMARS generator cluster from the 2026-08 audit triage (#513): issues #496
+to #499.
+
+### Fixed
+
+- `generate_omars(n_runs=n, center_runs=c)` now returns exactly `n` runs:
+  `n_runs` is the total run count of the returned design, centre runs included,
+  and `n_runs - center_runs` must be a positive even number. Previously the
+  extra centre runs were appended on top, so the design had `n + c - 1` rows
+  (#496).
+- The `a_optimal`, `d_efficiency`, and `min_second_order_correlation` selection
+  criteria (and the D axis of the default `dominance` rule) now find the true
+  optimum whenever the design class is small enough to enumerate, currently up
+  to four factors at moderate sizes. The search enumerates every feasible
+  half-design multiset, including designs that repeat a half-run, which the
+  previous binary ILP multistart could not represent at all; the reported
+  metadata carries `search_mode="exhaustive"` when the selection is exact and
+  `"multistart"` when the heuristic search was used (#497, #498, #499).
+- Design metrics (`d_efficiency`, `a_optimality`, `max_second_order_correlation`)
+  are now computed on the full returned design, extra centre runs included,
+  so the metadata describes the design the caller receives (#496).
+
+### Changed
+
+- In `generate_omars` selection and satisficing, a design containing a constant
+  second-order column (a term the design cannot estimate) now scores `inf` on
+  the maximum second-order correlation metric instead of having the column
+  skipped, so `min_second_order_correlation` no longer favours degenerate
+  designs. The descriptive statistic in `omars_properties` is unchanged (#499).
+- `generate_omars` docstrings state when a selection criterion is exact and
+  when it is heuristic, instead of claiming optimisation unconditionally
+  (#497, #498).
+
 ## [1.71.0] - 2026-08-22
 
 The multivariate statistical cluster from the 2026-08 audit triage (#513).
@@ -3475,7 +3510,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.71.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.72.0...HEAD
+[1.72.0]: https://github.com/kgdunn/process-improve/compare/v1.71.0...v1.72.0
 [1.71.0]: https://github.com/kgdunn/process-improve/compare/v1.70.0...v1.71.0
 [1.70.0]: https://github.com/kgdunn/process-improve/compare/v1.69.0...v1.70.0
 [1.69.0]: https://github.com/kgdunn/process-improve/compare/v1.68.0...v1.69.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.71.0
-date-released: "2026-08-22"
+version: 1.72.0
+date-released: "2026-08-29"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.71.0"
+version = "1.72.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ batch = [
 ]
 
 # MCP server entry-point.
-mcp = ["mcp>=1.0"]
+mcp = ["mcp>=2.0"]
 
 # JIT-compiled inner loops in ``process_improve.batch.alignment_helpers``.
 # Without numba the module still imports and runs; the ``@jit`` decorator
@@ -92,7 +92,7 @@ ilp = ["pulp>=2.8"]
 # Meta extra: reproduces the pre-ENG-13 install closure.
 all = [
     "matplotlib>=3.10.8",
-    "mcp>=1.0",
+    "mcp>=2.0",
     "numba>=0.63.1",
     "openpyxl>=3.1.5",
     "plotly>=6.5.2",

--- a/src/process_improve/experiments/designs_omars_ilp.py
+++ b/src/process_improve/experiments/designs_omars_ilp.py
@@ -71,7 +71,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from process_improve.experiments.designs_omars import _second_order_terms, is_omars, omars_properties
+from process_improve.experiments.designs_omars import _second_order_terms, is_omars
 
 try:
     import pulp
@@ -106,6 +106,16 @@ _SATISFICE_KEYS = ("d_efficiency", "max_second_order_correlation")
 # turn up a new distinct design: the feasible set is effectively exhausted (small
 # factor counts) and further solves only repeat designs already retained.
 _RESTART_PATIENCE = 25
+
+# The exhaustive search enumerates every feasible half-design multiset (counts
+# per sign class, replication allowed) when the class is small enough.  The caps
+# below bound the half-design size per factor count; beyond them, or past the
+# leaf budget, the search falls back to the randomized multistart.  The caps are
+# calibrated so the worst in-cap cell enumerates in seconds on ordinary hardware.
+_ENUM_MAX_HALF = {3: 18, 4: 12}
+_ENUM_MAX_LEAVES = 4_000_000
+# Batch size for the vectorised scoring of enumerated count vectors.
+_ENUM_SCORE_CHUNK = 65_536
 
 
 @dataclass
@@ -144,6 +154,14 @@ class OmarsSearchReport:
         Run count of the winning design.
     total_solve_seconds : float
         Cumulative wall-clock time spent inside the ILP solver.
+    search_mode : str
+        ``"exhaustive"`` when the feasible design class was enumerated in full
+        (the selection is then exact), ``"multistart"`` when the randomized
+        ILP multistart was used (the selection is then the best design found,
+        which may miss the optimum).
+    enumerated_designs : int
+        Number of feasible designs enumerated on the exhaustive path (0 on the
+        multistart path).
     """
 
     n_factors: int = 0
@@ -153,6 +171,8 @@ class OmarsSearchReport:
     feasible_designs: int = 0
     run_size: int = 0
     total_solve_seconds: float = 0.0
+    search_mode: str = ""
+    enumerated_designs: int = 0
 
 
 def _half_pool(n_factors: int) -> np.ndarray:
@@ -395,6 +415,7 @@ def _half_bounds(
     n_params: int,
     half_pool_size: int,
     min_half: int,
+    center_runs: int = 1,
 ) -> tuple[int, int]:
     """Inclusive ``(min, max)`` half-run window for a usable design.
 
@@ -403,17 +424,18 @@ def _half_bounds(
     * **Estimability**: ``min_half`` half-runs, from :func:`_min_half_runs`.
       Below this the sizing model is rank-deficient and cannot be fitted at
       all, whatever the parameter count says.
-    * **Error degrees of freedom**: ``n_runs > n_params``, so at least
-      ``n_params // 2 + 1`` half-runs.
+    * **Error degrees of freedom**: the total run count ``2h + center_runs``
+      must exceed ``n_params``.
 
     For the full second-order model estimability is the binding floor; for
-    ``"main_quadratic"`` the error-df floor usually is.
+    ``"main_quadratic"`` the error-df floor usually is.  *n_runs_range* is in
+    total runs, centre runs included.
     """
-    floor_half = max(1, min_half, n_params // 2 + 1)
+    floor_half = max(1, min_half, (n_params - center_runs) // 2 + 1)
     if n_runs_range is not None:
-        low, _high = n_runs_range
-        half_low = max(floor_half, math.ceil((low - 1) / 2))
-        half_high = max(half_low, (n_runs_range[1] - 1) // 2)
+        low, high = n_runs_range
+        half_low = max(floor_half, math.ceil((low - center_runs) / 2))
+        half_high = max(half_low, (high - center_runs) // 2)
     else:
         half_low = floor_half
         half_high = half_low + 6
@@ -488,6 +510,240 @@ def _sparsity(coded: np.ndarray) -> tuple[int, int]:
     return n_me0, n_ie0
 
 
+def _max_second_order_correlation_metric(coded: np.ndarray, tol: float = 1e-9) -> float:
+    """Largest absolute pairwise correlation among the second-order columns of a design.
+
+    Unlike the descriptive statistic in
+    :func:`process_improve.experiments.designs_omars.omars_properties` (which
+    skips constant columns), this selection metric returns ``inf`` when any
+    second-order column is constant: such a column belongs to a term the design
+    cannot estimate, and skipping it would flatter exactly the degenerate
+    designs a correlation-minimising selection would then crown as winners.
+    """
+    second_order, _ = _second_order_terms(coded)
+    if second_order.shape[1] < 2:
+        return 0.0
+    centered = second_order - second_order.mean(axis=0, keepdims=True)
+    norms = np.linalg.norm(centered, axis=0)
+    if np.any(norms <= tol):
+        return float("inf")
+    unit = centered / norms
+    corr = unit.T @ unit
+    off_diagonal = corr - np.diag(np.diag(corr))
+    return float(np.abs(off_diagonal).max())
+
+
+def _enumerate_feasible_counts(  # noqa: C901, PLR0915
+    pool: np.ndarray, n_half: int, max_leaves: int
+) -> tuple[np.ndarray, bool]:
+    """Enumerate every feasible half-design multiset of size *n_half*.
+
+    A foldover OMARS design is determined by how many times each sign class in
+    *pool* appears in the half-design (replication allowed), so the design class
+    at a fixed size is the set of count vectors ``m >= 0`` with
+    ``sum(m) = n_half`` that satisfy the pairwise main-effect orthogonality
+    equalities ``sum_r (x_ri * x_rj) m_r = 0``.  This walks that set with a
+    depth-first search over the counts, pruning on the running pair balances.
+
+    Returns ``(count_matrix, overflow)``: an integer array of shape
+    ``(n_designs, len(pool))`` with columns in the row order of *pool*, and an
+    ``overflow`` flag that is ``True`` when the *max_leaves* budget was hit
+    (the enumeration is then incomplete and must not be used).
+    """
+    n_rows, n_factors = pool.shape
+    pairs = list(itertools.combinations(range(n_factors), 2))
+    n_pairs = len(pairs)
+    # Deterministic order: widest-support rows first, so every orthogonality
+    # constraint closes out (and prunes) as early as possible; the k singleton
+    # rows, which touch no constraint, form the tail and are expanded
+    # vectorised below rather than recursed over.
+    support = (pool != 0).sum(axis=1)
+    order = sorted(range(n_rows), key=lambda r: (-int(support[r]), tuple(-pool[r])))
+    coeff: list[list[tuple[int, int]]] = []
+    for r in order:
+        row = pool[r]
+        coeff.append([(p, int(row[i] * row[j])) for p, (i, j) in enumerate(pairs) if row[i] * row[j] != 0])
+    tail_start = n_rows - n_factors
+    last_touch = [-1] * n_pairs
+    for pos, entries in enumerate(coeff):
+        for p, _ in entries:
+            last_touch[p] = pos
+    # Per DFS level: the constraints whose last touching row was just passed
+    # (they must have closed at zero) and those still open (prunable by the
+    # remaining budget).  Checking only these keeps the per-node work small.
+    closing_at = [[p for p in range(n_pairs) if last_touch[p] == pos - 1] for pos in range(tail_start + 1)]
+    open_at = [[p for p in range(n_pairs) if last_touch[p] >= pos] for pos in range(tail_start + 1)]
+
+    prefixes: list[tuple[tuple[int, ...], int]] = []
+    n_leaves = 0
+    counts = [0] * tail_start
+    balance = [0] * n_pairs
+    overflow = False
+    # Different prefixes converge on the same (position, remaining, balances)
+    # state; a state whose subtree yielded no feasible design once will yield
+    # none again, so dead states are memoized and skipped on revisits.
+    dead: set[tuple[int, ...]] = set()
+
+    def tail_leaves(remaining: int) -> int:
+        return math.comb(remaining + n_factors - 1, n_factors - 1)
+
+    def rec(pos: int, remaining: int) -> None:  # noqa: C901
+        nonlocal overflow, n_leaves
+        if overflow:
+            return
+        for p in closing_at[pos]:
+            if balance[p]:
+                return
+        if pos == tail_start:
+            n_leaves += tail_leaves(remaining)
+            if n_leaves > max_leaves:
+                overflow = True
+                return
+            prefixes.append((tuple(counts), remaining))
+            return
+        for p in open_at[pos]:
+            if abs(balance[p]) > remaining:
+                return
+        key = (pos, remaining, *(balance[p] for p in open_at[pos]))
+        if key in dead:
+            return
+        before = len(prefixes)
+        entries = coeff[pos]
+        for c in range(remaining, -1, -1):
+            counts[pos] = c
+            for p, v in entries:
+                balance[p] += c * v
+            rec(pos + 1, remaining - c)
+            for p, v in entries:
+                balance[p] -= c * v
+        counts[pos] = 0
+        if len(prefixes) == before and not overflow:
+            dead.add(key)
+
+    rec(0, n_half)
+    if overflow:
+        return np.empty((0, n_rows), dtype=np.int16), True
+
+    # Expand the unconstrained singleton tail: distribute each prefix's leftover
+    # budget over the n_factors singleton rows in every possible way.
+    comp_cache: dict[int, np.ndarray] = {}
+
+    def compositions(total: int) -> np.ndarray:
+        cached = comp_cache.get(total)
+        if cached is None:
+            rows = [
+                [total - sum(parts), *parts]
+                for parts in itertools.product(range(total + 1), repeat=n_factors - 1)
+                if sum(parts) <= total
+            ]
+            cached = np.asarray(rows, dtype=np.int16)
+            comp_cache[total] = cached
+        return cached
+
+    blocks = []
+    for prefix, remaining in prefixes:
+        tail = compositions(remaining)
+        head = np.tile(np.asarray(prefix, dtype=np.int16), (tail.shape[0], 1))
+        blocks.append(np.hstack([head, tail]))
+    if not blocks:
+        return np.empty((0, n_rows), dtype=np.int16), False
+    ordered = np.vstack(blocks)
+    # Map the DFS ordering back to pool row order.
+    inverse = np.argsort(order)
+    return ordered[:, inverse], False
+
+
+def _score_count_vectors(
+    count_matrix: np.ndarray,
+    pool: np.ndarray,
+    center_runs: int,
+    model: str,
+    tol: float = 1e-9,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Score enumerated count vectors: D-efficiency, A-optimality, max second-order correlation.
+
+    Works from the count vectors alone, without materialising any design: for a
+    foldover the model Gram matrix is a count-weighted sum of per-sign-class
+    contributions plus the centre-run block, and the second-order columns are
+    even functions, so their Gram doubles per half-row.  Scores match
+    :func:`_d_efficiency`, :func:`_a_optimality` and
+    :func:`_max_second_order_correlation_metric` evaluated on the materialised
+    design (foldover plus ``center_runs - 1`` appended centre rows).
+    """
+    n_rows = pool.shape[0]
+    n_leaves = count_matrix.shape[0]
+    n_half_total = int(count_matrix[0].sum()) if n_leaves else 0
+    n_total = 2 * n_half_total + center_runs
+
+    second_order, so_names = _second_order_terms(pool)
+    if model == "main_quadratic":
+        keep = [t for t, name in enumerate(so_names) if "^2" in name]
+        model_even = second_order[:, keep]
+    else:
+        model_even = second_order
+    # Model rows for +h and -h: [1 | +-x | even terms]; their outer products sum.
+    u_plus = np.column_stack([np.ones(n_rows), pool, model_even])
+    u_minus = np.column_stack([np.ones(n_rows), -pool, model_even])
+    n_params = u_plus.shape[1]
+    b_flat = (np.einsum("ri,rj->rij", u_plus, u_plus) + np.einsum("ri,rj->rij", u_minus, u_minus)).reshape(n_rows, -1)
+    b_center = np.zeros((n_params, n_params))
+    b_center[0, 0] = 1.0
+
+    q = second_order.shape[1]
+    so_gram_flat = 2.0 * np.einsum("ri,rj->rij", second_order, second_order).reshape(n_rows, -1)
+    so_colsum = 2.0 * second_order
+
+    d_eff = np.empty(n_leaves)
+    a_opt = np.empty(n_leaves)
+    max_corr = np.empty(n_leaves)
+    for start in range(0, n_leaves, _ENUM_SCORE_CHUNK):
+        chunk = count_matrix[start : start + _ENUM_SCORE_CHUNK].astype(float)
+        n_chunk = chunk.shape[0]
+        gram = (chunk @ b_flat).reshape(n_chunk, n_params, n_params)
+        gram += center_runs * b_center
+        eig = np.linalg.eigvalsh(gram)
+        singular = eig[:, 0] <= tol * np.maximum(1.0, eig[:, -1])
+        with np.errstate(divide="ignore", invalid="ignore"):
+            log_det = np.where(singular, -np.inf, np.log(np.where(eig > 0, eig, 1.0)).sum(axis=1))
+            d_chunk = np.where(singular, 0.0, 100.0 * np.exp(log_det / n_params) / n_total)
+            a_chunk = np.where(singular, np.inf, (1.0 / np.where(eig > 0, eig, 1.0)).sum(axis=1))
+
+        so_gram = (chunk @ so_gram_flat).reshape(n_chunk, q, q)
+        colsum = chunk @ so_colsum
+        centered = so_gram - colsum[:, :, None] * colsum[:, None, :] / n_total
+        variances = np.einsum("lii->li", centered)
+        constant = (variances <= tol).any(axis=1)
+        safe_var = np.where(variances > tol, variances, 1.0)
+        scale = np.sqrt(safe_var[:, :, None] * safe_var[:, None, :])
+        corr = np.abs(centered / scale)
+        idx = np.arange(q)
+        corr[:, idx, idx] = 0.0
+        corr_chunk = np.where(constant, np.inf, corr.max(axis=(1, 2)))
+
+        d_eff[start : start + n_chunk] = d_chunk
+        a_opt[start : start + n_chunk] = a_chunk
+        max_corr[start : start + n_chunk] = corr_chunk
+    return d_eff, a_opt, max_corr
+
+
+def _pick_exhaustive_winner(d_eff: np.ndarray, a_opt: np.ndarray, max_corr: np.ndarray, criterion: str) -> int:
+    """Index of the winning count vector, mirroring the tie-breaks of :func:`_select`.
+
+    All enumerated designs share the same run count, so the run-size terms of
+    the :func:`_select` tie-break tuples drop out.
+    """
+    if criterion == "d_efficiency":
+        keys = (max_corr, -d_eff)
+    elif criterion == "min_second_order_correlation":
+        keys = (-d_eff, max_corr)
+    elif criterion == "a_optimal":
+        keys = (max_corr, a_opt)
+    else:  # "dominance": the Pareto-front member with the highest D-efficiency.
+        keys = (max_corr, -d_eff)
+    # np.lexsort sorts by the last key first.
+    return int(np.lexsort(keys)[0])
+
+
 def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
     factors: list[Factor],
     *,
@@ -501,11 +757,16 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
     tol: float,
     verify: bool,
     random_seed: int,
+    center_runs: int = 1,
 ) -> tuple[np.ndarray, dict]:
-    """Run the ILP search and return ``(coded_matrix, metadata)`` for the winner.
+    """Run the design search and return ``(coded_matrix, metadata)`` for the winner.
 
-    The returned matrix is a foldover design and already contains exactly one
-    centre run; callers add any further centre runs during post-processing.
+    *n_runs*, *n_runs_range*, and every reported run count are **totals**,
+    centre runs included.  The returned matrix is a foldover design and
+    contains exactly one centre run; callers append the remaining
+    ``center_runs - 1`` centre rows during post-processing, but all quality
+    metrics here are computed with those rows included, so the metadata
+    describes the design the caller receives.
     """
     from process_improve.config import settings  # noqa: PLC0415
 
@@ -532,27 +793,35 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
         if n_runs <= n_params:
             msg = (
                 f"n_runs={n_runs} leaves no error degrees of freedom: the {model} model has "
-                f"{n_params} parameters, so n_runs must exceed {n_params}."
+                f"{n_params} parameters, so n_runs (the total run count, centre runs included) "
+                f"must exceed {n_params}."
             )
             raise ValueError(msg)
-        if n_runs % 2 == 0:
-            msg = f"n_runs={n_runs} must be odd: a foldover OMARS design has 2*h+1 runs (a centre run plus +/-H)."
+        if n_runs <= center_runs or (n_runs - center_runs) % 2 != 0:
+            msg = (
+                f"n_runs={n_runs} is incompatible with center_runs={center_runs}: a foldover OMARS "
+                f"design has n_runs = 2*h + center_runs runs (h half-runs, their h mirrors, and the "
+                f"centre runs), so n_runs - center_runs must be a positive even number. "
+                f"Try n_runs={n_runs + 1} or n_runs={n_runs - 1}."
+            )
             raise ValueError(msg)
-        min_runs = _min_runs(n_factors, model)
+        min_runs = 2 * _min_half_runs(n_factors, model) + center_runs
         if n_runs < min_runs:
             msg = (
-                f"n_runs={n_runs} cannot estimate the {model} model for {n_factors} factors: a foldover "
-                f"design repeats its second-order terms across H and -H, so the model matrix stays "
-                f"rank-deficient below {min_runs} runs. Use n_runs >= {min_runs}, or "
-                'model="main_quadratic" to size for main effects and pure quadratics only.'
+                f"n_runs={n_runs} cannot estimate the {model} model for {n_factors} factors with "
+                f"center_runs={center_runs}: a foldover design repeats its second-order terms across "
+                f"H and -H, so the model matrix stays rank-deficient below {min_runs} runs. Use "
+                f'n_runs >= {min_runs}, or model="main_quadratic" to size for main effects and pure '
+                "quadratics only."
             )
             raise ValueError(msg)
-        target_half = (n_runs - 1) // 2
+        target_half = (n_runs - center_runs) // 2
 
     pool = _half_pool(n_factors)
     report = OmarsSearchReport(n_factors=n_factors, half_pool_size=pool.shape[0], n_restarts=n_restarts)
     candidates: list[_Candidate] = []
     seen: set[frozenset[int]] = set()
+    extra_centers = np.zeros((center_runs - 1, n_factors))
 
     def _solve(**solve_kwargs: Any) -> tuple[np.ndarray | None, str, list[int]]:  # noqa: ANN401
         started = time.perf_counter()
@@ -569,15 +838,17 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
         seen.add(key)
         if verify and not is_omars(coded, tol=tol):
             return False
-        properties = omars_properties(coded, tol=tol)
+        # Score the design the caller will actually receive: the foldover plus
+        # the extra centre runs appended during post-processing.
+        scored = np.vstack([coded, extra_centers])
         candidates.append(
             _Candidate(
                 coded=coded,
-                n_runs=coded.shape[0],
+                n_runs=scored.shape[0],
                 half_indices=indices,
-                d_efficiency=_d_efficiency(coded, model),
-                a_optimality=_a_optimality(coded, model),
-                max_second_order_correlation=float(properties["max_second_order_correlation"]),
+                d_efficiency=_d_efficiency(scored, model),
+                a_optimality=_a_optimality(scored, model),
+                max_second_order_correlation=_max_second_order_correlation_metric(scored, tol=tol),
                 solver_status=status,
             )
         )
@@ -587,15 +858,81 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
     # the window (the minimize-size solution becomes the first candidate).
     if target_half is None:
         coded, status, indices = _solve(
-            half_bounds=_half_bounds(n_runs_range, n_params, pool.shape[0], _min_half_runs(n_factors, model)),
+            half_bounds=_half_bounds(
+                n_runs_range, n_params, pool.shape[0], _min_half_runs(n_factors, model), center_runs
+            ),
             minimize_size=True,
         )
         if coded is not None:
             target_half = len(indices)
             _record(coded, indices, status)
 
-    if target_half is not None:
-        report.run_size = 2 * target_half + 1
+    # Exhaustive path: when the design class at this size is small enough,
+    # enumerate every feasible half-design multiset (replication allowed) and
+    # pick the winner exactly.  The binary multistart below cannot even reach
+    # designs that repeat a half-run, so this is what makes the selection
+    # criteria live up to their names (issues #497, #498, #499).
+    exhausted = False
+    if target_half is not None and target_half <= _ENUM_MAX_HALF.get(n_factors, 0):
+        count_matrix, overflow = _enumerate_feasible_counts(pool, target_half, _ENUM_MAX_LEAVES)
+        n_enumerated = count_matrix.shape[0]
+        if not overflow:
+            if n_enumerated == 0:
+                target = f"n_runs={n_runs}" if n_runs is not None else f"n_runs_range={n_runs_range}"
+                msg = (
+                    f"No feasible OMARS design exists for {target} with center_runs={center_runs} "
+                    "(exhaustive enumeration). Try a different n_runs or a wider n_runs_range."
+                )
+                raise ValueError(msg)
+            d_eff, a_opt, max_corr = _score_count_vectors(count_matrix, pool, center_runs, model, tol=tol)
+            keep = np.ones(n_enumerated, dtype=bool)
+            if satisfice:
+                _satisfice([], satisfice)  # validate the threshold keys
+                d_min = satisfice.get("d_efficiency")
+                correlation_max = satisfice.get("max_second_order_correlation")
+                if d_min is not None:
+                    keep &= d_eff >= d_min
+                if correlation_max is not None:
+                    keep &= max_corr <= correlation_max
+                if not keep.any():
+                    finite_corr = max_corr[np.isfinite(max_corr)]
+                    best_corr = float(finite_corr.min()) if finite_corr.size else float("inf")
+                    msg = (
+                        f"No feasible OMARS design met the satisfice thresholds {satisfice}. "
+                        f"The best among {n_enumerated} enumerated design(s) reached "
+                        f"d_efficiency={float(d_eff.max()):.3f} and "
+                        f"max_second_order_correlation={best_corr:.3f}. Relax the thresholds "
+                        "or widen n_runs_range."
+                    )
+                    raise ValueError(msg)
+            kept_idx = np.flatnonzero(keep)
+            local = _pick_exhaustive_winner(d_eff[kept_idx], a_opt[kept_idx], max_corr[kept_idx], selection_criterion)
+            best = int(kept_idx[local])
+            counts = count_matrix[best]
+            coded = _foldover(np.repeat(pool, counts, axis=0))
+            half_indices = [int(r) for r in np.repeat(np.arange(pool.shape[0]), counts)]
+            candidates = [
+                _Candidate(
+                    coded=coded,
+                    n_runs=2 * target_half + center_runs,
+                    half_indices=half_indices,
+                    d_efficiency=float(d_eff[best]),
+                    a_optimality=float(a_opt[best]),
+                    max_second_order_correlation=float(max_corr[best]),
+                    solver_status="Enumerated",
+                )
+            ]
+            if verify and not is_omars(coded, tol=tol):  # pragma: no cover - defensive
+                msg = "Exhaustive OMARS enumeration produced a design that failed the is_omars re-check."
+                raise RuntimeError(msg)
+            report.search_mode = "exhaustive"
+            report.enumerated_designs = n_enumerated
+            report.feasible_designs = n_enumerated
+            exhausted = True
+
+    if not exhausted and target_half is not None:
+        report.run_size = 2 * target_half + center_runs
+        report.search_mode = "multistart"
 
         # A plain feasibility solve guarantees at least one design at this size,
         # even when n_restarts is 0 or every random objective turns out degenerate.
@@ -619,16 +956,23 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
             else:
                 stall += 1
 
-    report.feasible_designs = len(candidates)
+    if not exhausted:
+        report.feasible_designs = len(candidates)
     if not candidates:
         target = f"n_runs={n_runs}" if n_runs is not None else f"n_runs_range={n_runs_range}"
-        msg = f"No feasible OMARS design was found for {target}. Try a larger or odd n_runs, or a wider n_runs_range."
+        msg = (
+            f"No feasible OMARS design was found for {target}. "
+            "Try a different n_runs (n_runs - center_runs must be a positive even number), "
+            "or a wider n_runs_range."
+        )
         raise ValueError(msg)
 
     # Satisfice first (drop designs below the acceptability thresholds), then
-    # pick from the survivors by dominance / the chosen criterion.
+    # pick from the survivors by dominance / the chosen criterion.  On the
+    # exhaustive path the thresholds were already applied to the full
+    # enumeration, so the single retained winner passes them by construction.
     eligible = candidates
-    if satisfice:
+    if satisfice and not exhausted:
         eligible = _satisfice(candidates, satisfice)
         if not eligible:
             best_d = max(c.d_efficiency for c in candidates)
@@ -654,7 +998,7 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
         "full_second_order_params": _full_second_order_params(n_factors),
         "model_rank": _model_rank(winner.coded, model),
         "expected_error_df": winner.n_runs - _model_rank(winner.coded, model),
-        "min_runs_for_model": _min_runs(n_factors, model),
+        "min_runs_for_model": 2 * _min_half_runs(n_factors, model) + center_runs,
         "sparsity": _sparsity(winner.coded),
         "selection_criterion": selection_criterion,
         "satisfice": dict(satisfice) if satisfice else None,
@@ -663,6 +1007,7 @@ def _search_best_omars(  # noqa: C901, PLR0912, PLR0913, PLR0915
         "max_second_order_correlation": winner.max_second_order_correlation,
         "solver": (solver_options or {}).get("solver", "pulp"),
         "solver_status": winner.solver_status,
+        "search_mode": report.search_mode,
         "omars_verified": is_omars(winner.coded, tol=tol),
         "omars_search": report,
     }
@@ -685,12 +1030,13 @@ def generate_omars(  # noqa: PLR0913
     random_seed: int = 42,
     verify: bool = True,
 ) -> DesignResult:
-    """Generate a foldover OMARS design by integer-programming run selection.
+    """Generate a foldover OMARS design by exhaustive or integer-programming run selection.
 
     Builds a three-level OMARS design large enough to leave error degrees of
     freedom for the chosen analysis *model*, so it can be analysed with
     :func:`process_improve.experiments.analyze_omars`.  The design is a foldover
-    ``[H; -H; 0]`` with ``2*h + 1`` runs (an odd run count).  Regardless of
+    ``[H; -H; 0]`` (half-runs, their mirrors, and a centre run) plus any further
+    centre runs, for ``2*h + center_runs`` runs in total.  Regardless of
     *model*, the design is a genuine OMARS design: the main effects stay
     orthogonal to every second-order term (quadratics and interactions alike).
 
@@ -699,20 +1045,33 @@ def generate_omars(  # noqa: PLR0913
     factors : list[Factor]
         At least three continuous factors.
     n_runs : int, optional
-        Exact (odd) run size.  Must exceed the number of parameters in the chosen
-        *model* (``1 + 2k + k(k-1)/2`` for ``"full_second_order"``, ``1 + 2k`` for
-        ``"main_quadratic"``).  If ``None`` a size is chosen automatically.
+        Exact total run size of the returned design, centre runs included.
+        ``n_runs - center_runs`` must be a positive even number (the half-runs
+        and their mirrors), and *n_runs* must exceed the number of parameters in
+        the chosen *model* (``1 + 2k + k(k-1)/2`` for ``"full_second_order"``,
+        ``1 + 2k`` for ``"main_quadratic"``).  If ``None`` a size is chosen
+        automatically.
     n_runs_range : tuple[int, int], optional
-        Inclusive ``(min, max)`` run-size window to search when *n_runs* is
-        ``None``; the smallest feasible size is used.
+        Inclusive ``(min, max)`` total-run-size window to search when *n_runs*
+        is ``None``; the smallest feasible size is used.
     selection_criterion : {"dominance", "d_efficiency", "min_second_order_correlation", "a_optimal"}
-        How to choose among the feasible designs found.  ``"dominance"``
-        (default) keeps the Pareto front on D-efficiency and the maximum
-        second-order correlation, then prefers the smallest, most efficient
-        design.  ``"a_optimal"`` minimises the summed coefficient variance
-        ``trace((X'X)^-1)`` of the sizing model (lower prediction variance on
-        average), which is the natural choice when the design is judged on
-        precision rather than on aliasing.
+        How to choose among the feasible designs.  When the design class at the
+        chosen size is small enough (currently up to four factors at moderate
+        sizes), the search enumerates it exhaustively and the selection is exact
+        for the stated objective; the metadata reports
+        ``search_mode="exhaustive"``.  Otherwise the criterion selects the best
+        design among those found by the randomized multistart
+        (``search_mode="multistart"``), which may miss the optimum.
+        ``"dominance"`` (default) keeps the Pareto front on D-efficiency and the
+        maximum second-order correlation, then prefers the smallest, most
+        efficient design.  ``"a_optimal"`` selects the design with the lowest
+        summed coefficient variance ``trace((X'X)^-1)`` of the sizing model
+        (lower prediction variance on average), which is the natural choice when
+        the design is judged on precision rather than on aliasing.  A design
+        containing a constant second-order column (a term the design cannot
+        estimate) scores ``inf`` on the correlation metric, so it is never
+        selected by ``"min_second_order_correlation"`` when an alternative with
+        every term present exists.
     satisfice : dict, optional
         Acceptability thresholds applied *before* selection: a design is kept
         only if it clears every threshold.  Supported keys are
@@ -722,7 +1081,9 @@ def generate_omars(  # noqa: PLR0913
         A ``ValueError`` is raised if no enumerated design meets the thresholds.
     center_runs : int, optional
         Number of centre runs in the design (at least one; the foldover already
-        contributes one).  Default 1.
+        contributes one).  Centre runs count towards *n_runs*: asking for
+        ``n_runs=17, center_runs=3`` returns 17 rows, 3 of them centre runs.
+        Default 1.
     n_restarts : int, optional
         Number of randomized-objective ILP solves used to search for a
         high-quality design.  Each restart drives the solver to a different
@@ -771,7 +1132,7 @@ def generate_omars(  # noqa: PLR0913
     ValueError
         If fewer than three factors are given, the factor count exceeds the
         combinatorial cap, *model* is not recognised, *n_runs* is too small or
-        even, or no feasible design is found.
+        incompatible with *center_runs*, or no feasible design is found.
     ImportError
         If PuLP (the ``ilp`` extra) is not installed.
 
@@ -810,6 +1171,7 @@ def generate_omars(  # noqa: PLR0913
         tol=tol,
         verify=verify,
         random_seed=random_seed,
+        center_runs=center_runs,
     )
     return build_design_result(
         coded_matrix=coded,
@@ -839,4 +1201,5 @@ def _dispatch_omars_ilp(factors: list[Factor], **kwargs: Any) -> tuple[np.ndarra
         tol=1e-9,
         verify=True,
         random_seed=42,
+        center_runs=1,
     )

--- a/src/process_improve/mcp_server.py
+++ b/src/process_improve/mcp_server.py
@@ -36,7 +36,9 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.tools import Tool
+from mcp.server.mcpserver.utilities.func_metadata import ArgModelBase, FuncMetadata
 
 from process_improve.config import settings
 from process_improve.tool_safety import ToolSafetyError, safe_execute_tool_call
@@ -44,20 +46,17 @@ from process_improve.tool_spec import discover_tools, execute_tool_call, get_too
 
 logger = logging.getLogger(__name__)
 
+_INSTRUCTIONS = (
+    "Process improvement tools: robust statistics, multivariate analysis (PCA/PLS), "
+    "control charts, designed experiments, batch process analysis, and regression. "
+    "All tools accept JSON inputs and return JSON outputs."
+)
+
 # Opt-in safety. The default (stdio on the user's own machine) keeps the
 # fast in-process path so local Claude Desktop / Cursor integrations don't
 # pay subprocess overhead. Set ``PROCESS_IMPROVE_MCP_SAFE_MODE=1`` when the
 # server is fronted by HTTP or otherwise reachable from untrusted clients.
 # Reads via ``settings`` so tests can override at runtime (ENG-09 / ENG-27).
-
-mcp = FastMCP(
-    "process-improve",
-    instructions=(
-        "Process improvement tools: robust statistics, multivariate analysis (PCA/PLS), "
-        "control charts, designed experiments, batch process analysis, and regression. "
-        "All tools accept JSON inputs and return JSON outputs."
-    ),
-)
 
 
 def _serialise_tool_error(exc: Exception, tool_name: str) -> str:
@@ -74,19 +73,31 @@ def _serialise_tool_error(exc: Exception, tool_name: str) -> str:
     return json.dumps({"error": "internal error while executing tool", "tool": tool_name})
 
 
-def _register_all_tools() -> None:
-    """Register every ``@tool_spec`` tool as an MCP tool."""
-    discover_tools()
-    specs = get_tool_specs()
-    logger.info("Registering %d tools with MCP server", len(specs))
+class _SchemaPassthroughMetadata(FuncMetadata):
+    """Hand-built ``FuncMetadata`` that skips pydantic argument validation.
 
-    for spec in specs:
-        tool_name = spec["name"]
-        tool_description = spec["description"]
-        tool_schema = spec["input_schema"]
+    Each tool's published ``inputSchema`` comes from the ``@tool_spec``
+    registry, not from a Python signature, so there is no pydantic argument
+    model here to validate against. The arguments are passed through unchanged
+    to :func:`process_improve.tool_spec.execute_tool_call`, which validates
+    them against the tool's real pydantic input model (unknown keys raise
+    ``ToolInputInvalidError`` there; see SEC-15).
+    """
 
-        # Build parameter list from the JSON schema properties
-        _create_mcp_tool(tool_name, tool_description, tool_schema)
+    def validate_arguments(self, arguments_to_validate: dict[str, Any]) -> dict[str, Any]:
+        """Return a shallow copy of the arguments without validating them.
+
+        Parameters
+        ----------
+        arguments_to_validate : dict[str, Any]
+            The raw ``arguments`` dict from the MCP ``tools/call`` request.
+
+        Returns
+        -------
+        dict[str, Any]
+            The same key/value pairs, handed to the handler as ``**kwargs``.
+        """
+        return dict(arguments_to_validate)
 
 
 def _make_tool_handler(tool_name: str) -> Callable[..., Awaitable[str]]:
@@ -94,10 +105,10 @@ def _make_tool_handler(tool_name: str) -> Callable[..., Awaitable[str]]:
 
     ENG-30: the tool execution path is synchronous (in safe mode it blocks on a
     ``ProcessPoolExecutor`` future; otherwise it runs the tool in-process). To
-    avoid blocking the FastMCP event loop - which would serialise concurrent
-    requests when the server is fronted by HTTP / SSE - the blocking call is
-    offloaded to a worker thread via ``run_in_executor``. Single-call behaviour
-    is unchanged.
+    avoid blocking the MCP server's event loop - which would serialise
+    concurrent requests when the server is fronted by HTTP / SSE - the blocking
+    call is offloaded to a worker thread via ``run_in_executor``. Single-call
+    behaviour is unchanged.
     """
 
     async def handler(**kwargs: Any) -> str:  # noqa: ANN401
@@ -118,55 +129,63 @@ def _make_tool_handler(tool_name: str) -> Callable[..., Awaitable[str]]:
     return handler
 
 
-def _create_mcp_tool(
-    tool_name: str,
-    tool_description: str,
-    tool_schema: dict[str, Any],
-) -> None:
-    """Create and register a single MCP tool that delegates to execute_tool_call."""
-    handler = _make_tool_handler(tool_name)
+def _build_tool(spec: dict[str, Any]) -> Tool:
+    """Build one MCP ``Tool`` whose published ``inputSchema`` is the registry's schema.
 
-    # Set proper function metadata for FastMCP
-    handler.__name__ = tool_name
-    handler.__doc__ = tool_description
-    handler.__qualname__ = tool_name
+    The tool is constructed directly (not via ``Tool.from_function``) so the
+    ``parameters`` field - which the server publishes verbatim as the tool's
+    ``inputSchema`` - is exactly ``spec["input_schema"]``: parameter types,
+    required vs optional, enums, bounds, and ``anyOf`` unions all survive
+    (issue #506). Signature introspection of the generic ``(**kwargs)``
+    handler could not synthesise any of that.
 
-    # Build parameter annotations from JSON schema for FastMCP introspection
-    properties = tool_schema.get("properties", {})
-    required = set(tool_schema.get("required", []))
+    Parameters
+    ----------
+    spec : dict[str, Any]
+        One entry from :func:`process_improve.tool_spec.get_tool_specs`, with
+        ``"name"``, ``"description"``, and ``"input_schema"`` keys.
 
-    # Create type annotations mapping
-    type_map = {
-        "number": float,
-        "integer": int,
-        "string": str,
-        "boolean": bool,
-        "array": list,
-        "object": dict,
-    }
+    Returns
+    -------
+    Tool
+        The MCP tool registration object, ready to hand to ``MCPServer``.
+    """
+    return Tool(
+        fn=_make_tool_handler(spec["name"]),
+        name=spec["name"],
+        title=None,
+        description=spec["description"],
+        parameters=spec["input_schema"],
+        fn_metadata=_SchemaPassthroughMetadata(arg_model=ArgModelBase),
+        is_async=True,
+        context_kwarg=None,
+        annotations=None,
+    )
 
-    annotations: dict[str, Any] = {}
-    defaults: dict[str, Any] = {}
 
-    for param_name, param_spec in properties.items():
-        param_type = param_spec.get("type", "string")
-        annotations[param_name] = type_map.get(param_type, Any)
-        if param_name not in required:
-            # Provide a sentinel default for optional params
-            defaults[param_name] = None
+def create_server() -> MCPServer:
+    """Create the MCP server with every ``@tool_spec`` tool registered.
 
-    handler.__annotations__ = annotations
-    if defaults:
-        handler.__defaults__ = tuple(defaults.values())
-
-    # Register with FastMCP using the low-level add_tool
-    mcp.tool(name=tool_name, description=tool_description)(handler)
+    Returns
+    -------
+    MCPServer
+        A server whose ``list_tools()`` publishes, for each registered tool,
+        the same ``input_schema`` that
+        :func:`process_improve.tool_spec.get_tool_specs` reports.
+    """
+    discover_tools()
+    specs = get_tool_specs()
+    logger.info("Registering %d tools with MCP server", len(specs))
+    return MCPServer(
+        "process-improve",
+        instructions=_INSTRUCTIONS,
+        tools=[_build_tool(spec) for spec in specs],
+    )
 
 
 def main() -> None:
     """Entry point for the MCP server."""
-    _register_all_tools()
-    mcp.run()
+    create_server().run()
 
 
 if __name__ == "__main__":

--- a/tests/test_omars_ilp.py
+++ b/tests/test_omars_ilp.py
@@ -98,6 +98,7 @@ def test_exact_run_size_is_respected() -> None:
 
     result = generate_omars(_factors(3), n_runs=15, solver_options=_SOLVER)
     assert result.metadata["n_runs_selected"] == 15
+    assert _coded(result).shape[0] == 15
     assert is_omars(_coded(result))
 
 
@@ -109,12 +110,15 @@ def test_run_size_below_parameters_raises() -> None:
         generate_omars(_factors(3), n_runs=10, solver_options=_SOLVER)
 
 
-def test_even_run_size_raises() -> None:
+def test_incompatible_run_size_parity_raises() -> None:
     from process_improve.experiments import generate_omars
 
-    # Foldover designs have an odd run count (2*h + 1).
-    with pytest.raises(ValueError, match="must be odd"):
+    # n_runs - center_runs is the foldover part (h half-runs plus their mirrors),
+    # so it must be a positive even number.
+    with pytest.raises(ValueError, match="n_runs - center_runs must be a positive even number"):
         generate_omars(_factors(3), n_runs=16, solver_options=_SOLVER)
+    with pytest.raises(ValueError, match="n_runs - center_runs must be a positive even number"):
+        generate_omars(_factors(3), n_runs=15, center_runs=2, solver_options=_SOLVER)
 
 
 def test_too_few_factors_raises() -> None:
@@ -147,6 +151,24 @@ def test_extra_center_runs_are_added() -> None:
     coded = _coded(result)
     n_center = int(np.sum(np.all(coded == 0, axis=1)))
     assert n_center == 3
+    assert is_omars(coded)
+
+
+@pytest.mark.parametrize(
+    ("n_runs", "center_runs"),
+    [(17, 3), (16, 2), (13, 1), (19, 5)],
+)
+def test_center_runs_count_towards_n_runs(n_runs: int, center_runs: int) -> None:
+    """n_runs is the total run count of the returned design, centre runs included (#496)."""
+    from process_improve.experiments import generate_omars
+
+    result = generate_omars(
+        _factors(3), n_runs=n_runs, center_runs=center_runs, model="main_quadratic", solver_options=_SOLVER
+    )
+    coded = _coded(result)
+    assert coded.shape[0] == n_runs
+    assert int(np.sum(np.all(coded == 0, axis=1))) == center_runs
+    assert result.metadata["n_runs_selected"] == n_runs
     assert is_omars(coded)
 
 
@@ -241,6 +263,7 @@ def test_multistart_reaches_catalogue_quality() -> None:
     assert result.metadata["d_efficiency"] >= 39.0
     report = result.metadata["omars_search"]
     assert report.n_restarts == 40
+    assert report.search_mode == "multistart"
     # The search retains many distinct designs, not the handful the old no-good cuts found.
     assert report.feasible_designs > 1
 
@@ -436,6 +459,10 @@ def test_search_report_records_diagnostics() -> None:
     assert report.ilp_iterations >= 1
     assert report.feasible_designs >= 1
     assert report.total_solve_seconds >= 0.0
+    # Three factors at the automatic size fall within the exhaustive regime.
+    assert report.search_mode == "exhaustive"
+    assert report.enumerated_designs == report.feasible_designs
+    assert result.metadata["search_mode"] == "exhaustive"
 
 
 def test_generate_omars_rejects_categorical_factor() -> None:

--- a/tests/test_omars_ilp_optima.py
+++ b/tests/test_omars_ilp_optima.py
@@ -1,0 +1,173 @@
+"""Regression tests pinning generate_omars selection criteria to exhaustive optima.
+
+The pinned values are the exhaustively computed optima reported in issues #497
+(A-optimality), #498 (D) and #499 (maximum second-order correlation), verified
+there by two independent enumerators.  Every cell here falls inside the
+exhaustive-search regime of the generator, so the returned design must match
+the optimum exactly; a regression to a heuristic (or a broken enumeration)
+shows up as a worse metric.
+
+These cells run on the enumeration path with a pinned ``n_runs``, which needs
+no ILP solve, so the tests do not require pulp or a working CBC binary.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from process_improve.experiments import Factor, generate_omars
+
+
+def _factors(k: int) -> list[Factor]:
+    return [Factor(name=chr(65 + i), low=-1, high=1) for i in range(k)]
+
+
+def _design(result) -> np.ndarray:
+    return result.design[result.factor_names].to_numpy(dtype=float)
+
+
+def _main_quadratic_matrix(design: np.ndarray) -> np.ndarray:
+    k = design.shape[1]
+    columns = [np.ones(design.shape[0])]
+    columns += [design[:, i] for i in range(k)]
+    columns += [design[:, i] ** 2 for i in range(k)]
+    return np.column_stack(columns)
+
+
+def _a_value(design: np.ndarray) -> float:
+    """Compute A = trace((X'X)^-1) / p for the main-effects-and-quadratics model, as in #497."""
+    model_matrix = _main_quadratic_matrix(design)
+    gram = model_matrix.T @ model_matrix
+    return float(np.trace(np.linalg.inv(gram)) / gram.shape[0])
+
+
+def _d_value(design: np.ndarray) -> float:
+    """Compute D = det(X'X)^(1/p) for the main-effects-and-quadratics model, as in #498."""
+    model_matrix = _main_quadratic_matrix(design)
+    gram = model_matrix.T @ model_matrix
+    return float(np.exp(np.linalg.slogdet(gram)[1] / gram.shape[0]))
+
+
+def _max_abs_second_order_correlation(design: np.ndarray) -> float:
+    """Compute max |r| over all second-order columns, as in #499 (no constant columns expected)."""
+    k = design.shape[1]
+    columns = [design[:, i] * design[:, i] for i in range(k)]
+    columns += [design[:, i] * design[:, j] for i in range(k) for j in range(i + 1, k)]
+    second_order = np.column_stack(columns)
+    corr = np.abs(np.corrcoef(second_order, rowvar=False))
+    np.fill_diagonal(corr, 0.0)
+    return float(corr.max())
+
+
+def _generate(k: int, n_runs: int, center_runs: int, criterion: str):
+    result = generate_omars(
+        _factors(k),
+        n_runs=n_runs,
+        center_runs=center_runs,
+        model="main_quadratic",
+        selection_criterion=criterion,
+    )
+    design = _design(result)
+    assert design.shape[0] == n_runs
+    assert int(np.sum(np.all(design == 0, axis=1))) == center_runs
+    assert result.metadata["search_mode"] == "exhaustive"
+    return design
+
+
+# Exhaustive optima from the table in issue #497.
+_A_OPTIMA = [
+    (3, 13, 1, 0.273810),
+    (3, 15, 1, 0.217262),
+    (3, 17, 1, 0.198649),
+    (3, 19, 1, 0.174286),
+    (3, 21, 1, 0.152015),
+    (3, 15, 3, 0.217262),
+    (3, 17, 3, 0.183929),
+    (4, 13, 1, 0.279630),
+    (4, 15, 1, 0.227273),
+    (4, 17, 1, 0.187831),
+    (4, 17, 3, 0.187831),
+]
+
+_A_OPTIMA_SLOW = [
+    (4, 19, 1, 0.174411),
+    (4, 21, 1, 0.155556),
+]
+
+
+@pytest.mark.parametrize(("k", "n_runs", "center_runs", "optimum"), _A_OPTIMA)
+def test_a_optimal_matches_exhaustive_optimum(k: int, n_runs: int, center_runs: int, optimum: float) -> None:
+    design = _generate(k, n_runs, center_runs, "a_optimal")
+    assert _a_value(design) == pytest.approx(optimum, abs=5e-6)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(("k", "n_runs", "center_runs", "optimum"), _A_OPTIMA_SLOW)
+def test_a_optimal_matches_exhaustive_optimum_large(k: int, n_runs: int, center_runs: int, optimum: float) -> None:
+    design = _generate(k, n_runs, center_runs, "a_optimal")
+    assert _a_value(design) == pytest.approx(optimum, abs=5e-6)
+
+
+# Exhaustive optima from the table in issue #498.
+_D_OPTIMA = [
+    (3, 17, 7.401203),
+    (3, 21, 9.077880),
+    (3, 23, 10.010817),
+    (3, 25, 10.868684),
+    (4, 15, 6.090681),
+    (4, 17, 7.132557),
+]
+
+_D_OPTIMA_SLOW = [
+    (4, 19, 8.058584),
+    (4, 21, 8.741520),
+]
+
+
+@pytest.mark.parametrize(("k", "n_runs", "optimum"), _D_OPTIMA)
+def test_d_efficiency_matches_exhaustive_optimum(k: int, n_runs: int, optimum: float) -> None:
+    design = _generate(k, n_runs, 1, "d_efficiency")
+    assert _d_value(design) == pytest.approx(optimum, abs=5e-6)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(("k", "n_runs", "optimum"), _D_OPTIMA_SLOW)
+def test_d_efficiency_matches_exhaustive_optimum_large(k: int, n_runs: int, optimum: float) -> None:
+    design = _generate(k, n_runs, 1, "d_efficiency")
+    assert _d_value(design) == pytest.approx(optimum, abs=5e-6)
+
+
+# Exhaustive optima from the table in issue #499.
+_CORRELATION_OPTIMA = [
+    (3, 17, 0.367315),
+    (3, 21, 0.050000),
+    (3, 25, 0.161165),
+    (4, 13, 0.500000),
+    (4, 15, 0.500000),
+    (4, 17, 0.367315),
+]
+
+_CORRELATION_OPTIMA_SLOW = [
+    (4, 19, 0.457143),
+    (4, 21, 0.311805),
+]
+
+
+@pytest.mark.parametrize(("k", "n_runs", "optimum"), _CORRELATION_OPTIMA)
+def test_min_second_order_correlation_matches_exhaustive_optimum(k: int, n_runs: int, optimum: float) -> None:
+    design = _generate(k, n_runs, 1, "min_second_order_correlation")
+    assert _max_abs_second_order_correlation(design) == pytest.approx(optimum, abs=5e-6)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(("k", "n_runs", "optimum"), _CORRELATION_OPTIMA_SLOW)
+def test_min_second_order_correlation_matches_exhaustive_optimum_large(k: int, n_runs: int, optimum: float) -> None:
+    design = _generate(k, n_runs, 1, "min_second_order_correlation")
+    assert _max_abs_second_order_correlation(design) == pytest.approx(optimum, abs=5e-6)
+
+
+def test_dominance_shares_the_exact_d_axis() -> None:
+    """The default criterion picks its winner from the exact Pareto front (#498)."""
+    design = _generate(3, 17, 1, "dominance")
+    assert _d_value(design) == pytest.approx(7.401203, abs=5e-6)


### PR DESCRIPTION
## Summary

The OMARS generator cluster from the 2026-08-14 audit batch. Version bumped to 1.72.0 (MINOR: the `n_runs` semantics change plus the exact-search behaviour).

- Fixes #496: `n_runs` is now the total run count of the returned design, centre runs included: `generate_omars(n_runs=17, center_runs=3)` returns 17 rows, 3 of them centre runs. `n_runs - center_runs` must be a positive even number, and all reported metrics are computed on the full returned design.
- Fixes #497, fixes #498, fixes #499: the root cause of all three optimality gaps was representational, not just weak search: the exhaustive optima require designs that repeat a half-run, and the binary ILP multistart cannot represent repetition at all (the library's reported values in the issue tables match the binary-class optima exactly). The search now enumerates every feasible half-design multiset (counts per sign class, replication allowed) up to four factors at moderate sizes (`_ENUM_MAX_HALF = {3: 18, 4: 12}`), scores count vectors in vectorised batches (eigvalsh on the count-weighted Gram, no design materialisation), and selects exactly. Beyond the caps the multistart remains, and both the docstring and `metadata["search_mode"]` say which regime produced the design.
- Per #499's convention: a design containing a constant (non-estimable) second-order column scores `inf` on the selection correlation metric instead of having the column skipped. The descriptive statistic in `omars_properties` is unchanged.

**Every cell of all three issue tables was verified to reproduce the exhaustive optimum exactly** (A: 13 cells, D: 14 cells, max|r|: 14 cells), including the former worst cases (A gap 39.7% at k=3 N=21; max|r| gap 51.2% at k=4 N=25). Wall-clock for the largest cell (k=4, N=25, h=12: 2.42M feasible designs) is about 90 s; the k=3 cells and k=4 up to N=17 are sub-5 s.

## Test plan

- [x] New `tests/test_omars_ilp_optima.py` pins the tractable issue-table cells to their exhaustive optima (k=4 N=19/21 marked `slow`); the N=23/25 cells were verified in-session and left out of CI for runtime
- [x] New parity/sizing tests: returned row count equals `n_runs` for several `(n_runs, center_runs)` combinations, including an even total
- [x] `uv run pytest tests/test_omars_ilp.py tests/test_omars_ilp_optima.py --no-cov`: 63 passed
- [x] `uv run pytest tests/test_omars*.py tests/test_experiments_omars.py tests/test_design_generation.py tests/test_audit_regressions_experiments.py --no-cov`: 361 passed, 1 skipped (pre-existing skip)
- [x] `ruff check .`, `ruff format --check .` clean; `mypy src/process_improve` shows only the pre-existing `mcp_server.py` FastMCP attr error unrelated to this diff

## Checklist

- [x] Version bumped in `pyproject.toml` (PATCH for fixes/docs/config, MINOR for new features)
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated