### PR TITLE
ECharts adapter correctness and honest visualization tests (#509, #512)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ those changes.
 
 ## [Unreleased]
 
+## [1.73.1] - 2026-08-29
+
+### Fixed
+
+- ECharts adapter (#509): a panel's annotations now always attach to a series
+  of that panel, in both the single-panel and multi-panel paths; a panel with
+  annotations but no layers gets an empty carrier series instead of painting
+  the previous panel. A data row missing an encoded field raises `KeyError`
+  (matching the Plotly adapter) instead of silently plotting 0; a ragged
+  `z_matrix` raises `ValueError` instead of filling missing cells with 0; and
+  per-point `colors` / `error_y` style lists whose length does not match the
+  data raise `ValueError` instead of silently truncating the series. Both
+  adapters now raise `NotImplementedError` for the declared-but-unimplemented
+  `MarkType.area` and `AnnotationType.label` instead of silently falling back
+  to a scatter trace or dropping the annotation.
+- Visualization tests (#512): the Plotly annotation-rendering tests now assert
+  on the rendered `layout.shapes` / `layout.annotations` structure instead of
+  a tautology, and `test_themes.py` restores the `plotly.io.templates.default`
+  value that was in effect before the test rather than forcing the package
+  default, so the theme no longer leaks into later tests in the same worker.
+
 ## [1.71.0] - 2026-08-22
 
 The multivariate statistical cluster from the 2026-08 audit triage (#513).
@@ -3475,7 +3496,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.71.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.73.1...HEAD
+[1.73.1]: https://github.com/kgdunn/process-improve/compare/v1.73.0...v1.73.1
 [1.71.0]: https://github.com/kgdunn/process-improve/compare/v1.70.0...v1.71.0
 [1.70.0]: https://github.com/kgdunn/process-improve/compare/v1.69.0...v1.70.0
 [1.69.0]: https://github.com/kgdunn/process-improve/compare/v1.68.0...v1.69.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.71.0
-date-released: "2026-08-22"
+version: 1.73.1
+date-released: "2026-08-29"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.71.0"
+version = "1.73.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ batch = [
 ]
 
 # MCP server entry-point.
-mcp = ["mcp>=1.0"]
+mcp = ["mcp>=2.0"]
 
 # JIT-compiled inner loops in ``process_improve.batch.alignment_helpers``.
 # Without numba the module still imports and runs; the ``@jit`` decorator
@@ -92,7 +92,7 @@ ilp = ["pulp>=2.8"]
 # Meta extra: reproduces the pre-ENG-13 install closure.
 all = [
     "matplotlib>=3.10.8",
-    "mcp>=1.0",
+    "mcp>=2.0",
     "numba>=0.63.1",
     "openpyxl>=3.1.5",
     "plotly>=6.5.2",

--- a/src/process_improve/mcp_server.py
+++ b/src/process_improve/mcp_server.py
@@ -36,7 +36,9 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.tools import Tool
+from mcp.server.mcpserver.utilities.func_metadata import ArgModelBase, FuncMetadata
 
 from process_improve.config import settings
 from process_improve.tool_safety import ToolSafetyError, safe_execute_tool_call
@@ -44,20 +46,17 @@ from process_improve.tool_spec import discover_tools, execute_tool_call, get_too
 
 logger = logging.getLogger(__name__)
 
+_INSTRUCTIONS = (
+    "Process improvement tools: robust statistics, multivariate analysis (PCA/PLS), "
+    "control charts, designed experiments, batch process analysis, and regression. "
+    "All tools accept JSON inputs and return JSON outputs."
+)
+
 # Opt-in safety. The default (stdio on the user's own machine) keeps the
 # fast in-process path so local Claude Desktop / Cursor integrations don't
 # pay subprocess overhead. Set ``PROCESS_IMPROVE_MCP_SAFE_MODE=1`` when the
 # server is fronted by HTTP or otherwise reachable from untrusted clients.
 # Reads via ``settings`` so tests can override at runtime (ENG-09 / ENG-27).
-
-mcp = FastMCP(
-    "process-improve",
-    instructions=(
-        "Process improvement tools: robust statistics, multivariate analysis (PCA/PLS), "
-        "control charts, designed experiments, batch process analysis, and regression. "
-        "All tools accept JSON inputs and return JSON outputs."
-    ),
-)
 
 
 def _serialise_tool_error(exc: Exception, tool_name: str) -> str:
@@ -74,19 +73,31 @@ def _serialise_tool_error(exc: Exception, tool_name: str) -> str:
     return json.dumps({"error": "internal error while executing tool", "tool": tool_name})
 
 
-def _register_all_tools() -> None:
-    """Register every ``@tool_spec`` tool as an MCP tool."""
-    discover_tools()
-    specs = get_tool_specs()
-    logger.info("Registering %d tools with MCP server", len(specs))
+class _SchemaPassthroughMetadata(FuncMetadata):
+    """Hand-built ``FuncMetadata`` that skips pydantic argument validation.
 
-    for spec in specs:
-        tool_name = spec["name"]
-        tool_description = spec["description"]
-        tool_schema = spec["input_schema"]
+    Each tool's published ``inputSchema`` comes from the ``@tool_spec``
+    registry, not from a Python signature, so there is no pydantic argument
+    model here to validate against. The arguments are passed through unchanged
+    to :func:`process_improve.tool_spec.execute_tool_call`, which validates
+    them against the tool's real pydantic input model (unknown keys raise
+    ``ToolInputInvalidError`` there; see SEC-15).
+    """
 
-        # Build parameter list from the JSON schema properties
-        _create_mcp_tool(tool_name, tool_description, tool_schema)
+    def validate_arguments(self, arguments_to_validate: dict[str, Any]) -> dict[str, Any]:
+        """Return a shallow copy of the arguments without validating them.
+
+        Parameters
+        ----------
+        arguments_to_validate : dict[str, Any]
+            The raw ``arguments`` dict from the MCP ``tools/call`` request.
+
+        Returns
+        -------
+        dict[str, Any]
+            The same key/value pairs, handed to the handler as ``**kwargs``.
+        """
+        return dict(arguments_to_validate)
 
 
 def _make_tool_handler(tool_name: str) -> Callable[..., Awaitable[str]]:
@@ -94,10 +105,10 @@ def _make_tool_handler(tool_name: str) -> Callable[..., Awaitable[str]]:
 
     ENG-30: the tool execution path is synchronous (in safe mode it blocks on a
     ``ProcessPoolExecutor`` future; otherwise it runs the tool in-process). To
-    avoid blocking the FastMCP event loop - which would serialise concurrent
-    requests when the server is fronted by HTTP / SSE - the blocking call is
-    offloaded to a worker thread via ``run_in_executor``. Single-call behaviour
-    is unchanged.
+    avoid blocking the MCP server's event loop - which would serialise
+    concurrent requests when the server is fronted by HTTP / SSE - the blocking
+    call is offloaded to a worker thread via ``run_in_executor``. Single-call
+    behaviour is unchanged.
     """
 
     async def handler(**kwargs: Any) -> str:  # noqa: ANN401
@@ -118,55 +129,63 @@ def _make_tool_handler(tool_name: str) -> Callable[..., Awaitable[str]]:
     return handler
 
 
-def _create_mcp_tool(
-    tool_name: str,
-    tool_description: str,
-    tool_schema: dict[str, Any],
-) -> None:
-    """Create and register a single MCP tool that delegates to execute_tool_call."""
-    handler = _make_tool_handler(tool_name)
+def _build_tool(spec: dict[str, Any]) -> Tool:
+    """Build one MCP ``Tool`` whose published ``inputSchema`` is the registry's schema.
 
-    # Set proper function metadata for FastMCP
-    handler.__name__ = tool_name
-    handler.__doc__ = tool_description
-    handler.__qualname__ = tool_name
+    The tool is constructed directly (not via ``Tool.from_function``) so the
+    ``parameters`` field - which the server publishes verbatim as the tool's
+    ``inputSchema`` - is exactly ``spec["input_schema"]``: parameter types,
+    required vs optional, enums, bounds, and ``anyOf`` unions all survive
+    (issue #506). Signature introspection of the generic ``(**kwargs)``
+    handler could not synthesise any of that.
 
-    # Build parameter annotations from JSON schema for FastMCP introspection
-    properties = tool_schema.get("properties", {})
-    required = set(tool_schema.get("required", []))
+    Parameters
+    ----------
+    spec : dict[str, Any]
+        One entry from :func:`process_improve.tool_spec.get_tool_specs`, with
+        ``"name"``, ``"description"``, and ``"input_schema"`` keys.
 
-    # Create type annotations mapping
-    type_map = {
-        "number": float,
-        "integer": int,
-        "string": str,
-        "boolean": bool,
-        "array": list,
-        "object": dict,
-    }
+    Returns
+    -------
+    Tool
+        The MCP tool registration object, ready to hand to ``MCPServer``.
+    """
+    return Tool(
+        fn=_make_tool_handler(spec["name"]),
+        name=spec["name"],
+        title=None,
+        description=spec["description"],
+        parameters=spec["input_schema"],
+        fn_metadata=_SchemaPassthroughMetadata(arg_model=ArgModelBase),
+        is_async=True,
+        context_kwarg=None,
+        annotations=None,
+    )
 
-    annotations: dict[str, Any] = {}
-    defaults: dict[str, Any] = {}
 
-    for param_name, param_spec in properties.items():
-        param_type = param_spec.get("type", "string")
-        annotations[param_name] = type_map.get(param_type, Any)
-        if param_name not in required:
-            # Provide a sentinel default for optional params
-            defaults[param_name] = None
+def create_server() -> MCPServer:
+    """Create the MCP server with every ``@tool_spec`` tool registered.
 
-    handler.__annotations__ = annotations
-    if defaults:
-        handler.__defaults__ = tuple(defaults.values())
-
-    # Register with FastMCP using the low-level add_tool
-    mcp.tool(name=tool_name, description=tool_description)(handler)
+    Returns
+    -------
+    MCPServer
+        A server whose ``list_tools()`` publishes, for each registered tool,
+        the same ``input_schema`` that
+        :func:`process_improve.tool_spec.get_tool_specs` reports.
+    """
+    discover_tools()
+    specs = get_tool_specs()
+    logger.info("Registering %d tools with MCP server", len(specs))
+    return MCPServer(
+        "process-improve",
+        instructions=_INSTRUCTIONS,
+        tools=[_build_tool(spec) for spec in specs],
+    )
 
 
 def main() -> None:
     """Entry point for the MCP server."""
-    _register_all_tools()
-    mcp.run()
+    create_server().run()
 
 
 if __name__ == "__main__":

--- a/src/process_improve/visualization/adapters/echarts_adapter.py
+++ b/src/process_improve/visualization/adapters/echarts_adapter.py
@@ -86,14 +86,7 @@ class EChartsAdapter(AbstractAdapter):
             series.append(s)
 
         # Collect annotations as markLines / markAreas on the first series
-        mark_lines, mark_areas = self._collect_annotations(panel.annotations)
-        if series and (mark_lines or mark_areas):
-            if mark_lines:
-                self._merge_mark_lines(series[0], mark_lines)
-            if mark_areas:
-                series[0].setdefault("markArea", {})
-                series[0]["markArea"]["data"] = mark_areas
-                series[0]["markArea"]["silent"] = True
+        self._attach_annotations(series, panel.annotations)
 
         option: dict[str, Any] = {
             "title": {"text": title or panel.title, "left": "center"},
@@ -171,21 +164,19 @@ class EChartsAdapter(AbstractAdapter):
                 }
             )
 
+            # Build this panel's own series first, then attach this panel's
+            # annotations to them (never to a previous panel's series).
+            panel_series: list[dict[str, Any]] = []
             for layer in panel.layers:
                 s, _ = self._layer_to_series(layer)
+                panel_series.append(s)
+
+            self._attach_annotations(panel_series, panel.annotations)
+
+            for s in panel_series:
                 s["xAxisIndex"] = idx
                 s["yAxisIndex"] = idx
-                all_series.append(s)
-
-            mark_lines, mark_areas = self._collect_annotations(panel.annotations)
-            if all_series and (mark_lines or mark_areas):
-                last_series = all_series[-1]
-                if mark_lines:
-                    self._merge_mark_lines(last_series, mark_lines)
-                if mark_areas:
-                    last_series.setdefault("markArea", {})
-                    last_series["markArea"]["data"] = mark_areas
-                    last_series["markArea"]["silent"] = True
+            all_series.extend(panel_series)
 
         return {
             "title": {"text": spec.title, "left": "center"},
@@ -208,8 +199,18 @@ class EChartsAdapter(AbstractAdapter):
         -------
         tuple[dict, bool]
             The series dict and whether it is a 3D chart.
+
+        Raises
+        ------
+        NotImplementedError
+            If the layer uses :attr:`MarkType.area`, which is declared in
+            the spec vocabulary but not implemented here.
         """
         mark = layer.mark if isinstance(layer.mark, MarkType) else MarkType(layer.mark)
+
+        if mark == MarkType.area:
+            msg = "MarkType.area is declared in the spec vocabulary but not implemented in the ECharts adapter."
+            raise NotImplementedError(msg)
 
         if mark == MarkType.bar:
             return self._bar_series(layer), False
@@ -247,19 +248,18 @@ class EChartsAdapter(AbstractAdapter):
         }
         colors = layer.style.get("colors")
         if colors:
+            _check_per_point_style(layer, "colors", colors, len(data))
             series["itemStyle"] = {"color": None}
-            series["data"] = [
-                {"value": v, "itemStyle": {"color": c}}
-                for v, c in zip(data, colors)  # noqa: B905
-            ]
+            series["data"] = [{"value": v, "itemStyle": {"color": c}} for v, c in zip(data, colors, strict=True)]
         elif layer.color:
             series["itemStyle"] = {"color": layer.color}
 
         error_y = layer.style.get("error_y")
         if error_y and layer.x:
+            _check_per_point_style(layer, "error_y", error_y, len(data))
             categories = [row[layer.x.field] for row in layer.data]
             mark_data: list[list[dict[str, Any]]] = []
-            for cat, value, err in zip(categories, data, error_y):  # noqa: B905
+            for cat, value, err in zip(categories, data, error_y, strict=True):
                 if err is None:
                     continue
                 err_abs = abs(float(err))
@@ -308,26 +308,39 @@ class EChartsAdapter(AbstractAdapter):
             "symbolSize": size,
         }
         if colors:
-            series["data"] = [
-                {"value": d, "itemStyle": {"color": c}}
-                for d, c in zip(data, colors)  # noqa: B905
-            ]
+            _check_per_point_style(layer, "colors", colors, len(data))
+            series["data"] = [{"value": d, "itemStyle": {"color": c}} for d, c in zip(data, colors, strict=True)]
         elif layer.color:
             series["itemStyle"] = {"color": layer.color}
         return series
 
     def _heatmap_series(self, layer: LayerSpec) -> dict[str, Any]:
+        """Build an ECharts heatmap series from grid-style layer data.
+
+        Raises
+        ------
+        ValueError
+            If ``style['z_matrix']`` does not have exactly one row per
+            ``y_grid`` entry and one value per ``x_grid`` entry. A ragged
+            matrix would otherwise silently plot missing cells as 0.
+        """
         z_matrix = layer.style.get("z_matrix", [])
         x_grid = layer.style.get("x_grid", [])
         y_grid = layer.style.get("y_grid", [])
 
+        if len(z_matrix) != len(y_grid) or any(len(row) != len(x_grid) for row in z_matrix):
+            msg = (
+                f"style['z_matrix'] on layer {layer.name!r} must have shape "
+                f"({len(y_grid)}, {len(x_grid)}) to match y_grid and x_grid; "
+                f"got {len(z_matrix)} rows of lengths {[len(row) for row in z_matrix]}."
+            )
+            raise ValueError(msg)
+
         # ECharts heatmap needs [x_idx, y_idx, value] triples
         data = []
         for i, y_val in enumerate(y_grid):
-            row_data = z_matrix[i] if i < len(z_matrix) else []
             for j, x_val in enumerate(x_grid):
-                z_val = row_data[j] if j < len(row_data) else 0
-                data.append([x_val, y_val, z_val])
+                data.append([x_val, y_val, z_matrix[i][j]])
 
         return {
             "type": "heatmap",
@@ -364,15 +377,23 @@ class EChartsAdapter(AbstractAdapter):
         return series
 
     def _wireframe_series(self, layer: LayerSpec) -> dict[str, Any]:
+        """Build a 3D scatter series from a wireframe layer.
+
+        Raises
+        ------
+        KeyError
+            If a data row is missing an encoded field, matching the
+            Plotly adapter's behaviour for the same layer.
+        """
         data = []
         for row in layer.data:
             point: list[Any] = []
             if layer.x:
-                point.append(row.get(layer.x.field, 0))
+                point.append(row[layer.x.field])
             if layer.y:
-                point.append(row.get(layer.y.field, 0))
+                point.append(row[layer.y.field])
             if layer.z:
-                point.append(row.get(layer.z.field, 0))
+                point.append(row[layer.z.field])
             data.append(point)
 
         return {
@@ -391,7 +412,14 @@ class EChartsAdapter(AbstractAdapter):
         self,
         annotations: list[Annotation],
     ) -> tuple[list[dict], list[list[dict]]]:
-        """Convert annotations to ECharts markLine and markArea data."""
+        """Convert annotations to ECharts markLine and markArea data.
+
+        Raises
+        ------
+        NotImplementedError
+            If an annotation uses :attr:`AnnotationType.label`, which is
+            declared in the spec vocabulary but not implemented here.
+        """
         mark_lines: list[dict[str, Any]] = []
         mark_areas: list[list[dict[str, Any]]] = []
 
@@ -459,6 +487,13 @@ class EChartsAdapter(AbstractAdapter):
                             {"yAxis": y_max},
                         ]
                     )
+
+            elif at == AnnotationType.label:
+                msg = (
+                    "AnnotationType.label is declared in the spec vocabulary but not implemented "
+                    "in the ECharts adapter."
+                )
+                raise NotImplementedError(msg)
 
         return mark_lines, mark_areas
 
@@ -530,15 +565,89 @@ class EChartsAdapter(AbstractAdapter):
             existing.setdefault("symbol", "none")
 
     def _paired_data(self, layer: LayerSpec) -> list[list]:
-        """Build ECharts ``[[x, y], ...]`` paired data from a layer."""
+        """Build ECharts ``[[x, y], ...]`` paired data from a layer.
+
+        Raises
+        ------
+        KeyError
+            If a data row is missing the encoded x or y field, matching
+            the Plotly adapter's behaviour for the same layer.
+        """
         if not layer.x or not layer.y:
             return []
-        return [[row.get(layer.x.field, 0), row.get(layer.y.field, 0)] for row in layer.data]
+        return [[row[layer.x.field], row[layer.y.field]] for row in layer.data]
+
+    def _attach_annotations(
+        self,
+        series: list[dict[str, Any]],
+        annotations: list[Annotation],
+    ) -> None:
+        """Attach a panel's annotations to a series belonging to that panel.
+
+        The single-panel and multi-panel paths both call this with only the
+        current panel's series, so annotations can never end up on another
+        panel. When the panel has annotations but no layers, an empty,
+        invisible line series is created to carry them.
+
+        Parameters
+        ----------
+        series : list[dict]
+            The series built for the current panel; may be extended in place.
+        annotations : list[Annotation]
+            The panel's annotations.
+        """
+        mark_lines, mark_areas = self._collect_annotations(annotations)
+        if not (mark_lines or mark_areas):
+            return
+
+        if series:
+            target = series[0]
+        else:
+            target = {"type": "line", "name": "", "data": [], "silent": True}
+            series.append(target)
+
+        if mark_lines:
+            self._merge_mark_lines(target, mark_lines)
+        if mark_areas:
+            target.setdefault("markArea", {})
+            target["markArea"]["data"] = mark_areas
+            target["markArea"]["silent"] = True
 
 
 # ---------------------------------------------------------------------------
 # Module-level helpers
 # ---------------------------------------------------------------------------
+
+
+def _check_per_point_style(layer: LayerSpec, key: str, values: Any, n_points: int) -> None:  # noqa: ANN401
+    """Check that a per-point style list has one entry per data point.
+
+    A shorter list would otherwise silently truncate the series (marks
+    simply vanish from the chart), and a longer list indicates the style
+    was built for different data.
+
+    Parameters
+    ----------
+    layer : LayerSpec
+        The layer being rendered, used to name the offender in the message.
+    key : str
+        The ``layer.style`` key being checked (e.g. ``"colors"``).
+    values : Any
+        The per-point style entries.
+    n_points : int
+        Number of data points in the layer.
+
+    Raises
+    ------
+    ValueError
+        If ``len(values)`` differs from ``n_points``.
+    """
+    if len(values) != n_points:
+        msg = (
+            f"style[{key!r}] on layer {layer.name!r} has {len(values)} entries "
+            f"but the layer has {n_points} data points; provide one entry per point."
+        )
+        raise ValueError(msg)
 
 
 def _echarts_dash(dash: str) -> str:

--- a/src/process_improve/visualization/adapters/plotly_adapter.py
+++ b/src/process_improve/visualization/adapters/plotly_adapter.py
@@ -164,16 +164,26 @@ class PlotlyAdapter(AbstractAdapter):
     # Layer → Plotly trace
     # ------------------------------------------------------------------
 
-    def _layer_to_trace(self, layer: LayerSpec) -> tuple[BaseTraceType, bool]:  # noqa: PLR0911
+    def _layer_to_trace(self, layer: LayerSpec) -> tuple[BaseTraceType, bool]:  # noqa: C901, PLR0911
         """Convert a :class:`LayerSpec` to a Plotly trace.
 
         Returns
         -------
         tuple[go.BaseTraceType, bool]
             The trace and whether it targets the secondary y-axis.
+
+        Raises
+        ------
+        NotImplementedError
+            If the layer uses :attr:`MarkType.area`, which is declared in
+            the spec vocabulary but not implemented here.
         """
         on_secondary = layer.style.get("secondary_y", False)
         mark = layer.mark if isinstance(layer.mark, MarkType) else MarkType(layer.mark)
+
+        if mark == MarkType.area:
+            msg = "MarkType.area is declared in the spec vocabulary but not implemented in the Plotly adapter."
+            raise NotImplementedError(msg)
 
         # Marks that don't read from layer.x.field / layer.y.field at the
         # row level (they use layer.style grids or row-level ``q_stats``).
@@ -407,7 +417,7 @@ class PlotlyAdapter(AbstractAdapter):
     # Annotations → Plotly shapes / annotations
     # ------------------------------------------------------------------
 
-    def _add_annotation(  # noqa: C901
+    def _add_annotation(  # noqa: C901, PLR0912
         self,
         fig: go.Figure,
         ann: Annotation,
@@ -498,3 +508,7 @@ class PlotlyAdapter(AbstractAdapter):
                     row=row or "all",
                     col=col or "all",
                 )
+
+        elif at == AnnotationType.label:
+            msg = "AnnotationType.label is declared in the spec vocabulary but not implemented in the Plotly adapter."
+            raise NotImplementedError(msg)

--- a/tests/test_echarts_multi_panel.py
+++ b/tests/test_echarts_multi_panel.py
@@ -8,6 +8,8 @@ ChartSpec and never used a constraint region.
 
 from __future__ import annotations
 
+import pytest
+
 from process_improve.visualization.adapters.echarts_adapter import EChartsAdapter
 from process_improve.visualization.spec import (
     Annotation,
@@ -74,7 +76,7 @@ def test_three_panel_grid_two_columns() -> None:
 
 
 def test_multi_panel_with_annotations() -> None:
-    """Multi-panel rendering should also place annotations on each panel."""
+    """Multi-panel rendering should place annotations on their own panel."""
     panel = _scatter_panel("p")
     panel.annotations = [
         Annotation(
@@ -89,8 +91,70 @@ def test_multi_panel_with_annotations() -> None:
         title="With annotations",
     )
     option = EChartsAdapter().render(spec)
-    # The first panel's series should carry the markLine.
-    assert "markLine" in option["series"][0]
+    # The first panel's series carries the markLine, bound to panel 0's axes.
+    first = option["series"][0]
+    assert first["xAxisIndex"] == 0
+    assert first["yAxisIndex"] == 0
+    mark_data = first["markLine"]["data"]
+    assert len(mark_data) == 1
+    assert mark_data[0]["yAxis"] == 1.5
+    assert mark_data[0]["label"]["formatter"] == "threshold"
+    # The annotation-free second panel must not pick up any marks.
+    assert "markLine" not in option["series"][1]
+    assert "markArea" not in option["series"][1]
+
+
+def test_annotation_only_panel_does_not_paint_previous_panel() -> None:
+    """A panel with annotations but no layers gets its own carrier series.
+
+    Regression test for the ``all_series[-1]`` bug: the middle panel's
+    annotation used to land on the previous panel's series.
+    """
+    empty_panel = PanelSpec(
+        layers=[],
+        title="empty",
+        annotations=[
+            Annotation(
+                annotation_type=AnnotationType.reference_line,
+                value=3.0,
+                axis="y",
+                label="only-here",
+            ),
+        ],
+    )
+    spec = ChartSpec(panels=[_scatter_panel("p0"), empty_panel, _scatter_panel("p2")])
+    option = EChartsAdapter().render(spec)
+
+    # Three panels -> two scatter series plus one empty carrier series.
+    assert len(option["series"]) == 3
+    scatter_0, carrier, scatter_2 = option["series"]
+    assert "markLine" not in scatter_0
+    assert "markLine" not in scatter_2
+    # The carrier is bound to the middle panel's axes and holds the markLine.
+    assert carrier["xAxisIndex"] == 1
+    assert carrier["yAxisIndex"] == 1
+    assert carrier["data"] == []
+    assert carrier["markLine"]["data"][0]["yAxis"] == 3.0
+
+
+def test_single_and_multi_panel_attach_annotations_identically() -> None:
+    """The same panel renders its annotation on the same series either way."""
+
+    def _annotated_panel() -> PanelSpec:
+        panel = _scatter_panel("p")
+        panel.annotations = [
+            Annotation(
+                annotation_type=AnnotationType.reference_line,
+                value=1.5,
+                axis="y",
+                label="threshold",
+            ),
+        ]
+        return panel
+
+    single = EChartsAdapter().render(ChartSpec(panels=[_annotated_panel()]))
+    multi = EChartsAdapter().render(ChartSpec(panels=[_annotated_panel(), _scatter_panel("p2")]))
+    assert single["series"][0]["markLine"]["data"] == multi["series"][0]["markLine"]["data"]
 
 
 # ---------------------------------------------------------------------------
@@ -355,3 +419,129 @@ def test_line_series_basic() -> None:
     assert series["smooth"] is True
     # The dash mapping should turn "dot" into "dotted".
     assert series["lineStyle"]["type"] == "dotted"
+
+
+# ---------------------------------------------------------------------------
+# Silent-wrong-output defects now raise (issue #509)
+# ---------------------------------------------------------------------------
+
+
+def _render_one(layer: LayerSpec) -> dict:
+    return EChartsAdapter().render(ChartSpec(panels=[PanelSpec(layers=[layer])]))
+
+
+def test_missing_paired_field_raises_key_error() -> None:
+    """A typo'd field name raises KeyError instead of plotting 0."""
+    layer = LayerSpec(
+        mark=MarkType.scatter,
+        data=[{"x": 1, "y": 2}],
+        x=Encoding(field="x"),
+        y=Encoding(field="wrong_name"),
+    )
+    with pytest.raises(KeyError, match="wrong_name"):
+        _render_one(layer)
+
+
+def test_missing_wireframe_field_raises_key_error() -> None:
+    """A wireframe row missing an encoded field raises KeyError."""
+    layer = LayerSpec(
+        mark=MarkType.wireframe,
+        data=[{"x": 1, "y": 2}],  # no "z" key
+        x=Encoding(field="x"),
+        y=Encoding(field="y"),
+        z=Encoding(field="z"),
+    )
+    with pytest.raises(KeyError, match="z"):
+        _render_one(layer)
+
+
+def test_ragged_heatmap_z_matrix_raises() -> None:
+    """A z_matrix that does not match the grids raises ValueError."""
+    layer = LayerSpec(
+        mark=MarkType.heatmap,
+        data=[],
+        name="surface",
+        style={
+            "z_matrix": [[1.0, 2.0], [3.0]],  # second row too short
+            "x_grid": [10, 20],
+            "y_grid": [100, 200],
+        },
+    )
+    with pytest.raises(ValueError, match=r"z_matrix.*surface"):
+        _render_one(layer)
+
+
+def test_heatmap_z_matrix_missing_row_raises() -> None:
+    """A z_matrix with fewer rows than y_grid raises ValueError."""
+    layer = LayerSpec(
+        mark=MarkType.heatmap,
+        data=[],
+        style={
+            "z_matrix": [[1.0, 2.0]],
+            "x_grid": [10, 20],
+            "y_grid": [100, 200],
+        },
+    )
+    with pytest.raises(ValueError, match="z_matrix"):
+        _render_one(layer)
+
+
+def test_short_bar_colors_raise() -> None:
+    """A colors list shorter than the data raises instead of dropping bars."""
+    layer = LayerSpec(
+        mark=MarkType.bar,
+        data=[{"x": "A", "y": 1.0}, {"x": "B", "y": 2.0}],
+        x=Encoding(field="x"),
+        y=Encoding(field="y"),
+        name="bars",
+        style={"colors": ["#ff0000"]},
+    )
+    with pytest.raises(ValueError, match=r"colors.*bars"):
+        _render_one(layer)
+
+
+def test_short_scatter_colors_raise() -> None:
+    """A colors list shorter than the data raises instead of dropping points."""
+    layer = LayerSpec(
+        mark=MarkType.scatter,
+        data=[{"x": 1, "y": 2}, {"x": 3, "y": 4}],
+        x=Encoding(field="x"),
+        y=Encoding(field="y"),
+        name="points",
+        style={"colors": ["#ff0000"]},
+    )
+    with pytest.raises(ValueError, match=r"colors.*points"):
+        _render_one(layer)
+
+
+def test_short_error_y_raises() -> None:
+    """An error_y list shorter than the data raises instead of truncating."""
+    layer = LayerSpec(
+        mark=MarkType.bar,
+        data=[{"x": "A", "y": 1.0}, {"x": "B", "y": 2.0}],
+        x=Encoding(field="x"),
+        y=Encoding(field="y"),
+        style={"error_y": [1.0]},
+    )
+    with pytest.raises(ValueError, match="error_y"):
+        _render_one(layer)
+
+
+def test_mark_type_area_raises_not_implemented() -> None:
+    """MarkType.area is declared but unimplemented; it must raise, not fall back."""
+    layer = LayerSpec(
+        mark=MarkType.area,
+        data=[{"x": 1, "y": 2}],
+        x=Encoding(field="x"),
+        y=Encoding(field="y"),
+    )
+    with pytest.raises(NotImplementedError, match="area"):
+        _render_one(layer)
+
+
+def test_annotation_type_label_raises_not_implemented() -> None:
+    """AnnotationType.label is declared but unimplemented; it must raise."""
+    panel = _scatter_panel("p")
+    panel.annotations = [Annotation(annotation_type=AnnotationType.label, value=1.0, label="note")]
+    with pytest.raises(NotImplementedError, match="label"):
+        EChartsAdapter().render(ChartSpec(panels=[panel]))

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -62,14 +62,17 @@ def test_import_does_not_change_global_default() -> None:
     assert result.returncode == 0, result.stderr
 
 
-def test_set_theme_changes_default() -> None:
-    """set_theme switches the global default; restored afterwards."""
-    try:
-        for name in THEME_NAMES:
-            set_theme(name)
-            assert pio.templates.default == name
-    finally:
-        set_theme(DEFAULT_THEME)
+def test_set_theme_changes_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """set_theme switches the global default; the pre-test value is restored.
+
+    Restoring the value that was in effect *before* this test (rather than
+    the package's DEFAULT_THEME) keeps ``pio.templates.default`` untouched
+    for every test that runs afterwards in the same worker.
+    """
+    monkeypatch.setattr(pio.templates, "default", pio.templates.default)
+    for name in THEME_NAMES:
+        set_theme(name)
+        assert pio.templates.default == name
 
 
 def test_set_theme_rejects_unknown() -> None:
@@ -78,13 +81,21 @@ def test_set_theme_rejects_unknown() -> None:
         set_theme("not_a_theme")
 
 
-def test_themes_define_distinct_backgrounds() -> None:
-    """Each theme carries its own plot-area background colour."""
+def test_theme_plot_backgrounds_are_pinned() -> None:
+    """Pin every theme's plot-area background colour.
+
+    The colours are not all distinct: pi_tufte and pi_journal deliberately
+    share a white plot area, so this pins all four values rather than
+    claiming uniqueness.
+    """
+    register_themes()
     backgrounds = {name: pio.templates[name].layout.plot_bgcolor for name in THEME_NAMES}
-    assert backgrounds["pi_economist"] == "#D9E9F1"
-    assert backgrounds["pi_brand"] == "#FAFAFA"
-    # Tufte and journal both keep a white plot area.
-    assert backgrounds["pi_tufte"] == "#FFFFFF"
+    assert backgrounds == {
+        "pi_tufte": "#FFFFFF",
+        "pi_economist": "#D9E9F1",
+        "pi_journal": "#FFFFFF",
+        "pi_brand": "#FAFAFA",
+    }
 
 
 def test_score_plot_uses_default_theme(fitted_pca: PCA) -> None:

--- a/tests/test_visualization_spec.py
+++ b/tests/test_visualization_spec.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from process_improve.visualization.adapters import PlotlyAdapter
 from process_improve.visualization.spec import (
     Annotation,
@@ -48,7 +50,11 @@ class TestChartSpecSerialisation:
 
 
 class TestPlotlyAnnotationRendering:
-    """Exercise the reference-band and constraint-region adapter paths."""
+    """Exercise the reference-band and constraint-region adapter paths.
+
+    Assertions pin the rendered ``layout.shapes`` / ``layout.annotations``
+    structure, following the style of :class:`TestPlotlyContourStyling`.
+    """
 
     def test_reference_band_on_y_axis(self) -> None:
         band = Annotation(
@@ -59,7 +65,16 @@ class TestPlotlyAnnotationRendering:
         )
         spec = ChartSpec(panels=[_scatter_panel([band])])
         result = PlotlyAdapter().render(spec)
-        assert "data" in result
+        shapes = result["layout"]["shapes"]
+        assert len(shapes) == 1
+        shape = shapes[0]
+        assert shape["type"] == "rect"
+        # A y-axis band spans data coordinates on y and the full x domain.
+        assert shape["y0"] == 0.2
+        assert shape["y1"] == 0.8
+        assert shape["yref"] == "y"
+        assert shape["xref"] == "x domain"
+        assert shape["fillcolor"] == "rgba(37, 99, 235, 0.1)"
 
     def test_reference_band_on_x_axis(self) -> None:
         band = Annotation(
@@ -70,20 +85,47 @@ class TestPlotlyAnnotationRendering:
         )
         spec = ChartSpec(panels=[_scatter_panel([band])])
         result = PlotlyAdapter().render(spec)
-        assert "data" in result
+        shapes = result["layout"]["shapes"]
+        assert len(shapes) == 1
+        shape = shapes[0]
+        assert shape["type"] == "rect"
+        # An x-axis band spans data coordinates on x and the full y domain.
+        assert shape["x0"] == 0.2
+        assert shape["x1"] == 0.8
+        assert shape["xref"] == "x"
+        assert shape["yref"] == "y domain"
+        assert shape["fillcolor"] == "rgba(37, 99, 235, 0.1)"
 
     def test_constraint_region_renders(self) -> None:
         region = constraint_region(x_min=0.0, x_max=0.5, y_min=0.0, y_max=0.5)
         spec = ChartSpec(panels=[_scatter_panel([region])])
         result = PlotlyAdapter().render(spec)
-        assert "data" in result
+        shapes = result["layout"]["shapes"]
+        # Both bound pairs are given, so an x-rect and a y-rect are drawn.
+        assert len(shapes) == 2
+        x_rect, y_rect = shapes
+        assert x_rect["x0"] == 0.0
+        assert x_rect["x1"] == 0.5
+        assert x_rect["xref"] == "x"
+        assert x_rect["yref"] == "y domain"
+        assert y_rect["y0"] == 0.0
+        assert y_rect["y1"] == 0.5
+        assert y_rect["yref"] == "y"
+        assert y_rect["xref"] == "x domain"
+        assert all(shape["fillcolor"] == "rgba(220, 38, 38, 0.15)" for shape in shapes)
+        # Each rect carries the region label as a text annotation.
+        labels = [ann["text"] for ann in result["layout"]["annotations"]]
+        assert labels == ["Infeasible", "Infeasible"]
 
     def test_incomplete_reference_band_is_skipped(self) -> None:
-        # value_end is None: the band cannot be drawn and is silently skipped.
+        # value_end is None: the band cannot be drawn and is silently skipped,
+        # so the layout has exactly the shapes of a spec without the band.
         band = Annotation(annotation_type=AnnotationType.reference_band, axis="y", value=0.2)
         spec = ChartSpec(panels=[_scatter_panel([band])])
         result = PlotlyAdapter().render(spec)
-        assert "data" in result
+        baseline = PlotlyAdapter().render(ChartSpec(panels=[_scatter_panel([])]))
+        assert result["layout"].get("shapes") == baseline["layout"].get("shapes")
+        assert not result["layout"].get("shapes")
 
 
 def _contour_panel(style: dict, *, color: str | None = None, opacity: float = 1.0) -> PanelSpec:
@@ -152,3 +194,24 @@ class TestPlotlyContourStyling:
         assert _first_trace(_contour_panel({"ncontours": 8}))["ncontours"] == 8
         # Passing None would override plotly's own auto-ranging, so it is dropped.
         assert "ncontours" not in _first_trace(_contour_panel({}))
+
+
+class TestPlotlyUnimplementedMembers:
+    """Declared-but-unimplemented spec members raise instead of silently degrading."""
+
+    def test_mark_type_area_raises_not_implemented(self) -> None:
+        layer = LayerSpec(
+            mark=MarkType.area,
+            data=[{"x": 0.0, "y": 0.0}],
+            x=Encoding(field="x"),
+            y=Encoding(field="y"),
+        )
+        spec = ChartSpec(panels=[PanelSpec(layers=[layer])])
+        with pytest.raises(NotImplementedError, match="area"):
+            PlotlyAdapter().render(spec)
+
+    def test_annotation_type_label_raises_not_implemented(self) -> None:
+        ann = Annotation(annotation_type=AnnotationType.label, value=1.0, label="note")
+        spec = ChartSpec(panels=[_scatter_panel([ann])])
+        with pytest.raises(NotImplementedError, match="label"):
+            PlotlyAdapter().render(spec)


### PR DESCRIPTION
## Summary

Fixes #509 and Fixes #512.

- **#512 (tests only, no adapter behaviour changed):** the four `TestPlotlyAnnotationRendering` tests asserted only `"data" in result`, which every Plotly figure dict satisfies. They now assert on the rendered `layout["shapes"]` (count, `x0`/`x1` vs `y0`/`y1`, `xref`/`yref` to pin the axis, `fillcolor`) and `layout["annotations"]`, in the style of `TestPlotlyContourStyling`; the incomplete-band test compares against a band-free baseline so the skip is actually pinned. `test_set_theme_changes_default` now restores the `plotly.io.templates.default` value captured before the test (via `monkeypatch`) instead of forcing the package default, so the theme no longer leaks into later tests in the same xdist worker. The background-colour test no longer claims all four themes are distinct; it pins all four values (`pi_tufte` and `pi_journal` deliberately share white).
- **#509 (ECharts adapter):**
  - Annotations attach to a series of their own panel: single-panel and multi-panel paths share one `_attach_annotations` helper (attaching to the panel's first series), and a panel with annotations but no layers gets an empty, silent carrier series bound to its own axes instead of painting the previous panel via `all_series[-1]`.
  - `_paired_data` and `_wireframe_series` use direct `row[field]` lookups, so a missing or typo'd field raises `KeyError`, matching the Plotly adapter, instead of silently plotting 0.
  - A ragged or wrongly shaped `z_matrix` in `_heatmap_series` raises `ValueError` naming the layer and expected `(len(y_grid), len(x_grid))` shape instead of filling cells with 0.
  - The three non-strict zips are now `strict=True`, preceded by an explicit length check that raises a clear `ValueError` naming the layer and style key. Decision: `types.py` documents `style` as "extra visual properties" with nothing implying a shorter colour list should cycle, and every in-repo producer (`experiments/visualization/plots/significance.py`) builds `colors`/`error_y` one-per-point from the same data, so a length mismatch indicates a bug and raising (not cycling) is the behaviour that matches the spec and `visualization/tools.py`.
  - `MarkType.area` and `AnnotationType.label` are declared in `types.py` but implemented in neither adapter; both adapters now raise `NotImplementedError` with a message naming the member, instead of Plotly silently falling back to scatter and ECharts dropping the label.
- **Callers checked:** no in-repo caller uses `MarkType.area` or `AnnotationType.label`, and all producers of `colors`/`error_y`/grid-style layers (`src/process_improve/visualization/charts/`, `src/process_improve/experiments/visualization/plots/`, `experiments/_tools/visualize_doe.py`) build matched-length lists and rectangular matrices, so no caller adjustments were needed; `tests/test_experiments_tools.py` confirms.
- Housekeeping: version 1.73.1 in `pyproject.toml` and `CITATION.cff` (`date-released` 2026-08-29), new `## [1.73.1] - 2026-08-29` changelog section with footer links. The version is set assuming the earlier queued PRs (carrying 1.72.x/1.73.0) merge first; if they land differently this needs only a trivial rebase.

## Test plan

- [x] `uv run pytest tests/test_visualization_spec.py tests/test_themes.py tests/test_echarts_multi_panel.py tests/test_visualization.py tests/test_viz_boxplot.py --no-cov -q` : 240 passed
- [x] `uv run pytest tests/test_experiments_tools.py --no-cov -q` : 39 passed (DOE callers of the adapters unaffected)
- [x] New regression tests: annotation-only middle panel lands on its own panel; single vs multi panel attach identically; missing field raises `KeyError`; ragged heatmap raises `ValueError`; short `colors`/`error_y` raise `ValueError`; `MarkType.area` / `AnnotationType.label` raise `NotImplementedError` in both adapters
- [x] `uv run ruff check .` and `uv run ruff format --check .` both pass
- [x] `uv run mypy src/process_improve`: only the pre-existing `mcp_server.py:39` FastMCP error

## Checklist

- [x] Version bumped in `pyproject.toml` (PATCH for fixes/docs/config, MINOR for new features)
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated

---
_Generated by [Claude Code](https://claude.ai/code/session_019C3XXbJkuSYH9fMryLqNcU)_