### PR TITLE
Stop fit() mutating constructor parameters in PCA / PLS / OPLS (#505)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ those changes.
 
 ## [Unreleased]
 
+## [1.73.0] - 2026-08-29
+
+### Fixed
+
+- `PCA`, `PLS`, and `OPLS` no longer mutate their constructor parameters inside
+  `fit()`, restoring the sklearn `get_params` / `clone` contract that
+  `PLS.cross_validate` and `GridSearchCV` depend on (#505). The resolved
+  (possibly clamped) component count now lives on the fitted attribute
+  `n_components_`; `n_components` stays exactly as the user set it, including
+  `None`, so cloned resamples fit the requested configuration and refitting the
+  same instance on differently shaped data re-derives the clamp each time.
+  `PLS.fit` likewise no longer writes the resolved missing-data settings back
+  to `missing_data_settings`.
+
+### Changed
+
+- Reading `model.n_components` after fitting now returns the user's request
+  (which can be `None`), not the resolved count: read `model.n_components_`
+  for the fitted value. `OPLS`, which has no `n_components` constructor
+  parameter, exposes the fitted count only as `n_components_` and raises a
+  helpful rename message for the old name. `MBPCA` and `MBPLS` also expose
+  `n_components_` so the shared limit and plot helpers read one attribute
+  across all four estimators.
+
 ## [1.71.0] - 2026-08-22
 
 The multivariate statistical cluster from the 2026-08 audit triage (#513).
@@ -3475,7 +3499,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.71.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.73.0...HEAD
+[1.73.0]: https://github.com/kgdunn/process-improve/compare/v1.72.0...v1.73.0
 [1.71.0]: https://github.com/kgdunn/process-improve/compare/v1.70.0...v1.71.0
 [1.70.0]: https://github.com/kgdunn/process-improve/compare/v1.69.0...v1.70.0
 [1.69.0]: https://github.com/kgdunn/process-improve/compare/v1.68.0...v1.69.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.71.0
-date-released: "2026-08-22"
+version: 1.73.0
+date-released: "2026-08-29"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.71.0"
+version = "1.73.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ batch = [
 ]
 
 # MCP server entry-point.
-mcp = ["mcp>=1.0"]
+mcp = ["mcp>=2.0"]
 
 # JIT-compiled inner loops in ``process_improve.batch.alignment_helpers``.
 # Without numba the module still imports and runs; the ``@jit`` decorator
@@ -92,7 +92,7 @@ ilp = ["pulp>=2.8"]
 # Meta extra: reproduces the pre-ENG-13 install closure.
 all = [
     "matplotlib>=3.10.8",
-    "mcp>=1.0",
+    "mcp>=2.0",
     "numba>=0.63.1",
     "openpyxl>=3.1.5",
     "plotly>=6.5.2",

--- a/src/process_improve/mcp_server.py
+++ b/src/process_improve/mcp_server.py
@@ -36,7 +36,9 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.tools import Tool
+from mcp.server.mcpserver.utilities.func_metadata import ArgModelBase, FuncMetadata
 
 from process_improve.config import settings
 from process_improve.tool_safety import ToolSafetyError, safe_execute_tool_call
@@ -44,20 +46,17 @@ from process_improve.tool_spec import discover_tools, execute_tool_call, get_too
 
 logger = logging.getLogger(__name__)
 
+_INSTRUCTIONS = (
+    "Process improvement tools: robust statistics, multivariate analysis (PCA/PLS), "
+    "control charts, designed experiments, batch process analysis, and regression. "
+    "All tools accept JSON inputs and return JSON outputs."
+)
+
 # Opt-in safety. The default (stdio on the user's own machine) keeps the
 # fast in-process path so local Claude Desktop / Cursor integrations don't
 # pay subprocess overhead. Set ``PROCESS_IMPROVE_MCP_SAFE_MODE=1`` when the
 # server is fronted by HTTP or otherwise reachable from untrusted clients.
 # Reads via ``settings`` so tests can override at runtime (ENG-09 / ENG-27).
-
-mcp = FastMCP(
-    "process-improve",
-    instructions=(
-        "Process improvement tools: robust statistics, multivariate analysis (PCA/PLS), "
-        "control charts, designed experiments, batch process analysis, and regression. "
-        "All tools accept JSON inputs and return JSON outputs."
-    ),
-)
 
 
 def _serialise_tool_error(exc: Exception, tool_name: str) -> str:
@@ -74,19 +73,31 @@ def _serialise_tool_error(exc: Exception, tool_name: str) -> str:
     return json.dumps({"error": "internal error while executing tool", "tool": tool_name})
 
 
-def _register_all_tools() -> None:
-    """Register every ``@tool_spec`` tool as an MCP tool."""
-    discover_tools()
-    specs = get_tool_specs()
-    logger.info("Registering %d tools with MCP server", len(specs))
+class _SchemaPassthroughMetadata(FuncMetadata):
+    """Hand-built ``FuncMetadata`` that skips pydantic argument validation.
 
-    for spec in specs:
-        tool_name = spec["name"]
-        tool_description = spec["description"]
-        tool_schema = spec["input_schema"]
+    Each tool's published ``inputSchema`` comes from the ``@tool_spec``
+    registry, not from a Python signature, so there is no pydantic argument
+    model here to validate against. The arguments are passed through unchanged
+    to :func:`process_improve.tool_spec.execute_tool_call`, which validates
+    them against the tool's real pydantic input model (unknown keys raise
+    ``ToolInputInvalidError`` there; see SEC-15).
+    """
 
-        # Build parameter list from the JSON schema properties
-        _create_mcp_tool(tool_name, tool_description, tool_schema)
+    def validate_arguments(self, arguments_to_validate: dict[str, Any]) -> dict[str, Any]:
+        """Return a shallow copy of the arguments without validating them.
+
+        Parameters
+        ----------
+        arguments_to_validate : dict[str, Any]
+            The raw ``arguments`` dict from the MCP ``tools/call`` request.
+
+        Returns
+        -------
+        dict[str, Any]
+            The same key/value pairs, handed to the handler as ``**kwargs``.
+        """
+        return dict(arguments_to_validate)
 
 
 def _make_tool_handler(tool_name: str) -> Callable[..., Awaitable[str]]:
@@ -94,10 +105,10 @@ def _make_tool_handler(tool_name: str) -> Callable[..., Awaitable[str]]:
 
     ENG-30: the tool execution path is synchronous (in safe mode it blocks on a
     ``ProcessPoolExecutor`` future; otherwise it runs the tool in-process). To
-    avoid blocking the FastMCP event loop - which would serialise concurrent
-    requests when the server is fronted by HTTP / SSE - the blocking call is
-    offloaded to a worker thread via ``run_in_executor``. Single-call behaviour
-    is unchanged.
+    avoid blocking the MCP server's event loop - which would serialise
+    concurrent requests when the server is fronted by HTTP / SSE - the blocking
+    call is offloaded to a worker thread via ``run_in_executor``. Single-call
+    behaviour is unchanged.
     """
 
     async def handler(**kwargs: Any) -> str:  # noqa: ANN401
@@ -118,55 +129,63 @@ def _make_tool_handler(tool_name: str) -> Callable[..., Awaitable[str]]:
     return handler
 
 
-def _create_mcp_tool(
-    tool_name: str,
-    tool_description: str,
-    tool_schema: dict[str, Any],
-) -> None:
-    """Create and register a single MCP tool that delegates to execute_tool_call."""
-    handler = _make_tool_handler(tool_name)
+def _build_tool(spec: dict[str, Any]) -> Tool:
+    """Build one MCP ``Tool`` whose published ``inputSchema`` is the registry's schema.
 
-    # Set proper function metadata for FastMCP
-    handler.__name__ = tool_name
-    handler.__doc__ = tool_description
-    handler.__qualname__ = tool_name
+    The tool is constructed directly (not via ``Tool.from_function``) so the
+    ``parameters`` field - which the server publishes verbatim as the tool's
+    ``inputSchema`` - is exactly ``spec["input_schema"]``: parameter types,
+    required vs optional, enums, bounds, and ``anyOf`` unions all survive
+    (issue #506). Signature introspection of the generic ``(**kwargs)``
+    handler could not synthesise any of that.
 
-    # Build parameter annotations from JSON schema for FastMCP introspection
-    properties = tool_schema.get("properties", {})
-    required = set(tool_schema.get("required", []))
+    Parameters
+    ----------
+    spec : dict[str, Any]
+        One entry from :func:`process_improve.tool_spec.get_tool_specs`, with
+        ``"name"``, ``"description"``, and ``"input_schema"`` keys.
 
-    # Create type annotations mapping
-    type_map = {
-        "number": float,
-        "integer": int,
-        "string": str,
-        "boolean": bool,
-        "array": list,
-        "object": dict,
-    }
+    Returns
+    -------
+    Tool
+        The MCP tool registration object, ready to hand to ``MCPServer``.
+    """
+    return Tool(
+        fn=_make_tool_handler(spec["name"]),
+        name=spec["name"],
+        title=None,
+        description=spec["description"],
+        parameters=spec["input_schema"],
+        fn_metadata=_SchemaPassthroughMetadata(arg_model=ArgModelBase),
+        is_async=True,
+        context_kwarg=None,
+        annotations=None,
+    )
 
-    annotations: dict[str, Any] = {}
-    defaults: dict[str, Any] = {}
 
-    for param_name, param_spec in properties.items():
-        param_type = param_spec.get("type", "string")
-        annotations[param_name] = type_map.get(param_type, Any)
-        if param_name not in required:
-            # Provide a sentinel default for optional params
-            defaults[param_name] = None
+def create_server() -> MCPServer:
+    """Create the MCP server with every ``@tool_spec`` tool registered.
 
-    handler.__annotations__ = annotations
-    if defaults:
-        handler.__defaults__ = tuple(defaults.values())
-
-    # Register with FastMCP using the low-level add_tool
-    mcp.tool(name=tool_name, description=tool_description)(handler)
+    Returns
+    -------
+    MCPServer
+        A server whose ``list_tools()`` publishes, for each registered tool,
+        the same ``input_schema`` that
+        :func:`process_improve.tool_spec.get_tool_specs` reports.
+    """
+    discover_tools()
+    specs = get_tool_specs()
+    logger.info("Registering %d tools with MCP server", len(specs))
+    return MCPServer(
+        "process-improve",
+        instructions=_INSTRUCTIONS,
+        tools=[_build_tool(spec) for spec in specs],
+    )
 
 
 def main() -> None:
     """Entry point for the MCP server."""
-    _register_all_tools()
-    mcp.run()
+    create_server().run()
 
 
 if __name__ == "__main__":

--- a/src/process_improve/multivariate/_base.py
+++ b/src/process_improve/multivariate/_base.py
@@ -9,7 +9,7 @@ rename ``__getattr__``. This module factors that out:
 * :class:`_RenameGetattrMixin` - the migration ``__getattr__`` driven by a
   per-class ``_ATTRIBUTE_RENAMES`` dict and ``_RENAME_CONTEXT`` label.
 * :class:`_HotellingsT2LimitMixin` - the ``hotellings_t2_limit`` method shared,
-  byte-identically, by PCA / PLS / MBPLS / MBPCA (it reads ``self.n_components``
+  byte-identically, by PCA / PLS / MBPLS / MBPCA (it reads ``self.n_components_``
   and ``self.n_samples_``).
 * :class:`_LatentVariableModel` - the PCA/PLS convenience-method surface plus
   ``ellipse_coordinates``.
@@ -165,19 +165,19 @@ class _RenameGetattrMixin:
 class _HotellingsT2LimitMixin:
     """The ``hotellings_t2_limit`` method shared by PCA / PLS / MBPLS / MBPCA.
 
-    Reads ``self.n_components`` and ``self.n_samples_``; identical across those
+    Reads ``self.n_components_`` and ``self.n_samples_``; identical across those
     four estimators. (TPLS reads a differently-named row count and keeps its own.)
     """
 
     if typing.TYPE_CHECKING:  # fitted attributes provided by concrete subclasses
-        n_components: int
+        n_components_: int
         n_samples_: int
 
     def hotellings_t2_limit(self, conf_level: float = 0.95) -> float:
         """Hotelling's T2 limit at the given confidence level (see :func:`hotellings_t2_limit`)."""
         return _hotellings_t2_limit(
             conf_level=conf_level,
-            n_components=self.n_components,
+            n_components=self.n_components_,
             n_rows=self.n_samples_,
         )
 
@@ -240,7 +240,7 @@ class _LatentVariableModel(_RenameGetattrMixin, _HotellingsT2LimitMixin, BaseEst
             score_vert=score_vert,
             conf_level=conf_level,
             n_points=n_points,
-            n_components=self.n_components,
+            n_components=self.n_components_,
             scaling_factor_for_scores=self.scaling_factor_for_scores_,
             n_rows=self.n_samples_,
         )

--- a/src/process_improve/multivariate/_limits.py
+++ b/src/process_improve/multivariate/_limits.py
@@ -90,7 +90,7 @@ def spe_limit(model: BaseEstimator, conf_level: float = 0.95) -> float:
     check_is_fitted(model, "spe_")
 
     return spe_calculation(
-        spe_values=model.spe_.iloc[:, model.n_components - 1],
+        spe_values=model.spe_.iloc[:, model.n_components_ - 1],
         conf_level=conf_level,
     )
 

--- a/src/process_improve/multivariate/_mbpca.py
+++ b/src/process_improve/multivariate/_mbpca.py
@@ -235,6 +235,10 @@ class MBPCA(_HotellingsT2LimitMixin, TransformerMixin, BaseEstimator):
         # single-block estimator.
         self.feature_names_in_ = np.concatenate([self._block_columns[name].to_numpy() for name in self.block_names_])
         n_components = int(self.n_components)
+        # Fitted mirror of the constructor parameter, so shared helpers (the
+        # T2 limit mixin, spe_limit, the plot pre-checks) read one resolved
+        # attribute across PCA / PLS / MBPCA / MBPLS (#505).
+        self.n_components_ = n_components
         n_blocks = len(self.block_names_)
 
         self.has_missing_data_ = any(np.any(X[name].isna().values) for name in self.block_names_)

--- a/src/process_improve/multivariate/_mbpls.py
+++ b/src/process_improve/multivariate/_mbpls.py
@@ -272,6 +272,10 @@ class MBPLS(_HotellingsT2LimitMixin, RegressorMixin, BaseEstimator):
         # single-block estimator.
         self.feature_names_in_ = np.concatenate([self._block_columns[name].to_numpy() for name in self.block_names_])
         n_components = int(self.n_components)
+        # Fitted mirror of the constructor parameter, so shared helpers (the
+        # T2 limit mixin, spe_limit, the plot pre-checks) read one resolved
+        # attribute across PCA / PLS / MBPCA / MBPLS (#505).
+        self.n_components_ = n_components
         n_blocks = len(self.block_names_)
 
         self.has_missing_data_ = any(np.any(X[name].isna().values) for name in self.block_names_) or bool(

--- a/src/process_improve/multivariate/_opls.py
+++ b/src/process_improve/multivariate/_opls.py
@@ -75,6 +75,9 @@ class OPLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator
 
     Attributes (after fitting)
     --------------------------
+    n_components_ : int
+        The fitted component count: one predictive plus
+        ``n_orthogonal_components`` orthogonal components.
     predictive_scores_ : pd.DataFrame of shape (n_samples, 1)
         Predictive score ``t_p``.
     predictive_weights_ : pd.Series of length n_features
@@ -130,7 +133,7 @@ class OPLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator
     (4, 1)
     """
 
-    _ATTRIBUTE_RENAMES: typing.ClassVar[dict[str, str]] = {}
+    _ATTRIBUTE_RENAMES: typing.ClassVar[dict[str, str]] = {"n_components": "n_components_"}
     _RENAME_CONTEXT: typing.ClassVar[str] = "OPLS"
 
     # Lazily-built DataFrame views over the private ndarrays (ENG-18), matching
@@ -210,7 +213,10 @@ class OPLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator
         n_ortho = int(self.n_orthogonal_components)
         if n_ortho < 0:
             raise ValueError("n_orthogonal_components must be >= 0.")
-        self.n_components = 1 + n_ortho
+        # Fitted attribute: 1 predictive plus n_ortho orthogonal components.
+        # OPLS has no n_components constructor parameter, so the resolved
+        # count lives only on the fitted attribute (#505).
+        self.n_components_ = 1 + n_ortho
 
         self._x_scaler: MCUVScaler | None = None
         self._y_scaler: MCUVScaler | None = None
@@ -301,7 +307,7 @@ class OPLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator
         self.x_filtered_ = pd.DataFrame(Xmat @ filt, index=X.index, columns=X.columns)
         x_hat = t_p @ p_p.T + T_o @ P_o.T
         residuals = Xmat - x_hat
-        self._spe = np.sqrt(np.sum(residuals**2, axis=1)).reshape(-1, 1) * np.ones((1, self.n_components))
+        self._spe = np.sqrt(np.sum(residuals**2, axis=1)).reshape(-1, 1) * np.ones((1, self.n_components_))
 
         # Cumulative Hotelling's T2 across the combined score space.
         std = self.scaling_factor_for_scores_.to_numpy()

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -241,6 +241,10 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
 
     Attributes (after fitting)
     --------------------------
+    n_components_ : int
+        The resolved number of components actually fitted (the constructor
+        parameter clamped to ``min(n_samples, n_features)``; the parameter
+        itself is left as the user set it, including ``None``).
     scores_ : pd.DataFrame of shape (n_samples, n_components)
         The score matrix (T).
     loadings_ : pd.DataFrame of shape (n_features, n_components)
@@ -408,7 +412,10 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
                 stacklevel=2,
             )
             A = min_dim
-        self.n_components = A
+        # The resolved (possibly clamped) component count is a fitted attribute;
+        # the constructor parameter n_components is left exactly as the user set
+        # it, per the sklearn clone/get_params contract (#505).
+        self.n_components_ = A
 
         # Detect missing data and resolve algorithm
         self.has_missing_data_ = bool(np.any(X.isna()))
@@ -820,8 +827,8 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
 
         # Hotelling's T² (cumulative)
         component_names = self._component_names
-        t2 = pd.DataFrame(np.zeros((X.shape[0], self.n_components)), columns=component_names, index=X.index)
-        for a in range(self.n_components):
+        t2 = pd.DataFrame(np.zeros((X.shape[0], self.n_components_)), columns=component_names, index=X.index)
+        for a in range(self.n_components_):
             t2.iloc[:, a] = (
                 t2.iloc[:, max(0, a - 1)] + (scores.iloc[:, a] / self.scaling_factor_for_scores_.iloc[a]) ** 2
             )

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -175,6 +175,10 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
 
     Attributes (after fitting)
     --------------------------
+    n_components_ : int
+        The resolved number of components actually fitted (the constructor
+        parameter clamped to ``min(n_samples, n_features)``; the parameter
+        itself is left as the user set it, including ``None``).
     scores_ : pd.DataFrame of shape (n_samples, n_components)
         X-block score matrix (T). This is the primary score matrix; equivalent
         to ``x_scores`` in older versions.
@@ -684,19 +688,26 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
                 f"the number of columns ({K})."
             )
             warnings.warn(warn, SpecificationWarning, stacklevel=2)
-            A = self.n_components = min_dim
+            A = min_dim
+        # The resolved (possibly clamped) component count is a fitted attribute;
+        # the constructor parameter n_components is left exactly as the user set
+        # it, per the sklearn clone/get_params contract (#505).
+        self.n_components_ = A
 
+        resolved_mds = self.missing_data_settings
         if np.any(Y.isna()) or np.any(X.isna()):
             self.has_missing_data_ = True
             # Default to the NIPALS path because TSR / PMP for PLS are still
             # NotImplementedError in _fit_nipals; NIPALS handles per-cell NaN
-            # directly via skipna sums inside the NIPALS iterations.
+            # directly via skipna sums inside the NIPALS iterations.  The
+            # resolved settings stay local: mutating the constructor parameter
+            # would leak into clone() (#505).
             default_mds = dict(md_method="nipals", md_tol=epsqrt, md_max_iter=self.max_iter)
             if isinstance(self.missing_data_settings, dict):
                 default_mds.update(self.missing_data_settings)
-            self.missing_data_settings = default_mds
+            resolved_mds = default_mds
 
-        settings = self.missing_data_settings or {
+        settings = resolved_mds or {
             "md_method": "nipals",
             "md_tol": self.tol,
             "md_max_iter": self.max_iter,
@@ -2302,7 +2313,7 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         t2_new = np.asarray(diagnostics.hotellings_t2, dtype=float)
 
         n_samples = self.n_samples_
-        n_components = int(self.n_components)
+        n_components = int(self.n_components_)
 
         # Residual error std per Y variable: prefer the cross-validated RMSE
         # when a cross_validate() result is supplied (calibration RMSE is

--- a/src/process_improve/multivariate/plots.py
+++ b/src/process_improve/multivariate/plots.py
@@ -46,9 +46,26 @@ def _decode_highlight_style(key: str) -> dict:
         ) from exc
 
 
+def _fitted_n_components(model: BaseEstimator) -> int:
+    """Return the resolved component count of a fitted model (or its TPLS parent).
+
+    Reads the fitted ``n_components_`` (#505: the constructor parameter is the
+    user's request and can be ``None``); TPLS sub-model wrappers without one
+    delegate to their ``_parent``.
+    """
+    for candidate in (model, getattr(model, "_parent", None)):
+        if candidate is None:
+            continue
+        if hasattr(candidate, "n_components_"):
+            return int(candidate.n_components_)
+        if getattr(candidate, "n_components", None) is not None:
+            return int(candidate.n_components)
+    raise AttributeError("The model has no fitted n_components_; fit the model first.")
+
+
 def plot_pre_checks(model: BaseEstimator, pc_horiz: int, pc_vert: int, pc_depth: int) -> bool:
     """Check the inputs for the plot functions are valid."""
-    n_components = model.n_components if hasattr(model, "n_components") else model._parent.n_components
+    n_components = _fitted_n_components(model)
     if not 0 < pc_horiz <= n_components:
         raise ValueError(f"The model has {n_components} components. Ensure that 1 <= pc_horiz <= {n_components}.")
     if not 0 < pc_vert <= n_components:
@@ -456,8 +473,9 @@ def spe_plot(  # noqa: C901
     elif with_a == 0:
         raise ValueError("`with_a` must be >= 1, or specified with negative indexing.")
 
-    if not with_a <= model.n_components:
-        raise ValueError(f"`with_a` must be <= the number of components fitted ({model.n_components}); got {with_a}.")
+    n_components = _fitted_n_components(model)
+    if not with_a <= n_components:
+        raise ValueError(f"`with_a` must be <= the number of components fitted ({n_components}); got {with_a}.")
 
     class Settings(BaseModel):
         """Validated display settings for the SPE plot."""
@@ -612,8 +630,9 @@ def t2_plot(  # noqa: C901
     elif with_a == 0:
         raise ValueError("`with_a` must be >= 1, or specified with negative indexing.")
 
-    if not with_a <= model.n_components:
-        raise ValueError(f"`with_a` must be <= the number of components fitted ({model.n_components}); got {with_a}.")
+    n_components = _fitted_n_components(model)
+    if not with_a <= n_components:
+        raise ValueError(f"`with_a` must be <= the number of components fitted ({n_components}); got {with_a}.")
 
     class Settings(BaseModel):
         """Validated display settings for the Hotelling's T2 plot."""

--- a/tests/test_multivariate_contribution_plots.py
+++ b/tests/test_multivariate_contribution_plots.py
@@ -644,3 +644,44 @@ def test_eq4_q_contributions_for_a_multiblock_model(
     from_arrays = model.spe_contributions(as_arrays)
     for name, frame in from_arrays.items():
         assert frame.to_numpy() == pytest.approx(contributions[name].to_numpy(), abs=1e-12)
+
+
+class TestFittedNComponentsResolution:
+    """_fitted_n_components covers the fitted, TPLS-parent, and unfitted paths (#505)."""
+
+    def test_reads_fitted_attribute_first(self) -> None:
+        from process_improve.multivariate.plots import _fitted_n_components
+
+        class Fitted:
+            n_components = None
+            n_components_ = 3
+
+        assert _fitted_n_components(Fitted()) == 3
+
+    def test_delegates_to_tpls_parent(self) -> None:
+        from process_improve.multivariate.plots import _fitted_n_components
+
+        class Parent:
+            n_components_ = 2
+
+        class SubModelWrapper:
+            _parent = Parent()
+
+        assert _fitted_n_components(SubModelWrapper()) == 2
+
+    def test_falls_back_to_integer_constructor_parameter(self) -> None:
+        from process_improve.multivariate.plots import _fitted_n_components
+
+        class TplsLike:
+            n_components = 4  # TPLS stores a plain int and has no n_components_
+
+        assert _fitted_n_components(TplsLike()) == 4
+
+    def test_unfitted_model_raises(self) -> None:
+        from process_improve.multivariate.plots import _fitted_n_components
+
+        class Unfitted:
+            n_components = None
+
+        with pytest.raises(AttributeError, match="fit the model first"):
+            _fitted_n_components(Unfitted())

--- a/tests/test_multivariate_opls.py
+++ b/tests/test_multivariate_opls.py
@@ -113,7 +113,7 @@ def test_opls_scores_shape_and_labels(cheese: tuple[pd.DataFrame, pd.DataFrame])
     opls = OPLS(n_orthogonal_components=2).fit(X, y)
     assert list(opls.scores_.columns) == ["t_predictive", "t_orthogonal_1", "t_orthogonal_2"]
     assert opls.scores_.shape == (X.shape[0], 3)
-    assert opls.n_components == 3
+    assert opls.n_components_ == 3
 
 
 def test_opls_transform_matches_predictive_scores(cheese: tuple[pd.DataFrame, pd.DataFrame]) -> None:

--- a/tests/test_sklearn_compat.py
+++ b/tests/test_sklearn_compat.py
@@ -259,3 +259,91 @@ def test_halving_grid_search_cv_with_mcuvscaler_and_pls() -> None:
     )
     rng_search.fit(X, Y.values.ravel())
     assert rng_search.best_params_["pls__n_components"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# #505: fit() must not mutate constructor parameters (clone contract)
+# ---------------------------------------------------------------------------
+
+
+def _small_xy(n_samples: int = 12, n_features: int = 4, seed: int = 0) -> tuple[pd.DataFrame, pd.DataFrame]:
+    rng = np.random.default_rng(seed)
+    X = pd.DataFrame(rng.normal(size=(n_samples, n_features)))
+    beta = rng.normal(size=(n_features, 1))
+    Y = pd.DataFrame(X.values @ beta + 0.05 * rng.normal(size=(n_samples, 1)))
+    return X, Y
+
+
+def test_pca_fit_leaves_constructor_params_untouched() -> None:
+    """After fit(), get_params() returns exactly what was passed to __init__ (#505)."""
+    X, _ = _small_xy()
+    model = PCA(n_components=None).fit(X)
+    assert model.get_params()["n_components"] is None
+    assert model.n_components is None
+    assert model.n_components_ == min(X.shape)
+
+    with pytest.warns(UserWarning, match="requested number of components"):
+        clamped = PCA(n_components=99).fit(X)
+    assert clamped.get_params()["n_components"] == 99
+    assert clamped.n_components_ == min(X.shape)
+
+
+def test_pls_fit_leaves_constructor_params_untouched() -> None:
+    """PLS keeps n_components and missing_data_settings as the user set them (#505)."""
+    X, Y = _small_xy()
+    X_missing = X.copy()
+    X_missing.iloc[0, 0] = np.nan
+    requested = {"md_max_iter": 250}
+    model = PLS(n_components=2, missing_data_settings=dict(requested)).fit(X_missing, Y)
+    assert model.get_params()["n_components"] == 2
+    assert model.get_params()["missing_data_settings"] == requested
+    assert model.missing_data_settings == requested
+    assert model.n_components_ == 2
+
+    with pytest.warns(UserWarning, match="requested number of components"):
+        clamped = PLS(n_components=99).fit(X, Y)
+    assert clamped.get_params()["n_components"] == 99
+    assert clamped.n_components_ == min(X.shape)
+
+
+def test_clone_reproduces_requested_configuration_after_fit() -> None:
+    """clone() of a fitted estimator carries the request, not the resolved value (#505)."""
+    X, Y = _small_xy()
+    with pytest.warns(UserWarning, match="requested number of components"):
+        parent = PLS(n_components=99).fit(X, Y)
+    cloned = clone(parent)
+    assert cloned.get_params()["n_components"] == 99
+
+    pca_parent = PCA(n_components=None).fit(X)
+    assert clone(pca_parent).get_params()["n_components"] is None
+
+
+def test_refit_resolves_component_count_per_dataset() -> None:
+    """Fitting the same instance twice on different shapes re-derives the clamp (#505)."""
+    rng = np.random.default_rng(1)
+    model = PCA(n_components=None)
+    model.fit(pd.DataFrame(rng.normal(size=(10, 3))))
+    assert model.n_components_ == 3
+    model.fit(pd.DataFrame(rng.normal(size=(10, 6))))
+    assert model.n_components_ == 6
+    assert model.n_components is None
+
+
+def test_cross_validate_submodels_use_requested_n_components() -> None:
+    """cross_validate() resamples fit the user's requested configuration (#505)."""
+    X, Y = _small_xy(n_samples=20)
+    model = PLS(n_components=2).fit(X, Y)
+    seen: list[int | None] = []
+    original_fit = PLS.fit
+
+    def spy_fit(self: PLS, *args: object, **kwargs: object) -> PLS:
+        seen.append(self.get_params()["n_components"])
+        return original_fit(self, *args, **kwargs)
+
+    PLS.fit = spy_fit  # type: ignore[method-assign]
+    try:
+        model.cross_validate(X, Y, cv=3, random_state=0, show_progress=False)
+    finally:
+        PLS.fit = original_fit  # type: ignore[method-assign]
+    assert seen, "cross_validate() fitted no sub-models"
+    assert all(value == 2 for value in seen)


### PR DESCRIPTION
## Summary

- Fixes #505: `fit()` no longer writes the resolved component count (or, in PLS, the resolved missing-data settings) back onto constructor parameters. The resolved value is the new fitted attribute `n_components_`; `n_components` stays exactly what the user passed, including `None`, so `get_params`/`clone`/`PLS.cross_validate` resamples fit the requested configuration and refitting one instance on differently shaped data re-derives the clamp each time. Clamping logic and its `SpecificationWarning` are unchanged, per the issue's non-goals.
- Internal post-fit readers migrated to `n_components_`: the shared Hotelling's T2 limit mixin and `ellipse_coordinates` in `_base.py`, `spe_limit` in `_limits.py`, the plot pre-checks in `plots.py` (new `_fitted_n_components` helper that also handles the TPLS `_parent` wiring), PCA's `hotellings_t2`, and PLS `prediction_interval`. MBPCA/MBPLS now also set `n_components_` in `fit()` so those shared helpers read one attribute across all four estimators.
- OPLS (which has no `n_components` constructor parameter) exposes the fitted count only as `n_components_` and maps the old attribute name to a helpful rename message via its existing `_ATTRIBUTE_RENAMES` machinery.

All four acceptance criteria from the issue are covered by new tests in `tests/test_sklearn_compat.py`: `get_params()` round-trip after fit (including `None`), `clone()` reproduces the request, refit on different shapes resolves independently, and a spy on `PLS.fit` pins that every `cross_validate` sub-model is constructed with the user's requested `n_components`.

Version 1.73.0 (MINOR: post-fit meaning of `n_components` changes; assumes queued PR #524 merges first, trivial rebase otherwise).

## Test plan

- [x] New #505 acceptance tests in `tests/test_sklearn_compat.py` (20 passed)
- [x] `uv run pytest tests/test_multivariate.py tests/test_multivariate_opls.py tests/test_sklearn_compat.py tests/test_multivariate_contribution_plots.py tests/test_audit_regressions_multivariate.py --no-cov`: 269 passed, 2 pre-existing skips
- [x] `uv run pytest tests/test_multiblock_reference.py tests/test_multiblock_oracles.py tests/test_multivariate_tpls_display.py tests/test_multivariate_adaptive.py tests/test_multivariate_tpls_feature_importance.py --no-cov`: 154 passed
- [x] `ruff check` and `ruff format --check` clean; `mypy src/process_improve` shows only the pre-existing `mcp_server.py` FastMCP error unrelated to this diff

## Checklist

- [x] Version bumped in `pyproject.toml` (PATCH for fixes/docs/config, MINOR for new features)
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated

---
_Generated by [Claude Code](https://claude.ai/code/session_019C3XXbJkuSYH9fMryLqNcU)_