### PR TITLE
Signal-ladder API renames, and two real defects the naming proposal missed (2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,86 @@ those changes.
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-30
+
+Renames the functions that answer "is this relationship real, or is it noise?"
+so their names state the question rather than the technique, and fixes two
+naming defects the rename exposed.
+
+**No deprecation cycle.** `CONTRIBUTING.md` requires one for breaking changes;
+this release deliberately departs from that. The two multivariate names were
+added in 1.76.0, one release and one day before this one, and nothing depends
+on them yet, so warning shims would have carried dead weight to 2.0.0 for names
+nobody could have adopted. Every removed name raises `AttributeError` naming its
+replacement, following the migration-helper pattern already used in
+`process_improve.univariate.metrics`.
+
+### Removed
+
+- **`permutation_q2`** in `process_improve.multivariate`, renamed to
+  `check_predictive_signal`.
+- **`pipeline_null`** in `process_improve.multivariate`, renamed to
+  `count_discoveries_under_null`. "Pipeline" collided with
+  `sklearn.pipeline.Pipeline`, which it has nothing to do with, and "null" read
+  as a missing value.
+- **`discriminate_observational`** in `process_improve.sensory`, renamed to
+  `find_predictive_descriptors`. "Discriminate" read as discriminant analysis;
+  the function selects descriptors, it does not assign observations to classes.
+- The `q_value` field on the descriptor records of that function, renamed to
+  `p_value_fwer`; the `discriminator_significant` field, renamed to
+  `is_predictive`; the `empirical_fdr` key returned by the pipeline null,
+  renamed to `null_to_observed_ratio`.
+- The `discriminator=` keyword on `relate_observational`,
+  `analyze_descriptive` and the `sensory_analyze_descriptive` tool, renamed to
+  `find_predictive=`; the `result.relate["discriminator"]` key, renamed to
+  `result.relate["predictive_descriptors"]`.
+
+### Added
+
+- **`check_predictive_signal`** takes `x` and `y` first and makes `fit_predict`
+  optional, defaulting to leave-one-out cross-validated PLS with `n_components`.
+  The default receives the raw blocks so every fold derives its own centring and
+  scaling constants, which is the trap the parameter documentation warns callers
+  about. Its docstring now quantifies the cost: an out-of-sample null refits once
+  per fold per permutation, so leave-one-out on twenty products at the default
+  `n_perm=500` is ten thousand fits.
+
+### Changed
+
+- **`null_to_observed_ratio` is no longer clipped to `[0, 1]`.** The old
+  `empirical_fdr` reported 1.0 whenever shuffling found at least as much as the
+  real response did. That is the single most informative reading the function
+  can produce, and clipping rounded it away behind a number that looked like a
+  well-behaved rate.
+- `find_predictive_descriptors` documents that its multiplicity correction is
+  **within an attribute, not across attributes**: the max-statistic null is
+  rebuilt per attribute, so on a panel of `A` attributes at `alpha` roughly
+  `alpha * A` are expected to yield a spurious family. Documented, not changed;
+  closing the gap would change results and belongs on its own.
+- `q2_cv > 0.0` in the same function is annotated as what it is: a cheap,
+  deliberately uncalibrated pre-screen that decides whether the permutation loop
+  is worth running, ANDed with the calibrated p-value and the jackknife flag.
+  Passing it cannot make a descriptor a finding.
+- `permutation_column_null` and `find_predictive_descriptors` now cross-
+  reference each other, stating that the first is a block-level screen over one
+  multi-response fit and the second is per-attribute with family-wise error
+  control, so the choice between them is explicit.
+- `class_enrichment` keeps its name. The module docstring now says why: it
+  already states its question, and it tests a ranking you supply rather than a
+  model this module fits.
+
+### Fixed
+
+- **`find_predictive_descriptors` claimed a correction it never applied.** Its
+  docstring said the permutation p-value was Benjamini-Hochberg corrected across
+  the whole family. The code builds a max-statistic (Westfall-Young) null, as its
+  own inline comment says; `_attach_fdr`, the real BH helper, is only ever called
+  from `relate_observational`.
+- **The field carrying that value was named `q_value`**, FDR vocabulary for a
+  family-wise-error-adjusted p-value. `q_value` in the sibling `associations`
+  list of the same result dict genuinely is a BH q-value, so one key name meant
+  two different quantities. It is now `p_value_fwer`.
+
 ## [1.76.0] - 2026-08-29
 
 ### Added
@@ -3884,7 +3964,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.76.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/kgdunn/process-improve/compare/v1.76.0...v2.0.0
 [1.76.0]: https://github.com/kgdunn/process-improve/compare/v1.75.2...v1.76.0
 [1.75.2]: https://github.com/kgdunn/process-improve/compare/v1.75.1...v1.75.2
 [1.75.1]: https://github.com/kgdunn/process-improve/compare/v1.75.0...v1.75.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.76.0
-date-released: "2026-08-29"
+version: 2.0.0
+date-released: "2026-08-30"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/docs/user_guide/permutation_nulls.rst
+++ b/docs/user_guide/permutation_nulls.rst
@@ -43,13 +43,9 @@ performance.
 
 .. code-block:: python
 
-   from process_improve.multivariate import permutation_q2
+   from process_improve.multivariate import check_predictive_signal
 
-   def fit_predict(x, y):
-       """Return out-of-sample predictions, one row per product."""
-       ...  # your own CV loop; see the two responsibilities below
-
-   permutation_q2(fit_predict, chem_scaled, sensory_means, n_perm=999)
+   check_predictive_signal(chem, sensory_means, n_perm=999)
 
 .. code-block:: text
 
@@ -61,8 +57,27 @@ performance.
 ``green`` sits inside its own null. That is a distinction the VIP count above
 cannot draw.
 
-Two things :func:`~process_improve.multivariate.permutation_q2` leaves to you,
-inside ``fit_predict``:
+Note the blocks go in **unscaled**. The default cross-validates PLS for you and
+re-derives the centring and scaling constants inside every fold, which is the
+second of the two traps below; scaling first would hand each fold constants
+computed from the row it is meant to be predicting.
+
+This is expensive, and irreducibly so: every permutation refits once per fold,
+so leave-one-out on twenty products with ``n_perm=999`` is twenty thousand fits.
+Develop at ``n_perm=50`` and raise it for the number you intend to report.
+
+Pass your own ``fit_predict`` to use a different model or a cheaper fold scheme:
+
+.. code-block:: python
+
+   def fit_predict(x, y):
+       """Return out-of-sample predictions, one row per product."""
+       ...  # your own CV loop; see the two responsibilities below
+
+   check_predictive_signal(chem, sensory_means, fit_predict, n_perm=999)
+
+Two things :func:`~process_improve.multivariate.check_predictive_signal` then
+leaves to you, inside ``fit_predict``:
 
 * **The cross-validation scheme is yours to choose.** Leave-one-out is right
   when every product is precious, and needlessly expensive at hundreds of rows,
@@ -90,17 +105,22 @@ attributes needs a floor well below the corrected threshold.
 Testing the whole procedure, not one model
 ------------------------------------------
 
-:func:`~process_improve.multivariate.pipeline_null` takes a callable that runs
-filtering, transformation, scaling and selection end to end, and counts
-discoveries under a permuted response:
+:func:`~process_improve.multivariate.count_discoveries_under_null` takes a
+callable that runs filtering, transformation, scaling and selection end to end,
+and counts discoveries under a permuted response:
 
 .. code-block:: python
 
-   >>> result = pipeline_null(select, chem, sensory_means, n_perm=200)
-   >>> result["observed"], result["null_mean"], result["empirical_fdr"]
+   >>> result = count_discoveries_under_null(select, chem, sensory_means, n_perm=200)
+   >>> result["observed"], result["null_mean"], result["null_to_observed_ratio"]
    (9, 1.8, 0.2)
 
-That FDR is a property of the procedure **as run**, which is the only version
+``null_to_observed_ratio`` is not clipped. A value above 1 says shuffling found
+*more* than the real response did, which is the strongest evidence the procedure
+has nothing, and it is precisely the case worth seeing rather than rounding to a
+tidy-looking rate.
+
+That ratio is a property of the procedure **as run**, which is the only version
 worth quoting: a procedure whose selection step is honest but whose filtering
 step peeked at the response has an FDR no formula recovers.
 

--- a/docs/user_guide/sensory_panel.rst
+++ b/docs/user_guide/sensory_panel.rst
@@ -159,8 +159,8 @@ The observational relate output is:
 - ``result.relate["associations"]`` gives the per-(attribute, descriptor)
   correlation with a raw p-value, a Benjamini-Hochberg ``q_value`` across the
   whole family of tests, and a ``significant`` flag.
-- ``result.relate["discriminator"]`` adds the out-of-sample evidence described
-  in the next section.
+- ``result.relate["predictive_descriptors"]`` adds the out-of-sample evidence
+  described in the next section.
 
 The result also carries supporting context: ``result.product_means`` (each
 product-by-attribute mean with a confidence interval) and ``result.pca`` (a PCA
@@ -169,20 +169,21 @@ sensory map of the products over the attributes).
 The designed-mode relate (factor *effects* rather than associations) is planned;
 ``mode="designed"`` raises ``NotImplementedError`` for now.
 
-Telling genuine drivers from proxies: the discriminator
--------------------------------------------------------
+Telling genuine drivers from proxies: the predictive descriptors
+-----------------------------------------------------------------
 
 The ``associations`` table reports *marginal* correlations: each
 attribute-descriptor pair on its own. A pair can be significant for three
 different reasons, which a marginal correlation cannot tell apart: the
 descriptor genuinely drives the attribute; the descriptor only rides on a
 genuine driver (a proxy); or the descriptor happens to line up with the
-attribute in this particular set of products (a coincidence). The
-``discriminator`` adds out-of-sample evidence to separate these:
+attribute in this particular set of products (a coincidence).
+:func:`~process_improve.sensory.find_predictive_descriptors` adds out-of-sample
+evidence to separate these:
 
 - a per-attribute **cross-validated** :math:`Q^2` (leave-one-out): is the
   attribute predictable from the descriptor block at all, on products the model
-  did not see? ``result.relate["discriminator"]["per_attribute"]`` reports
+  did not see? ``result.relate["predictive_descriptors"]["per_attribute"]`` reports
   ``q2_cv`` and a ``predictable`` flag. A coincidence does not predict held-out
   products, so its attribute often fails this gate.
 - a **selectivity ratio** per descriptor, computed on the *target-projected*
@@ -191,22 +192,40 @@ attribute in this particular set of products (a coincidence). The
   predictive direction explains; unlike the marginal correlation it is judged
   *given the other descriptors*, so a descriptor that adds nothing beyond the
   real drivers scores low. Significance is assessed with a permutation test that
-  controls for testing many descriptors at once (a max-statistic null), gated on
-  the attribute being predictable. ``result.relate["discriminator"]["descriptors"]``
-  reports ``selectivity_ratio``, a permutation ``q_value`` and a
-  ``discriminator_significant`` flag.
+  controls for testing many descriptors at once (a max-statistic, or
+  Westfall-Young, null), gated on the attribute being predictable.
+  ``result.relate["predictive_descriptors"]["descriptors"]`` reports
+  ``selectivity_ratio``, the raw permutation ``p_value``, the adjusted
+  ``p_value_fwer`` and an ``is_predictive`` flag.
+
+  .. important::
+
+     That adjustment is **within an attribute, not across attributes**. The
+     max-statistic null is rebuilt for each attribute over its own descriptors,
+     so ``p_value_fwer`` controls the family-wise error rate for that
+     attribute's descriptor family alone. On a panel of :math:`A` attributes at
+     ``alpha``, roughly :math:`\alpha A` attributes are expected to throw up a
+     spurious family by chance. Read one flagged descriptor on a wide panel with
+     that in mind.
 - a **collinear cluster id** per descriptor (``cluster_id``): descriptors whose
   absolute correlation exceeds a threshold are grouped. Two descriptors in the
-  same cluster carry the same information, so they predict equally well and the
-  discriminator keeps them both. This is the honest limit of an observational
+  same cluster carry the same information, so they predict equally well and
+  both are kept. This is the honest limit of an observational
   analysis: it can report that a group of descriptors is predictive, but it
   cannot say *which one* inside a collinear cluster is the cause. Separating
   them needs an external dataset that breaks the collinearity, a designed
   experiment, or mechanistic knowledge.
 
-So the discriminator demotes coincidences (they fail the gate or the
+So the search demotes coincidences (they fail the gate or the
 selectivity-ratio test) and groups proxies with their driver, but it does not,
 and cannot, rank descriptors within a collinear cluster.
+
+To screen a wide descriptor block *before* committing to this per-attribute
+work, :func:`~process_improve.sensory.permutation_column_null` fits a single
+multi-response PLS over the whole attribute block and returns one record per
+descriptor, against a knockoff null. It answers "which descriptors matter for
+the panel as a whole"; use it to triage, and this function when the answer has
+to name an attribute.
 
 Under the hood, the two predictive-importance steps are the standalone
 diagnostics :func:`~process_improve.multivariate.target_projection` and
@@ -491,14 +510,15 @@ correlates with Liking (r about -0.67) purely by chance in these eighteen
 products. A within-sample correlation on its own cannot tell these three cases
 apart.
 
-**Step 5, discriminate.** The discriminator adds the out-of-sample evidence.
+**Step 5, find the predictive descriptors.** This adds the out-of-sample
+evidence.
 
 .. code-block:: python
 
-   disc = result.relate["discriminator"]
+   disc = result.relate["predictive_descriptors"]
    gate = pd.DataFrame(disc["per_attribute"])      # cross-validated Q-squared per attribute
    drivers = pd.DataFrame(disc["descriptors"])     # selectivity ratio, q-value, cluster id
-   print(drivers[drivers["discriminator_significant"]])
+   print(drivers[drivers["is_predictive"]])
 
 It narrows the sixteen marginal hits to twelve:
 
@@ -510,7 +530,7 @@ It narrows the sixteen marginal hits to twelve:
   while the genuine ``brix`` and ``price`` for Liking remain significant. This is
   the coincidence caught.
 - ``brix``, ``refractive_index`` and ``specific_gravity`` all stay significant
-  for Sweetness and share one ``cluster_id``. The discriminator reports them as a
+  for Sweetness and share one ``cluster_id``. They are reported as a
   single inseparable group: from these data you cannot say which of the three is
   the cause, because each carries the same information.
 
@@ -539,8 +559,7 @@ and covariate tables as lists of row-records and returning JSON:
   with ``align=true``, the rescaled panel.
 - ``sensory_analyze_descriptive`` - the full pipeline, with a ``correction``
   option (``"none"`` / ``"align"`` / ``"drop"``), the MAM results, and (unless
-  ``discriminator`` is set false) the cross-validated discriminator in its
-  output.
+  ``find_predictive`` is set false) the predictive descriptors in its output.
 
 The analyze tool validates first and refuses to run if validation fails, so an
 agent cannot skip the gate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.76.0"
+version = "2.0.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/__init__.py
+++ b/src/process_improve/multivariate/__init__.py
@@ -1,5 +1,7 @@
 """Multivariate analysis: PCA, PLS, TPLS, scaling, and diagnostic plots."""
 
+from typing import NoReturn
+
 from process_improve.multivariate.methods import (
     OPLS,
     PCA,
@@ -9,12 +11,12 @@ from process_improve.multivariate.methods import (
     AdaptivePLS,
     MCUVScaler,
     center,
+    check_predictive_signal,
     class_enrichment,
+    count_discoveries_under_null,
     eigenvalue_summary,
     group_contributions,
     observation_contributions,
-    permutation_q2,
-    pipeline_null,
     project_variables,
     rv2_coefficient,
     rv_coefficient,
@@ -45,16 +47,16 @@ __all__ = [
     "AdaptivePLS",
     "MCUVScaler",
     "center",
+    "check_predictive_signal",
     "class_enrichment",
     "coefficient_plot",
     "correlation_loadings_plot",
+    "count_discoveries_under_null",
     "eigenvalue_summary",
     "explained_variance_plot",
     "group_contributions",
     "loading_plot",
     "observation_contributions",
-    "permutation_q2",
-    "pipeline_null",
     "predictions_vs_observed_plot",
     "project_variables",
     "rv2_coefficient",
@@ -69,3 +71,20 @@ __all__ = [
     "t2_plot",
     "vip",
 ]
+
+# ---------------------------------------------------------------------------
+# Migration helpers - old names raise helpful errors
+# ---------------------------------------------------------------------------
+
+_RENAMED = {
+    "permutation_q2": "check_predictive_signal",
+    "pipeline_null": "count_discoveries_under_null",
+}
+
+
+def __getattr__(name: str) -> NoReturn:
+    """Raise a helpful error when a renamed module attribute is accessed."""
+    if name in _RENAMED:
+        new = _RENAMED[name]
+        raise AttributeError(f"{name!r} has been renamed to {new!r}. Use: from {__name__} import {new}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/process_improve/multivariate/_diagnostics.py
+++ b/src/process_improve/multivariate/_diagnostics.py
@@ -88,11 +88,11 @@ def vip(model: BaseEstimator, n_components: int | None = None) -> pd.Series:
     false-discovery rate near 100% on data that genuinely contains signal. If
     you want to ask "is there anything here at all", permute the response and
     compare *out-of-sample* performance instead. See
-    :func:`~process_improve.multivariate.permutation_q2`.
+    :func:`~process_improve.multivariate.check_predictive_signal`.
 
     See Also
     --------
-    process_improve.multivariate.permutation_q2 :
+    process_improve.multivariate.check_predictive_signal :
         A permutation null on Q² that does respond to signal.
 
     Examples

--- a/src/process_improve/multivariate/_null.py
+++ b/src/process_improve/multivariate/_null.py
@@ -13,18 +13,22 @@ false-discovery rate near 100% on data that does contain signal.
 
 What does work is asking a permutation what it can achieve:
 
-* :func:`permutation_q2` permutes the response across products, refits, and
-  compares observed *out-of-sample* performance with what random reassignment
-  reaches. Out-of-sample is what makes it bite; the same test on in-sample
-  :math:`R^2` would mostly measure model capacity.
-* :func:`pipeline_null` does the same for a whole selection procedure, counting
-  discoveries under a permuted response, which gives an empirical
-  false-discovery rate for the procedure as run rather than for a model in
-  isolation.
+* :func:`check_predictive_signal` permutes the response across products,
+  refits, and compares observed *out-of-sample* performance with what random
+  reassignment reaches. Out-of-sample is what makes it bite; the same test on
+  in-sample :math:`R^2` would mostly measure model capacity. Ask this first: if
+  it fails, nothing below can rescue the analysis.
+* :func:`count_discoveries_under_null` does the same for a whole selection
+  procedure, counting discoveries under a permuted response, which audits the
+  procedure as run rather than a model in isolation.
 * :func:`class_enrichment` asks whether a chemically expected class of compounds
   sits at the top of a ranking more often than chance allows. At small sample
   sizes this is frequently the stronger evidence: recovering the right class for
-  an attribute is structure that noise does not produce.
+  an attribute is structure that noise does not produce. Its name is unchanged
+  by the question-first naming used for the two functions above, because it
+  already states its question, and because it tests a *ranking* you supply
+  rather than a model this module fits: it sits alongside the pair, not on the
+  same ladder.
 
 References
 ----------
@@ -37,14 +41,16 @@ from __future__ import annotations
 import re
 import warnings
 from collections.abc import Callable, Iterable, Sequence
+from typing import NoReturn
 
 import numpy as np
 import pandas as pd
 from scipy.stats import hypergeom
 
 from ._common import SpecificationWarning
+from ._pls import PLS
 
-__all__ = ["class_enrichment", "permutation_q2", "pipeline_null"]
+__all__ = ["check_predictive_signal", "class_enrichment", "count_discoveries_under_null"]
 
 
 def _as_frame(values: pd.DataFrame | pd.Series | np.ndarray, like: pd.DataFrame) -> pd.DataFrame:
@@ -92,27 +98,59 @@ def _permute_rows(y: pd.DataFrame, rng: np.random.Generator) -> pd.DataFrame:
     return pd.DataFrame(y.to_numpy()[order], index=y.index, columns=y.columns)
 
 
-def permutation_q2(
-    fit_predict: Callable,
+def _loo_fit_predict(n_components: int) -> Callable:
+    """Return the default ``fit_predict``: leave-one-out cross-validated PLS.
+
+    The **raw** blocks are handed to :class:`PLS` with ``scale=True``, so each
+    leave-one-out fold derives its own centring and scaling constants from the
+    training rows only (:meth:`PLS.cross_validate` refits a clone per fold).
+    Scaling the blocks *before* calling this leaks the held-out row's mean and
+    spread into the fold, which is the trap the ``fit_predict`` documentation
+    warns about, so do not pre-scale.
+    """
+
+    def fit_predict(x: pd.DataFrame, y: pd.DataFrame) -> pd.DataFrame:
+        # PLS needs at least one component and cannot use more than the block
+        # supports; leave-one-out also costs a row.
+        a = max(1, min(int(n_components), x.shape[1], x.shape[0] - 2))
+        model = PLS(n_components=a, scale=True).fit(x, y)
+        return model.cross_validate(x, y, cv="loo", show_progress=False).y_hat_cv
+
+    return fit_predict
+
+
+def check_predictive_signal(  # noqa: PLR0913
     x: pd.DataFrame,
     y: pd.DataFrame,
+    fit_predict: Callable | None = None,
+    n_components: int = 2,
     n_perm: int = 500,
     seed: int = 0,
 ) -> pd.DataFrame:
-    """Test observed out-of-sample performance against a permuted response.
+    """Test whether the predictors carry signal, against a shuffled response.
 
-    This is the replacement for a VIP-exceedance null. The question a
+    Ask this before asking which columns carry the signal. The question a
     permutation test can answer is "does this model predict held-out products
     better than it would if the responses were shuffled", and unlike a VIP count
-    the answer responds to whether signal is present.
+    (see :func:`~process_improve.multivariate.vip`) the answer responds to
+    whether signal is present.
 
     Parameters
     ----------
-    fit_predict : callable
+    x : pandas.DataFrame
+        Predictor block, one row per product. Not permuted. Pass it **unscaled**
+        when using the default ``fit_predict``; see below.
+    y : pandas.DataFrame
+        Response block, one row per product and one column per attribute.
+    fit_predict : callable, optional
         ``fit_predict(x, y)`` returning **out-of-sample** predictions with one
         row per row of ``y`` and one column per attribute: a DataFrame, or an
-        array of the same shape. Everything the pipeline does lives inside this
-        callable, and two things about it are the caller's responsibility:
+        array of the same shape.
+
+        The default is leave-one-out cross-validated PLS with ``n_components``,
+        which is the right first thing to try and handles the two traps below
+        for you. Supply your own to use a different model or a cheaper
+        cross-validation scheme, in which case both traps become yours:
 
         * **The cross-validation scheme is yours to choose.** Leave-one-out is
           right when every product is precious and needlessly expensive at
@@ -123,12 +161,12 @@ def permutation_q2(
           and scale the response on the training rows, predict, then
           back-transform with those same training constants before the
           prediction is returned; otherwise the score is computed on a scale the
-          fold never saw.
+          fold never saw. Equivalently: do not scale ``x`` and ``y`` before
+          calling, because the constants would then carry the held-out row.
 
-    x : pandas.DataFrame
-        Predictor block, one row per product. Not permuted.
-    y : pandas.DataFrame
-        Response block, one row per product and one column per attribute.
+    n_components : int, default 2
+        Latent components for the default ``fit_predict``. Ignored when
+        ``fit_predict`` is supplied. Capped at what the block supports.
     n_perm : int, default 500
         Number of permutations. See the note on the p-value floor below.
     seed : int, default 0
@@ -161,6 +199,14 @@ def permutation_q2(
 
     Notes
     -----
+    **This is expensive, and irreducibly so.** Every permutation refits the
+    model once per cross-validation fold, so the default leave-one-out scheme
+    costs ``n_perm * n_products`` fits: on twenty products with the default 500
+    permutations that is ten thousand fits, a few minutes. The cost is the
+    method, not the implementation - an out-of-sample null has to refit to be
+    out-of-sample. Develop with ``n_perm`` around 50, then raise it for the
+    number you intend to report, keeping the p-value floor below in mind.
+
     The p-value uses the ``(1 + count) / (n_perm + 1)`` form, which counts the
     observed statistic as one of its own null draws so the result can never be
     exactly zero. That also puts a floor on it: **the smallest attainable
@@ -169,11 +215,22 @@ def permutation_q2(
     apply in mind, and remember that a multiplicity correction over many
     attributes needs a floor well below the corrected threshold.
 
+    See Also
+    --------
+    count_discoveries_under_null :
+        Audits a whole selection procedure rather than one model.
+
     Examples
     --------
+    The default cross-validates PLS for you, on unscaled blocks:
+
+    >>> check_predictive_signal(chem, sensory_means, n_perm=999)
+
+    Supply your own when the model or the fold scheme has to change:
+
     >>> def fit_predict(x, y):
     ...     return loo_predictions(x, y, n_components=2)  # your own CV loop
-    >>> permutation_q2(fit_predict, chem_scaled, sensory_means, n_perm=999)
+    >>> check_predictive_signal(chem, sensory_means, fit_predict, n_perm=999)
     """
     if not isinstance(x, pd.DataFrame) or not isinstance(y, pd.DataFrame):
         raise TypeError("x and y must both be pandas DataFrames, one row per product.")
@@ -183,6 +240,8 @@ def permutation_q2(
         raise ValueError(f"a permutation null needs at least 2 products; got {len(y)}.")
     if int(n_perm) < 1:
         raise ValueError(f"n_perm must be >= 1; got {n_perm!r}.")
+    if fit_predict is None:
+        fit_predict = _loo_fit_predict(n_components)
 
     observed = _q2_per_column(y, _as_frame(fit_predict(x, y), y))
 
@@ -219,17 +278,17 @@ def permutation_q2(
     )
 
 
-def pipeline_null(
+def count_discoveries_under_null(
     select: Callable,
     x: pd.DataFrame,
     y: pd.DataFrame,
     n_perm: int = 500,
     seed: int = 0,
 ) -> dict:
-    """Count a selection procedure's discoveries against a permuted response.
+    """Count how many of these findings shuffling alone would have produced.
 
-    :func:`permutation_q2` tests one model; this tests the whole procedure that
-    produced it. Pass a callable that runs filtering, transformation, scaling and
+    :func:`check_predictive_signal` tests one model; this tests the whole
+    procedure that produced it. Pass a callable that runs filtering, transformation, scaling and
     selection end to end, and it is re-run in full on each permuted response.
     The average number of discoveries under permutation, divided by the number
     actually made, is an empirical false-discovery rate for the procedure **as
@@ -269,11 +328,13 @@ def pipeline_null(
             Number of names selected on the real response.
         ``null_mean``, ``null_p95``
             Mean and 95th percentile of the selection count under permutation.
-        ``empirical_fdr``
-            ``null_mean / observed``, clipped to ``[0, 1]``; ``NaN`` when
-            nothing was selected. Read it as "of the names this procedure
-            returned, about this fraction is what shuffling alone would have
-            produced".
+        ``null_to_observed_ratio``
+            ``null_mean / observed``; ``NaN`` when nothing was selected. Read it
+            as "of the names this procedure returned, about this fraction is
+            what shuffling alone would have produced". It is **not** clipped:
+            a value above 1 means shuffling found *more* than the real response
+            did, which is the strongest evidence this procedure has nothing, and
+            clipping it away would hide exactly the case worth seeing.
         ``null_counts``
             The per-permutation counts, as an ndarray, for plotting the null.
         ``selected``
@@ -285,13 +346,18 @@ def pipeline_null(
     ValueError
         If the blocks disagree on rows or ``n_perm`` is below 1.
 
+    See Also
+    --------
+    check_predictive_signal :
+        Tests one model rather than the procedure around it.
+
     Examples
     --------
     >>> def select(x, y):
     ...     kept, _dropped, _presence = trim_by_prevalence(x)
     ...     return names_above_threshold(kept, y)
-    >>> result = pipeline_null(select, chem, sensory_means, n_perm=200)
-    >>> result["empirical_fdr"]
+    >>> result = count_discoveries_under_null(select, chem, sensory_means, n_perm=200)
+    >>> result["null_to_observed_ratio"]
     """
     if not isinstance(x, pd.DataFrame) or not isinstance(y, pd.DataFrame):
         raise TypeError("x and y must both be pandas DataFrames, one row per product.")
@@ -324,12 +390,14 @@ def pipeline_null(
 
     observed = len(selected)
     null_mean = float(counts.mean())
-    empirical_fdr = float(np.clip(null_mean / observed, 0.0, 1.0)) if observed else float("nan")
+    # Deliberately unclipped: a ratio above 1 says shuffling beat the real
+    # response, and that is the reading most worth surfacing.
+    ratio = float(null_mean / observed) if observed else float("nan")
     return {
         "observed": observed,
         "null_mean": null_mean,
         "null_p95": float(np.percentile(counts, 95)),
-        "empirical_fdr": empirical_fdr,
+        "null_to_observed_ratio": ratio,
         "null_counts": counts,
         "selected": selected,
     }
@@ -436,3 +504,23 @@ def class_enrichment(
         "p_value": p_value,
         "matched": matched,
     }
+
+
+# ---------------------------------------------------------------------------
+# Migration helpers - old names raise helpful errors
+# ---------------------------------------------------------------------------
+
+_RENAMED = {
+    "permutation_q2": "check_predictive_signal",
+    "pipeline_null": "count_discoveries_under_null",
+}
+
+
+def __getattr__(name: str) -> NoReturn:
+    """Raise a helpful error when a renamed module attribute is accessed."""
+    if name in _RENAMED:
+        new = _RENAMED[name]
+        raise AttributeError(
+            f"{name!r} has been renamed to {new!r}. Use: from process_improve.multivariate import {new}"
+        )
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/process_improve/multivariate/methods.py
+++ b/src/process_improve/multivariate/methods.py
@@ -12,6 +12,8 @@ The older :mod:`process_improve.multivariate._pca_pls` path is kept as a thin
 backward-compatibility shim that re-exports from here.
 """
 
+from typing import NoReturn
+
 from .._linalg import safe_inverse
 from .._random import check_random_state
 from ..univariate.metrics import detect_outliers_esd
@@ -50,7 +52,7 @@ from ._nipals import (
     ssq,
     terminate_check,
 )
-from ._null import class_enrichment, permutation_q2, pipeline_null
+from ._null import check_predictive_signal, class_enrichment, count_discoveries_under_null
 from ._opls import OPLS
 from ._pca import PCA
 from ._pls import PLS
@@ -86,10 +88,12 @@ __all__ = [
     "Resampler",
     "SpecificationWarning",
     "center",
+    "check_predictive_signal",
     "check_random_state",
     "class_enrichment",
     "coefficient_plot",
     "correlation_loadings_plot",
+    "count_discoveries_under_null",
     "detect_outliers_esd",
     "eigenvalue_summary",
     "ellipse_coordinates",
@@ -101,8 +105,6 @@ __all__ = [
     "loading_plot",
     "nan_to_zeros",
     "observation_contributions",
-    "permutation_q2",
-    "pipeline_null",
     "predictions_vs_observed_plot",
     "project_variables",
     "quick_regress",
@@ -128,3 +130,20 @@ __all__ = [
     "terminate_check",
     "vip",
 ]
+
+# ---------------------------------------------------------------------------
+# Migration helpers - old names raise helpful errors
+# ---------------------------------------------------------------------------
+
+_RENAMED = {
+    "permutation_q2": "check_predictive_signal",
+    "pipeline_null": "count_discoveries_under_null",
+}
+
+
+def __getattr__(name: str) -> NoReturn:
+    """Raise a helpful error when a renamed module attribute is accessed."""
+    if name in _RENAMED:
+        new = _RENAMED[name]
+        raise AttributeError(f"{name!r} has been renamed to {new!r}. Use: from {__name__} import {new}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/process_improve/sensory/__init__.py
+++ b/src/process_improve/sensory/__init__.py
@@ -15,11 +15,13 @@ The public entry points are :func:`validate_descriptive` and
 ``process_improve.sensory.tools``.
 """
 
+from typing import NoReturn
+
 from process_improve.sensory.analysis import (
     AnalysisResult,
     aggregate_to_product,
     analyze_descriptive,
-    discriminate_observational,
+    find_predictive_descriptors,
     permutation_column_null,
     product_means,
     relate_designed,
@@ -63,9 +65,9 @@ __all__ = [
     "boundary_occupancy",
     "compare_products",
     "detection_rate",
-    "discriminate_observational",
     "dunnett_vs_control",
     "factorial_anova",
+    "find_predictive_descriptors",
     "mixed_assessor_model",
     "panel_scorecard",
     "permutation_column_null",
@@ -76,3 +78,20 @@ __all__ = [
     "tukey_hsd",
     "validate_descriptive",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Migration helpers - old names raise helpful errors
+# ---------------------------------------------------------------------------
+
+_RENAMED = {
+    "discriminate_observational": "find_predictive_descriptors",
+}
+
+
+def __getattr__(name: str) -> NoReturn:
+    """Raise a helpful error when a renamed module attribute is accessed."""
+    if name in _RENAMED:
+        new = _RENAMED[name]
+        raise AttributeError(f"{name!r} has been renamed to {new!r}. Use: from {__name__} import {new}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/process_improve/sensory/analysis.py
+++ b/src/process_improve/sensory/analysis.py
@@ -18,8 +18,8 @@ attribute to the product. The relate step dispatches on the validation mode:
 The observational relate corrects across the family of tests with
 Benjamini-Hochberg FDR and returns supporting product means with confidence
 intervals and a PCA sensory map. Both the marginal associations and the
-cross-validated discriminator are additionally gated on a leave-one-out
-jackknife, so an association or predictive coefficient that rests on a single
+per-attribute predictive-descriptor search are additionally gated on a
+leave-one-out jackknife, so an association or predictive coefficient that rests on a single
 high-leverage observation (a predictor that is non-zero on only one product,
 common in sparse, wide descriptor blocks) is demoted rather than reported. The
 jackknife adds no threshold of its own: it reuses the same ``alpha`` and the
@@ -31,7 +31,7 @@ from __future__ import annotations
 import itertools
 import warnings
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, NoReturn
 
 import numpy as np
 import pandas as pd
@@ -261,8 +261,8 @@ def _collinear_clusters(x_block: pd.DataFrame, threshold: float) -> dict[str, in
     two descriptors join the same cluster when their absolute Pearson
     correlation is at least ``threshold``. Returns ``{descriptor: cluster_id}``
     with cluster ids assigned in column order (a singleton descriptor gets its
-    own id). Collinear proxies therefore share an id, which is how the
-    discriminator reports that they cannot be told apart.
+    own id). Collinear proxies therefore share an id, which is how
+    :func:`find_predictive_descriptors` reports that they cannot be told apart.
     """
     cols = list(x_block.columns)
     n = len(cols)
@@ -292,7 +292,7 @@ def _collinear_clusters(x_block: pd.DataFrame, threshold: float) -> dict[str, in
     return cluster_of
 
 
-def discriminate_observational(  # noqa: PLR0913, PLR0915
+def find_predictive_descriptors(  # noqa: PLR0913, PLR0915
     agg: pd.DataFrame,
     covariates: pd.DataFrame,
     *,
@@ -303,7 +303,7 @@ def discriminate_observational(  # noqa: PLR0913, PLR0915
     cluster_threshold: float = 0.95,
     max_components_cv: int = 4,
 ) -> dict[str, Any]:
-    """Cross-validated discriminator of which descriptors carry predictive signal.
+    """Find which descriptors carry predictive signal, per attribute.
 
     The marginal associations (:func:`relate_observational`) flag every
     descriptor that correlates with an attribute in-sample, genuine drivers and
@@ -312,15 +312,27 @@ def discriminate_observational(  # noqa: PLR0913, PLR0915
     1. a per-attribute cross-validated Q-squared gate (is the attribute
        predictable from the descriptor block at all),
     2. a selectivity ratio per descriptor on the target-projected predictive
-       direction, with a permutation p-value (Benjamini-Hochberg corrected
-       across the whole family), so a descriptor that merely correlates by
-       chance but does not enter the predictive direction is demoted, and
+       direction, with a permutation p-value corrected for multiplicity by the
+       max-statistic (Westfall-Young) permutation, so a descriptor that merely
+       correlates by chance but does not enter the predictive direction is
+       demoted, and
     3. a collinear-cluster id per descriptor.
 
     What it cannot do is rank descriptors *within* a collinear cluster: two
     descriptors that carry the same information predict equally well out of
     sample, so they share a cluster id and both stay significant. Separating
     them needs an external dataset or a designed experiment.
+
+    .. important::
+
+       **The multiplicity correction is within an attribute, not across them.**
+       The max-statistic null is rebuilt for each attribute over its own
+       descriptors, so ``p_value_fwer`` controls the family-wise error rate for
+       *that attribute's* descriptor family only. Nothing corrects across
+       attributes: on a panel of ``A`` attributes at ``alpha``, roughly
+       ``alpha * A`` attributes are expected to produce a spurious family by
+       chance alone. Read a single flagged descriptor on a many-attribute panel
+       with that in mind.
 
     Parameters
     ----------
@@ -346,12 +358,23 @@ def discriminate_observational(  # noqa: PLR0913, PLR0915
     -------
     dict
         ``per_attribute`` (the Q-squared gate per attribute), ``descriptors``
-        (the per attribute-descriptor selectivity ratio, permutation q-value,
+        (the per attribute-descriptor selectivity ratio, raw permutation
+        ``p_value``, family-wise-error-adjusted ``p_value_fwer``,
         ``jackknife_significant`` flag from the leave-one-out beta confidence
-        interval, ``discriminator_significant`` flag and ``cluster_id``),
-        ``clusters`` (the descriptor-to-cluster map), and the settings used. A
-        descriptor is ``discriminator_significant`` only when it also survives the
-        jackknife, so a coefficient carried by a single product is demoted.
+        interval, ``is_predictive`` flag and ``cluster_id``), ``clusters`` (the
+        descriptor-to-cluster map), and the settings used. A descriptor is
+        ``is_predictive`` only when it also survives the jackknife, so a
+        coefficient carried by a single product is demoted.
+
+    See Also
+    --------
+    permutation_column_null :
+        The block-level counterpart. It fits one multi-response PLS over the
+        whole attribute block and returns one record per descriptor, answering
+        "which descriptors matter for the panel as a whole" rather than "which
+        matter for this attribute". Reach for it to screen a descriptor block
+        before committing to per-attribute work; reach for this function when
+        the answer has to name the attribute.
     """
     x_all = covariates.loc[agg.index]
     descriptors = [c for c in x_all.columns if c != "product" and pd.api.types.is_numeric_dtype(x_all[c])]
@@ -383,6 +406,16 @@ def discriminate_observational(  # noqa: PLR0913, PLR0915
         #    coefficient (Martens' uncertainty test); it is reused below so a
         #    descriptor whose predictive weight rests on a single high-leverage
         #    product is demoted even when it survives the permutation null.
+        #
+        #    `q2_cv > 0.0` is deliberately a low, uncalibrated bar. It is a
+        #    cheap pre-screen, not the test: it decides whether the 199-refit
+        #    permutation loop below is worth running, and it is ANDed with the
+        #    calibrated max-statistic p-value and the jackknife flag when
+        #    `is_predictive` is set. Passing it therefore cannot make a
+        #    descriptor a finding; only failing it can rule one out early.
+        #    Tightening it would remove findings that already cleared a
+        #    family-wise-error-controlled null, at the cost of a permutation
+        #    null per attribute on top of the one already here.
         predictable = False
         q2_cv = float("nan")
         rmsep_cv = float("nan")
@@ -451,9 +484,9 @@ def discriminate_observational(  # noqa: PLR0913, PLR0915
                     "descriptor": str(desc),
                     "selectivity_ratio": float(sr_values[i]),
                     "p_value": float(p_raw[i]),
-                    "q_value": float(p_maxt[i]),
+                    "p_value_fwer": float(p_maxt[i]),
                     "jackknife_significant": bool(desc_robust),
-                    "discriminator_significant": bool(p_maxt[i] <= alpha and predictable and desc_robust),
+                    "is_predictive": bool(p_maxt[i] <= alpha and predictable and desc_robust),
                     "cluster_id": clusters[str(desc)],
                 }
             )
@@ -499,7 +532,7 @@ def relate_observational(  # noqa: PLR0913
     *,
     n_components: int = 2,
     alpha: float = 0.05,
-    discriminator: bool = True,
+    find_predictive: bool = True,
     n_permutations: int = 199,
     random_state: int = 0,
     influence_deletions: int = 1,
@@ -552,8 +585,8 @@ def relate_observational(  # noqa: PLR0913
         "vip": drivers,
         "associations": assoc,
     }
-    if discriminator:
-        result["discriminator"] = discriminate_observational(
+    if find_predictive:
+        result["predictive_descriptors"] = find_predictive_descriptors(
             agg,
             covariates.loc[agg.index],
             n_components=max_comp,
@@ -639,6 +672,19 @@ def permutation_column_null(  # noqa: PLR0913
         ``descriptors`` (per surviving descriptor: ``vip`` / ``cv_beta`` and the
         ``*_null_threshold`` and ``*_exceeds_null`` fields), plus the settings used and
         the counts (``n_descriptors``, ``n_knockoffs``, ``n_iter``, ``ignored``).
+
+    See Also
+    --------
+    find_predictive_descriptors :
+        The per-attribute counterpart, and the one to prefer when the answer
+        has to name an attribute. It reports one record per (attribute,
+        descriptor) pair and controls the family-wise error rate within each
+        attribute by a max-statistic permutation. This function instead fits a
+        single multi-response PLS over the whole attribute block and returns one
+        record per descriptor, so it answers "which descriptors matter for the
+        panel as a whole"; its knockoff quantile band is a calibrated screen
+        rather than formal error control. Use it to triage a wide descriptor
+        block before committing to the per-attribute work.
     """
     if fraction <= 0.0:
         raise ValueError(f"fraction must be positive, got {fraction}.")
@@ -758,7 +804,7 @@ def analyze_descriptive(  # noqa: PLR0913
     n_components: int = 2,
     conf_level: float = 0.95,
     alpha: float = 0.05,
-    discriminator: bool = True,
+    find_predictive: bool = True,
     n_permutations: int = 199,
     random_state: int = 0,
     influence_deletions: int = 1,
@@ -790,13 +836,13 @@ def analyze_descriptive(  # noqa: PLR0913
         Confidence level for the product-mean intervals.
     alpha : float
         Target false-discovery rate for the relate step.
-    discriminator : bool
-        Whether to run the cross-validated discriminator
-        (:func:`discriminate_observational`) in the observational relate step.
+    find_predictive : bool
+        Whether to run the per-attribute predictive-descriptor search
+        (:func:`find_predictive_descriptors`) in the observational relate step.
     n_permutations : int
-        Permutations for the discriminator's selectivity-ratio null.
+        Permutations for the selectivity-ratio null.
     random_state : int
-        Seed for the discriminator's permutations and cross-validation folds.
+        Seed for the permutations and cross-validation folds.
     influence_deletions : int
         How many observations the marginal-association jackknife removes together
         (default 1, ordinary leave-one-out). Raising it to 2 also demotes a
@@ -843,7 +889,7 @@ def analyze_descriptive(  # noqa: PLR0913
             validated.covariates,
             n_components=n_components,
             alpha=alpha,
-            discriminator=discriminator,
+            find_predictive=find_predictive,
             n_permutations=n_permutations,
             random_state=random_state,
             influence_deletions=influence_deletions,
@@ -865,10 +911,27 @@ def analyze_descriptive(  # noqa: PLR0913
             "n_components": n_components,
             "conf_level": conf_level,
             "alpha": alpha,
-            "discriminator": discriminator,
+            "find_predictive": find_predictive,
             "n_permutations": n_permutations,
             "random_state": random_state,
             "influence_deletions": influence_deletions,
             "content_hash": validated.content_hash,
         },
     )
+
+
+# ---------------------------------------------------------------------------
+# Migration helpers - old names raise helpful errors
+# ---------------------------------------------------------------------------
+
+_RENAMED = {
+    "discriminate_observational": "find_predictive_descriptors",
+}
+
+
+def __getattr__(name: str) -> NoReturn:
+    """Raise a helpful error when a renamed module attribute is accessed."""
+    if name in _RENAMED:
+        new = _RENAMED[name]
+        raise AttributeError(f"{name!r} has been renamed to {new!r}. Use: from process_improve.sensory import {new}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/process_improve/sensory/recipes.py
+++ b/src/process_improve/sensory/recipes.py
@@ -197,8 +197,9 @@ _RELATE_COVARIATES = AnalysisRecipe(
     title="Relate panel attributes to product covariates",
     summary=(
         "Relate each sensory attribute to measured product covariates and separate genuine drivers from "
-        "proxies and chance correlations. Runs PLS plus per-pair correlations and the cross-validated "
-        "discriminator (out-of-sample Q-squared gate, selectivity ratio, collinear clustering), then "
+        "proxies and chance correlations. Runs PLS plus per-pair correlations and the per-attribute "
+        "predictive-descriptor search (out-of-sample Q-squared gate, selectivity ratio, collinear "
+        "clustering), then "
         "interprets which descriptors really carry signal. Use this after the panel has been processed."
     ),
     domain=_DOMAIN,
@@ -243,7 +244,7 @@ _RELATE_COVARIATES = AnalysisRecipe(
                 "correction to what was already applied in the processing recipe (use 'none' if the panel "
                 "is already aligned) and drop the genuine disagreers identified there. This one call "
                 "validates, relates the attributes to the descriptors with PLS and per-pair correlations, "
-                "and runs the cross-validated discriminator."
+                "and finds the predictive descriptors per attribute."
             ),
             tools=["sensory_analyze_descriptive"],
             arg_hints={
@@ -264,19 +265,20 @@ _RELATE_COVARIATES = AnalysisRecipe(
         RecipeStep(
             order=4,
             directive=(
-                "Read the discriminator in relate.discriminator: per_attribute gives the cross-validated "
-                "q2_cv and a predictable flag; descriptors gives, per (attribute, descriptor), the "
-                "selectivity_ratio, a permutation q_value, a discriminator_significant flag, and a "
-                "cluster_id."
+                "Read relate.predictive_descriptors: per_attribute gives the cross-validated q2_cv and a "
+                "predictable flag; descriptors gives, per (attribute, descriptor), the "
+                "selectivity_ratio, a raw permutation p_value, a family-wise-error-adjusted "
+                "p_value_fwer, an is_predictive flag, and a cluster_id. The p_value_fwer correction "
+                "is within an attribute, not across attributes."
             ),
         ),
         RecipeStep(
             order=5,
             directive=(
-                "Interpret for a non-statistician. An association that survives the discriminator (the "
-                "attribute is predictable out of sample and the descriptor is selectivity-significant) "
-                "carries real, transferable predictive signal. An association that the marginal test flags "
-                "but the discriminator demotes is most likely a coincidence of this sample. Descriptors "
+                "Interpret for a non-statistician. An association that is is_predictive (the attribute is "
+                "predictable out of sample and the descriptor is selectivity-significant) carries "
+                "real, transferable predictive signal. An association that the marginal test flags "
+                "but this step demotes is most likely a coincidence of this sample. Descriptors "
                 "that share a cluster_id carry the same information and cannot be told apart, so a "
                 "significant one may be a proxy riding on the true driver."
             ),
@@ -299,7 +301,7 @@ _VISUALISATION = AnalysisRecipe(
     key="sensory_visualisation",
     title="Sensory visualisation (planned)",
     summary=(
-        "A planned workflow to turn relate and discriminator output into sensory maps, driver biplots and "
+        "A planned workflow to turn relate and predictive-descriptor output into sensory maps, driver biplots and "
         "small-multiple panels. Not yet available; this entry advertises the workflow so the agent can tell "
         "the user it is coming rather than improvising plots."
     ),

--- a/src/process_improve/sensory/tools.py
+++ b/src/process_improve/sensory/tools.py
@@ -227,16 +227,16 @@ class _AnalyzeInput(BaseModel):
     n_components: int = Field(2, ge=1, description="Components for the PLS relate step and PCA map.")
     conf_level: float = Field(0.95, gt=0, lt=1, description="Confidence level for product-mean intervals.")
     alpha: float = Field(0.05, gt=0, lt=1, description="Target false-discovery rate for the relate step.")
-    discriminator: bool = Field(
+    find_predictive: bool = Field(
         True,
         description=(
-            "Run the cross-validated discriminator: a per-attribute out-of-sample Q-squared gate, a "
+            "Run the per-attribute predictive-descriptor search: an out-of-sample Q-squared gate, a "
             "selectivity ratio per descriptor with a permutation test, and collinear-cluster grouping. "
             "Set false to skip it (faster)."
         ),
     )
-    n_permutations: int = Field(199, ge=1, description="Permutations for the discriminator's selectivity-ratio null.")
-    random_state: int = Field(0, description="Seed for the discriminator's permutations and CV folds.")
+    n_permutations: int = Field(199, ge=1, description="Permutations for the selectivity-ratio null.")
+    random_state: int = Field(0, description="Seed for the permutations and CV folds.")
     score_min: float | None = Field(None, description="Optional lower bound for the score scale.")
     score_max: float | None = Field(None, description="Optional upper bound for the score scale.")
 
@@ -249,7 +249,7 @@ class _AnalyzeInput(BaseModel):
         "attribute to the product. Observational mode relates attributes to measured descriptors with "
         "PLS and correlations (association). Returns the panel scorecard flags, dropped panelists, the "
         "MAM scaling coefficients and product F-tests, the relate results with Benjamini-Hochberg "
-        "q-values, and (unless disabled) a cross-validated discriminator: a per-attribute Q-squared "
+        "q-values, and (unless disabled) the predictive descriptors: a per-attribute Q-squared "
         "gate, a selectivity ratio per descriptor with a permutation q-value, and collinear-cluster ids "
         "that mark proxies which cannot be separated from a genuine driver. Also returns product means "
         "with CIs and a PCA map. Refuses to run if validation fails. "
@@ -259,12 +259,12 @@ class _AnalyzeInput(BaseModel):
         "product_means, pca}. 'flagged'/'dropped' are panelist-id lists; 'mam' has 'scaling' and "
         "'ftests' (as in sensory_panel_check); 'product_means' is rows of product, attribute, mean, "
         "ci_low, ci_high; 'pca' has 'explained_variance' and 'scores'. 'relate' (observational) holds "
-        "{mode, n_components, alpha, vip, associations, discriminator}: 'vip' is rows of descriptor, vip; "
+        "{mode, n_components, alpha, vip, associations, predictive_descriptors}: 'vip' is rows of descriptor, vip; "
         "'associations' is the marginal table, rows of attribute, descriptor, r, p_value, q_value, "
-        "significant. 'discriminator' (present unless disabled) holds {per_attribute, descriptors, "
+        "significant. 'predictive_descriptors' (present unless disabled) holds {per_attribute, descriptors, "
         "clusters, alpha, n_permutations, cluster_threshold}: 'per_attribute' is rows of attribute, "
         "n_components_cv, q2_cv, rmsep_cv, predictable; 'descriptors' is rows of attribute, descriptor, "
-        "selectivity_ratio, p_value, q_value, discriminator_significant, cluster_id; 'clusters' maps "
+        "selectivity_ratio, p_value, p_value_fwer, is_predictive, cluster_id; 'clusters' maps "
         "each descriptor to an integer collinear-cluster id (descriptors sharing an id cannot be told "
         "apart, so a significant one may be a proxy for another in the same cluster)."
     ),
@@ -293,7 +293,7 @@ def sensory_analyze_descriptive(spec: _AnalyzeInput) -> dict:
         n_components=spec.n_components,
         conf_level=spec.conf_level,
         alpha=spec.alpha,
-        discriminator=spec.discriminator,
+        find_predictive=spec.find_predictive,
         n_permutations=spec.n_permutations,
         random_state=spec.random_state,
     )

--- a/tests/test_multivariate_null.py
+++ b/tests/test_multivariate_null.py
@@ -410,7 +410,14 @@ class TestRenamedNamesRaise:
                 _ = module.pipeline_null
 
     def test_an_unrelated_missing_attribute_still_raises_plainly(self) -> None:
-        from process_improve.multivariate import _null
+        """Every surface carrying a migration helper must keep normal lookup honest.
 
-        with pytest.raises(AttributeError, match="has no attribute"):
-            _ = _null.not_a_real_name
+        The helper intercepts *all* failed attribute lookups, so its fallback
+        branch is what stands between a typo and a misleading rename message.
+        """
+        import process_improve.multivariate as mv
+        from process_improve.multivariate import _null, methods
+
+        for module in (mv, methods, _null):
+            with pytest.raises(AttributeError, match="has no attribute"):
+                _ = module.not_a_real_name

--- a/tests/test_multivariate_null.py
+++ b/tests/test_multivariate_null.py
@@ -200,9 +200,7 @@ class TestPipelineNull:
         # is the point. Clipping it would round exactly this evidence away.
         assert max(ratios) > 1.0
         for result in results:
-            assert result["null_to_observed_ratio"] == pytest.approx(
-                result["null_mean"] / result["observed"]
-            )
+            assert result["null_to_observed_ratio"] == pytest.approx(result["null_mean"] / result["observed"])
 
     def test_a_real_relationship_puts_the_count_beyond_the_null(self) -> None:
         x, y = _blocks(n_products=40, noise=0.2)

--- a/tests/test_multivariate_null.py
+++ b/tests/test_multivariate_null.py
@@ -400,7 +400,7 @@ class TestRenamedNamesRaise:
     """The 2.0.0 renames removed the old names outright; they must say so."""
 
     def test_old_multivariate_names_name_their_replacement(self) -> None:
-        import process_improve.multivariate as mv
+        from process_improve import multivariate as mv
         from process_improve.multivariate import _null, methods
 
         for module in (mv, methods, _null):
@@ -415,7 +415,7 @@ class TestRenamedNamesRaise:
         The helper intercepts *all* failed attribute lookups, so its fallback
         branch is what stands between a typo and a misleading rename message.
         """
-        import process_improve.multivariate as mv
+        from process_improve import multivariate as mv
         from process_improve.multivariate import _null, methods
 
         for module in (mv, methods, _null):

--- a/tests/test_multivariate_null.py
+++ b/tests/test_multivariate_null.py
@@ -18,11 +18,12 @@ from sklearn.model_selection import KFold
 from process_improve.multivariate import (
     PLS,
     MCUVScaler,
+    check_predictive_signal,
     class_enrichment,
-    permutation_q2,
-    pipeline_null,
+    count_discoveries_under_null,
 )
 from process_improve.multivariate._common import SpecificationWarning
+from process_improve.multivariate._null import _loo_fit_predict
 
 
 def _blocks(
@@ -71,7 +72,7 @@ class TestPermutationQ2:
     @pytest.mark.slow
     def test_signal_beats_the_null_and_noise_does_not(self) -> None:
         x, y = _blocks()
-        table = permutation_q2(_cv_predict(), x, y, n_perm=99, seed=0).set_index("attribute")
+        table = check_predictive_signal(x, y, _cv_predict(), n_perm=99, seed=0).set_index("attribute")
         assert table.loc["real", "q2_observed"] > 0.5
         assert table.loc["real", "p_value"] <= 0.02
         assert table.loc["noise", "p_value"] > 0.10
@@ -80,20 +81,20 @@ class TestPermutationQ2:
     def test_the_null_mean_sits_below_zero(self) -> None:
         """A shuffled response predicts worse than the mean, so Q2 is negative."""
         x, y = _blocks()
-        table = permutation_q2(_cv_predict(), x, y, n_perm=99, seed=0).set_index("attribute")
+        table = check_predictive_signal(x, y, _cv_predict(), n_perm=99, seed=0).set_index("attribute")
         assert table.loc["real", "q2_null_mean"] < 0
         assert table.loc["real", "q2_observed"] > table.loc["real", "q2_null_p95"]
 
     @pytest.mark.slow
     def test_p_value_can_never_be_zero(self) -> None:
         x, y = _blocks(noise=0.01)
-        table = permutation_q2(_cv_predict(), x, y, n_perm=49, seed=0).set_index("attribute")
+        table = check_predictive_signal(x, y, _cv_predict(), n_perm=49, seed=0).set_index("attribute")
         assert table.loc["real", "p_value"] > 0
         assert table.loc["real", "p_value"] == pytest.approx(1 / 50)
 
     def test_columns_are_as_documented(self) -> None:
         x, y = _blocks()
-        table = permutation_q2(_cv_predict(), x, y, n_perm=9, seed=0)
+        table = check_predictive_signal(x, y, _cv_predict(), n_perm=9, seed=0)
         assert list(table.columns) == [
             "attribute",
             "q2_observed",
@@ -114,7 +115,7 @@ class TestPermutationQ2:
 
         x = pd.DataFrame({"a": np.arange(8.0)})
         y = pd.DataFrame({"u": np.arange(8.0), "v": np.arange(8.0) * 3})
-        permutation_q2(recorder, x, y, n_perm=5, seed=0)
+        check_predictive_signal(x, y, recorder, n_perm=5, seed=0)
         for frame in seen[1:]:
             # v == 3 * u in every row of every permutation: the pairing survived.
             assert np.allclose(frame["v"].to_numpy(), 3 * frame["u"].to_numpy())
@@ -122,37 +123,37 @@ class TestPermutationQ2:
     @pytest.mark.slow
     def test_seed_makes_the_answer_reproducible(self) -> None:
         x, y = _blocks()
-        first = permutation_q2(_cv_predict(), x, y, n_perm=19, seed=3)
-        second = permutation_q2(_cv_predict(), x, y, n_perm=19, seed=3)
+        first = check_predictive_signal(x, y, _cv_predict(), n_perm=19, seed=3)
+        second = check_predictive_signal(x, y, _cv_predict(), n_perm=19, seed=3)
         pd.testing.assert_frame_equal(first, second)
 
     @pytest.mark.slow
     def test_a_different_seed_moves_the_null(self) -> None:
         x, y = _blocks()
-        first = permutation_q2(_cv_predict(), x, y, n_perm=19, seed=1)
-        second = permutation_q2(_cv_predict(), x, y, n_perm=19, seed=2)
+        first = check_predictive_signal(x, y, _cv_predict(), n_perm=19, seed=1)
+        second = check_predictive_signal(x, y, _cv_predict(), n_perm=19, seed=2)
         assert first["q2_null_mean"].iloc[0] != second["q2_null_mean"].iloc[0]
 
     def test_a_one_dimensional_return_is_accepted(self) -> None:
         x = pd.DataFrame({"a": np.arange(10.0)})
         y = pd.DataFrame({"u": np.arange(10.0)})
-        table = permutation_q2(lambda _x, yy: np.asarray(yy).ravel(), x, y, n_perm=5)
+        table = check_predictive_signal(x, y, lambda _x, yy: np.asarray(yy).ravel(), n_perm=5)
         assert table["q2_observed"].iloc[0] == pytest.approx(1.0)
 
     def test_a_wrong_shape_return_raises(self) -> None:
         x, y = _blocks(n_products=8, n_features=2)
         with pytest.raises(ValueError, match="one out-of-sample prediction per row"):
-            permutation_q2(lambda _x, _y: np.zeros((3, 3)), x, y, n_perm=2)
+            check_predictive_signal(x, y, lambda _x, _y: np.zeros((3, 3)), n_perm=2)
 
     def test_mismatched_rows_raise(self) -> None:
         x, y = _blocks(n_products=8, n_features=2)
         with pytest.raises(ValueError, match="same number of rows"):
-            permutation_q2(_cv_predict(), x, y.iloc[:4], n_perm=2)
+            check_predictive_signal(x, y.iloc[:4], _cv_predict(), n_perm=2)
 
     def test_n_perm_below_one_raises(self) -> None:
         x, y = _blocks(n_products=8, n_features=2)
         with pytest.raises(ValueError, match="n_perm"):
-            permutation_q2(_cv_predict(), x, y, n_perm=0)
+            check_predictive_signal(x, y, _cv_predict(), n_perm=0)
 
 
 class TestPipelineNull:
@@ -164,14 +165,14 @@ class TestPipelineNull:
 
         return select
 
-    def test_a_real_relationship_gives_a_low_empirical_fdr(self) -> None:
+    def test_a_real_relationship_gives_a_low_null_to_observed_ratio(self) -> None:
         x, y = _blocks(n_products=40, noise=0.2)
-        result = pipeline_null(self._selector(), x, y[["real"]], n_perm=100, seed=0)
+        result = count_discoveries_under_null(self._selector(), x, y[["real"]], n_perm=100, seed=0)
         assert result["observed"] >= 1
-        assert result["empirical_fdr"] < 0.2
+        assert result["null_to_observed_ratio"] < 0.2
 
     @pytest.mark.slow
-    def test_pure_noise_gives_an_fdr_near_one(self) -> None:
+    def test_pure_noise_gives_a_ratio_near_one(self) -> None:
         """Averaged over responses, everything a noise pipeline finds is what noise finds.
 
         Read over one response draw the ratio is noisy in both directions, which
@@ -181,7 +182,7 @@ class TestPipelineNull:
         rng = np.random.default_rng(1)
         x = pd.DataFrame(rng.normal(size=(15, 30)), columns=[f"c{i}" for i in range(30)])
         results = [
-            pipeline_null(
+            count_discoveries_under_null(
                 self._selector(threshold=0.45),
                 x,
                 pd.DataFrame({"noise": np.random.default_rng(100 + draw).normal(size=15)}),
@@ -190,23 +191,32 @@ class TestPipelineNull:
             )
             for draw in range(7)
         ]
-        assert float(np.median([result["empirical_fdr"] for result in results])) > 0.5
+        ratios = [result["null_to_observed_ratio"] for result in results]
+        assert float(np.median(ratios)) > 0.5
         # And the count itself never gets out beyond the null it was drawn from.
         assert all(result["observed"] <= result["null_p95"] for result in results)
+        # The ratio is deliberately not clipped to [0, 1]: on pure noise some
+        # draws have shuffling out-finding the real response, and that reading
+        # is the point. Clipping it would round exactly this evidence away.
+        assert max(ratios) > 1.0
+        for result in results:
+            assert result["null_to_observed_ratio"] == pytest.approx(
+                result["null_mean"] / result["observed"]
+            )
 
     def test_a_real_relationship_puts_the_count_beyond_the_null(self) -> None:
         x, y = _blocks(n_products=40, noise=0.2)
-        result = pipeline_null(self._selector(), x, y[["real"]], n_perm=100, seed=0)
+        result = count_discoveries_under_null(self._selector(), x, y[["real"]], n_perm=100, seed=0)
         assert result["observed"] > result["null_p95"]
 
     def test_keys_are_as_documented(self) -> None:
         x, y = _blocks(n_products=20)
-        result = pipeline_null(self._selector(), x, y[["real"]], n_perm=10, seed=0)
+        result = count_discoveries_under_null(self._selector(), x, y[["real"]], n_perm=10, seed=0)
         assert set(result) == {
             "observed",
             "null_mean",
             "null_p95",
-            "empirical_fdr",
+            "null_to_observed_ratio",
             "null_counts",
             "selected",
         }
@@ -214,9 +224,9 @@ class TestPipelineNull:
 
     def test_selecting_nothing_gives_nan_rather_than_a_divide_by_zero(self) -> None:
         x, y = _blocks(n_products=20)
-        result = pipeline_null(lambda _x, _y: [], x, y[["real"]], n_perm=5, seed=0)
+        result = count_discoveries_under_null(lambda _x, _y: [], x, y[["real"]], n_perm=5, seed=0)
         assert result["observed"] == 0
-        assert np.isnan(result["empirical_fdr"])
+        assert np.isnan(result["null_to_observed_ratio"])
 
     def test_a_nondeterministic_selector_warns(self) -> None:
         x, y = _blocks(n_products=12, n_features=3)
@@ -227,13 +237,13 @@ class TestPipelineNull:
             return ["c0"] if counter["n"] % 2 else ["c1"]
 
         with pytest.warns(SpecificationWarning, match="different names on two identical calls"):
-            pipeline_null(flaky, x, y, n_perm=3, seed=0)
+            count_discoveries_under_null(flaky, x, y, n_perm=3, seed=0)
 
     def test_a_deterministic_selector_does_not_warn(self) -> None:
         x, y = _blocks(n_products=12, n_features=3)
         with warnings.catch_warnings():
             warnings.simplefilter("error", SpecificationWarning)
-            pipeline_null(self._selector(), x, y, n_perm=3, seed=0)
+            count_discoveries_under_null(self._selector(), x, y, n_perm=3, seed=0)
 
     def test_the_selector_is_re_run_end_to_end_per_permutation(self) -> None:
         """Response-independent steps are not hoisted: that would be an assumption."""
@@ -244,7 +254,7 @@ class TestPipelineNull:
             return ["c0"]
 
         x, y = _blocks(n_products=10, n_features=2)
-        pipeline_null(counting, x, y, n_perm=7, seed=0)
+        count_discoveries_under_null(counting, x, y, n_perm=7, seed=0)
         # One observed call, one determinism check, seven permutations.
         assert sum(calls) == 9
 
@@ -311,7 +321,7 @@ class TestDegenerateInputs:
     def test_a_constant_response_column_gives_nan_rather_than_a_divide_by_zero(self) -> None:
         x = pd.DataFrame({"a": np.arange(8.0)})
         y = pd.DataFrame({"flat": np.full(8, 3.0)})
-        table = permutation_q2(lambda _x, yy: yy.to_numpy(), x, y, n_perm=3)
+        table = check_predictive_signal(x, y, lambda _x, yy: yy.to_numpy(), n_perm=3)
         assert np.isnan(table["q2_observed"].iloc[0])
         assert np.isnan(table["p_value"].iloc[0])
         assert table["n_permutations"].iloc[0] == 0
@@ -319,27 +329,90 @@ class TestDegenerateInputs:
     def test_all_missing_predictions_give_nan(self) -> None:
         x = pd.DataFrame({"a": np.arange(8.0)})
         y = pd.DataFrame({"u": np.arange(8.0)})
-        table = permutation_q2(lambda _x, yy: np.full(yy.shape, np.nan), x, y, n_perm=3)
+        table = check_predictive_signal(x, y, lambda _x, yy: np.full(yy.shape, np.nan), n_perm=3)
         assert np.isnan(table["q2_observed"].iloc[0])
 
-    def test_permutation_q2_rejects_a_non_dataframe(self) -> None:
+    def test_check_predictive_signal_rejects_a_non_dataframe(self) -> None:
         with pytest.raises(TypeError, match="must both be pandas DataFrames"):
-            permutation_q2(lambda _x, _y: None, np.zeros((8, 2)), pd.DataFrame({"y": np.zeros(8)}))
+            check_predictive_signal(np.zeros((8, 2)), pd.DataFrame({"y": np.zeros(8)}), lambda _x, _y: None)
 
-    def test_permutation_q2_needs_at_least_two_products(self) -> None:
+    def test_check_predictive_signal_needs_at_least_two_products(self) -> None:
         with pytest.raises(ValueError, match="at least 2 products"):
-            permutation_q2(lambda _x, yy: yy, pd.DataFrame({"a": [1.0]}), pd.DataFrame({"y": [1.0]}))
+            check_predictive_signal(pd.DataFrame({"a": [1.0]}), pd.DataFrame({"y": [1.0]}), lambda _x, yy: yy)
 
-    def test_pipeline_null_rejects_a_non_dataframe(self) -> None:
+    def test_count_discoveries_under_null_rejects_a_non_dataframe(self) -> None:
         with pytest.raises(TypeError, match="must both be pandas DataFrames"):
-            pipeline_null(lambda _x, _y: [], np.zeros((8, 2)), pd.DataFrame({"y": np.zeros(8)}))
+            count_discoveries_under_null(lambda _x, _y: [], np.zeros((8, 2)), pd.DataFrame({"y": np.zeros(8)}))
 
-    def test_pipeline_null_rejects_mismatched_rows(self) -> None:
+    def test_count_discoveries_under_null_rejects_mismatched_rows(self) -> None:
         x, y = _blocks(n_products=10, n_features=2)
         with pytest.raises(ValueError, match="same number of rows"):
-            pipeline_null(lambda _x, _y: [], x, y.iloc[:4])
+            count_discoveries_under_null(lambda _x, _y: [], x, y.iloc[:4])
 
-    def test_pipeline_null_rejects_n_perm_below_one(self) -> None:
+    def test_count_discoveries_under_null_rejects_n_perm_below_one(self) -> None:
         x, y = _blocks(n_products=10, n_features=2)
         with pytest.raises(ValueError, match="n_perm"):
-            pipeline_null(lambda _x, _y: [], x, y, n_perm=0)
+            count_discoveries_under_null(lambda _x, _y: [], x, y, n_perm=0)
+
+
+class TestDefaultFitPredict:
+    """The built-in leave-one-out default, which is what most callers will use."""
+
+    @pytest.mark.slow
+    def test_the_default_separates_signal_from_noise(self) -> None:
+        x, y = _blocks(n_products=20, n_features=5, noise=0.3)
+        table = check_predictive_signal(x, y, n_perm=49, seed=0).set_index("attribute")
+        assert table.loc["real", "q2_observed"] > 0.5
+        assert table.loc["real", "p_value"] <= 0.05
+        # The noise column must not look predictable: a negative Q-squared means
+        # the model does worse than predicting the mean.
+        assert table.loc["noise", "q2_observed"] < 0.0
+        assert table.loc["noise", "p_value"] > 0.2
+
+    @pytest.mark.slow
+    def test_the_default_matches_an_explicit_equivalent_callable(self) -> None:
+        x, y = _blocks(n_products=16, n_features=4)
+        default = check_predictive_signal(x, y, n_perm=19, seed=0)
+        explicit = check_predictive_signal(x, y, _loo_fit_predict(2), n_perm=19, seed=0)
+        pd.testing.assert_frame_equal(default, explicit)
+
+    @pytest.mark.slow
+    def test_pre_scaling_the_blocks_does_not_change_the_answer(self) -> None:
+        """The default must not be sensitive to preprocessing done by the caller.
+
+        Q-squared is invariant to an affine transform of ``y``, and the default
+        hands raw blocks to a PLS that re-derives its own constants inside every
+        fold. A caller who scales first therefore gets the same number, rather
+        than a quietly inflated one.
+        """
+        x, y = _blocks(n_products=16, n_features=4)
+        raw = check_predictive_signal(x, y, n_perm=9, seed=0)
+        scaled = check_predictive_signal(MCUVScaler().fit_transform(x), MCUVScaler().fit_transform(y), n_perm=9, seed=0)
+        np.testing.assert_allclose(raw["q2_observed"].to_numpy(), scaled["q2_observed"].to_numpy(), atol=1e-8)
+
+    def test_n_components_is_capped_at_what_the_block_supports(self) -> None:
+        """A silly component count must not raise; it is clamped to the block."""
+        x, y = _blocks(n_products=8, n_features=2)
+        table = check_predictive_signal(x, y, n_components=99, n_perm=3, seed=0)
+        assert len(table) == y.shape[1]
+        assert table["q2_observed"].notna().all()
+
+
+class TestRenamedNamesRaise:
+    """The 2.0.0 renames removed the old names outright; they must say so."""
+
+    def test_old_multivariate_names_name_their_replacement(self) -> None:
+        import process_improve.multivariate as mv
+        from process_improve.multivariate import _null, methods
+
+        for module in (mv, methods, _null):
+            with pytest.raises(AttributeError, match="check_predictive_signal"):
+                _ = module.permutation_q2
+            with pytest.raises(AttributeError, match="count_discoveries_under_null"):
+                _ = module.pipeline_null
+
+    def test_an_unrelated_missing_attribute_still_raises_plainly(self) -> None:
+        from process_improve.multivariate import _null
+
+        with pytest.raises(AttributeError, match="has no attribute"):
+            _ = _null.not_a_real_name

--- a/tests/test_sensory.py
+++ b/tests/test_sensory.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from process_improve import sensory
 from process_improve.sensory import (
     DESCRIPTIVE_LONG_COLUMNS,
     align_scores,
@@ -21,7 +22,7 @@ from process_improve.sensory import (
 from process_improve.sensory.analysis import (
     _collinear_clusters,
     _jackknife_correlation,
-    discriminate_observational,
+    find_predictive_descriptors,
     permutation_column_null,
     relate_designed,
 )
@@ -285,8 +286,8 @@ def test_scorecard_clean_panel_has_no_flags():
 
 def test_dropping_panelist_changes_means():
     validated = validate_descriptive(_panel(), _obs(), mode="observational")
-    kept = analyze_descriptive(validated, drop_panelists=None, discriminator=False)
-    dropped = analyze_descriptive(validated, drop_panelists="auto", discriminator=False)
+    kept = analyze_descriptive(validated, drop_panelists=None, find_predictive=False)
+    dropped = analyze_descriptive(validated, drop_panelists="auto", find_predictive=False)
     assert "P8" in dropped.dropped
     assert kept.product_means.shape == dropped.product_means.shape
     merged = kept.product_means.merge(dropped.product_means, on=["product", "attribute"], suffixes=("_keep", "_drop"))
@@ -310,7 +311,7 @@ def test_relate_designed_is_stub():
 
 def test_relate_observational_finds_descriptor():
     validated = validate_descriptive(_panel(), _obs(), mode="observational")
-    result = analyze_descriptive(validated, discriminator=False)
+    result = analyze_descriptive(validated, find_predictive=False)
     assoc = pd.DataFrame(result.relate["associations"])
     a_sodium = assoc[(assoc["attribute"] == "A") & (assoc["descriptor"] == "sodium")].iloc[0]
     a_fat = assoc[(assoc["attribute"] == "A") & (assoc["descriptor"] == "fat")].iloc[0]
@@ -321,7 +322,7 @@ def test_relate_observational_finds_descriptor():
 
 def test_relate_observational_q_values_monotone():
     validated = validate_descriptive(_panel(), _obs(), mode="observational")
-    result = analyze_descriptive(validated, discriminator=False)
+    result = analyze_descriptive(validated, find_predictive=False)
     assoc = pd.DataFrame(result.relate["associations"]).sort_values("p_value")
     assert np.all(np.diff(assoc["q_value"].to_numpy()) >= -1e-12)
 
@@ -335,13 +336,13 @@ def test_collinear_clusters_groups_correlated_descriptors():
     assert clusters["c"] != clusters["a"]  # an independent column is its own cluster
 
 
-def test_discriminator_gate_and_clusters():
+def test_predictive_descriptor_gate_and_clusters():
     products = [f"P{i}" for i in range(9)]
     rng = np.random.default_rng(3)
     u = np.linspace(0.0, 1.0, 9) + rng.normal(0, 0.02, 9)
     agg = pd.DataFrame({"A": 2.0 * u + rng.normal(0, 0.05, 9), "B": rng.normal(0, 1, 9)}, index=products)
     cov = pd.DataFrame({"d1": u, "d2": u + 0.005 * rng.normal(0, 1, 9), "d3": rng.normal(0, 1, 9)}, index=products)
-    disc = discriminate_observational(agg, cov, n_components=1, n_permutations=49, random_state=0)
+    disc = find_predictive_descriptors(agg, cov, n_components=1, n_permutations=49, random_state=0)
 
     # The collinear pair shares a cluster; the noise descriptor does not.
     assert disc["clusters"]["d1"] == disc["clusters"]["d2"] != disc["clusters"]["d3"]
@@ -351,11 +352,11 @@ def test_discriminator_gate_and_clusters():
     assert not bool(gate.loc["B", "predictable"])  # B is noise, not predictable
 
     desc = pd.DataFrame(disc["descriptors"])
-    assert set(desc.columns) >= {"selectivity_ratio", "p_value", "q_value", "discriminator_significant"}
+    assert set(desc.columns) >= {"selectivity_ratio", "p_value", "p_value_fwer", "is_predictive"}
     # Nothing is flagged for the unpredictable attribute, and the noise
     # descriptor is never flagged.
-    assert not desc[desc["attribute"] == "B"]["discriminator_significant"].any()
-    assert not desc[desc["descriptor"] == "d3"]["discriminator_significant"].any()
+    assert not desc[desc["attribute"] == "B"]["is_predictive"].any()
+    assert not desc[desc["descriptor"] == "d3"]["is_predictive"].any()
 
 
 def test_jackknife_correlation_edge_cases():
@@ -482,7 +483,7 @@ def test_relate_influence_deletions_two_demotes_two_support_spike():
     validated = validate_descriptive(panel, cov, mode="observational")
 
     def spike_robust(deletions: int) -> bool:
-        result = analyze_descriptive(validated, discriminator=False, influence_deletions=deletions)
+        result = analyze_descriptive(validated, find_predictive=False, influence_deletions=deletions)
         assoc = pd.DataFrame(result.relate["associations"])
         row = assoc[(assoc["attribute"] == "C") & (assoc["descriptor"] == "two_spike")].iloc[0]
         return bool(row["influence_robust"])
@@ -502,7 +503,7 @@ def test_relate_marginal_demotes_single_support_spike():
     """
     panel, cov = _leverage_case()
     validated = validate_descriptive(panel, cov, mode="observational")
-    result = analyze_descriptive(validated, discriminator=False)
+    result = analyze_descriptive(validated, find_predictive=False)
     assoc = pd.DataFrame(result.relate["associations"])
 
     # New influence-robustness fields are surfaced per association.
@@ -523,8 +524,8 @@ def test_relate_marginal_demotes_single_support_spike():
     assert genuine_a["significant"]
 
 
-def test_discriminator_demotes_single_support_spike():
-    """The cross-validated discriminator must also demote a single-support spike."""
+def test_predictive_search_demotes_single_support_spike():
+    """The predictive-descriptor search must also demote a single-support spike."""
     n = len(LEVERAGE_PRODUCTS)
     rng = np.random.default_rng(2)
     genuine = np.linspace(0.0, 1.0, n)
@@ -538,7 +539,7 @@ def test_discriminator_demotes_single_support_spike():
         index=LEVERAGE_PRODUCTS,
     )
     cov = pd.DataFrame({"genuine": genuine, "spike": spike, "noise": rng.normal(0, 1, n)}, index=LEVERAGE_PRODUCTS)
-    disc = discriminate_observational(agg, cov, n_components=1, n_permutations=99, random_state=0)
+    disc = find_predictive_descriptors(agg, cov, n_components=1, n_permutations=99, random_state=0)
     desc = pd.DataFrame(disc["descriptors"])
 
     assert "jackknife_significant" in desc.columns
@@ -546,7 +547,7 @@ def test_discriminator_demotes_single_support_spike():
     # spans zero and it is never confirmed.
     spike_rows = desc[desc["descriptor"] == "spike"]
     assert not spike_rows["jackknife_significant"].any()
-    assert not spike_rows["discriminator_significant"].any()
+    assert not spike_rows["is_predictive"].any()
     # The genuine driver stays jackknife-stable on the attribute it drives, so the
     # jackknife gate demotes the single-support spike without over-pruning a real
     # driver's predictive coefficient.
@@ -554,7 +555,7 @@ def test_discriminator_demotes_single_support_spike():
     assert genuine_a["jackknife_significant"]
 
 
-def test_discriminator_small_sample_skips_jackknife_gate():
+def test_predictive_search_small_sample_skips_jackknife_gate():
     """With too few products the LOO gate is skipped, so nothing is confirmed.
 
     Below the cross-validation floor the per-coefficient jackknife cannot be run, so
@@ -566,10 +567,10 @@ def test_discriminator_small_sample_skips_jackknife_gate():
     agg = pd.DataFrame({"A": 2.0 * u + rng.normal(0, 0.05, 4)}, index=products)
     cov = pd.DataFrame({"d1": u, "d2": rng.normal(0, 1, 4)}, index=products)
 
-    disc = discriminate_observational(agg, cov, n_components=1, n_permutations=19, random_state=0)
+    disc = find_predictive_descriptors(agg, cov, n_components=1, n_permutations=19, random_state=0)
     desc = pd.DataFrame(disc["descriptors"])
     assert not desc["jackknife_significant"].any()
-    assert not desc["discriminator_significant"].any()
+    assert not desc["is_predictive"].any()
 
 
 def _null_case(seed: int = 0) -> tuple[pd.DataFrame, pd.DataFrame]:
@@ -772,8 +773,8 @@ def test_analyze_correction_align_changes_means_and_reports_mam():
     panel = _scaling_panel()
     obs = pd.DataFrame({"product": sorted(panel["product"].unique()), "d": range(panel["product"].nunique())})
     validated = validate_descriptive(panel, obs, mode="observational")
-    none = analyze_descriptive(validated, correction="none", discriminator=False)
-    aligned = analyze_descriptive(validated, correction="align", discriminator=False)
+    none = analyze_descriptive(validated, correction="none", find_predictive=False)
+    aligned = analyze_descriptive(validated, correction="align", find_predictive=False)
     assert aligned.correction == "align"
     assert not aligned.mam.scaling.empty
     merged = none.product_means.merge(aligned.product_means, on=["product", "attribute"], suffixes=("_none", "_align"))
@@ -963,10 +964,34 @@ def test_tool_analyze_exposes_correction_and_mam():
         "covariates": [{"product": p, "d": i} for i, p in enumerate(products)],
         "mode": "observational",
         "correction": "align",
-        "discriminator": False,
+        "find_predictive": False,
     }
     out = execute_tool_call("sensory_analyze_descriptive", payload)
     assert out["ok"]
     assert out["correction"] == "align"
     ftest = out["mam"]["ftests"][0]
     assert ftest["f_product_mam"] > ftest["f_product_classical"]
+
+
+def test_renamed_sensory_name_points_at_its_replacement():
+    """The 2.0.0 rename removed the old name outright; it must say what to use."""
+    from process_improve import sensory
+    from process_improve.sensory import analysis
+
+    for module in (sensory, analysis):
+        with pytest.raises(AttributeError, match="find_predictive_descriptors"):
+            _ = module.discriminate_observational
+
+
+def test_permutation_column_null_is_still_exported():
+    """It was proposed for deletion and deliberately kept: block-level screening.
+
+    All three stated reasons for removing it failed on review - it answers a
+    block-level question the per-attribute function does not, its knockoff band
+    is not the VIP-exceedance count the library warns against, and a calibration
+    experiment measured it conservative rather than anti-conservative.
+    """
+    from process_improve.sensory import permutation_column_null
+
+    assert callable(permutation_column_null)
+    assert "permutation_column_null" in sensory.__all__

--- a/tests/test_sensory_end_to_end.py
+++ b/tests/test_sensory_end_to_end.py
@@ -12,7 +12,7 @@ nuisances. Three assessors are planted to misbehave:
 * ``J03`` rates everything high (a location shift),
 * ``J09`` uses only the middle of the scale (a compressed range).
 
-The covariate families exercise the cross-validated discriminator: it keeps the
+The covariate families exercise the predictive-descriptor search: it keeps the
 genuine drivers, reports the collinear proxies as one inseparable cluster, and
 demotes a nuisance that correlates with an attribute only by chance.
 """
@@ -111,7 +111,7 @@ def make_panel_and_covariates(seed: int = 0) -> tuple[pd.DataFrame, pd.DataFrame
     # Three unrelated measurement-condition nuisances (no causal link to any
     # attribute). A dedicated RNG seed is chosen so one of them (lab_humidity)
     # lands a chance correlation with an attribute in this small sample, which
-    # the marginal test flags but the cross-validated discriminator demotes.
+    # the marginal test flags but the predictive-descriptor search demotes.
     noise_rng = np.random.default_rng(16)
     covariates["headspace_volume"] = _sig(noise_rng.uniform(5.0, 25.0, n), 3)  # mL
     covariates["sample_mass"] = _sig(noise_rng.uniform(180.0, 260.0, n), 3)  # g
@@ -213,16 +213,16 @@ def test_pipeline_end_to_end():  # noqa: PLR0915
     assert set(assoc["attribute"]) == set(ATTRIBUTES)
     assert _assoc_row(assoc, "Bitterness", "polyphenols")["significant"]
 
-    # Step 5: the cross-validated discriminator separates predictive structure
+    # Step 5: the predictive-descriptor search separates predictive structure
     # from in-sample coincidence.
-    disc = result.relate["discriminator"]
+    disc = result.relate["predictive_descriptors"]
     gate = pd.DataFrame(disc["per_attribute"]).set_index("attribute")
     desc = pd.DataFrame(disc["descriptors"])
     clusters = disc["clusters"]
 
     def _disc(attribute: str, descriptor: str) -> bool:
         row = desc[(desc["attribute"] == attribute) & (desc["descriptor"] == descriptor)].iloc[0]
-        return bool(row["discriminator_significant"])
+        return bool(row["is_predictive"])
 
     # Q-squared gate: attributes with a real driver are predictable out of
     # sample; attributes with none are not.
@@ -244,20 +244,20 @@ def test_pipeline_end_to_end():  # noqa: PLR0915
     assert clusters["titratable_acidity"] != clusters["brix"]
 
     # Trap A: a nuisance that correlates with an attribute only by chance is
-    # flagged by the marginal test but demoted by the discriminator, while the
+    # flagged by the marginal test but demoted by the predictive search, while the
     # genuine drivers of that same attribute survive.
     assert _assoc_row(assoc, "Liking", "lab_humidity")["significant"]
     assert not _disc("Liking", "lab_humidity")
     assert _disc("Liking", "brix")
     assert _disc("Liking", "price")
 
-    # No measurement-condition nuisance is ever discriminator-significant, and
-    # the discriminator flags strictly fewer pairs than the marginal test.
+    # No measurement-condition nuisance is ever flagged predictive, and the
+    # search flags strictly fewer pairs than the marginal test.
     nuisances = {"headspace_volume", "sample_mass", "lab_humidity", "serving_temperature"}
-    assert not desc[desc["descriptor"].isin(nuisances)]["discriminator_significant"].any()
+    assert not desc[desc["descriptor"].isin(nuisances)]["is_predictive"].any()
     marginal_pairs = set(map(tuple, assoc[assoc["significant"]][["attribute", "descriptor"]].to_numpy()))
-    disc_pairs = set(map(tuple, desc[desc["discriminator_significant"]][["attribute", "descriptor"]].to_numpy()))
-    assert disc_pairs < marginal_pairs  # strict subset: the discriminator narrows the findings
+    disc_pairs = set(map(tuple, desc[desc["is_predictive"]][["attribute", "descriptor"]].to_numpy()))
+    assert disc_pairs < marginal_pairs  # strict subset: the predictive search narrows the findings
 
 
 def test_means_only_table_is_refused():


### PR DESCRIPTION
## Summary

- Rename the permutation-null functions so their names state the question they answer: `permutation_q2` -> `check_predictive_signal`, `pipeline_null` -> `count_discoveries_under_null`, `discriminate_observational` -> `find_predictive_descriptors`. The "discriminator" vocabulary goes with them (`result.relate["discriminator"]` -> `["predictive_descriptors"]`, `discriminator_significant` -> `is_predictive`, kwarg `discriminator=` -> `find_predictive=`, including on the `sensory_analyze_descriptive` tool schema). Removed names raise `AttributeError` naming their replacement, following the precedent in `univariate/metrics.py`.
- Fix two real naming defects that a review turned up and the original proposal walked past. `find_predictive_descriptors` claimed in its docstring to apply Benjamini-Hochberg correction; it does not, and never did, the code builds a Westfall-Young max-statistic null as its own inline comment says. And the field carrying that value was named `q_value`, FDR vocabulary for a family-wise-error-adjusted p-value, while `q_value` in the sibling `associations` list of the same result dict genuinely is a BH q-value. One key name, two quantities. It is now `p_value_fwer`.
- `check_predictive_signal` takes `x` and `y` first and makes `fit_predict` optional, defaulting to leave-one-out cross-validated PLS on the raw blocks, so each fold derives its own constants rather than inheriting constants computed from the row it is predicting.
- `empirical_fdr` -> `null_to_observed_ratio`, with the `[0, 1]` clip dropped. On pure noise the old field reported a tidy `1.0` for draws where shuffling actually out-found the real response, which is the single most informative reading the function can give. A test now pins that at least one such draw exceeds 1.

### Two things the proposal asked for that this does not do

- **Its section-5 "defect fix" is dropped.** `predictable = q2_cv > 0.0` is one of three conjunctive conditions at `analysis.py:456`, ANDed with a FWER-controlled max-statistic p-value and a jackknife flag, so a loose gate cannot manufacture findings. Its real role is to skip the 199-refit permutation loop. Routing it through a permutation null would have cost roughly 20-46x on the default `analyze_descriptive` path to fix a problem that is not there. The gate is now documented as the deliberate pre-screen it is.
- **`permutation_column_null` is kept, not deleted.** All three stated reasons fail: it answers a block-level question (one multi-response fit, one record per descriptor) that the per-attribute function does not; the `vip` note it cited condemns *counting* VIP > 1 exceedances under *response* permutation, which is not what it does; and a calibration experiment measured it conservative (VIP 1.9%, `cv_beta` 4.4% against a nominal 5%). It and `find_predictive_descriptors` now cross-reference each other so the choice between them is explicit.

The cross-attribute multiplicity gap is real (the max-statistic family is rebuilt per attribute, so nothing corrects across them) and is **documented, not closed** in this PR, since closing it changes results.

This is a breaking release with no deprecation cycle, departing from `CONTRIBUTING.md`. Deliberate and recorded in the CHANGELOG: the two multivariate names shipped in 1.76.0, one release and one day earlier, so shims would have carried dead weight to 2.0.0 for names nobody could have adopted.

## Test plan

- [x] `uv run pytest` green: **2978 passed, 3 skipped**, coverage 94.45% against the 92% gate
- [x] New coverage: the LOO default separates signal from noise, matches an explicit equivalent callable, and clamps an oversized `n_components`; pre-scaling the blocks does not change the answer; every removed name raises with its replacement on all import surfaces; `null_to_observed_ratio` equals the raw quotient and exceeds 1 on noise; `permutation_column_null` is still exported
- [x] `uv run ruff check .` and `uv run ruff format --check .` both pass
- [x] `uv run mypy src/process_improve` passes, 153 files
- [x] `uv run sphinx-build docs docs/_build/html -b html -W` succeeds, which is where a stale `:func:` role would have failed CI

## Checklist

- [x] Version bumped in `pyproject.toml` to `2.0.0` (MAJOR: public names removed), with `CITATION.cff` set to the identical version and date in the same commit
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated