### PR TITLE
Make the signal-ladder renames backward compatible, and ship 1.77.0 instead of 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,57 +11,59 @@ those changes.
 
 ## [Unreleased]
 
-## [2.0.0] - 2026-08-30
+## [1.77.0] - 2026-08-30
 
 Renames the functions that answer "is this relationship real, or is it noise?"
 so their names state the question rather than the technique, and fixes two
 naming defects the rename exposed.
 
-**No deprecation cycle.** `CONTRIBUTING.md` requires one for breaking changes;
-this release deliberately departs from that. The two multivariate names were
-added in 1.76.0, one release and one day before this one, and nothing depends
-on them yet, so warning shims would have carried dead weight to 2.0.0 for names
-nobody could have adopted. Every removed name raises `AttributeError` naming its
-replacement, following the migration-helper pattern already used in
-`process_improve.univariate.metrics`.
-
-### Removed
-
-- **`permutation_q2`** in `process_improve.multivariate`, renamed to
-  `check_predictive_signal`.
-- **`pipeline_null`** in `process_improve.multivariate`, renamed to
-  `count_discoveries_under_null`. "Pipeline" collided with
-  `sklearn.pipeline.Pipeline`, which it has nothing to do with, and "null" read
-  as a missing value.
-- **`discriminate_observational`** in `process_improve.sensory`, renamed to
-  `find_predictive_descriptors`. "Discriminate" read as discriminant analysis;
-  the function selects descriptors, it does not assign observations to classes.
-- The `q_value` field on the descriptor records of that function, renamed to
-  `p_value_fwer`; the `discriminator_significant` field, renamed to
-  `is_predictive`; the `empirical_fdr` key returned by the pipeline null,
-  renamed to `null_to_observed_ratio`.
-- The `discriminator=` keyword on `relate_observational`,
-  `analyze_descriptive` and the `sensory_analyze_descriptive` tool, renamed to
-  `find_predictive=`; the `result.relate["discriminator"]` key, renamed to
-  `result.relate["predictive_descriptors"]`.
+**Nothing is removed in this release.** Every old name, output key and keyword
+still works and now emits a `DeprecationWarning` naming its replacement. This is
+the Announce phase of `docs/development/deprecation_policy.rst`; removal is
+scheduled for 2.0.0.
 
 ### Added
 
-- **`check_predictive_signal`** takes `x` and `y` first and makes `fit_predict`
-  optional, defaulting to leave-one-out cross-validated PLS with `n_components`.
-  The default receives the raw blocks so every fold derives its own centring and
+- **`check_predictive_signal`** in `process_improve.multivariate`, replacing
+  `permutation_q2`. It takes `x` and `y` first and makes `fit_predict` optional,
+  defaulting to leave-one-out cross-validated PLS with `n_components`. The
+  default receives the raw blocks so every fold derives its own centring and
   scaling constants, which is the trap the parameter documentation warns callers
-  about. Its docstring now quantifies the cost: an out-of-sample null refits once
-  per fold per permutation, so leave-one-out on twenty products at the default
+  about. Its docstring quantifies the cost: an out-of-sample null refits once per
+  fold per permutation, so leave-one-out on twenty products at the default
   `n_perm=500` is ten thousand fits.
+- **`count_discoveries_under_null`**, replacing `pipeline_null`. "Pipeline"
+  collided with `sklearn.pipeline.Pipeline`, which it has nothing to do with, and
+  "null" read as a missing value.
+- **`find_predictive_descriptors`** in `process_improve.sensory`, replacing
+  `discriminate_observational`. "Discriminate" read as discriminant analysis; the
+  function selects descriptors, it does not assign observations to classes.
+- **`null_to_observed_ratio`**, the unclipped form of `empirical_fdr`. The old
+  key reported `1.0` whenever shuffling found at least as much as the real
+  response did, which is the single most informative reading the function can
+  produce; clipping rounded it away behind a number that looked like a
+  well-behaved rate. `empirical_fdr` is still returned, still clipped, so no
+  existing caller changes behaviour.
+- **`p_value_fwer`** and **`is_predictive`** on the descriptor records, replacing
+  `q_value` and `discriminator_significant`. Both old keys are still emitted with
+  identical values.
+- **`result.relate["predictive_descriptors"]`**, replacing
+  `result.relate["discriminator"]`. Both keys reference the same object.
+- **`find_predictive=`**, replacing the `discriminator=` keyword on
+  `relate_observational`, `analyze_descriptive` and the
+  `sensory_analyze_descriptive` tool. Passing both raises `ValueError`.
+
+### Deprecated
+
+Deprecated since 1.77.0; will be removed in 2.0.0:
+
+- `permutation_q2`, `pipeline_null` and `discriminate_observational`, which now
+  forward to their replacements and warn.
+- The `empirical_fdr`, `q_value`, `discriminator_significant` and
+  `discriminator` keys, and the `discriminator=` keyword.
 
 ### Changed
 
-- **`null_to_observed_ratio` is no longer clipped to `[0, 1]`.** The old
-  `empirical_fdr` reported 1.0 whenever shuffling found at least as much as the
-  real response did. That is the single most informative reading the function
-  can produce, and clipping rounded it away behind a number that looked like a
-  well-behaved rate.
 - `find_predictive_descriptors` documents that its multiplicity correction is
   **within an attribute, not across attributes**: the max-statistic null is
   rebuilt per attribute, so on a panel of `A` attributes at `alpha` roughly
@@ -89,7 +91,7 @@ replacement, following the migration-helper pattern already used in
 - **The field carrying that value was named `q_value`**, FDR vocabulary for a
   family-wise-error-adjusted p-value. `q_value` in the sibling `associations`
   list of the same result dict genuinely is a BH q-value, so one key name meant
-  two different quantities. It is now `p_value_fwer`.
+  two different quantities. The new `p_value_fwer` says what it holds.
 
 ## [1.76.0] - 2026-08-29
 
@@ -3964,8 +3966,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v2.0.0...HEAD
-[2.0.0]: https://github.com/kgdunn/process-improve/compare/v1.76.0...v2.0.0
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.77.0...HEAD
+[1.77.0]: https://github.com/kgdunn/process-improve/compare/v1.76.0...v1.77.0
 [1.76.0]: https://github.com/kgdunn/process-improve/compare/v1.75.2...v1.76.0
 [1.75.2]: https://github.com/kgdunn/process-improve/compare/v1.75.1...v1.75.2
 [1.75.1]: https://github.com/kgdunn/process-improve/compare/v1.75.0...v1.75.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 2.0.0
+version: 1.77.0
 date-released: "2026-08-30"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "2.0.0"
+version = "1.77.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/__init__.py
+++ b/src/process_improve/multivariate/__init__.py
@@ -1,7 +1,5 @@
 """Multivariate analysis: PCA, PLS, TPLS, scaling, and diagnostic plots."""
 
-from typing import NoReturn
-
 from process_improve.multivariate.methods import (
     OPLS,
     PCA,
@@ -17,6 +15,8 @@ from process_improve.multivariate.methods import (
     eigenvalue_summary,
     group_contributions,
     observation_contributions,
+    permutation_q2,
+    pipeline_null,
     project_variables,
     rv2_coefficient,
     rv_coefficient,
@@ -57,6 +57,8 @@ __all__ = [
     "group_contributions",
     "loading_plot",
     "observation_contributions",
+    "permutation_q2",
+    "pipeline_null",
     "predictions_vs_observed_plot",
     "project_variables",
     "rv2_coefficient",
@@ -71,20 +73,3 @@ __all__ = [
     "t2_plot",
     "vip",
 ]
-
-# ---------------------------------------------------------------------------
-# Migration helpers - old names raise helpful errors
-# ---------------------------------------------------------------------------
-
-_RENAMED = {
-    "permutation_q2": "check_predictive_signal",
-    "pipeline_null": "count_discoveries_under_null",
-}
-
-
-def __getattr__(name: str) -> NoReturn:
-    """Raise a helpful error when a renamed module attribute is accessed."""
-    if name in _RENAMED:
-        new = _RENAMED[name]
-        raise AttributeError(f"{name!r} has been renamed to {new!r}. Use: from {__name__} import {new}")
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/process_improve/multivariate/_null.py
+++ b/src/process_improve/multivariate/_null.py
@@ -41,7 +41,6 @@ from __future__ import annotations
 import re
 import warnings
 from collections.abc import Callable, Iterable, Sequence
-from typing import NoReturn
 
 import numpy as np
 import pandas as pd
@@ -50,7 +49,13 @@ from scipy.stats import hypergeom
 from ._common import SpecificationWarning
 from ._pls import PLS
 
-__all__ = ["check_predictive_signal", "class_enrichment", "count_discoveries_under_null"]
+__all__ = [
+    "check_predictive_signal",
+    "class_enrichment",
+    "count_discoveries_under_null",
+    "permutation_q2",
+    "pipeline_null",
+]
 
 
 def _as_frame(values: pd.DataFrame | pd.Series | np.ndarray, like: pd.DataFrame) -> pd.DataFrame:
@@ -328,6 +333,12 @@ def count_discoveries_under_null(
             Number of names selected on the real response.
         ``null_mean``, ``null_p95``
             Mean and 95th percentile of the selection count under permutation.
+        ``empirical_fdr``
+            .. deprecated:: 1.77.0
+                The old name for the ratio below, kept for one release and
+                clipped to ``[0, 1]`` as it always was. Prefer
+                ``null_to_observed_ratio``, which is unclipped. Will be removed
+                in 2.0.0.
         ``null_to_observed_ratio``
             ``null_mean / observed``; ``NaN`` when nothing was selected. Read it
             as "of the names this procedure returned, about this fraction is
@@ -398,6 +409,9 @@ def count_discoveries_under_null(
         "null_mean": null_mean,
         "null_p95": float(np.percentile(counts, 95)),
         "null_to_observed_ratio": ratio,
+        # Deprecated since 1.77.0, removed in 2.0.0: the same quantity under its
+        # old name, still clipped so an existing caller sees no change in value.
+        "empirical_fdr": float(np.clip(ratio, 0.0, 1.0)) if observed else float("nan"),
         "null_counts": counts,
         "selected": selected,
     }
@@ -507,20 +521,51 @@ def class_enrichment(
 
 
 # ---------------------------------------------------------------------------
-# Migration helpers - old names raise helpful errors
+# Deprecated aliases - removal scheduled for 2.0.0
 # ---------------------------------------------------------------------------
 
-_RENAMED = {
-    "permutation_q2": "check_predictive_signal",
-    "pipeline_null": "count_discoveries_under_null",
-}
+
+def permutation_q2(
+    fit_predict: Callable,
+    x: pd.DataFrame,
+    y: pd.DataFrame,
+    n_perm: int = 500,
+    seed: int = 0,
+) -> pd.DataFrame:
+    """Forward to :func:`check_predictive_signal`; emits a :class:`DeprecationWarning`.
+
+    .. deprecated:: 1.77.0
+        Use :func:`check_predictive_signal` instead. Note the argument order
+        changed: the blocks come first and ``fit_predict`` is now optional.
+        Will be removed in 2.0.0.
+    """
+    warnings.warn(
+        "process_improve.multivariate.permutation_q2 is deprecated since 1.77.0 and will be "
+        "removed in 2.0.0; use check_predictive_signal instead. Note the argument order changed: "
+        "check_predictive_signal(x, y, fit_predict=None, ...).",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    return check_predictive_signal(x, y, fit_predict, n_perm=n_perm, seed=seed)
 
 
-def __getattr__(name: str) -> NoReturn:
-    """Raise a helpful error when a renamed module attribute is accessed."""
-    if name in _RENAMED:
-        new = _RENAMED[name]
-        raise AttributeError(
-            f"{name!r} has been renamed to {new!r}. Use: from process_improve.multivariate import {new}"
-        )
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+def pipeline_null(
+    select: Callable,
+    x: pd.DataFrame,
+    y: pd.DataFrame,
+    n_perm: int = 500,
+    seed: int = 0,
+) -> dict:
+    """Forward to :func:`count_discoveries_under_null`; emits a :class:`DeprecationWarning`.
+
+    .. deprecated:: 1.77.0
+        Use :func:`count_discoveries_under_null` instead. Will be removed in
+        2.0.0.
+    """
+    warnings.warn(
+        "process_improve.multivariate.pipeline_null is deprecated since 1.77.0 and will be "
+        "removed in 2.0.0; use count_discoveries_under_null instead.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    return count_discoveries_under_null(select, x, y, n_perm=n_perm, seed=seed)

--- a/src/process_improve/multivariate/methods.py
+++ b/src/process_improve/multivariate/methods.py
@@ -12,8 +12,6 @@ The older :mod:`process_improve.multivariate._pca_pls` path is kept as a thin
 backward-compatibility shim that re-exports from here.
 """
 
-from typing import NoReturn
-
 from .._linalg import safe_inverse
 from .._random import check_random_state
 from ..univariate.metrics import detect_outliers_esd
@@ -52,7 +50,13 @@ from ._nipals import (
     ssq,
     terminate_check,
 )
-from ._null import check_predictive_signal, class_enrichment, count_discoveries_under_null
+from ._null import (
+    check_predictive_signal,
+    class_enrichment,
+    count_discoveries_under_null,
+    permutation_q2,
+    pipeline_null,
+)
 from ._opls import OPLS
 from ._pca import PCA
 from ._pls import PLS
@@ -105,6 +109,8 @@ __all__ = [
     "loading_plot",
     "nan_to_zeros",
     "observation_contributions",
+    "permutation_q2",
+    "pipeline_null",
     "predictions_vs_observed_plot",
     "project_variables",
     "quick_regress",
@@ -130,20 +136,3 @@ __all__ = [
     "terminate_check",
     "vip",
 ]
-
-# ---------------------------------------------------------------------------
-# Migration helpers - old names raise helpful errors
-# ---------------------------------------------------------------------------
-
-_RENAMED = {
-    "permutation_q2": "check_predictive_signal",
-    "pipeline_null": "count_discoveries_under_null",
-}
-
-
-def __getattr__(name: str) -> NoReturn:
-    """Raise a helpful error when a renamed module attribute is accessed."""
-    if name in _RENAMED:
-        new = _RENAMED[name]
-        raise AttributeError(f"{name!r} has been renamed to {new!r}. Use: from {__name__} import {new}")
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/process_improve/sensory/__init__.py
+++ b/src/process_improve/sensory/__init__.py
@@ -15,12 +15,11 @@ The public entry points are :func:`validate_descriptive` and
 ``process_improve.sensory.tools``.
 """
 
-from typing import NoReturn
-
 from process_improve.sensory.analysis import (
     AnalysisResult,
     aggregate_to_product,
     analyze_descriptive,
+    discriminate_observational,
     find_predictive_descriptors,
     permutation_column_null,
     product_means,
@@ -65,6 +64,7 @@ __all__ = [
     "boundary_occupancy",
     "compare_products",
     "detection_rate",
+    "discriminate_observational",
     "dunnett_vs_control",
     "factorial_anova",
     "find_predictive_descriptors",
@@ -78,20 +78,3 @@ __all__ = [
     "tukey_hsd",
     "validate_descriptive",
 ]
-
-
-# ---------------------------------------------------------------------------
-# Migration helpers - old names raise helpful errors
-# ---------------------------------------------------------------------------
-
-_RENAMED = {
-    "discriminate_observational": "find_predictive_descriptors",
-}
-
-
-def __getattr__(name: str) -> NoReturn:
-    """Raise a helpful error when a renamed module attribute is accessed."""
-    if name in _RENAMED:
-        new = _RENAMED[name]
-        raise AttributeError(f"{name!r} has been renamed to {new!r}. Use: from {__name__} import {new}")
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/process_improve/sensory/analysis.py
+++ b/src/process_improve/sensory/analysis.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import itertools
 import warnings
 from dataclasses import dataclass, field
-from typing import Any, NoReturn
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -113,6 +113,29 @@ _MIN_OBS_FOR_JACKKNIFE = 4
 #: Correlations are clipped off +/-1 before the Fisher-z transform so ``arctanh``
 #: stays finite.
 _R_CLIP = 1.0 - 1e-12
+
+
+def _resolve_find_predictive(find_predictive: bool, discriminator: bool | None) -> bool:
+    """Accept the deprecated ``discriminator=`` spelling of ``find_predictive=``.
+
+    .. deprecated:: 1.77.0
+        ``discriminator`` will be removed in 2.0.0.
+    """
+    if discriminator is None:
+        return find_predictive
+    if not find_predictive:
+        msg = (
+            "Pass either 'find_predictive' or the deprecated 'discriminator', not both. "
+            "They set the same thing: whether to run the per-attribute predictive-descriptor search."
+        )
+        raise ValueError(msg)
+    warnings.warn(
+        "The 'discriminator' argument is deprecated since 1.77.0 and will be removed in 2.0.0; "
+        "use 'find_predictive' instead.",
+        category=DeprecationWarning,
+        stacklevel=3,
+    )
+    return discriminator
 
 
 def _attach_fdr(records: list[dict[str, Any]], alpha: float) -> list[dict[str, Any]]:
@@ -485,8 +508,14 @@ def find_predictive_descriptors(  # noqa: PLR0913, PLR0915
                     "selectivity_ratio": float(sr_values[i]),
                     "p_value": float(p_raw[i]),
                     "p_value_fwer": float(p_maxt[i]),
+                    # Deprecated since 1.77.0, removed in 2.0.0: q_value is the
+                    # old name for p_value_fwer. It was always a family-wise
+                    # error rate, never an FDR q-value, which is why it moved.
+                    "q_value": float(p_maxt[i]),
                     "jackknife_significant": bool(desc_robust),
                     "is_predictive": bool(p_maxt[i] <= alpha and predictable and desc_robust),
+                    # Deprecated since 1.77.0, removed in 2.0.0.
+                    "discriminator_significant": bool(p_maxt[i] <= alpha and predictable and desc_robust),
                     "cluster_id": clusters[str(desc)],
                 }
             )
@@ -536,6 +565,7 @@ def relate_observational(  # noqa: PLR0913
     n_permutations: int = 199,
     random_state: int = 0,
     influence_deletions: int = 1,
+    discriminator: bool | None = None,
 ) -> dict[str, Any]:
     """Relate the attribute block to measured descriptors with PLS plus correlations.
 
@@ -547,6 +577,7 @@ def relate_observational(  # noqa: PLR0913
     sets how many observations are removed together: raise it to 2 to also demote a
     correlation carried by a single pair of observations.
     """
+    find_predictive = _resolve_find_predictive(find_predictive, discriminator)
     x_block = covariates.loc[agg.index].astype(float)
     y_block = agg.astype(float)
     max_comp = max(1, min(n_components, x_block.shape[1], x_block.shape[0] - 1))
@@ -594,6 +625,9 @@ def relate_observational(  # noqa: PLR0913
             n_permutations=n_permutations,
             random_state=random_state,
         )
+        # Deprecated since 1.77.0, removed in 2.0.0: the same object under its
+        # old key, so an existing caller reading result["discriminator"] works.
+        result["discriminator"] = result["predictive_descriptors"]
     return result
 
 
@@ -808,6 +842,7 @@ def analyze_descriptive(  # noqa: PLR0913
     n_permutations: int = 199,
     random_state: int = 0,
     influence_deletions: int = 1,
+    discriminator: bool | None = None,
 ) -> AnalysisResult:
     """Run the descriptive pipeline: panel check, correction, and relate.
 
@@ -878,6 +913,7 @@ def analyze_descriptive(  # noqa: PLR0913
         dropped = drop_panelists
     else:
         dropped = []
+    find_predictive = _resolve_find_predictive(find_predictive, discriminator)
     clean = apply_correction(working, dropped)
 
     agg = aggregate_to_product(clean)
@@ -912,6 +948,8 @@ def analyze_descriptive(  # noqa: PLR0913
             "conf_level": conf_level,
             "alpha": alpha,
             "find_predictive": find_predictive,
+            # Deprecated since 1.77.0, removed in 2.0.0.
+            "discriminator": find_predictive,
             "n_permutations": n_permutations,
             "random_state": random_state,
             "influence_deletions": influence_deletions,
@@ -921,17 +959,40 @@ def analyze_descriptive(  # noqa: PLR0913
 
 
 # ---------------------------------------------------------------------------
-# Migration helpers - old names raise helpful errors
+# Deprecated aliases - removal scheduled for 2.0.0
 # ---------------------------------------------------------------------------
 
-_RENAMED = {
-    "discriminate_observational": "find_predictive_descriptors",
-}
 
+def discriminate_observational(  # noqa: PLR0913
+    agg: pd.DataFrame,
+    covariates: pd.DataFrame,
+    *,
+    n_components: int = 2,
+    alpha: float = 0.05,
+    n_permutations: int = 199,
+    random_state: int = 0,
+    cluster_threshold: float = 0.95,
+    max_components_cv: int = 4,
+) -> dict[str, Any]:
+    """Forward to :func:`find_predictive_descriptors`; emits a :class:`DeprecationWarning`.
 
-def __getattr__(name: str) -> NoReturn:
-    """Raise a helpful error when a renamed module attribute is accessed."""
-    if name in _RENAMED:
-        new = _RENAMED[name]
-        raise AttributeError(f"{name!r} has been renamed to {new!r}. Use: from process_improve.sensory import {new}")
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    .. deprecated:: 1.77.0
+        Use :func:`find_predictive_descriptors` instead. Will be removed in
+        2.0.0.
+    """
+    warnings.warn(
+        "process_improve.sensory.discriminate_observational is deprecated since 1.77.0 and will "
+        "be removed in 2.0.0; use find_predictive_descriptors instead.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    return find_predictive_descriptors(
+        agg,
+        covariates,
+        n_components=n_components,
+        alpha=alpha,
+        n_permutations=n_permutations,
+        random_state=random_state,
+        cluster_threshold=cluster_threshold,
+        max_components_cv=max_components_cv,
+    )

--- a/src/process_improve/sensory/tools.py
+++ b/src/process_improve/sensory/tools.py
@@ -235,6 +235,13 @@ class _AnalyzeInput(BaseModel):
             "Set false to skip it (faster)."
         ),
     )
+    discriminator: bool | None = Field(
+        None,
+        description=(
+            "Deprecated since 1.77.0, removed in 2.0.0: the old name for find_predictive. "
+            "Leave unset and use find_predictive."
+        ),
+    )
     n_permutations: int = Field(199, ge=1, description="Permutations for the selectivity-ratio null.")
     random_state: int = Field(0, description="Seed for the permutations and CV folds.")
     score_min: float | None = Field(None, description="Optional lower bound for the score scale.")
@@ -294,6 +301,7 @@ def sensory_analyze_descriptive(spec: _AnalyzeInput) -> dict:
         conf_level=spec.conf_level,
         alpha=spec.alpha,
         find_predictive=spec.find_predictive,
+        discriminator=spec.discriminator,
         n_permutations=spec.n_permutations,
         random_state=spec.random_state,
     )

--- a/tests/test_multivariate_null.py
+++ b/tests/test_multivariate_null.py
@@ -21,6 +21,8 @@ from process_improve.multivariate import (
     check_predictive_signal,
     class_enrichment,
     count_discoveries_under_null,
+    permutation_q2,
+    pipeline_null,
 )
 from process_improve.multivariate._common import SpecificationWarning
 from process_improve.multivariate._null import _loo_fit_predict
@@ -396,28 +398,46 @@ class TestDefaultFitPredict:
         assert table["q2_observed"].notna().all()
 
 
-class TestRenamedNamesRaise:
-    """The 2.0.0 renames removed the old names outright; they must say so."""
+class TestDeprecatedAliases:
+    """1.77.0 renamed these; the old spellings still work and warn until 2.0.0."""
 
-    def test_old_multivariate_names_name_their_replacement(self) -> None:
+    def test_permutation_q2_warns_and_forwards(self) -> None:
+        x, y = _blocks(n_products=12, n_features=3)
+        with pytest.warns(DeprecationWarning, match="check_predictive_signal"):
+            old = permutation_q2(lambda _x, yy: yy.to_numpy(), x, y, n_perm=3, seed=0)
+        new = check_predictive_signal(x, y, lambda _x, yy: yy.to_numpy(), n_perm=3, seed=0)
+        pd.testing.assert_frame_equal(old, new)
+
+    def test_pipeline_null_warns_and_forwards(self) -> None:
+        x, y = _blocks(n_products=12, n_features=3)
+        with pytest.warns(DeprecationWarning, match="count_discoveries_under_null"):
+            old = pipeline_null(lambda _x, _y: ["c0"], x, y, n_perm=3, seed=0)
+        new = count_discoveries_under_null(lambda _x, _y: ["c0"], x, y, n_perm=3, seed=0)
+        assert old["observed"] == new["observed"]
+        assert old["null_to_observed_ratio"] == new["null_to_observed_ratio"]
+
+    def test_empirical_fdr_is_still_returned_and_still_clipped(self) -> None:
+        """The old key keeps its old value, so an existing caller sees no change.
+
+        ``null_to_observed_ratio`` is the same quantity unclipped; the pair only
+        differ once shuffling out-finds the real response.
+        """
+        x, y = _blocks(n_products=12, n_features=3)
+        result = count_discoveries_under_null(lambda _x, _y: ["c0"], x, y, n_perm=5, seed=0)
+        assert "empirical_fdr" in result
+        assert result["empirical_fdr"] == pytest.approx(min(result["null_to_observed_ratio"], 1.0))
+        assert 0.0 <= result["empirical_fdr"] <= 1.0
+
+    def test_the_old_names_are_still_exported(self) -> None:
         from process_improve import multivariate as mv
-        from process_improve.multivariate import _null, methods
+        from process_improve.multivariate import methods
 
-        for module in (mv, methods, _null):
-            with pytest.raises(AttributeError, match="check_predictive_signal"):
-                _ = module.permutation_q2
-            with pytest.raises(AttributeError, match="count_discoveries_under_null"):
-                _ = module.pipeline_null
+        for module in (mv, methods):
+            assert "permutation_q2" in module.__all__
+            assert "pipeline_null" in module.__all__
 
     def test_an_unrelated_missing_attribute_still_raises_plainly(self) -> None:
-        """Every surface carrying a migration helper must keep normal lookup honest.
+        from process_improve.multivariate import _null
 
-        The helper intercepts *all* failed attribute lookups, so its fallback
-        branch is what stands between a typo and a misleading rename message.
-        """
-        from process_improve import multivariate as mv
-        from process_improve.multivariate import _null, methods
-
-        for module in (mv, methods, _null):
-            with pytest.raises(AttributeError, match="has no attribute"):
-                _ = module.not_a_real_name
+        with pytest.raises(AttributeError):
+            _ = _null.not_a_real_name

--- a/tests/test_multivariate_null.py
+++ b/tests/test_multivariate_null.py
@@ -219,6 +219,9 @@ class TestPipelineNull:
             "null_to_observed_ratio",
             "null_counts",
             "selected",
+            # Deprecated since 1.77.0, removed in 2.0.0. Listed here so dropping
+            # it in 2.0.0 fails this test rather than passing silently.
+            "empirical_fdr",
         }
         assert len(result["null_counts"]) == 10
 

--- a/tests/test_sensory.py
+++ b/tests/test_sensory.py
@@ -15,6 +15,7 @@ from process_improve.sensory import (
     DESCRIPTIVE_LONG_COLUMNS,
     align_scores,
     analyze_descriptive,
+    discriminate_observational,
     mixed_assessor_model,
     panel_scorecard,
     validate_descriptive,
@@ -25,6 +26,7 @@ from process_improve.sensory.analysis import (
     find_predictive_descriptors,
     permutation_column_null,
     relate_designed,
+    relate_observational,
 )
 from process_improve.sensory.ingest import reshape_to_long
 from process_improve.univariate.metrics import benjamini_hochberg
@@ -973,14 +975,48 @@ def test_tool_analyze_exposes_correction_and_mam():
     assert ftest["f_product_mam"] > ftest["f_product_classical"]
 
 
-def test_renamed_sensory_name_points_at_its_replacement():
-    """The 2.0.0 rename removed the old name outright; it must say what to use."""
-    from process_improve import sensory
-    from process_improve.sensory import analysis
+def _discriminator_case():
+    """Build a small predictable case: one real driver, one noise descriptor."""
+    rng = np.random.default_rng(0)
+    n = 12
+    lat = rng.normal(size=n)
+    index = [f"p{i}" for i in range(n)]
+    agg = pd.DataFrame({"A": 3 * lat + rng.normal(scale=0.3, size=n)}, index=index)
+    cov = pd.DataFrame({"d1": lat + rng.normal(scale=0.2, size=n), "d2": rng.normal(size=n)}, index=index)
+    return agg, cov
 
-    for module in (sensory, analysis):
-        with pytest.raises(AttributeError, match="find_predictive_descriptors"):
-            _ = module.discriminate_observational
+
+def test_discriminate_observational_warns_and_forwards():
+    """1.77.0 renamed it; the old spelling still works and warns until 2.0.0."""
+    agg, cov = _discriminator_case()
+    with pytest.warns(DeprecationWarning, match="find_predictive_descriptors"):
+        old = discriminate_observational(agg, cov, n_components=1, n_permutations=19, random_state=0)
+    new = find_predictive_descriptors(agg, cov, n_components=1, n_permutations=19, random_state=0)
+    assert pd.DataFrame(old["descriptors"]).equals(pd.DataFrame(new["descriptors"]))
+
+
+def test_deprecated_descriptor_fields_mirror_their_replacements():
+    """The old field names are still emitted, carrying identical values."""
+    agg, cov = _discriminator_case()
+    desc = pd.DataFrame(
+        find_predictive_descriptors(agg, cov, n_components=1, n_permutations=19, random_state=0)["descriptors"]
+    )
+    assert desc["q_value"].equals(desc["p_value_fwer"])
+    assert desc["discriminator_significant"].equals(desc["is_predictive"])
+
+
+def test_discriminator_keyword_still_works_and_warns():
+    agg, cov = _discriminator_case()
+    with pytest.warns(DeprecationWarning, match="find_predictive"):
+        result = relate_observational(agg, cov, n_components=1, discriminator=True, n_permutations=19)
+    # Both result keys reference the same object, so an existing reader is fine.
+    assert result["discriminator"] is result["predictive_descriptors"]
+
+
+def test_passing_both_spellings_of_the_keyword_is_an_error():
+    agg, cov = _discriminator_case()
+    with pytest.raises(ValueError, match="not both"):
+        relate_observational(agg, cov, find_predictive=False, discriminator=True)
 
 
 def test_permutation_column_null_is_still_exported():


### PR DESCRIPTION
## Summary

- #534 landed the signal-ladder renames as a breaking `2.0.0`, removing four public names with no deprecation cycle. Nothing had been published (no `v2.0.0` tag; latest is `v1.75.2`), so this reworks the same change into the **Announce** phase `docs/development/deprecation_policy.rst` calls for: every old spelling still works and emits a `DeprecationWarning` naming its replacement, which makes the release purely additive and correctly a **MINOR**. Version is now `1.77.0`, with `CITATION.cff` in step.
- Restored as forwarding shims: `permutation_q2`, `pipeline_null`, `discriminate_observational`. The `permutation_q2` shim keeps the old argument order and adapts, since `check_predictive_signal` now takes the blocks first. All three take explicit signatures rather than `**kwargs`, so `help()` and `inspect.signature` stay accurate.
- Restored as deprecated output keys, alongside their replacements and carrying identical values: `q_value` (→ `p_value_fwer`), `discriminator_significant` (→ `is_predictive`), `result.relate["discriminator"]` (→ `["predictive_descriptors"]`, same object).
- Restored the `discriminator=` keyword on `relate_observational`, `analyze_descriptive` and the `sensory_analyze_descriptive` tool input. Passing both spellings raises `ValueError` rather than silently picking one, following the `desirability_weights` precedent in `experiments/optimization.py`.
- `empirical_fdr` is returned again, **still clipped to `[0, 1]`** exactly as before, so an existing caller reads the same number it always did. `null_to_observed_ratio` is the same quantity unclipped; the two only diverge once shuffling out-finds the real response, which is the case the old key was hiding.

Removal of all of the above is scheduled for `2.0.0`.

The substance of the rename is unchanged from #534, including the two defects it fixed: the `find_predictive_descriptors` docstring claimed Benjamini-Hochberg correction while the code builds a Westfall-Young max-statistic null, and the field named `q_value` held a family-wise-error-adjusted p-value while `q_value` in the sibling `associations` list of the same dict genuinely is a BH q-value.

## Test plan

- [x] Full `uv run pytest` suite with the coverage gate: **2984 passed, 3 skipped**, coverage 94.46% against the 92% gate
- [x] `uv run pytest tests/test_sensory.py tests/test_sensory_end_to_end.py` green: 63 passed
- [x] `uv run pytest tests/test_multivariate_null.py` green, including the new `TestDeprecatedAliases`
- [x] New coverage: each old function name warns and returns a result identical to its replacement; the deprecated descriptor fields mirror their replacements exactly; the `discriminator=` keyword warns and both result keys reference the same object; passing both keyword spellings raises; `empirical_fdr` is still clipped and equals `min(null_to_observed_ratio, 1.0)`
- [x] The package does not warn on itself: the default `relate_observational` path runs clean under `-W error::DeprecationWarning`
- [x] `uv run ruff check .` and `uv run ruff format --check .` both pass
- [x] `uv run mypy src/process_improve` passes, 153 files

The one CI failure on this head was `test (3.13, macos-latest)` hitting the known pulp/CBC-under-Rosetta flake in `tests/test_omars_ilp.py`, which this PR does not touch. It passed on re-run of the same commit, confirming the intermittency. Details in the comment below.

## Checklist

- [x] Version bumped in `pyproject.toml` to `1.77.0` (MINOR: additive only, nothing removed), with `CITATION.cff` set to the identical version in the same commit
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated, with an `### Added` and a `### Deprecated` section replacing the previous `### Removed`