### PR TITLE
docs: fix docstring drift across computational and user-facing APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ those changes.
 
 ## [Unreleased]
 
+## [1.78.1] - 2026-09-04
+
+### Changed
+
+- Docs-only sweep across the computational and user-facing APIs: fixed
+  sixteen concrete drifts between docstrings and current code behaviour,
+  covering `multivariate.scale` / `center` / `spe_limit` /
+  `PCA.n_components` / `PLS.n_components` / `PLS.fit_transform`,
+  `regression.multiple_linear_regression`,
+  `experiments.dispatch_d_optimal` / `dispatch_i_optimal` /
+  `dispatch_a_optimal` / `AnalysisResult`, `batch.f_crossing` /
+  `apply_scaling` / `reverse_scaling`,
+  `multivariate.TPLS.score`, and `sensory.validate_descriptive`. No
+  runtime behaviour changed.
+
 ## [1.78.0] - 2026-08-30
 
 ### Added
@@ -4002,7 +4017,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.78.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.78.1...HEAD
+[1.78.1]: https://github.com/kgdunn/process-improve/compare/v1.78.0...v1.78.1
 [1.78.0]: https://github.com/kgdunn/process-improve/compare/v1.77.0...v1.78.0
 [1.77.0]: https://github.com/kgdunn/process-improve/compare/v1.76.0...v1.77.0
 [1.76.0]: https://github.com/kgdunn/process-improve/compare/v1.75.2...v1.76.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.78.0
-date-released: "2026-08-30"
+version: 1.78.1
+date-released: "2026-09-04"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.78.0"
+version = "1.78.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/batch/features.py
+++ b/src/process_improve/batch/features.py
@@ -640,13 +640,14 @@ def f_crossing(  # noqa: PLR0913
     between the indices. If you prefer the index itself, use `only_index=True`,
     but the default for that setting is `False`.
 
-    Does this for each unique batch in the `batch_col` indicator column, and
-    within each unique phase, per batch, of the `phase_col` column.
+    Does this for each unique batch in the `batch_col` indicator column. The
+    `phase_col` argument is accepted for signature-compatibility with the
+    other ``f_*`` features but is not consumed here: the crossing is looked
+    up over the whole batch, not per phase.
 
     `suffix`: what to add to the data tag, to name to this feature.
 
-    Note: NaN is returned for a given batch and phase, if the crossing is not
-    found.
+    Note: NaN is returned for a given batch, if the crossing is not found.
 
     """
     base_name = f"cross-{int(threshold)}" if suffix is None else str(suffix)

--- a/src/process_improve/batch/preprocessing.py
+++ b/src/process_improve/batch/preprocessing.py
@@ -108,12 +108,17 @@ def apply_scaling(
     batches : dict[str, pd.DataFrame]
         The batches, in standard format.
     scale_df : pd.DataFrame
-        The scaling dataframe, from `determine_scaling`
+        The scaling dataframe, from `determine_scaling`.
+    columns_to_align : list, pd.Index, or None, optional
+        Which columns of each batch to scale. Columns outside this list are
+        dropped from the output. When ``None`` (the default) the columns of
+        the first batch are used, matching :func:`determine_scaling`.
 
     Returns
     -------
     dict
-        The scaled batch data.
+        The scaled batch data. Each value carries only the ``columns_to_align``
+        columns, in the same order as the input.
     """
     # TODO: handle the case of DataFrames still
     if columns_to_align is None:
@@ -140,7 +145,24 @@ def reverse_scaling(
     scale_df: pd.DataFrame,
     columns_to_align: list | pd.Index | None = None,
 ) -> dict:
-    """Reverse the scaling applied by `apply_scaling`."""
+    """Reverse the scaling applied by `apply_scaling`.
+
+    Parameters
+    ----------
+    batches : dict[str, pd.DataFrame]
+        The scaled batches, in standard format.
+    scale_df : pd.DataFrame
+        The scaling dataframe, from :func:`determine_scaling`.
+    columns_to_align : list, pd.Index, or None, optional
+        Which columns of each batch to un-scale. Columns outside this list
+        are dropped from the output. When ``None`` (the default) the columns
+        of the first batch are used, matching :func:`apply_scaling`.
+
+    Returns
+    -------
+    dict
+        The un-scaled batch data.
+    """
     # TODO: handle the case of DataFrames still
     if columns_to_align is None:
         if isinstance(batches, dict):

--- a/src/process_improve/experiments/analysis.py
+++ b/src/process_improve/experiments/analysis.py
@@ -104,9 +104,14 @@ def build_formula(
 
 @dataclass
 class AnalysisResult:
-    """Container returned by :func:`analyze_experiment`.
+    """Internal, unused container.
 
-    Holds the fitted OLS result and all requested analysis outputs.
+    Retained for backwards compatibility with any external caller that
+    imports the name from this module. :func:`analyze_experiment` returns
+    a plain :class:`dict` (see its ``Returns`` section), not an instance of
+    this class, so downstream code that expects the return type of
+    ``analyze_experiment`` should key into that dict rather than access
+    attributes here.
     """
 
     ols_result: RegressionResultsWrapper = None

--- a/src/process_improve/experiments/designs_optimal.py
+++ b/src/process_improve/experiments/designs_optimal.py
@@ -455,6 +455,11 @@ def dispatch_d_optimal(  # noqa: PLR0913
         Factor-space constraints (logged as warning; not yet enforced).
     model_type : str
         Model assumption: ``"main_effects"``, ``"interactions"``, or ``"quadratic"``.
+    fixed_runs : pd.DataFrame or None
+        Runs to hold fixed while the optimizer fills the rest (design
+        augmentation). Requires pyoptex; a value here raises ``ImportError``
+        when pyoptex is not installed. Occupies the first rows of the returned
+        design and counts towards ``budget``.
 
     Returns
     -------
@@ -524,9 +529,14 @@ def dispatch_i_optimal(  # noqa: PLR0913
     hard_to_change : list[str] or None
         Names of hard-to-change factors.
     constraints : list[Constraint] or None
-        Factor-space constraints.
+        Factor-space constraints (logged; not yet enforced by the underlying
+        pyoptex path).
     model_type : str
         Model assumption.
+    fixed_runs : pd.DataFrame or None
+        Runs to hold fixed while the optimizer fills the rest (design
+        augmentation). Occupies the first rows of the returned design and
+        counts towards ``budget``.
 
     Returns
     -------
@@ -577,9 +587,14 @@ def dispatch_a_optimal(  # noqa: PLR0913
     hard_to_change : list[str] or None
         Names of hard-to-change factors.
     constraints : list[Constraint] or None
-        Factor-space constraints.
+        Factor-space constraints (logged; not yet enforced by the underlying
+        pyoptex path).
     model_type : str
         Model assumption.
+    fixed_runs : pd.DataFrame or None
+        Runs to hold fixed while the optimizer fills the rest (design
+        augmentation). Occupies the first rows of the returned design and
+        counts towards ``budget``.
 
     Returns
     -------

--- a/src/process_improve/multivariate/_limits.py
+++ b/src/process_improve/multivariate/_limits.py
@@ -78,7 +78,11 @@ def spe_limit(model: BaseEstimator, conf_level: float = 0.95) -> float:
     ----------
     model : BaseEstimator
         A fitted multivariate model exposing a ``spe_`` attribute and an
-        ``n_components`` attribute (e.g. a fitted PCA or PLS instance).
+        ``n_components_`` attribute (e.g. a fitted PCA or PLS instance).
+        The fitted ``n_components_`` (with the trailing underscore) is used,
+        not the constructor's ``n_components`` parameter, so a model whose
+        component count was clamped at ``min(n_samples, n_features)`` at fit
+        time is read with the value it actually holds.
     conf_level : float, optional
         Fractional confidence limit, less that 1.00; by default 0.95
 

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -226,8 +226,12 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
 
     Parameters
     ----------
-    n_components : int
-        Number of principal components to extract.
+    n_components : int or None
+        Number of principal components to extract. ``None`` (also accepted by
+        ``_parameter_constraints``) asks for as many components as the data
+        supports: it is clamped at fit time to ``min(n_samples, n_features)``,
+        and the resolved count is available on the fitted attribute
+        ``n_components_``.
 
     algorithm : str, default="auto"
         Algorithm to use for fitting the model.

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -195,8 +195,11 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
 
     Parameters
     ----------
-    n_components : int
-        Number of latent components to extract.
+    n_components : int or None
+        Number of latent components to extract. ``None`` asks for as many
+        components as the data supports: it is clamped at fit time to
+        ``min(n_samples, n_features)``, and the resolved count is available on
+        the fitted attribute ``n_components_``.
     scale : bool, default=True
         Mean-center and unit-variance-scale both the X and Y blocks internally
         before fitting (``ddof=1``, done with :class:`MCUVScaler`). This mirrors

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -965,6 +965,10 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         ----------
         X : array-like of shape (n_samples, n_features)
         Y : array-like of shape (n_samples, n_targets)
+            Required despite the ``None`` default: the default is present only
+            for signature-compatibility with the sklearn ``fit_transform``
+            protocol, and PLS cannot be fitted without responses. Calling
+            without ``Y`` raises :class:`AssertionError`.
 
         Returns
         -------

--- a/src/process_improve/multivariate/_preprocessing.py
+++ b/src/process_improve/multivariate/_preprocessing.py
@@ -168,7 +168,7 @@ def center(
     Perform centering of data, using a function, `func` (default: np.mean).
     The function, if supplied, must return a vector with as many columns as the matrix X.
 
-    `axis` [optional; default=0] {integer or None}
+    `axis` [optional; default=0] {integer}
 
     This specifies the axis along which the centering vector will be calculated if not provided.
     The function is applied along the `axis`: 0=down the columns; 1 = across the rows.
@@ -269,7 +269,7 @@ def scale(
     X = ...  # data matrix
     X = scale(center(X))
     X = scale(center(X), ddof=1)  # sample standard deviation, matches MCUVScaler
-    my_scale = np.mad
+    from scipy.stats import median_abs_deviation as my_scale
     X = scale(center(X), func=my_scale)
 
     Returns

--- a/src/process_improve/multivariate/_tpls.py
+++ b/src/process_improve/multivariate/_tpls.py
@@ -864,23 +864,33 @@ class TPLS(RegressorMixin, BaseEstimator):
         return output
 
     def score(self, X: DataFrameDict, y: None = None, sample_weight: np.ndarray | None = None) -> float:  # noqa: ARG002
-        """Return r2_score` on test data.
+        """Return the mean :func:`~sklearn.metrics.r2_score` across Y blocks on test data.
 
-        See RegressorMixin.score for more details.
+        See RegressorMixin.score for the general contract.
 
         Parameters
         ----------
         X : DataFrameDict
-            Test samples.
+            Test samples. The nested ``"Y"`` block supplies the actual response
+            values; ``X["Z"]`` and ``X["F"]`` drive the prediction.
 
-        y : Not used. In the `X` input, there is a already a "Y" block. This will be the Y-data.
+        y : None
+            Ignored. The Y-data comes from ``X["Y"]``, not from a separate
+            argument (the sklearn ``RegressorMixin.score`` signature is preserved
+            only for API compatibility).
 
-        sample_weight : Not used.
+        sample_weight : np.ndarray or None
+            Optional per-sample weight forwarded to
+            :func:`~sklearn.metrics.r2_score`.
 
         Returns
         -------
         score : float
-            :math:`R^2` of ``self.diagnose(X)``.
+            The mean of :func:`~sklearn.metrics.r2_score` computed separately on
+            every Y block in ``X["Y"]``, using ``self.diagnose(X).hat`` as the
+            prediction. A single Y block gives its own :math:`R^2`; more than
+            one is an unweighted average across blocks (not a pooled multiblock
+            :math:`R^2`).
         """
         # Use diagnose() directly to avoid emitting the predict()
         # DeprecationWarning from inside the package's own score path.

--- a/src/process_improve/regression/_robust_regression.py
+++ b/src/process_improve/regression/_robust_regression.py
@@ -327,7 +327,9 @@ def multiple_linear_regression(  # noqa: PLR0913
         N:                        number of observations actually used to fit
         coefficients:             a vector of K coefficients, one for each column in X;
                                   shape ``[np.nan]`` on the degenerate/unfitted path
-        intercept:                returned if fit_intercept==True
+        intercept:                the fitted intercept; ``np.nan`` when
+                                  ``fit_intercept=False`` or on the
+                                  degenerate/unfitted path
         standard_errors:          a vector of K standard errors, one per column in X
         standard_error_intercept: standard error for the intercept
         R2:                       the R^2 value

--- a/src/process_improve/sensory/validation.py
+++ b/src/process_improve/sensory/validation.py
@@ -154,10 +154,11 @@ def validate_descriptive(  # noqa: PLR0912, PLR0913, PLR0915, C901
         by product. In ``observational`` mode the remaining columns are measured
         numeric descriptors. ``designed`` mode (the columns being controlled
         factor levels) is not implemented yet.
-    mode : {"observational"}
+    mode : {"observational", "designed"}
         How the covariate table is interpreted. Only ``"observational"`` is
-        supported for now; ``"designed"`` raises ``NotImplementedError`` and is
-        planned for a later release.
+        supported for now; ``"designed"`` is accepted by the argument parser
+        but raises ``NotImplementedError`` at call time, and is planned for a
+        later release. Any other value raises ``ValueError`` up front.
     score_min, score_max : float or None
         Optional inclusive bounds for the ``score`` column; out-of-range values
         are reported as a warning.


### PR DESCRIPTION
## Summary

Docs-only sweep across the computational and user-facing APIs
(`multivariate`, `univariate`, `experiments`, `monitoring`, `batch`,
`regression`, `bivariate`, plus the MCP tool wrappers, `recipes.py` and
`tool_spec.py`). Every commit fixes a concrete, defensible mismatch
between a docstring and what the code actually does. No runtime
behaviour changes; the fix in each case is to bring the docstring in
line with the implementation.

Patch bump `1.78.0` -> `1.78.1`; `CITATION.cff` and `CHANGELOG.md` are
updated in the same series.

## Inconsistencies fixed

- **`src/process_improve/multivariate/_preprocessing.py`** — `scale()`
  (around line 269, docstring "Usage" block): the example wrote
  `my_scale = np.mad`, but `np.mad` does not exist. Repointed at
  `scipy.stats.median_abs_deviation`, which is the standard replacement
  and does the same job.
- **`src/process_improve/multivariate/_preprocessing.py`** — `center()`
  (around line 168, "axis" line): the axis type was documented as
  `{integer or None}`, but the code path at `axis == 1` reshapes with
  `-1, 1` and the `pd.DataFrame.apply(func, axis=None)` call would fail
  before that. None is not accepted; the docstring type is now `{integer}`.
- **`src/process_improve/multivariate/_limits.py`** — `spe_limit()`
  (line 78): the docstring said the model must expose an
  `n_components` attribute, but the code reads `model.n_components_`
  (the fitted, possibly clamped, value). Corrected the attribute name
  and note the distinction from the constructor parameter.
- **`src/process_improve/regression/_robust_regression.py`** —
  `multiple_linear_regression()` (line ~318, keys list): the docstring
  said `intercept: returned if fit_intercept==True`, but `OLS.to_dict()`
  always includes the `intercept` key (NaN when `fit_intercept=False` or
  on the degenerate/unfitted path). Reflect the actual behaviour.
- **`src/process_improve/experiments/designs_optimal.py`** —
  `dispatch_d_optimal` (line 432): the `fixed_runs` parameter (pyoptex
  design augmentation) was in the signature but missing from the
  Parameters section. Added, and noted that a value there requires
  pyoptex.
- **`src/process_improve/experiments/designs_optimal.py`** —
  `dispatch_i_optimal` (line 506): same missing `fixed_runs` parameter,
  same fix. Also clarified that `constraints` are logged but not
  enforced by the pyoptex path.
- **`src/process_improve/experiments/designs_optimal.py`** —
  `dispatch_a_optimal` (line 559): same missing `fixed_runs` parameter,
  same fix.
- **`src/process_improve/batch/features.py`** — `f_crossing()` (line
  621): the docstring said the crossing was found "within each unique
  phase, per batch, of the `phase_col` column", but the implementation
  passes `phase_col=None` to `_prepare_data` unconditionally — the
  `phase_col` argument is silently ignored. Documented the actual
  batch-only behaviour and noted the argument is retained only for
  signature-compatibility with the sibling `f_*` features.
- **`src/process_improve/experiments/analysis.py`** — `AnalysisResult`
  class (line 106): the docstring said it is the container "returned by
  `analyze_experiment`", but `analyze_experiment` returns a
  `dict[str, Any]` and never constructs one of these. Retagged as an
  internal, unused container kept for backwards compatibility, and point
  at the dict return.
- **`src/process_improve/multivariate/_pls.py`** — `PLS.fit_transform`
  (line 961): `Y` is required despite the `None` default in the
  signature. The default only exists to match the sklearn
  `fit_transform` protocol, and the code raises `AssertionError` when
  called without it. Say so in the parameter doc.
- **`src/process_improve/batch/preprocessing.py`** — `apply_scaling`
  (line 99): the signature accepts a `columns_to_align` argument, but
  the docstring only listed `batches` and `scale_df`. Documented the
  parameter and its default-to-first-batch-columns behaviour.
- **`src/process_improve/batch/preprocessing.py`** — `reverse_scaling`
  (line 138): one-line docstring gave no Parameters or Returns section
  at all; three parameters plus the return type were undocumented.
  Filled in the same Parameters/Returns block as `apply_scaling`.
- **`src/process_improve/multivariate/_pca.py`** — `PCA` class docstring
  (line 231, Parameters/`n_components`): documented as `int` only, but
  `_parameter_constraints` allows `None` and `fit()` special-cases it to
  the maximum supported count and clamps to `min(n_samples, n_features)`.
  Broadened the type to `int or None` and documented the clamp.
- **`src/process_improve/multivariate/_pls.py`** — `PLS` class docstring
  (line 197, Parameters/`n_components`): same drift as PCA — signature
  says `int` but `fit()` handles `None` the same way. Same fix, and same
  clamp note.
- **`src/process_improve/sensory/validation.py`** — `validate_descriptive`
  (line 156, "mode" line): the docstring listed the accepted values as
  `{"observational"}`, but the code accepts both `"observational"` and
  `"designed"`; `"designed"` reaches the body and raises
  `NotImplementedError`, any other value raises `ValueError` up front.
  Broadened the type tag to `{"observational", "designed"}` and
  clarified the two error paths.
- **`src/process_improve/multivariate/_tpls.py`** — `TPLS.score` (line
  867): the docstring was "Return r2_score\` on test data" (with a
  stray backtick) and said the return was "R² of `self.diagnose(X)`".
  The implementation actually accumulates `sklearn.metrics.r2_score` over
  every block in `X["Y"]` and divides by the number of blocks, so it is
  a per-block mean rather than a pooled R². Also `sample_weight` was
  documented as "Not used" but is threaded through to `r2_score`.
  Rewrote to match the implementation.

## Test plan

- [x] `ruff check .` and `ruff format --check .` clean on the touched
      files (docstring-only edits, so no runtime tests were re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8R2KLB6gvM92ByAQtVU95