### PR TITLE
Pass raw blocks to select_n_components in tests and docs; add the matching warnings to PCA (#533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ those changes.
 
 ## [Unreleased]
 
+## [1.79.0] - 2026-09-04
+
+### Changed
+
+- `PCA.select_n_components` now carries the same two `SpecificationWarning`s as
+  `PLS.select_n_components` (#533): one on `scale_inside_folds=False`, where
+  scaling fit on the full matrix leaks into every element-fold, and one on
+  `scale_inside_folds=True` when the X handed in is already centred and
+  unit-variance scaled, where the in-fold re-standardisation erases the scaling
+  the caller chose. Both fire only under `cv_scheme="ekf"`, the scheme that
+  honours the flag. The two selectors share one helper, so their messages and
+  their detection rule (`_looks_prescaled`) cannot drift apart.
+- The pre-scaled warning's wording no longer claims identical RMSECV "to several
+  decimal places". That was true for PLS, where RMSECV is in the units of Y,
+  but PCA reports PRESS in the units X arrived in; the message now says that a
+  comparison between two pre-scalings reflects only those units, never which
+  scaling suits the data.
+
+### Documentation
+
+- The user guide (`cross_validation`, `showcase`), the quickstart and the README
+  pass the raw, unscaled blocks to `PCA.select_n_components` and
+  `PLS.select_n_components`, which is the usage the default
+  `scale_inside_folds=True` is designed for. A reader who copied the previous
+  examples was warned by the library for following them. The PCA docstring said
+  the opposite ("should already be on the analysis scale") and now matches PLS.
+- The library's own tests do the same, so the suite no longer emits the warning.
+
 ## [1.78.0] - 2026-08-30
 
 ### Added
@@ -4002,7 +4030,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.78.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.79.0...HEAD
+[1.79.0]: https://github.com/kgdunn/process-improve/compare/v1.78.0...v1.79.0
 [1.78.0]: https://github.com/kgdunn/process-improve/compare/v1.77.0...v1.78.0
 [1.77.0]: https://github.com/kgdunn/process-improve/compare/v1.76.0...v1.77.0
 [1.76.0]: https://github.com/kgdunn/process-improve/compare/v1.75.2...v1.76.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.78.0
-date-released: "2026-08-30"
+version: 1.79.0
+date-released: "2026-09-04"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ result.y_hat                      # point predictions
 result.spe                        # squared prediction error
 result.hotellings_t2              # Hotelling's T² for new observations
 
-# Cross-validated component selection
-cv_select = PLS.select_n_components(X_s, Y_s, max_components=6)
+# Cross-validated component selection: raw blocks in, each fold scales itself
+cv_select = PLS.select_n_components(X, Y, max_components=6)
 print(cv_select.n_components)     # recommended number of components
 print(cv_select.rmsecv)           # RMSECV per component count
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -71,11 +71,13 @@ PLS Example
 Component Selection
 -------------------
 
-Use cross-validation to select the number of PCA components:
+Use cross-validation to select the number of PCA components. Pass the raw
+``X``, not ``X_scaled``: the selector fits the centring and scaling inside
+each fold, and warns if it is handed a block that is already scaled.
 
 .. code-block:: python
 
-   result = PCA.select_n_components(X_scaled, max_components=10)
+   result = PCA.select_n_components(X, max_components=10)
    print(f"Recommended: {result.n_components} components")
    print(f"PRESS ratios: {result.press_ratio}")
 

--- a/docs/user_guide/cross_validation.rst
+++ b/docs/user_guide/cross_validation.rst
@@ -28,12 +28,13 @@ Sum of Squares (PRESS) with K-fold cross-validation:
 
 .. code-block:: python
 
-   from process_improve.multivariate.methods import PCA, MCUVScaler
+   from process_improve.multivariate.methods import PCA
 
-   X_scaled = MCUVScaler().fit_transform(X)
-
+   # Pass the raw, unscaled X: with the default ``scale_inside_folds=True``
+   # the centring and scaling are fit inside each fold, so nothing about the
+   # held-out cells leaks into the model that predicts them.
    result = PCA.select_n_components(
-       X_scaled,
+       X,
        max_components=10,
        cv=7,  # 7-fold cross-validation
        threshold=0.95,  # Wold's criterion threshold
@@ -70,16 +71,24 @@ components are added.
 
 .. code-block:: python
 
-   from process_improve.multivariate.methods import PLS, MCUVScaler
+   from process_improve.multivariate.methods import PLS
 
-   X_s = MCUVScaler().fit_transform(X)
-   Y_s = MCUVScaler().fit_transform(Y)
-
-   result = PLS.select_n_components(X_s, Y_s, max_components=8, cv=5)
+   # Raw, unscaled blocks: each training fold fits its own MCUVScaler and
+   # RMSECV is reported on the original Y scale.
+   result = PLS.select_n_components(X, Y, max_components=8, cv=5)
 
    print(f"Recommended components: {result.n_components}")
    print(result.rmsecv["total"])         # RMSECV per component count
    print(result.r2y_validated["total"])  # Validated R2 of Y
+
+Do not scale the blocks yourself before calling either selector. In-fold
+re-standardisation overwrites whatever scaling you applied, so two
+deliberately different choices (autoscale versus Pareto, say) become the
+same model and a comparison between them shows no difference. Both
+selectors emit a ``SpecificationWarning`` when they receive an ``X`` that
+is already centred and unit-variance scaled. If you must keep your own
+scaling, pass ``scale_inside_folds=False``; the scaling then leaks from the
+full dataset into every fold, and a warning says so.
 
 The result is a ``Bunch`` with:
 

--- a/docs/user_guide/showcase.rst
+++ b/docs/user_guide/showcase.rst
@@ -5,8 +5,9 @@ After fitting a PCA or PLS model, the next questions are practical: how many
 components should the model keep, how well does it predict, and which
 variables drive it? This page is a worked tour of the evaluation and plotting
 tools, built around a PLS model that relates a set of process measurements
-(``X``) to quality outcomes (``Y``). Each example assumes ``X`` and ``Y`` are
-already scaled, for example with ``MCUVScaler``.
+(``X``) to quality outcomes (``Y``). ``X`` and ``Y`` are the raw blocks: the
+component selector scales them inside each fold, and the fitted models below
+scale them once with ``MCUVScaler``.
 
 Choosing the Number of Components
 ---------------------------------
@@ -18,8 +19,9 @@ the validated explained variance:
 
 .. code-block:: python
 
-   from process_improve.multivariate import PLS
+   from process_improve.multivariate import PLS, MCUVScaler
 
+   # Raw blocks in: each training fold fits its own scaling.
    result = PLS.select_n_components(X, Y, max_components=8, cv=5)
    print(result.n_components)        # recommended component count
    print(result.rmsecv["total"])     # RMSECV per component count
@@ -35,7 +37,9 @@ each component captures, both per component and cumulatively:
 
 .. code-block:: python
 
-   model = PLS(n_components=result.n_components).fit(X, Y)
+   X_s = MCUVScaler().fit_transform(X)
+   Y_s = MCUVScaler().fit_transform(Y)
+   model = PLS(n_components=result.n_components).fit(X_s, Y_s)
    model.explained_variance_plot()
 
 For PCA the bars refer to variance in the X-block; for PLS they refer to the
@@ -73,7 +77,7 @@ RMSE annotation:
 
 .. code-block:: python
 
-   model.predictions_vs_observed_plot(y_observed=Y, variable="quality")
+   model.predictions_vs_observed_plot(y_observed=Y_s, variable="quality")
 
 Points close to the reference line indicate accurate predictions; systematic
 departures from it point to model bias.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.78.0"
+version = "1.79.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -35,7 +35,7 @@ from ._common import (
     epsqrt,
 )
 from ._nipals import quick_regress, ssq, terminate_check
-from ._preprocessing import MCUVScaler
+from ._preprocessing import MCUVScaler, _warn_scaling_traps
 from ._projection import coerce_observed_mask, operator_for_pattern, project_rows
 
 logger = logging.getLogger(__name__)
@@ -1212,8 +1212,10 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : array-like of shape (n_samples, n_features)
-            Training data. Should already be on the analysis scale (e.g.
-            mean-centred and unit-variance via :class:`MCUVScaler`).
+            Training data. With the default ``scale_inside_folds=True`` pass
+            the raw, unscaled X; mean-centring and unit-variance scaling are
+            fit on each fold's in-fold cells. Pre-scale it yourself only
+            with ``scale_inside_folds=False``.
         max_components : int, optional
             Maximum number of components to evaluate. Default is
             ``min(n_samples - 1, n_features)``.
@@ -1251,8 +1253,22 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             leakage of the prior implementation. Set to ``False`` to
             reproduce the previous behaviour (column mean recomputed each
             EM iteration from the imputed matrix, no scaling); this is
-            useful only when ``X`` is already pre-scaled. Ignored under
-            ``cv_scheme="row_wise"``.
+            useful only when ``X`` is already pre-scaled, and a
+            :class:`SpecificationWarning` is emitted because scaling
+            constants fit on the full matrix leak into every element-fold.
+            Ignored under ``cv_scheme="row_wise"``.
+
+            Pass the **raw, unscaled** X under the default. In-fold
+            re-standardisation overwrites whatever scaling the caller
+            applied, so two deliberately different strategies (autoscale
+            versus Pareto, say) become the same model and report the same
+            PRESS: a comparison between them shows no difference for
+            reasons that have nothing to do with the data. A
+            :class:`SpecificationWarning` is emitted when ``X`` arrives
+            already centred and unit-variance scaled, which is the
+            detectable half of that case; a block scaled some other way
+            cannot be recognised, so the rule is the caller's to keep.
+            Same contract as :meth:`PLS.select_n_components`.
         n_iter, tol : int and float, default 50 and 1e-6
             EM iteration cap and convergence tolerance for the ekf imputation
             step. Ignored under ``cv_scheme="row_wise"``.
@@ -1369,6 +1385,9 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             press_scale_multiplier = n_folds
             if n_repeats < 1:
                 raise ValueError(f"n_repeats must be >= 1; got {n_repeats}.")
+            # Same two traps as PLS.select_n_components, checked only here
+            # because row_wise ignores the flag.
+            _warn_scaling_traps(X, scale_inside_folds=scale_inside_folds, fold="element-fold", metric="PRESS")
             press_arr, per_fold_press_arr = _pca_ekf_press(
                 X_arr,
                 max_components,

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -44,7 +44,7 @@ from ._diagnostics import (
     target_projection as _target_projection,
 )
 from ._nipals import quick_regress, ssq, terminate_check
-from ._preprocessing import MCUVScaler, _looks_prescaled, _uncentred_columns
+from ._preprocessing import MCUVScaler, _uncentred_columns, _warn_scaling_traps
 from ._projection import coerce_observed_mask, operator_for_pattern, project_rows
 from .plots import (
     coefficient_plot as _coefficient_plot,
@@ -1596,29 +1596,7 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         elif not isinstance(Y, pd.DataFrame):
             Y = pd.DataFrame(Y)
 
-        if not scale_inside_folds:
-            warnings.warn(
-                "scale_inside_folds=False leaks centring/scaling estimated on the "
-                "full dataset into every CV fold, making the reported RMSECV "
-                "optimistic. The default scale_inside_folds=True is preferred.",
-                SpecificationWarning,
-                stacklevel=2,
-            )
-        elif _looks_prescaled(X):
-            warnings.warn(
-                "X is already centred and unit-variance scaled, so "
-                "scale_inside_folds=True is not protecting you from leakage: it "
-                "re-standardises inside every training fold and overwrites the "
-                "scaling you chose. Two deliberately different scalings (say "
-                "autoscale versus Pareto) collapse onto the same model this way "
-                "and report the same RMSECV to several decimal places, so a "
-                "comparison between them silently shows no difference. Pass the "
-                "raw, unscaled X and let the folds scale it, or keep your own "
-                "scaling and set scale_inside_folds=False (accepting the "
-                "optimism that flag warns about).",
-                SpecificationWarning,
-                stacklevel=2,
-            )
+        _warn_scaling_traps(X, scale_inside_folds=scale_inside_folds, fold="CV fold", metric="RMSECV")
 
         N, K = X.shape
         M = Y.shape[1]

--- a/src/process_improve/multivariate/_preprocessing.py
+++ b/src/process_improve/multivariate/_preprocessing.py
@@ -16,7 +16,7 @@ import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import _check_feature_names_in, check_is_fitted, validate_data
 
-from ._common import DataMatrix
+from ._common import DataMatrix, SpecificationWarning
 
 
 class MCUVScaler(TransformerMixin, BaseEstimator):
@@ -402,3 +402,53 @@ def _looks_prescaled(X: DataMatrix) -> bool:
         np.all(np.abs(means[usable]) <= _PRESCALED_MEAN_ATOL)
         and np.all(np.abs(sds[usable] - 1.0) <= _PRESCALED_SD_ATOL)
     )
+
+
+def _warn_scaling_traps(X: DataMatrix, *, scale_inside_folds: bool, fold: str, metric: str) -> None:
+    """Warn about the two ways scaling goes wrong in ``select_n_components``.
+
+    Shared by :meth:`PCA.select_n_components` and :meth:`PLS.select_n_components`
+    so the two selectors keep the same contract. With ``scale_inside_folds=False``
+    the caller's full-data scaling leaks into every fold. With ``True`` and an
+    ``X`` that is already centred and unit-variance scaled, the in-fold
+    re-standardisation erases the scaling the caller chose, so a comparison
+    between two scalings can never show which suits the data.
+
+    Parameters
+    ----------
+    X : array-like of shape (n_samples, n_features)
+        The block handed to the selector, before any in-fold scaling.
+    scale_inside_folds : bool
+        The flag as the caller passed it.
+    fold : str
+        What one fold is called in the message, e.g. ``"CV fold"`` or
+        ``"element-fold"``.
+    metric : str
+        The reported error the message names, e.g. ``"RMSECV"`` or ``"PRESS"``.
+
+    Notes
+    -----
+    ``stacklevel=3`` attributes the warning to the caller of the selector,
+    not to the selector or to this helper.
+    """
+    if not scale_inside_folds:
+        warnings.warn(
+            f"scale_inside_folds=False leaks centring/scaling estimated on the full "
+            f"dataset into every {fold}, making the reported {metric} optimistic. "
+            "The default scale_inside_folds=True is preferred.",
+            SpecificationWarning,
+            stacklevel=3,
+        )
+    elif _looks_prescaled(X):
+        warnings.warn(
+            "X is already centred and unit-variance scaled, so scale_inside_folds=True "
+            f"is not protecting you from leakage: it re-standardises inside every {fold} "
+            "and overwrites the scaling you chose. Two deliberately different scalings "
+            "(say autoscale versus Pareto) collapse onto the same standardised model "
+            f"this way, so a comparison of their {metric} reflects only the units the "
+            "blocks arrived in, never which scaling suits the data. Pass the raw, "
+            "unscaled X and let the folds scale it, or keep your own scaling and set "
+            "scale_inside_folds=False (accepting the optimism that flag warns about).",
+            SpecificationWarning,
+            stacklevel=3,
+        )

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -718,8 +718,9 @@ def test_pca_select_n_components() -> None:
     P_true = rng.standard_normal((2, K))
     P_true /= np.linalg.norm(P_true, axis=1, keepdims=True)
     noise = rng.standard_normal((N, K)) * 1.0
+    # Raw block: the default scale_inside_folds=True fits the scaling on each
+    # element-fold's in-fold cells, which is the usage the library recommends.
     X = pd.DataFrame(T_true @ P_true + noise)
-    X = MCUVScaler().fit_transform(X)
 
     max_comp = 6
     result = PCA.select_n_components(X, max_components=max_comp, cv=5, random_state=0)
@@ -733,10 +734,12 @@ def test_pca_select_n_components() -> None:
     assert result.selection_rule == "min"
 
     # q2_se is the per-component Q2-scale standard error (the +/-1 SE band): an
-    # exact rescale of se_press by the constant null-model sum-of-squares.
+    # exact rescale of se_press by the constant null-model sum-of-squares,
+    # which is the CENTRED total SS because X is passed raw.
     assert "q2_se" in result
     assert (result.q2_se >= 0).all()
-    null_ss = float(np.nansum(np.asarray(X, dtype=float) ** 2))
+    X_arr = np.asarray(X, dtype=float)
+    null_ss = float(np.nansum((X_arr - X_arr.mean(axis=0)) ** 2))
     np.testing.assert_allclose(result.q2_se.to_numpy(), result.se_press.to_numpy() / null_ss, rtol=1e-9)
 
     # With 2 true components and N < K, should recommend 2 (or at most 3)
@@ -767,8 +770,7 @@ def test_pca_select_n_components() -> None:
     assert result.q2[2] > result.q2[1]
     # Q2 is exactly the normalised PRESS under ekf (total SS rather than
     # mean-cell SS so it stays directly comparable to r2_cumulative_).
-    null_model_ss = float(np.nansum(np.asarray(X, dtype=float) ** 2))
-    assert result.q2.to_numpy() == pytest.approx(1.0 - result.press.to_numpy() / null_model_ss)
+    assert result.q2.to_numpy() == pytest.approx(1.0 - result.press.to_numpy() / null_ss)
 
     # cv_scores aliases per_fold_press under ekf; shape (A, n_folds).
     assert isinstance(result.cv_scores, pd.DataFrame)
@@ -790,9 +792,8 @@ def test_pca_select_n_components_ekf_recovers_known_rank() -> None:
     P = rng.standard_normal((true_rank, K))
     P /= np.linalg.norm(P, axis=1, keepdims=True)
     X = pd.DataFrame(T @ P + 0.3 * rng.standard_normal((N, K)))
-    X_s = MCUVScaler().fit_transform(X)
 
-    result = PCA.select_n_components(X_s, max_components=10, cv=5, random_state=0)
+    result = PCA.select_n_components(X, max_components=10, cv=5, random_state=0)
     # ekf with GlobalMin recovers the true rank (or one beside it).
     assert true_rank - 1 <= result.n_components <= true_rank + 1
     # PRESS rises again past the true rank when extra components fit noise.
@@ -807,17 +808,18 @@ def test_pca_select_n_components_row_wise_warns_and_overselects() -> None:
     T = rng.standard_normal((N, true_rank)) * np.array([6.0, 4.0])
     P = rng.standard_normal((true_rank, K))
     X = pd.DataFrame(T @ P + 0.4 * rng.standard_normal((N, K)))
-    X_s = MCUVScaler().fit_transform(X)
 
+    # Both schemes scale inside the folds (row_wise through PCA(scale=True)),
+    # so the raw block goes in.
     with pytest.warns(SpecificationWarning, match="row_wise"):
-        legacy = PCA.select_n_components(X_s, max_components=8, cv=5, cv_scheme="row_wise", random_state=0)
+        legacy = PCA.select_n_components(X, max_components=8, cv=5, cv_scheme="row_wise", random_state=0)
     assert legacy.cv_scheme == "row_wise"
     # The row-wise scheme over-fits monotonically; argmin sits at (or near) the
     # maximum even though the true rank is 2.
     a_star_legacy = int(np.argmin(legacy.press.to_numpy())) + 1
     assert a_star_legacy >= 6
     # The ekf scheme on the same data lands much closer to the true rank.
-    ekf = PCA.select_n_components(X_s, max_components=8, cv=5, random_state=0)
+    ekf = PCA.select_n_components(X, max_components=8, cv=5, random_state=0)
     a_star_ekf = int(np.argmin(ekf.press.to_numpy())) + 1
     assert a_star_ekf <= a_star_legacy
 
@@ -825,7 +827,7 @@ def test_pca_select_n_components_row_wise_warns_and_overselects() -> None:
 def test_pca_select_n_components_threshold_deprecated() -> None:
     """The legacy ``threshold`` kwarg emits a DeprecationWarning and is ignored."""
     rng = np.random.default_rng(0)
-    X = pd.DataFrame(MCUVScaler().fit_transform(pd.DataFrame(rng.standard_normal((30, 8)))))
+    X = pd.DataFrame(rng.standard_normal((30, 8)) * 3.0 + 10.0)
     with pytest.warns(DeprecationWarning, match="threshold"):
         result = PCA.select_n_components(X, max_components=4, cv=3, threshold=0.95, random_state=0)
     assert 1 <= result.n_components <= 4
@@ -838,12 +840,11 @@ def test_pca_select_n_components_rule_dispatch() -> None:
     T = rng.standard_normal((N, true_rank)) * np.array([6.0, 4.0])
     P = rng.standard_normal((true_rank, K))
     X = pd.DataFrame(T @ P + 0.35 * rng.standard_normal((N, K)))
-    X_s = MCUVScaler().fit_transform(X)
 
-    res_min = PCA.select_n_components(X_s, max_components=6, cv=5, random_state=0)
-    res_1se = PCA.select_n_components(X_s, max_components=6, cv=5, random_state=0, selection_rule="1se")
+    res_min = PCA.select_n_components(X, max_components=6, cv=5, random_state=0)
+    res_1se = PCA.select_n_components(X, max_components=6, cv=5, random_state=0, selection_rule="1se")
     res_q2 = PCA.select_n_components(
-        X_s,
+        X,
         max_components=6,
         cv=5,
         random_state=0,
@@ -856,7 +857,7 @@ def test_pca_select_n_components_rule_dispatch() -> None:
     assert 1 <= res_q2.n_components <= 6
 
     with pytest.raises(ValueError, match="Unknown cv_scheme"):
-        PCA.select_n_components(X_s, max_components=3, cv=3, cv_scheme="bogus")  # type: ignore[arg-type]
+        PCA.select_n_components(X, max_components=3, cv=3, cv_scheme="bogus")  # type: ignore[arg-type]
 
 
 @pytest.mark.slow
@@ -867,10 +868,9 @@ def test_pca_select_n_components_n_repeats_narrows_se() -> None:
     T = rng.standard_normal((N, true_rank)) * np.array([6.0, 4.0, 2.5])
     P = rng.standard_normal((true_rank, K))
     X = pd.DataFrame(T @ P + 0.4 * rng.standard_normal((N, K)))
-    X_s = MCUVScaler().fit_transform(X)
 
-    one = PCA.select_n_components(X_s, max_components=8, cv=5, n_repeats=1, random_state=0)
-    many = PCA.select_n_components(X_s, max_components=8, cv=5, n_repeats=8, random_state=0)
+    one = PCA.select_n_components(X, max_components=8, cv=5, n_repeats=1, random_state=0)
+    many = PCA.select_n_components(X, max_components=8, cv=5, n_repeats=8, random_state=0)
     # 1 repeat -> 5 fold columns; 8 repeats -> 40.
     assert one.per_fold_press.shape == (8, 5)
     assert many.per_fold_press.shape == (8, 40)
@@ -879,12 +879,12 @@ def test_pca_select_n_components_n_repeats_narrows_se() -> None:
     # SE narrows with more repeats (more samples of fold-PRESS).
     assert (many.se_press <= one.se_press + 1e-9).all()
     # Reproducible given a fixed seed.
-    again = PCA.select_n_components(X_s, max_components=8, cv=5, n_repeats=8, random_state=0)
+    again = PCA.select_n_components(X, max_components=8, cv=5, n_repeats=8, random_state=0)
     np.testing.assert_allclose(many.press.to_numpy(), again.press.to_numpy())
     np.testing.assert_allclose(many.per_fold_press.to_numpy(), again.per_fold_press.to_numpy())
 
     with pytest.raises(ValueError, match="n_repeats must be >= 1"):
-        PCA.select_n_components(X_s, max_components=3, cv=3, n_repeats=0)
+        PCA.select_n_components(X, max_components=3, cv=3, n_repeats=0)
 
 
 def test_pca_select_n_components_scale_inside_folds_no_leakage() -> None:
@@ -904,18 +904,20 @@ def test_pca_select_n_components_scale_inside_folds_no_leakage() -> None:
     assert (raw.press > 0).all()
     assert 1 <= raw.n_components <= 6
 
-    # Opt-out path: caller pre-scales (the prior contract) and asks for the
-    # legacy iterative-recentering EM behaviour. Both should converge to a
-    # comparable recommendation on this clean low-rank data.
+    # Opt-out path: caller pre-scales (the prior contract), is warned about
+    # the leakage, and gets the legacy iterative-recentering EM behaviour.
+    # Both should converge to a comparable recommendation on this clean
+    # low-rank data.
     X_s = MCUVScaler().fit_transform(X_raw)
-    legacy = PCA.select_n_components(
-        X_s,
-        max_components=6,
-        cv=5,
-        n_repeats=2,
-        random_state=0,
-        scale_inside_folds=False,
-    )
+    with pytest.warns(SpecificationWarning, match="leaks"):
+        legacy = PCA.select_n_components(
+            X_s,
+            max_components=6,
+            cv=5,
+            n_repeats=2,
+            random_state=0,
+            scale_inside_folds=False,
+        )
     assert 1 <= legacy.n_components <= 6
 
 

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -2734,10 +2734,9 @@ def test_pls_select_n_components_synthetic() -> None:
     gamma = rng.normal(size=(2, 1))
     Y = pd.DataFrame(T_true @ gamma + 0.3 * rng.normal(size=(N, 1)), columns=["y"])
 
-    X_s = MCUVScaler().fit_transform(X)
-    Y_s = MCUVScaler().fit_transform(Y)
-
-    result = PLS.select_n_components(X_s, Y_s, max_components=10, random_state=0)
+    # Raw blocks: the default scale_inside_folds=True fits the scaling on each
+    # training fold, which is the usage the library recommends.
+    result = PLS.select_n_components(X, Y, max_components=10, random_state=0)
 
     assert isinstance(result, Bunch)
     assert set(result.keys()) == {
@@ -2797,11 +2796,8 @@ def test_pls_select_n_components_ldpe(
     n_samples, n_features = X.shape
     n_targets = Y.shape[1]
 
-    X_s = MCUVScaler().fit_transform(X)
-    Y_s = MCUVScaler().fit_transform(Y)
-
     max_comp = 6
-    result = PLS.select_n_components(X_s, Y_s, max_components=max_comp, cv=5)
+    result = PLS.select_n_components(X, Y, max_components=max_comp, cv=5)
 
     assert 1 <= result.n_components <= max_comp
     assert result.rmsecv.shape == (max_comp, n_targets + 1)
@@ -2821,14 +2817,12 @@ def test_pls_select_n_components_accepts_splitters() -> None:
     X = pd.DataFrame(rng.standard_normal((N, K)), columns=[f"x{i}" for i in range(K)])
     beta = rng.standard_normal((K, 2))
     Y = pd.DataFrame(X.values @ beta + 0.2 * rng.standard_normal((N, 2)), columns=["y0", "y1"])
-    X_s = MCUVScaler().fit_transform(X)
-    Y_s = MCUVScaler().fit_transform(Y)
 
-    res_kfold = PLS.select_n_components(X_s, Y_s, max_components=4, cv=KFold(5, shuffle=True, random_state=0))
+    res_kfold = PLS.select_n_components(X, Y, max_components=4, cv=KFold(5, shuffle=True, random_state=0))
     assert 1 <= res_kfold.n_components <= 4
     assert res_kfold.rmsecv.shape == (4, 3)
 
-    res_loo = PLS.select_n_components(X_s, Y_s, max_components=4, cv=LeaveOneOut())
+    res_loo = PLS.select_n_components(X, Y, max_components=4, cv=LeaveOneOut())
     assert 1 <= res_loo.n_components <= 4
     assert res_loo.cv_predictions.shape == (N, 2)
     assert not res_loo.cv_predictions.isna().any().any()
@@ -2840,14 +2834,12 @@ def test_pls_select_n_components_caps_max_components() -> None:
     N, K = 30, 25
     X = pd.DataFrame(rng.standard_normal((N, K)), columns=[f"x{i}" for i in range(K)])
     Y = pd.DataFrame(rng.standard_normal((N, 1)), columns=["y"])
-    X_s = MCUVScaler().fit_transform(X)
-    Y_s = MCUVScaler().fit_transform(Y)
 
     # 5-fold CV leaves a training fold of 24 rows; in-fold mean-centring
     # removes one DoF, so at most 23 components can be evaluated despite the
     # absurdly large request. (n_repeats=1 keeps the cap-vs-singularity test
     # focused on the cap; the rank-boundary fit is fragile by nature.)
-    result = PLS.select_n_components(X_s, Y_s, max_components=1000, cv=5, n_repeats=1, random_state=0)
+    result = PLS.select_n_components(X, Y, max_components=1000, cv=5, n_repeats=1, random_state=0)
     assert len(result.rmsecv) == 23
     assert result.n_components <= 23
 

--- a/tests/test_multivariate_centring_traps.py
+++ b/tests/test_multivariate_centring_traps.py
@@ -22,7 +22,7 @@ import pandas as pd
 import pytest
 from sklearn.model_selection import KFold
 
-from process_improve.multivariate import PLS, vip
+from process_improve.multivariate import PCA, PLS, vip
 from process_improve.multivariate._common import SpecificationWarning
 from process_improve.multivariate._preprocessing import _looks_prescaled
 
@@ -184,6 +184,81 @@ class TestPreScaledInsideFoldsWarning:
             }
         assert np.isclose(rmsecv["autoscale"], rmsecv["pareto"])
         assert not np.isclose(unscaled["autoscale"], unscaled["pareto"])
+
+
+class TestPreScaledInsideFoldsWarningPCA:
+    """A3 for PCA: ``PCA.select_n_components`` carries the same two warnings as PLS."""
+
+    _EQUAL_SPREADS = np.full(8, 25.0)
+    _UNEQUAL_SPREADS = np.array([0.1, 0.5, 1.0, 5.0, 10.0, 50.0, 100.0, 500.0])
+
+    @staticmethod
+    def _blocks(column_spreads: np.ndarray) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+        """Raw, autoscaled and Pareto-scaled views of one low-rank block.
+
+        Each raw column is given exactly the spread requested. With equal spreads
+        the Pareto block is the autoscaled block times one constant, so the two
+        in-fold standardised matrices are identical cell for cell and the collapse
+        can be pinned exactly. With unequal spreads the two scalings weight the
+        columns differently, which is what a caller comparing them wants to see.
+        """
+        rng = np.random.default_rng(0)
+        scores = rng.normal(size=(40, 2)) * np.array([6.0, 3.0])
+        loadings = rng.normal(size=(2, 8))
+        raw = pd.DataFrame(scores @ loadings + 0.3 * rng.normal(size=(40, 8)), columns=[f"v{i}" for i in range(8)])
+        raw = (raw - raw.mean()) / raw.std(ddof=1) * column_spreads + 100.0
+        autoscale = (raw - raw.mean()) / raw.std(ddof=1)
+        pareto = (raw - raw.mean()) / np.sqrt(raw.std(ddof=1))
+        return raw, autoscale, pareto
+
+    @staticmethod
+    def _q2_curve(block: pd.DataFrame, *, scale_inside_folds: bool) -> np.ndarray:
+        result = PCA.select_n_components(
+            block, max_components=4, cv=5, random_state=0, scale_inside_folds=scale_inside_folds
+        )
+        return result["q2"].to_numpy()
+
+    def test_prescaled_x_warns(self) -> None:
+        _raw, autoscale, _pareto = self._blocks(self._UNEQUAL_SPREADS)
+        with pytest.warns(SpecificationWarning, match="already centred and unit-variance"):
+            PCA.select_n_components(autoscale, max_components=4, cv=5, random_state=0)
+
+    def test_scale_inside_folds_false_warns(self) -> None:
+        _raw, autoscale, _pareto = self._blocks(self._UNEQUAL_SPREADS)
+        with pytest.warns(SpecificationWarning, match="leaks"):
+            PCA.select_n_components(autoscale, max_components=4, cv=5, random_state=0, scale_inside_folds=False)
+
+    def test_raw_x_does_not_warn(self) -> None:
+        raw, _autoscale, _pareto = self._blocks(self._UNEQUAL_SPREADS)
+        with _no_specification_warning():
+            PCA.select_n_components(raw, max_components=4, cv=5, random_state=0)
+
+    def test_row_wise_ignores_the_flag_and_so_does_the_warning(self) -> None:
+        """``row_wise`` warns about itself only; the flag it ignores earns no second warning."""
+        _raw, autoscale, _pareto = self._blocks(self._UNEQUAL_SPREADS)
+        with pytest.warns(SpecificationWarning) as record:
+            PCA.select_n_components(autoscale, max_components=4, cv=5, cv_scheme="row_wise", random_state=0)
+        messages = [str(w.message) for w in record if issubclass(w.category, SpecificationWarning)]
+        assert len(messages) == 1
+        assert "row_wise" in messages[0]
+
+    def test_two_deliberate_scalings_collapse_inside_folds(self) -> None:
+        """The behaviour the warning is about: in-fold standardisation undoes the caller's scaling.
+
+        With equal column spreads the Pareto block is a constant multiple of the
+        autoscaled one, so the in-fold standardised matrices coincide exactly and
+        so do the Q2 curves. The same two blocks with unequal spreads are told
+        apart only when the folds leave the caller's scaling alone.
+        """
+        _raw, autoscale, pareto = self._blocks(self._EQUAL_SPREADS)
+        with _numbers_only():
+            inside = [self._q2_curve(block, scale_inside_folds=True) for block in (autoscale, pareto)]
+        np.testing.assert_allclose(inside[0], inside[1], rtol=1e-10)
+
+        _raw, autoscale, pareto = self._blocks(self._UNEQUAL_SPREADS)
+        with _numbers_only():
+            kept = [self._q2_curve(block, scale_inside_folds=False) for block in (autoscale, pareto)]
+        assert not np.allclose(kept[0], kept[1])
 
 
 class TestVipNormalisation:


### PR DESCRIPTION
## Summary

Closes #533. Takes the issue's proposed option: raw blocks in, folds do the scaling; and resolves the PCA / PLS asymmetry it flagged.

- The library's own tests and documented examples pass **raw, unscaled** blocks to `PLS.select_n_components` and `PCA.select_n_components` under the default `scale_inside_folds=True`, so the user guide no longer demonstrates the pattern the library warns about. The four PLS tests named in the issue, and the six PCA tests that had the same shape, now pass raw blocks; the synthetic PLS test still recovers rank 2.
- `PCA.select_n_components` gains the same two `SpecificationWarning`s that `PLS.select_n_components` already had: one on `scale_inside_folds=False` (full-matrix scaling leaks into every element-fold) and one on `scale_inside_folds=True` with an X that is already centred and unit-variance scaled (in-fold re-standardisation erases the caller's scaling). Both fire only under `cv_scheme="ekf"`, the scheme that honours the flag. The two selectors now share one helper, `_warn_scaling_traps` in `_preprocessing.py`, so the messages and the detection rule cannot drift apart. The shared message drops the "identical to several decimal places" claim, which held for PLS (RMSECV is in Y units) but not for PCA (PRESS is in the units X arrived in).
- The PCA docstring said the opposite of PLS ("should already be on the analysis scale") and now matches. `docs/user_guide/cross_validation.rst`, `docs/user_guide/showcase.rst`, `docs/quickstart.rst` and the README are updated; the showcase page now scales once for the fitted model and passes raw blocks to the selector.

Not changed: the `cross_validation.rst` PCA example still passes the deprecated `threshold=0.95` and the surrounding Wold's-criterion prose is pre-ekf. That is a separate staleness from this issue and is left for a follow-up.

## Test plan

- [x] Four PLS tests and six PCA tests re-run with raw blocks and `SpecificationWarning` turned into an error; all pass.
- [x] New `TestPreScaledInsideFoldsWarningPCA` in `tests/test_multivariate_centring_traps.py`: warns on pre-scaled X, warns on `scale_inside_folds=False`, quiet on raw X, `row_wise` emits only its own warning, and an exact pin that autoscaled and Pareto-scaled blocks with equal column spreads give identical Q2 curves inside the folds but differ when the folds leave the scaling alone.
- [x] `uv run pytest` full suite with all extras: 3081 passed, 3 skipped, coverage 94.04%.
- [x] `ruff check .`, `ruff format --check .`, `mypy src/process_improve` all clean.
- [x] Sphinx build of the edited pages (notebooks excluded, no pandoc in the sandbox) renders without warnings.

## Checklist

- [x] Version bumped in `pyproject.toml` (MINOR, 1.79.0: a new warning on a public method, matching how the PLS warning shipped in 1.76.0)
- [x] Tests added or updated where relevant
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkLrfRbhDPfgXPcS7ttvYq