### PR TITLE
Consistency fixes surfaced by executing the book against the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ Improvement using Data* book against this package (kgdunn/pid-book#274).
   `hat_matrix_diag` and `cooks_distance` to machine precision. They previously
   held a single `nan` outside the single-predictor-with-intercept case, which is
   silent when the single-predictor recipe is applied to a multiple regression.
-  `x_ssq_` and `pi_range_` remain single-predictor quantities.
+  `x_ssq_` and `pi_range_` remain single-predictor quantities. A row whose
+  leverage is 1 sets its own fitted value, so its Cook's distance is reported as
+  zero while every other row keeps its own value.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,25 @@ those changes.
 
 ## [Unreleased]
 
-## [1.78.1] - 2026-09-04
+## [1.79.0] - 2026-09-04
 
-Fixes surfaced by executing every Python case in the *Process Improvement using
-Data* book against this package (kgdunn/pid-book#274).
+Everything here was surfaced by executing every Python case in the *Process
+Improvement using Data* book against this package (kgdunn/pid-book#274).
+
+### Added
+
+- `OLS.leverage_` and `OLS.influence_` are computed for **any** number of
+  predictors, with or without an intercept (#545). Both come from the hat-matrix
+  diagonal of the fitted model matrix and agree with `statsmodels`'
+  `hat_matrix_diag` and `cooks_distance` to machine precision. They previously
+  held a single `nan` outside the single-predictor-with-intercept case, which is
+  silent when the single-predictor recipe is applied to a multiple regression.
+  `x_ssq_` and `pi_range_` remain single-predictor quantities.
+
+### Changed
+
+- `OLS.influence_` is now always a plain `np.ndarray`, matching its documented
+  type and `leverage_`. It was a `pd.Series` when `y` arrived as one.
 
 ### Fixed
 
@@ -4022,8 +4037,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.78.1...HEAD
-[1.78.1]: https://github.com/kgdunn/process-improve/compare/v1.78.0...v1.78.1
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.79.0...HEAD
+[1.79.0]: https://github.com/kgdunn/process-improve/compare/v1.78.0...v1.79.0
 [1.78.0]: https://github.com/kgdunn/process-improve/compare/v1.77.0...v1.78.0
 [1.77.0]: https://github.com/kgdunn/process-improve/compare/v1.76.0...v1.77.0
 [1.76.0]: https://github.com/kgdunn/process-improve/compare/v1.75.2...v1.76.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ those changes.
 
 ## [Unreleased]
 
+## [1.78.1] - 2026-09-04
+
+Fixes surfaced by executing every Python case in the *Process Improvement using
+Data* book against this package (kgdunn/pid-book#274).
+
+### Fixed
+
+- `AdaptivePCA.fit` and `AdaptivePLS.fit` now set `n_components_`, so the
+  inherited `hotellings_t2_limit` method works on the adaptive estimators instead
+  of raising `AttributeError` (#542). The value agrees with the
+  `hotellings_t2_limit` field of the `update()` Bunch.
+- The robust-regression tool description claimed the repeated-median slope
+  tolerates "~29%" contamination, which is the Theil-Sen figure; Siegel's
+  repeated median, the estimator implemented, has a 50% breakdown point (#544).
+- Project URLs in `pyproject.toml` and the Sphinx `github_url` pointed at
+  `github.com/kgdunn/process_improve` (underscore, HTTP 403); corrected to
+  `process-improve` (#543).
+- The `raincloud` docstring no longer claims a package default theme is applied
+  when `template=None`; none is.
+
 ## [1.78.0] - 2026-08-30
 
 ### Added
@@ -4002,7 +4022,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.78.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.78.1...HEAD
+[1.78.1]: https://github.com/kgdunn/process-improve/compare/v1.78.0...v1.78.1
 [1.78.0]: https://github.com/kgdunn/process-improve/compare/v1.77.0...v1.78.0
 [1.77.0]: https://github.com/kgdunn/process-improve/compare/v1.76.0...v1.77.0
 [1.76.0]: https://github.com/kgdunn/process-improve/compare/v1.75.2...v1.76.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ Improvement using Data* book against this package (kgdunn/pid-book#274).
 
 ### Fixed
 
+- `PCA.select_n_components` no longer leaks a numpy `RuntimeWarning` from its
+  own internals when handed a block with no variation in it. `press` is then
+  zero at every component count and the `press_ratio` is 0/0, which now reaches
+  the caller as `NaN` rather than as a warning pointing into library code. The
+  standard error beside it already guarded the same case.
 - The element-wise cross-validation's EM loop judged convergence on the held-out
   cells in the input units, so a column re-expressed in different units changed
   how many iterations were taken and moved the result in the last significant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Improvement using Data* book against this package (kgdunn/pid-book#274).
 
 ### Added
 
+- `PCA.select_n_components` reports `q2_per_variable`, the cross-validated `Q2`
+  of each column beside the pooled figure, which is what shows
+  whether one variable is carrying the curve (#546). `NaN` under
+  `cv_scheme="row_wise"`, which scores whole rows and has no per-cell error to
+  split.
+- `PCA.select_n_components` reports `press_input_units`, the PRESS curve in the
+  units of the matrix that was passed in, for comparing prediction error against
+  instrument error (#546).
 - `OLS.leverage_` and `OLS.influence_` are computed for **any** number of
   predictors, with or without an intercept (#545). Both come from the hat-matrix
   diagonal of the fitted model matrix and agree with `statsmodels`'
@@ -30,11 +38,33 @@ Improvement using Data* book against this package (kgdunn/pid-book#274).
 
 ### Changed
 
+- **`PCA.select_n_components(cv_scheme="ekf")` returns different `press`, `q2`,
+  `se_press` and `q2_se` values** (#546). The element-wise scheme standardises
+  the matrix inside every fold, but it used to undo that standardisation before
+  measuring the error, so PRESS came back in the input units and each variable
+  weighed on the curve in proportion to its variance rather than its structure.
+  On the LDPE data the `Mw` column carries 99.5% of the raw sum of squares, and
+  the raw block (which the library's own warning recommends passing) gave the
+  `Q2` curve of `Mw` alone: monotonic to 0.94, with none of the turnover at two
+  components that the same data show once every variable counts equally. PRESS
+  is now measured in the space each fold was fitted in, and compared against a
+  null model measured the same way, so the curve no longer depends on the units
+  the columns arrived in. Passing the raw block and passing the pre-scaled block
+  now give the same answer, and re-expressing one column in different units
+  leaves the curve unmoved. `Q2` keeps its meaning, "the fraction of held-out
+  variation the model predicts", and stays comparable to `r2_cumulative_`; the
+  numbers it takes are lower on a block with one dominant column, because they
+  are no longer that column's numbers. `scale_inside_folds=False`, the opt-out
+  for callers who scale their own block, is unchanged.
 - `OLS.influence_` is now always a plain `np.ndarray`, matching its documented
   type and `leverage_`. It was a `pd.Series` when `y` arrived as one.
 
 ### Fixed
 
+- The element-wise cross-validation's EM loop judged convergence on the held-out
+  cells in the input units, so a column re-expressed in different units changed
+  how many iterations were taken and moved the result in the last significant
+  figures (#546). It now judges convergence in the space the fold is fitted in.
 - `AdaptivePCA.fit` and `AdaptivePLS.fit` now set `n_components_`, so the
   inherited `hotellings_t2_limit` method works on the adaptive estimators instead
   of raising `AttributeError` (#542). The value agrees with the
@@ -47,6 +77,7 @@ Improvement using Data* book against this package (kgdunn/pid-book#274).
   `process-improve` (#543).
 - The `raincloud` docstring no longer claims a package default theme is applied
   when `template=None`; none is.
+
 ## [1.79.1] - 2026-09-05
 
 ### Documentation

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.78.1
+version: 1.79.0
 date-released: "2026-09-04"
 keywords:
   - chemometrics

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.78.0
-date-released: "2026-08-30"
+version: 1.78.1
+date-released: "2026-09-04"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,7 @@ html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
 
 html_theme_options = {
-    "github_url": "https://github.com/kgdunn/process_improve",
+    "github_url": "https://github.com/kgdunn/process-improve",
     "show_toc_level": 2,
     "navigation_with_keys": True,
     "pygments_light_style": "default",

--- a/docs/user_guide/cross_validation.rst
+++ b/docs/user_guide/cross_validation.rst
@@ -58,14 +58,51 @@ The result is a ``Bunch`` with:
 
 - ``n_components``: recommended number of components
 - ``press``: PRESS for each number of components
+- ``press_input_units``: the same curve in the units of the matrix that was
+  passed in, for comparing the prediction error against a known instrument
+  error
 - ``q2``: cross-validated :math:`R^2_X` per component count, on the same
   scale as the calibration ``r2_cumulative_`` of a fitted model
+- ``q2_per_variable``: that same quantity for each column on its own
 - ``per_fold_press``, ``se_press`` and ``q2_se``: the per-fold PRESS
   contributions and the standard error built from them, which is what the
   1-SE rule needs
 - ``press_ratio``: the ratio ``PRESS_a / PRESS_{a-1}``, for inspection
 - ``cv_scores``: per-fold scores (an alias of ``per_fold_press`` under ekf)
 - ``cv_scheme`` and ``selection_rule``: which scheme and rule were used
+
+What PRESS is measured in
+--------------------------
+
+With ``scale_inside_folds=True`` each fold centres and scales the matrix
+before fitting it, and the error is measured in that same space. Every
+variable therefore contributes to ``press`` in proportion to how much of its
+own variation the model predicts, not in proportion to its units. This
+matters whenever the columns are on different scales: on the LDPE data used
+in the book, the ``Mw`` column carries 99.5% of the raw sum of squares, so a
+PRESS accumulated in the raw units would be ``Mw``'s prediction error and
+almost nothing else.
+
+``q2`` is that PRESS divided by what a null model would have got wrong on the
+same held-out cells, measured the same way. The null model predicts each
+held-out cell by the mean of the cells that were not held out, so
+:math:`Q^2 = 0` is "no better than the column mean" and :math:`Q^2 = 1` is
+exact prediction, the same reading as ``r2_cumulative_``.
+
+Two consequences are worth knowing. Re-expressing a column in different units
+(kilograms instead of grams, say) leaves the whole curve unchanged. And
+passing the raw block gives the same curve as passing a mean-centred,
+unit-variance block, so the recommendation in the paragraph above costs
+nothing.
+
+When a single number in the original units is what you need, for instance to
+compare the prediction error against a known instrument error, read
+``press_input_units`` instead. To see whether one column is carrying the
+pooled figure, read ``q2_per_variable``, which splits ``q2`` by variable.
+
+``scale_inside_folds=False`` is the opt-out for callers who have scaled their
+own block. There is then no in-fold scale, so ``press`` is in the units of
+whatever matrix was passed and the two PRESS fields coincide.
 
 ``n_repeats`` runs the whole pass again with a fresh fold permutation.
 Each repeat still covers every cell exactly once; more repeats narrow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.78.1"
+version = "1.79.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.78.0"
+version = "1.78.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"
@@ -134,9 +134,9 @@ dev = [
 process-improve-mcp = "process_improve.mcp_server:main"
 
 [project.urls]
-Homepage = "https://github.com/kgdunn/process_improve"
-Repository = "https://github.com/kgdunn/process_improve"
-Issues = "https://github.com/kgdunn/process_improve/issues"
+Homepage = "https://github.com/kgdunn/process-improve"
+Repository = "https://github.com/kgdunn/process-improve"
+Issues = "https://github.com/kgdunn/process-improve/issues"
 
 
 [build-system]

--- a/src/process_improve/multivariate/_adaptive.py
+++ b/src/process_improve/multivariate/_adaptive.py
@@ -646,6 +646,7 @@ class AdaptivePCA(_AdaptiveModel, TransformerMixin, BaseEstimator):
         N, K = X_df.shape
         A = int(self.n_components)
         self.n_components = A
+        self.n_components_ = A
         self.n_features_in_ = K
         self.n_samples_ = N
         self._component_names = list(range(1, A + 1))
@@ -972,6 +973,7 @@ class AdaptivePLS(_AdaptiveModel, RegressorMixin, TransformerMixin, BaseEstimato
         M = Y_df.shape[1]
         A = int(self.n_components)
         self.n_components = A
+        self.n_components_ = A
         self.n_features_in_ = K
         self.n_targets_ = M
         self.n_samples_ = N

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -1570,7 +1570,12 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         q2.index = component_index
 
         # PRESS ratio: still computable under either scheme, kept for inspection.
-        ratio_values = {a: press[a] / press[a - 1] for a in range(2, max_components + 1)}
+        # A block with no variation anywhere gives PRESS 0 at every component
+        # count, and 0/0 should reach the caller as a NaN ratio rather than as a
+        # numpy warning pointing into this function. The standard error below
+        # already guards the same case.
+        with np.errstate(divide="ignore", invalid="ignore"):
+            ratio_values = {a: press[a] / press[a - 1] for a in range(2, max_components + 1)}
         press_ratio = pd.Series(ratio_values, name="PRESS ratio")
         press_ratio.index.name = "n_components"
 

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -41,6 +41,17 @@ from ._projection import coerce_observed_mask, operator_for_pattern, project_row
 logger = logging.getLogger(__name__)
 
 
+class _EkfPress(typing.NamedTuple):
+    """What one element-wise k-fold pass measured. See :func:`_pca_ekf_press`."""
+
+    press: np.ndarray
+    per_fold_press: np.ndarray
+    per_column_press: np.ndarray
+    null_model_ss: float
+    per_column_null_ss: np.ndarray
+    press_input_units: np.ndarray
+
+
 def _pca_ekf_press(  # noqa: PLR0913, PLR0915, PLR0912, C901
     X: np.ndarray,
     max_components: int,
@@ -51,7 +62,7 @@ def _pca_ekf_press(  # noqa: PLR0913, PLR0915, PLR0912, C901
     tol: float = 1e-6,
     scale_inside_folds: bool = True,
     random_state: int | None = None,
-) -> tuple[np.ndarray, np.ndarray]:
+) -> _EkfPress:
     """Element-wise k-fold (ekf) PCA cross-validation.
 
     Partitions the elements of ``X`` into ``n_folds`` element-folds (each cell
@@ -89,24 +100,48 @@ def _pca_ekf_press(  # noqa: PLR0913, PLR0915, PLR0912, C901
     scale_inside_folds : bool, default True
         If True, fit per-column mean and unit-variance constants on each
         fold's in-fold cells and apply them to the whole matrix before
-        running EM; predictions are inverse-transformed before PRESS is
-        accumulated. This removes the centring/scaling leakage of the
+        running EM. This removes the centring/scaling leakage of the
         previous default (which used a single set of constants iteratively
-        recomputed from the imputed matrix). If False, the scheme reverts
-        to the prior behaviour (caller is responsible for scaling, and the
-        in-loop column-mean is allowed to drift with the EM imputation).
+        recomputed from the imputed matrix). PRESS is then measured in that
+        same space, so a variable's contribution reflects its correlation
+        structure rather than its units; ``press_input_units`` carries the
+        other scale for callers who need it. If False, the scheme reverts to
+        the prior behaviour: the caller is responsible for scaling, the
+        in-loop column-mean drifts with the EM imputation, and PRESS is in
+        the units of whatever matrix was passed.
     random_state : int, optional
         Seed for the element-fold permutation, for reproducibility across
         repeats.
 
     Returns
     -------
-    press : np.ndarray of shape (max_components,)
-        Per-cell PRESS per component count, averaged over ``n_repeats``
-        passes so the scale is comparable to a single-pass run.
-    per_fold_press : np.ndarray of shape (max_components, n_folds * n_repeats)
-        Per-fold PRESS contributions across every fold of every repeat;
-        drives the 1-SE rule's standard error.
+    _EkfPress
+        A named tuple with five fields. Under ``scale_inside_folds=True`` the
+        first three live in the space each fold was fitted in, so every column
+        contributes to the total in proportion to its correlation structure
+        rather than its units; under ``False`` there is no in-fold scale and
+        they are in the input units, unchanged from earlier releases.
+
+        press : np.ndarray of shape (max_components,)
+            PRESS per component count, averaged over ``n_repeats`` passes so
+            the scale is comparable to a single-pass run.
+        per_fold_press : np.ndarray of shape (max_components, n_folds * n_repeats)
+            Per-fold PRESS contributions across every fold of every repeat;
+            drives the 1-SE rule's standard error.
+        per_column_press : np.ndarray of shape (max_components, n_features)
+            The same total, split by variable, for the per-variable Q2.
+        null_model_ss : float
+            What the null model ("predict every held-out cell by the mean of
+            the cells that were not held out") got wrong, measured the same
+            way ``press`` is: the reference ``press`` is compared against.
+            Computed here rather than by the caller because it needs each
+            fold's own centring and scaling constants.
+        per_column_null_ss : np.ndarray of shape (n_features,)
+            That reference, split by variable.
+        press_input_units : np.ndarray of shape (max_components,)
+            PRESS in the units of the matrix that was passed in, for callers
+            comparing prediction error against instrument error. Always in
+            input units, whatever ``scale_inside_folds`` is.
 
     References
     ----------
@@ -130,6 +165,15 @@ def _pca_ekf_press(  # noqa: PLR0913, PLR0915, PLR0912, C901
     # fabricated a standard error out of zeros. np.nansum below keeps the
     # PRESS total itself unchanged, since an empty fold contributes nothing.
     per_fold_press = np.full((max_components, total_folds), np.nan)
+    # PRESS is what the model got wrong; the null reference is what predicting
+    # the in-fold column mean would have got wrong on the same cells. Both are
+    # accumulated here, in the same space, because only this loop knows each
+    # fold's centring and scaling constants. The reference does not depend on
+    # the component count, hence one value per fold rather than a grid.
+    per_fold_null = np.zeros(total_folds)
+    per_column_press = np.zeros((max_components, p))
+    per_column_null = np.zeros(p)
+    press_input_units = np.zeros(max_components)
     fold_counter = 0
 
     n_cells = n * p
@@ -153,21 +197,21 @@ def _pca_ekf_press(  # noqa: PLR0913, PLR0915, PLR0912, C901
                 fold_counter += 1
                 continue
 
-            # Fit per-column centring/scaling on the in-fold cells. Only
-            # consumed under scale_inside_folds=True; the False path uses
-            # in_fold_vals.mean() for the initial imputation and recomputes
-            # the column mean inside EM, so we skip the work here.
+            # Fit per-column centring/scaling on the in-fold cells. The centre
+            # is needed either way, as the null model's prediction for every
+            # held-out cell in this fold; only the True path also centres and
+            # scales the matrix it fits, and recomputes nothing inside EM.
             col_centre = np.zeros(p)
             col_scale = np.ones(p)
-            if scale_inside_folds:
-                for j in range(p):
-                    in_fold = X[~mask[:, j], j]
-                    if in_fold.size > 1:
-                        col_centre[j] = float(in_fold.mean())
+            for j in range(p):
+                in_fold = X[~mask[:, j], j]
+                if in_fold.size > 1:
+                    col_centre[j] = float(in_fold.mean())
+                    if scale_inside_folds:
                         sd = float(in_fold.std(ddof=1))
                         col_scale[j] = sd if sd > epsqrt else 1.0
-                    elif in_fold.size == 1:
-                        col_centre[j] = float(in_fold[0])
+                elif in_fold.size == 1:
+                    col_centre[j] = float(in_fold[0])
 
             # Initial imputation in original space: held-out cells take the
             # in-fold column mean (which is ``col_centre`` under
@@ -176,15 +220,26 @@ def _pca_ekf_press(  # noqa: PLR0913, PLR0915, PLR0912, C901
             for j in range(p):
                 m_j = mask[:, j]
                 if m_j.any():
-                    if scale_inside_folds:
-                        Xtr[m_j, j] = col_centre[j]
-                    else:
-                        in_fold_vals = X[~m_j, j]
-                        Xtr[m_j, j] = in_fold_vals.mean() if in_fold_vals.size > 0 else 0.0
+                    Xtr[m_j, j] = col_centre[j]
+
+            # The cells' own scale and centre for this fold, one value per
+            # held-out cell. Under scale_inside_folds=False the scale is 1, so
+            # every measurement below stays in the input units, as it was.
+            cell_scale = np.broadcast_to(col_scale, X.shape)[mask]
+            cell_centre = np.broadcast_to(col_centre, X.shape)[mask]
+            column_of_cell = np.broadcast_to(np.arange(p), X.shape)[mask]
+            null_residual = (X[mask] - cell_centre) / cell_scale
+            per_fold_null[fold_counter] = float(np.sum(null_residual**2))
+            per_column_null += np.bincount(column_of_cell, weights=null_residual**2, minlength=p)
 
             for a in range(1, max_components + 1):
                 Xa = Xtr.copy()
-                prev_held = Xa[mask].copy()
+                # Convergence is judged on the held-out cells in the space the
+                # fold is fitted in, not in the input units. Otherwise a column
+                # re-expressed in different units dominates the norm and changes
+                # how many EM iterations are taken (#546). Under
+                # scale_inside_folds=False the divisor is 1 throughout.
+                prev_held = Xa[mask] / cell_scale
                 for _iteration in range(n_iter):
                     if scale_inside_folds:
                         # Centre and scale by the FIXED in-fold constants; the
@@ -206,19 +261,70 @@ def _pca_ekf_press(  # noqa: PLR0913, PLR0915, PLR0912, C901
                         recon_centred = (Xc @ Vt[:rank].T) @ Vt[:rank]
                         recon = recon_centred + col_mean
                     Xa[mask] = recon[mask]
-                    delta = np.linalg.norm(Xa[mask] - prev_held)
+                    held = Xa[mask] / cell_scale
+                    delta = np.linalg.norm(held - prev_held)
                     scale = max(1.0, float(np.linalg.norm(prev_held)))
                     if delta < tol * scale:
                         break
-                    prev_held = Xa[mask].copy()
+                    prev_held = held
 
-                per_fold_press[a - 1, fold_counter] = float(np.sum((X[mask] - Xa[mask]) ** 2))
+                error_input_units = X[mask] - Xa[mask]
+                error = error_input_units / cell_scale
+                per_fold_press[a - 1, fold_counter] = float(np.sum(error**2))
+                per_column_press[a - 1] += np.bincount(column_of_cell, weights=error**2, minlength=p)
+                press_input_units[a - 1] += float(np.sum(error_input_units**2))
             fold_counter += 1
 
     # Average over repeats so PRESS stays on the per-cell scale. nansum so the
     # empty-fold NaNs above do not propagate into the total.
-    press = np.nansum(per_fold_press, axis=1) / max(1, n_repeats)
-    return press, per_fold_press
+    repeats = max(1, n_repeats)
+    press = np.nansum(per_fold_press, axis=1) / repeats
+    return _EkfPress(
+        press=press,
+        per_fold_press=per_fold_press,
+        per_column_press=per_column_press / repeats,
+        null_model_ss=float(np.sum(per_fold_null)) / repeats,
+        per_column_null_ss=per_column_null / repeats,
+        press_input_units=press_input_units / repeats,
+    )
+
+
+def _ekf_null_reference(
+    ekf: _EkfPress,
+    X: np.ndarray,
+    *,
+    scale_inside_folds: bool,
+) -> tuple[float, np.ndarray]:
+    """Return the sum of squares :math:`Q^2` measures the ekf PRESS against.
+
+    The reference has to be measured the same way PRESS was, or the ratio of the
+    two is not a fraction of anything. Under in-fold scaling it therefore comes
+    from the fold loop, which is the only place that knows each fold's constants;
+    a reference computed out here could only be in the input units, and then a
+    single high-variance column would set the whole curve however the folds were
+    actually fitted (#546). Under ``scale_inside_folds=False`` there is no
+    in-fold scale to match, so the centred total sum of squares of the matrix the
+    caller passed stays the reference, unchanged from earlier releases.
+
+    Parameters
+    ----------
+    ekf : _EkfPress
+        What the fold loop measured.
+    X : np.ndarray of shape (n_samples, n_features)
+        The matrix as it was passed to the cross-validation.
+    scale_inside_folds : bool
+        Whether each fold standardised the matrix before fitting it.
+
+    Returns
+    -------
+    tuple[float, np.ndarray]
+        The pooled reference, and the same split by variable (shape
+        ``(n_features,)``).
+    """
+    if scale_inside_folds:
+        return ekf.null_model_ss, ekf.per_column_null_ss
+    centred_ss = np.nansum((X - np.nanmean(X, axis=0)) ** 2, axis=0)
+    return float(centred_ss.sum()), centred_ss
 
 
 class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
@@ -1299,7 +1405,13 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
 
             - ``n_components`` - recommended number of components (int).
             - ``press`` - pooled PRESS per component count (pd.Series,
-              indexed ``1..A_max``).
+              indexed ``1..A_max``). Under ``cv_scheme="ekf"`` with
+              ``scale_inside_folds=True`` this is measured in the space each
+              fold was fitted in, so every variable weighs the same; see
+              ``press_input_units`` for the other scale.
+            - ``press_input_units`` - the same curve in the units of the
+              matrix that was passed in, for comparing prediction error
+              against instrument error (pd.Series, indexed ``1..A_max``).
             - ``per_fold_press`` - per-fold PRESS contributions
               (pd.DataFrame, ``A_max`` rows x ``n_folds`` columns).
             - ``se_press`` - standard error of the per-fold PRESS curve
@@ -1311,9 +1423,15 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
               (pd.Series, indexed ``2..A_max``).
             - ``q2`` - cross-validated :math:`R^2_X` per component count
               (pd.Series, indexed ``1..A_max``). Computed as
-              ``1 - press / (n_samples * n_features * mean_cell_ss)``,
-              so it is directly comparable to ``r2_cumulative_`` and to
-              PLS's ``r2y_validated``.
+              ``1 - press / null_model_ss``, where the null model predicts
+              each held-out cell by its in-fold column mean, measured the
+              same way ``press`` is. Directly comparable to
+              ``r2_cumulative_`` and to PLS's ``r2y_validated``.
+            - ``q2_per_variable`` - that same quantity split by variable
+              (pd.DataFrame, ``A_max`` rows x ``K`` columns), which is what
+              shows whether one column is carrying the pooled figure. All
+              ``NaN`` under ``cv_scheme="row_wise"``, which has no per-cell
+              error to split.
             - ``cv_scores`` - alias of ``per_fold_press`` under ekf, or
               per-fold negative MSE from ``cross_val_score`` under row-wise
               (preserved for back-compat).
@@ -1388,7 +1506,7 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             # Same two traps as PLS.select_n_components, checked only here
             # because row_wise ignores the flag.
             _warn_scaling_traps(X, scale_inside_folds=scale_inside_folds, fold="element-fold", metric="PRESS")
-            press_arr, per_fold_press_arr = _pca_ekf_press(
+            ekf = _pca_ekf_press(
                 X_arr,
                 max_components,
                 n_folds=n_folds,
@@ -1398,21 +1516,21 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
                 scale_inside_folds=scale_inside_folds,
                 random_state=random_state,
             )
-            press = pd.Series(press_arr, index=component_index, name="PRESS")
+            press = pd.Series(ekf.press, index=component_index, name="PRESS")
             per_fold_press = pd.DataFrame(
-                per_fold_press_arr,
+                ekf.per_fold_press,
                 index=component_index,
-                columns=[f"fold_{i + 1}" for i in range(per_fold_press_arr.shape[1])],
+                columns=[f"fold_{i + 1}" for i in range(ekf.per_fold_press.shape[1])],
             )
             cv_scores = per_fold_press
-            # Q^2 normalisation: the null-model "predict the column mean"
-            # reference is the CENTRED total sum-of-squares, sum((x - x_bar)^2).
-            # PRESS is accumulated in the original units, so the raw unscaled
-            # matrix may be passed here; the uncentred sum(x^2) previously used
-            # coincides only when X is already mean-centred and otherwise
-            # inflates the denominator, biasing Q^2 optimistically.
-            null_model_ss = float(np.nansum((X_arr - np.nanmean(X_arr, axis=0)) ** 2))
+            press_input_units = pd.Series(ekf.press_input_units, index=component_index, name="PRESS (input units)")
+            null_model_ss, per_column_null_ss = _ekf_null_reference(ekf, X_arr, scale_inside_folds=scale_inside_folds)
             q2 = 1.0 - press / null_model_ss if null_model_ss > epsqrt else press * np.nan
+            # A column with no spread across the held-out cells has nothing to
+            # predict, so its Q^2 is undefined rather than zero.
+            safe_null = np.where(per_column_null_ss > epsqrt, per_column_null_ss, np.nan)
+            per_variable = 1.0 - ekf.per_column_press / safe_null
+            q2_per_variable = pd.DataFrame(per_variable, index=component_index, columns=list(X.columns))
         elif cv_scheme == "row_wise":
             warnings.warn(
                 "cv_scheme='row_wise' uses the legacy whole-row CV scheme that "
@@ -1440,6 +1558,11 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             per_fold_press = -cv_scores
             null_model_ss = float(np.nanmean((X_arr - np.nanmean(X_arr, axis=0)) ** 2))
             q2 = 1.0 - press / null_model_ss if null_model_ss > epsqrt else press * np.nan
+            # row_wise scores whole rows through the estimator, so there is no
+            # per-cell error to split by variable and no in-fold scale to
+            # report against. Both fields exist so the Bunch has one shape.
+            press_input_units = press.rename("PRESS (input units)")
+            q2_per_variable = pd.DataFrame(np.nan, index=component_index, columns=list(X.columns))
         else:
             raise ValueError(f"Unknown cv_scheme {cv_scheme!r}; expected 'ekf' or 'row_wise'.")
 
@@ -1508,6 +1631,8 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             q2_se=q2_se,
             press_ratio=press_ratio,
             q2=q2,
+            q2_per_variable=q2_per_variable,
+            press_input_units=press_input_units,
             cv_scores=cv_scores,
             cv_scheme=cv_scheme,
             selection_rule=selection_rule,

--- a/src/process_improve/regression/_robust_regression.py
+++ b/src/process_improve/regression/_robust_regression.py
@@ -632,16 +632,18 @@ class OLS(RegressorMixin, BaseEstimator):
 
         eps = np.finfo(np.float32).eps
         residual_room = 1.0 - self.leverage_
-        if self.se_ < eps or np.any(np.abs(residual_room) < eps):
-            # A saturated fit has no residual to distribute, or a row with leverage 1
-            # determines its own fitted value; either way Cook's distance is not defined
-            # by the usual ratio, and reporting zero movement is the honest reading.
-            self.influence_ = np.zeros_like(self.leverage_)
-        else:
+        self.influence_ = np.zeros_like(self.leverage_)
+        if self.se_ >= eps:
+            # A row with leverage 1 sets its own fitted value, so it has no residual to
+            # redistribute and Cook's distance is not defined by the usual ratio. Zero is
+            # the reading for that row alone; every other row keeps its own value.
             # np.asarray: results.resid is a Series when y arrives as one, and the
             # documented type of both diagnostics is a plain array.
             resid = np.asarray(results.resid, dtype=float)
-            self.influence_ = np.power(resid / (residual_room * self.se_), 2) * self.leverage_ / k_params
+            movable = np.abs(residual_room) >= eps
+            self.influence_[movable] = (
+                np.power(resid[movable] / (residual_room[movable] * self.se_), 2) * self.leverage_[movable] / k_params
+            )
 
         # A prediction-interval grid and the x sum of squares only mean something for a
         # single predictor with an intercept.

--- a/src/process_improve/regression/_robust_regression.py
+++ b/src/process_improve/regression/_robust_regression.py
@@ -362,7 +362,7 @@ def multiple_linear_regression(  # noqa: PLR0913
 
 
 class OLS(RegressorMixin, BaseEstimator):
-    """Ordinary Least Squares regression with statistical diagnostics.
+    r"""Ordinary Least Squares regression with statistical diagnostics.
 
     A scikit-learn-compatible estimator that fits an OLS model and exposes
     inferential statistics (standard errors, t-values, p-values, confidence
@@ -425,9 +425,10 @@ class OLS(RegressorMixin, BaseEstimator):
     residuals_ : np.ndarray of shape (N_original,)
         In-sample residuals (NaN at rows removed by ``na_rm``).
     leverage_ : np.ndarray of shape (N,)
-        Hat-matrix diagonal (only computed for single-feature X).
+        Hat-matrix diagonal :math:`h_i = \mathbf{x}_i^T (X^T X)^{-1} \mathbf{x}_i`, over
+        the rows that were fitted. Matches ``statsmodels`` ``hat_matrix_diag``.
     influence_ : np.ndarray of shape (N,)
-        Cook's distance (only computed for single-feature X with intercept).
+        Cook's distance per fitted row. Matches ``statsmodels`` ``cooks_distance``.
     pi_range_ : np.ndarray of shape (pi_resolution, 3) or float
         Columns are x-grid, lower bound, upper bound of the prediction
         interval. ``np.nan`` if not applicable.
@@ -622,10 +623,29 @@ class OLS(RegressorMixin, BaseEstimator):
         self.r2_regression_based_ = regression_ssq / total_ssq if total_ssq > 0 else float("nan")
         self.r2_residual_based_ = 1.0 - residual_ssq / total_ssq if total_ssq > 0 else float("nan")
 
-        # Single-feature diagnostics: leverage, influence, and a prediction interval grid.
+        # Leverage and Cook's distance, for any number of predictors. Both come from
+        # the hat-matrix diagonal of the model matrix statsmodels fitted, so they hold
+        # for multiple regression and with or without an intercept. The pseudo-inverse
+        # keeps a rank-deficient model matrix from raising.
+        exog = np.asarray(results.model.exog, dtype=float)
+        self.leverage_ = np.einsum("ij,ji->i", exog, np.linalg.pinv(exog))
+
+        eps = np.finfo(np.float32).eps
+        residual_room = 1.0 - self.leverage_
+        if self.se_ < eps or np.any(np.abs(residual_room) < eps):
+            # A saturated fit has no residual to distribute, or a row with leverage 1
+            # determines its own fitted value; either way Cook's distance is not defined
+            # by the usual ratio, and reporting zero movement is the honest reading.
+            self.influence_ = np.zeros_like(self.leverage_)
+        else:
+            # np.asarray: results.resid is a Series when y arrives as one, and the
+            # documented type of both diagnostics is a plain array.
+            resid = np.asarray(results.resid, dtype=float)
+            self.influence_ = np.power(resid / (residual_room * self.se_), 2) * self.leverage_ / k_params
+
+        # A prediction-interval grid and the x sum of squares only mean something for a
+        # single predictor with an intercept.
         self.x_ssq_ = float("nan")
-        self.leverage_ = np.array([np.nan])
-        self.influence_ = np.array([np.nan])
         self.pi_range_: np.ndarray | float = float("nan")
 
         if n_features == 1:
@@ -634,22 +654,13 @@ class OLS(RegressorMixin, BaseEstimator):
             x_ssq = float(np.sum(np.power(x_col - mean_x, 2)))
             self.x_ssq_ = x_ssq
 
-            if self.fit_intercept and x_ssq > 0:
-                self.leverage_ = 1.0 / n_samples + np.power(x_col - mean_x, 2) / x_ssq
-
-                eps = np.finfo(np.float32).eps
-                if self.se_ < eps:
-                    self.influence_ = np.zeros(n_samples)
-                else:
-                    self.influence_ = (
-                        np.power(results.resid / ((1 - self.leverage_) * self.se_), 2) * self.leverage_ / k_params
-                    )
-                    pi_range = np.linspace(np.min(x_col), np.max(x_col), self.pi_resolution)
-                    pi_y_pred = self.intercept_ + self.coefficients_[0] * pi_range
-                    var_y = (self.se_**2) * (1 + 1.0 / n_samples + (pi_range - mean_x) ** 2 / x_ssq)
-                    std_y = np.sqrt(var_y)
-                    c_t = t_value(1 - (1 - self.conflevel) / 2, n_samples - 2)
-                    self.pi_range_ = np.vstack([pi_range, pi_y_pred - c_t * std_y, pi_y_pred + c_t * std_y]).T
+            if self.fit_intercept and x_ssq > 0 and self.se_ >= eps:
+                pi_range = np.linspace(np.min(x_col), np.max(x_col), self.pi_resolution)
+                pi_y_pred = self.intercept_ + self.coefficients_[0] * pi_range
+                var_y = (self.se_**2) * (1 + 1.0 / n_samples + (pi_range - mean_x) ** 2 / x_ssq)
+                std_y = np.sqrt(var_y)
+                c_t = t_value(1 - (1 - self.conflevel) / 2, n_samples - 2)
+                self.pi_range_ = np.vstack([pi_range, pi_y_pred - c_t * std_y, pi_y_pred + c_t * std_y]).T
 
         self._k_ = k_params
         self.is_fitted_ = True

--- a/src/process_improve/regression/tools.py
+++ b/src/process_improve/regression/tools.py
@@ -61,8 +61,8 @@ class RobustRegressionInput(BaseModel):
     description=(
         "Fit a robust simple linear regression between x and y variables using the repeated "
         "median slope estimator. Unlike ordinary least squares, the repeated median method is "
-        "highly resistant to outliers - up to ~29% of the data can be contaminated without "
-        "affecting the fit. "
+        "highly resistant to outliers - up to half of the data can be contaminated before "
+        "the slope estimate breaks down (Siegel's repeated median has a 50% breakdown point). "
         "Returns slope, intercept, R-squared, standard errors, prediction intervals, and "
         "fitted values. "
         "Use this when you suspect outliers in the data or want a more reliable fit."

--- a/src/process_improve/visualization/raincloud.py
+++ b/src/process_improve/visualization/raincloud.py
@@ -45,8 +45,8 @@ def raincloud(  # noqa: PLR0913
         ``"h"`` draws horizontal rainclouds (the default and usual
         orientation); ``"v"`` draws them vertically.
     template : str or None, optional
-        Plotly template name. When ``None``, the package's registered default
-        theme is used.
+        Plotly template name applied to the figure. When ``None`` (the default),
+        no template is set and plotly's active default applies.
 
     Returns
     -------

--- a/tests/test_audit_regressions_multivariate.py
+++ b/tests/test_audit_regressions_multivariate.py
@@ -173,17 +173,25 @@ class TestSelectNComponentsScales:
         np.testing.assert_allclose(result.se_press.to_numpy(), expected_se)
 
     def test_q2_null_model_is_centred(self) -> None:
+        """A large column offset must not make every Q2 look like 1.
+
+        The uncentred ``sum(x^2)`` reference this replaced was dominated by the
+        offset, so it could not discriminate between component counts. The
+        reference is now each fold's own held-out cells, measured the same way
+        PRESS is, which is centred by construction.
+        """
         rng = np.random.default_rng(10)
         x = _low_rank_matrix(n=30, k=6, rank=2, noise=0.4, seed=11) + 100.0  # large offset
         x += rng.standard_normal(x.shape) * 0.01
         result = PCA.select_n_components(pd.DataFrame(x), max_components=3, cv=4, random_state=0)
-        x_arr = np.asarray(x, dtype=float)
-        null_ss = float(np.nansum((x_arr - np.nanmean(x_arr, axis=0)) ** 2))
-        expected_q2 = 1.0 - result.press.to_numpy() / null_ss
-        np.testing.assert_allclose(result.q2.to_numpy(), expected_q2)
-        # With the uncentred sum(x^2) null model the offset made every Q2
-        # indistinguishable from 1; the centred reference must discriminate.
         assert result.q2.iloc[0] < 0.9999
+        # The identity Q2 = 1 - PRESS / null_model_ss still holds, against the
+        # reference the folds measured rather than one recomputed out here.
+        from process_improve.multivariate._pca import _pca_ekf_press
+
+        ekf = _pca_ekf_press(np.asarray(x, dtype=float), 3, n_folds=4, random_state=0)
+        expected_q2 = 1.0 - result.press.to_numpy() / ekf.null_model_ss
+        np.testing.assert_allclose(result.q2.to_numpy(), expected_q2)
 
 
 class TestPLSInference:
@@ -426,7 +434,8 @@ class TestStatisticalCorrectnessTriage:
         """
         from process_improve.multivariate._pca import _pca_ekf_press
 
-        press, per_fold = _pca_ekf_press(np.array([[1.0, 2], [3, 4]]), 1, n_folds=5, random_state=0)
+        result_ekf = _pca_ekf_press(np.array([[1.0, 2], [3, 4]]), 1, n_folds=5, random_state=0)
+        press, per_fold = result_ekf.press, result_ekf.per_fold_press
         assert np.isnan(per_fold[0, :4]).all(), "empty folds must be NaN, not zero"
         assert np.isfinite(per_fold[0, 4])
         # PRESS itself is unchanged: an empty fold contributes nothing to a sum.
@@ -441,7 +450,8 @@ class TestStatisticalCorrectnessTriage:
 
         rng = np.random.default_rng(0)
         X = rng.normal(size=(20, 4))
-        press, per_fold = _pca_ekf_press(X, 3, n_folds=5, random_state=42)
+        result_ekf = _pca_ekf_press(X, 3, n_folds=5, random_state=42)
+        press, per_fold = result_ekf.press, result_ekf.per_fold_press
         assert not np.isnan(per_fold).any()
         assert np.all(np.isfinite(press))
 

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -22,6 +22,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils import Bunch
 
+from process_improve.multivariate._pca import _pca_ekf_press
 from process_improve.multivariate.methods import (
     PCA,
     PLS,
@@ -734,12 +735,13 @@ def test_pca_select_n_components() -> None:
     assert result.selection_rule == "min"
 
     # q2_se is the per-component Q2-scale standard error (the +/-1 SE band): an
-    # exact rescale of se_press by the constant null-model sum-of-squares,
-    # which is the CENTRED total SS because X is passed raw.
+    # exact rescale of se_press by the null-model sum of squares, which the
+    # folds measure in the space they were fitted in (#546), so it comes back
+    # from the helper rather than being recomputed here.
     assert "q2_se" in result
     assert (result.q2_se >= 0).all()
     X_arr = np.asarray(X, dtype=float)
-    null_ss = float(np.nansum((X_arr - X_arr.mean(axis=0)) ** 2))
+    null_ss = _pca_ekf_press(X_arr, max_comp, n_folds=5, random_state=0).null_model_ss
     np.testing.assert_allclose(result.q2_se.to_numpy(), result.se_press.to_numpy() / null_ss, rtol=1e-9)
 
     # With 2 true components and N < K, should recommend 2 (or at most 3)
@@ -768,9 +770,14 @@ def test_pca_select_n_components() -> None:
     assert np.isfinite(result.q2.to_numpy()).all()
     assert (result.q2 <= 1.0 + 1e-9).all()
     assert result.q2[2] > result.q2[1]
-    # Q2 is exactly the normalised PRESS under ekf (total SS rather than
-    # mean-cell SS so it stays directly comparable to r2_cumulative_).
+    # Q2 is exactly the normalised PRESS under ekf, against the reference the
+    # folds measured, so it stays directly comparable to r2_cumulative_.
     assert result.q2.to_numpy() == pytest.approx(1.0 - result.press.to_numpy() / null_ss)
+
+    # Every variable's own Q2 is reported beside the pooled figure, which is
+    # what shows whether one column is carrying it (#546).
+    assert result.q2_per_variable.shape == (max_comp, X.shape[1])
+    assert list(result.q2_per_variable.index) == list(range(1, max_comp + 1))
 
     # cv_scores aliases per_fold_press under ekf; shape (A, n_folds).
     assert isinstance(result.cv_scores, pd.DataFrame)
@@ -876,8 +883,18 @@ def test_pca_select_n_components_n_repeats_narrows_se() -> None:
     assert many.per_fold_press.shape == (8, 40)
     # PRESS stays on the per-cell scale (averaged over repeats).
     assert (many.press > 0).all()
-    # SE narrows with more repeats (more samples of fold-PRESS).
-    assert (many.se_press <= one.se_press + 1e-9).all()
+    # SE narrows with more repeats: 8 repeats sample fold-PRESS 40 times rather
+    # than 5, so the standard error of the mean shrinks by roughly sqrt(8) ~ 2.8x.
+    # Checked on the median across components rather than component by component:
+    # an SE built from only 5 folds carries a relative sampling error near
+    # 1 / sqrt(2 * (5 - 1)) ~ 35%, so a single component can come out lower on 5
+    # folds than on 40 by chance. The per-component bound catches a real blow-up
+    # without pinning that noise.
+    se_ratio = (many.se_press / one.se_press).to_numpy()
+    assert np.median(se_ratio) < 0.7
+    assert (se_ratio < 1.5).all()
+    # The extra repeats sharpen the estimate without moving the recommendation.
+    assert one.n_components == many.n_components == true_rank
     # Reproducible given a fixed seed.
     again = PCA.select_n_components(X, max_components=8, cv=5, n_repeats=8, random_state=0)
     np.testing.assert_allclose(many.press.to_numpy(), again.press.to_numpy())
@@ -919,6 +936,125 @@ def test_pca_select_n_components_scale_inside_folds_no_leakage() -> None:
             scale_inside_folds=False,
         )
     assert 1 <= legacy.n_components <= 6
+
+
+def test_pca_select_n_components_ekf_q2_is_scale_invariant() -> None:
+    """Re-expressing one column in different units must not move the Q2 curve (#546).
+
+    The element-wise scheme standardises inside every fold, so what it fits does
+    not depend on a column's units. Before #546 it then measured PRESS after
+    inverting that standardisation, and a column carried weight in proportion to
+    its variance: multiplying one column by 1000 handed it the whole curve.
+    """
+    rng = np.random.default_rng(11)
+    N, K, true_rank = 45, 10, 3
+    T = rng.standard_normal((N, true_rank)) * np.array([5.0, 3.0, 1.5])
+    P = rng.standard_normal((true_rank, K))
+    X = pd.DataFrame(T @ P + 0.3 * rng.standard_normal((N, K)))
+    X_stretched = X.copy()
+    X_stretched.iloc[:, 0] *= 1000.0
+
+    kwargs = {"max_components": 6, "cv": 5, "n_repeats": 3, "random_state": 7}
+    base = PCA.select_n_components(X, **kwargs)
+    stretched = PCA.select_n_components(X_stretched, **kwargs)
+
+    # The folds are the same cells in both runs and the in-fold standardisation
+    # removes the factor of 1000 exactly, so this is an identity, not an
+    # approximation: only floating point separates the two curves.
+    np.testing.assert_allclose(stretched.q2.to_numpy(), base.q2.to_numpy(), rtol=1e-8, atol=1e-10)
+    np.testing.assert_allclose(stretched.press.to_numpy(), base.press.to_numpy(), rtol=1e-8)
+    assert stretched.n_components == base.n_components == true_rank
+
+    # press_input_units does follow the units, which is the point of having it:
+    # the stretched column contributes a million times more squared error.
+    assert (stretched.press_input_units > base.press_input_units).all()
+
+
+def test_pca_select_n_components_ekf_q2_per_variable_reconciles() -> None:
+    """The per-variable Q2 splits the pooled figure rather than restating it (#546)."""
+    rng = np.random.default_rng(12)
+    N, K = 40, 8
+    T = rng.standard_normal((N, 2))
+    P = rng.standard_normal((2, K))
+    # One column is pure noise: it has nothing for a component to predict, so
+    # its own Q2 should sit far below the pooled value.
+    X = pd.DataFrame(T @ P + 0.3 * rng.standard_normal((N, K)), columns=[f"v{j}" for j in range(K)])
+    X["noise"] = rng.standard_normal(N) * 4.0
+
+    result = PCA.select_n_components(X, max_components=4, cv=5, n_repeats=3, random_state=3)
+
+    assert list(result.q2_per_variable.columns) == list(X.columns)
+    assert result.q2_per_variable.shape == (4, X.shape[1])
+    assert np.isfinite(result.q2_per_variable.to_numpy()).all()
+    # Every structured column beats the pooled figure at the chosen rank; the
+    # noise column drags it down, which is exactly what this table is for.
+    at_rank = result.q2_per_variable.loc[result.n_components]
+    assert at_rank["noise"] < result.q2[result.n_components] < at_rank.drop("noise").min()
+
+
+def test_pca_select_n_components_ekf_q2_matches_on_raw_and_prescaled_ldpe() -> None:
+    """On LDPE the raw and pre-scaled blocks now give the same curve (#546).
+
+    ``Mw`` holds over 99% of the raw block's sum of squares. Before #546, passing
+    the raw block (which the library's own warning recommends) produced the Q2
+    curve of ``Mw`` alone, rising monotonically past 0.9 with no interior
+    maximum, while the pre-scaled block peaked at two components. The two are the
+    same computation and must agree.
+    """
+    folder = pathlib.Path(__file__).parents[1] / "src" / "process_improve" / "datasets" / "multivariate"
+    ldpe = pd.read_csv(folder / "LDPE" / "LDPE.csv", index_col=0)
+    # The premise of the test: one column dominates the raw sum of squares.
+    centred = ldpe - ldpe.mean()
+    assert (centred**2).sum().max() / (centred**2).to_numpy().sum() > 0.99
+    assert (centred**2).sum().idxmax() == "Mw"
+
+    kwargs = {"max_components": 11, "cv": 7, "n_repeats": 3, "random_state": 42}
+    raw = PCA.select_n_components(ldpe, **kwargs)
+    with pytest.warns(SpecificationWarning, match="already centred and unit-variance"):
+        prescaled = PCA.select_n_components(MCUVScaler().fit_transform(ldpe), **kwargs)
+
+    # Not bit-identical: pre-scaling uses each column's whole-sample mean and
+    # standard deviation, the raw path uses each fold's own, so the two runs
+    # standardise by slightly different constants. The gap has to be negligible
+    # against the curve's own standard error, which is about 0.015 here.
+    gap = np.abs(raw.q2.to_numpy() - prescaled.q2.to_numpy())
+    assert gap.max() < 0.001
+    assert gap.max() < 0.1 * float(raw.q2_se.min())
+    assert raw.q2.idxmax() == prescaled.q2.idxmax()
+
+    # The curve turns over inside the range rather than climbing to the end,
+    # which is the reading these data support and which the Mw-dominated curve
+    # this used to produce did not show.
+    assert raw.q2[2] > raw.q2[1]
+    assert raw.q2[7] < raw.q2[2]
+    assert raw.q2.loc[1:8].idxmax() == 2
+
+
+def test_pca_select_n_components_scale_inside_folds_false_is_unchanged() -> None:
+    """The opt-out path keeps its input-units PRESS and centred reference (#546).
+
+    #546 changes what ``scale_inside_folds=True`` measures. ``False`` is the
+    legacy contract for callers who scale their own block, and stays as it was:
+    PRESS in the units of the matrix passed in, against the centred total sum of
+    squares of that same matrix.
+    """
+    rng = np.random.default_rng(13)
+    N, K = 40, 9
+    T = rng.standard_normal((N, 2))
+    P = rng.standard_normal((2, K))
+    X = pd.DataFrame(MCUVScaler().fit_transform(pd.DataFrame(T @ P + 0.3 * rng.standard_normal((N, K)))))
+
+    with pytest.warns(SpecificationWarning, match="leaks"):
+        result = PCA.select_n_components(
+            X, max_components=5, cv=5, n_repeats=2, random_state=0, scale_inside_folds=False
+        )
+
+    # No in-fold scale, so the two PRESS scales coincide.
+    np.testing.assert_allclose(result.press_input_units.to_numpy(), result.press.to_numpy(), rtol=1e-12)
+    # And Q2 is still normalised by the caller-side centred sum of squares.
+    X_arr = np.asarray(X, dtype=float)
+    null_ss = float(np.nansum((X_arr - np.nanmean(X_arr, axis=0)) ** 2))
+    np.testing.assert_allclose(result.q2.to_numpy(), 1.0 - result.press.to_numpy() / null_ss, rtol=1e-12)
 
 
 def test_pca_minka_mle_recovers_known_rank() -> None:

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -3,6 +3,7 @@
 import io
 import pathlib
 import urllib.request
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -990,6 +991,56 @@ def test_pca_select_n_components_ekf_q2_per_variable_reconciles() -> None:
     # noise column drags it down, which is exactly what this table is for.
     at_rank = result.q2_per_variable.loc[result.n_components]
     assert at_rank["noise"] < result.q2[result.n_components] < at_rank.drop("noise").min()
+
+
+def test_pca_select_n_components_ekf_q2_per_variable_is_nan_for_a_flat_column() -> None:
+    """A column with no spread has no Q2, rather than a spurious zero (#546)."""
+    rng = np.random.default_rng(21)
+    N, K = 40, 6
+    T = rng.standard_normal((N, 2))
+    P = rng.standard_normal((2, K))
+    X = pd.DataFrame(T @ P + 0.3 * rng.standard_normal((N, K)), columns=[f"v{j}" for j in range(K)])
+    X["flat"] = 7.5
+
+    result = PCA.select_n_components(X, max_components=3, cv=5, n_repeats=2, random_state=0)
+
+    # The null model predicts a constant column exactly, so its reference sum of
+    # squares is zero and the ratio is undefined. Reporting 0.0 there would read
+    # as "predicted no better than the mean" rather than "nothing to predict".
+    assert result.q2_per_variable["flat"].isna().all()
+    # It is only that column: the rest are unaffected and the pooled figure,
+    # which the flat column contributes nothing to on either side of the ratio,
+    # stays finite.
+    assert np.isfinite(result.q2_per_variable.drop(columns="flat").to_numpy()).all()
+    assert np.isfinite(result.q2.to_numpy()).all()
+
+
+def test_pca_select_n_components_ekf_degenerate_blocks_stay_quiet() -> None:
+    """Degenerate inputs give NaN answers, not exceptions and not numpy warnings.
+
+    Two edges the element-wise loop has to survive: a matrix small enough that a
+    column can be left with a single in-fold cell to estimate its centre from,
+    and a matrix with no variation at all, where the null model is exact and the
+    ratio PRESS / null is 0/0.
+    """
+    rng = np.random.default_rng(5)
+    tiny = pd.DataFrame(rng.standard_normal((4, 3)))
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        small = PCA.select_n_components(tiny, max_components=2, cv=4, random_state=0)
+    assert 1 <= small.n_components <= 2
+    assert np.isfinite(small.q2.to_numpy()).all()
+
+    flat = pd.DataFrame(np.full((20, 4), 3.0))
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        result = PCA.select_n_components(flat, max_components=2, cv=5, random_state=0)
+    # Nothing varies, so nothing is predicted and nothing is left over: PRESS is
+    # zero and every Q2 is undefined rather than a perfect 1.0.
+    assert (result.press.to_numpy() == 0).all()
+    assert result.q2.isna().all()
+    assert result.q2_per_variable.isna().to_numpy().all()
+    assert result.press_ratio.isna().all()
 
 
 def test_pca_select_n_components_ekf_q2_matches_on_raw_and_prescaled_ldpe() -> None:

--- a/tests/test_multivariate_adaptive.py
+++ b/tests/test_multivariate_adaptive.py
@@ -564,3 +564,26 @@ def test_adaptation_plot_builds(
     pca.partial_fit(synthetic_pca_data)
     fig_pca = pca.adaptation_plot()
     assert len(fig_pca.data) == 3  # 2 preprocessing + 1 kernel trace (no channels)
+
+
+def test_adaptive_models_expose_hotellings_t2_limit(
+    synthetic_pca_data: pd.DataFrame, synthetic_pls_data: tuple[pd.DataFrame, pd.DataFrame]
+) -> None:
+    """The inherited limit method needs ``n_components_``; both adaptive fits must set it.
+
+    Regression test for #542: ``hotellings_t2_limit`` raised ``AttributeError`` on a
+    fitted ``AdaptivePLS`` because ``fit`` stored the count only in ``n_components``.
+    The value must also agree with the limit the ``update`` Bunch reports.
+    """
+    pca = AdaptivePCA(n_components=2).fit(synthetic_pca_data)
+    assert pca.n_components_ == 2
+    limit_pca = float(pca.hotellings_t2_limit(conf_level=0.99))
+    assert np.isfinite(limit_pca)
+    assert limit_pca > 0
+
+    X, Y = synthetic_pls_data
+    pls = AdaptivePLS(n_components=2, forgetting_factor=0, lambda_center=0, alpha_scale=0, conf_level=0.99).fit(X, Y)
+    assert pls.n_components_ == 2
+    limit_pls = float(pls.hotellings_t2_limit(conf_level=0.99))
+    probe = pls.update(X.iloc[0].to_numpy())
+    assert limit_pls == pytest.approx(float(probe.hotellings_t2_limit))

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -874,3 +874,71 @@ def test_get_regression_tool_specs_lists_both_tools() -> None:
     specs = get_regression_tool_specs()
     names = {spec.get("name") for spec in specs}
     assert {"robust_regression", "repeated_median"}.issubset(names)
+
+
+class TestLeverageAndInfluence:
+    """`leverage_` and `influence_` hold for any number of predictors (#545).
+
+    Both used to be computed only for a single predictor with an intercept, and to
+    hold a lone ``nan`` otherwise, which is silent when a reader applies the
+    single-predictor recipe to a multiple regression. They now come from the
+    hat-matrix diagonal of the fitted model matrix, so they are defined wherever
+    the model is, and agree with the reference implementation in statsmodels.
+    """
+
+    @staticmethod
+    def _reference(X: pd.DataFrame, y: pd.Series, *, fit_intercept: bool) -> tuple[np.ndarray, np.ndarray]:
+        sm = pytest.importorskip("statsmodels.api")
+        from statsmodels.stats.outliers_influence import OLSInfluence
+
+        exog = sm.add_constant(X) if fit_intercept else X
+        influence = OLSInfluence(sm.OLS(y, exog).fit())
+        return np.asarray(influence.hat_matrix_diag), np.asarray(influence.cooks_distance[0])
+
+    @pytest.fixture
+    def data(self) -> tuple[pd.DataFrame, pd.Series]:
+        rng = np.random.default_rng(7)
+        n = 40
+        X = pd.DataFrame(
+            {"a": rng.normal(size=n), "b": rng.normal(size=n), "c": rng.normal(size=n)},
+        )
+        X.loc[0, "a"] = 6.0  # one high-leverage row, so the test has something to detect
+        y = pd.Series(2.0 + 3.0 * X["a"] - 1.5 * X["b"] + rng.normal(scale=0.4, size=n), name="y")
+        return X, y
+
+    @pytest.mark.parametrize("columns", [["a"], ["a", "b"], ["a", "b", "c"]])
+    def test_matches_statsmodels_with_intercept(self, data: tuple[pd.DataFrame, pd.Series], columns: list[str]) -> None:
+        X, y = data
+        model = OLS().fit(X[columns], y)
+        hat, cooks = self._reference(X[columns], y, fit_intercept=True)
+        assert model.leverage_ == pytest.approx(hat)
+        assert model.influence_ == pytest.approx(cooks)
+
+    def test_matches_statsmodels_without_intercept(self, data: tuple[pd.DataFrame, pd.Series]) -> None:
+        X, y = data
+        model = OLS(fit_intercept=False).fit(X[["a", "b"]], y)
+        hat, cooks = self._reference(X[["a", "b"]], y, fit_intercept=False)
+        assert model.leverage_ == pytest.approx(hat)
+        assert model.influence_ == pytest.approx(cooks)
+
+    def test_leverage_sums_to_the_parameter_count(self, data: tuple[pd.DataFrame, pd.Series]) -> None:
+        """A property of the hat matrix: its trace is the number of parameters."""
+        X, y = data
+        model = OLS().fit(X, y)
+        assert float(np.sum(model.leverage_)) == pytest.approx(4.0)  # intercept plus three predictors
+        assert model.leverage_.shape == (len(y),)
+        assert model.influence_.shape == (len(y),)
+
+    def test_high_leverage_row_is_flagged(self, data: tuple[pd.DataFrame, pd.Series]) -> None:
+        X, y = data
+        model = OLS().fit(X, y)
+        assert int(np.argmax(model.leverage_)) == 0
+        assert model.leverage_[0] > 4.0 / len(y)  # above the 2k/n rule of thumb
+
+    def test_saturated_fit_reports_zero_influence(self) -> None:
+        """With as many parameters as rows there is no residual to redistribute."""
+        X = pd.DataFrame({"a": [0.0, 1.0, 2.0]})
+        y = pd.Series([1.0, 3.0, 2.0])
+        model = OLS().fit(pd.concat([X, X**2], axis=1).set_axis(["a", "a2"], axis=1), y)
+        assert np.all(np.isfinite(model.leverage_))
+        assert model.influence_ == pytest.approx(np.zeros(3))

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -942,3 +942,20 @@ class TestLeverageAndInfluence:
         model = OLS().fit(pd.concat([X, X**2], axis=1).set_axis(["a", "a2"], axis=1), y)
         assert np.all(np.isfinite(model.leverage_))
         assert model.influence_ == pytest.approx(np.zeros(3))
+
+    def test_one_row_at_leverage_one_does_not_blank_the_others(self) -> None:
+        """A single determined row reads zero; the rest keep their own values.
+
+        An indicator column that is on for exactly one row fits that row exactly, so its
+        leverage is 1 and its Cook's distance is not defined by the usual ratio. That is
+        a property of that row, not of the fit, so the other rows still report.
+        """
+        rng = np.random.default_rng(3)
+        n = 12
+        X = pd.DataFrame({"a": rng.normal(size=n), "only_row_0": np.eye(n)[0]})
+        y = pd.Series(rng.normal(size=n))
+        model = OLS().fit(X, y)
+        assert model.leverage_[0] == pytest.approx(1.0)
+        assert model.influence_[0] == 0.0
+        assert np.count_nonzero(model.influence_[1:]) == n - 1
+        assert np.all(np.isfinite(model.influence_))


### PR DESCRIPTION
## Summary

Every Python case in the *Process Improvement using Data* book is now executed against this package in the book's CI (kgdunn/pid-book#274). Doing that sweep surfaced six defects and one gap on this side. Released here as **1.80.0**.

- **Element-wise cross-validation measured its error in the wrong space** (#546). The scheme standardises the matrix inside every fold, then undid that standardisation before measuring the squared error, so PRESS came back in the input units and each variable weighed on the `Q2` curve in proportion to its variance rather than its structure. On the LDPE data used in the book, one column (`Mw`) carries 99.5% of the raw sum of squares, so passing the raw block, which the library's own warning from #539 recommends, gave the `Q2` curve of `Mw` alone: monotonic to 0.94, with none of the turnover at two components that the same data show once every variable counts equally. Details below.
- **`AdaptivePCA` and `AdaptivePLS` never set `n_components_`** (#542), so the inherited `hotellings_t2_limit` raised `AttributeError` on every fitted adaptive model. `hasattr` returns `True`, so the gap only appeared at call time; it took out a section of the book's adaptive soft-sensor chapter and the figure script behind it. Both `fit` methods now set it, and a test checks the limit against the value the `update()` Bunch already reports.
- **`OLS.leverage_` and `OLS.influence_` only existed for a single predictor with an intercept** (#545), holding a lone `nan` otherwise, silently. Both are now computed from the hat-matrix diagonal of the fitted model matrix, so they hold for multiple regression and with or without an intercept, and they match `statsmodels`' `hat_matrix_diag` and `cooks_distance` to machine precision. A rank-deficient model matrix no longer raises, and a saturated fit reports zero influence rather than dividing by a residual that does not exist. `influence_` is now always an `ndarray`, matching its documented type.
- **The robust-regression tool description quoted the wrong breakdown point** (#544): "~29%" is Theil-Sen; Siegel's repeated median, which is what is implemented, tolerates 50%. The book had it right and the library contradicted it.
- **Project URLs pointed at `github.com/kgdunn/process_improve`** (#543), with an underscore, which returns HTTP 403. Fixed in `pyproject.toml` and the Sphinx `github_url`.
- **`select_n_components` leaked a numpy `RuntimeWarning`** from its own internals on a block with no variation in it, where `press_ratio` is 0/0. That now reaches the caller as `NaN`. Found while writing a degenerate-input test; the standard error computed two lines below already guarded the same case. Adjacent to #546 rather than part of it, and a clean revert if you would rather keep this PR strictly to the issues above.
- The `raincloud` docstring no longer claims a package default theme is applied when `template=None`; none is.

## About #546, which changes published numbers

This one was filed first and fixed second, deliberately, because it changes what `PCA.select_n_components(cv_scheme="ekf")` returns for everyone. `press`, `q2`, `se_press` and `q2_se` all move.

PRESS is now accumulated after the in-fold scaling, and compared against a null model measured the same way: predict each held-out cell by the mean of the cells that were not held out. `Q2` keeps its meaning, "the fraction of held-out variation the model predicts", and stays comparable to `r2_cumulative_`. The numbers it takes are lower on a block with one dominant column, because they are no longer that column's numbers.

Three properties now hold that did not:

- Re-expressing a column in different units leaves the whole curve unchanged (exactly, not approximately).
- Passing the raw block and passing an `MCUVScaler` block give the same answer. On LDPE they agree to 7e-5, against a standard error of 0.016.
- The LDPE curve peaks at two components on both, which is the reading the data support and what the book's section is about.

Two smaller scale dependencies went with it. The EM loop judged convergence on the held-out cells in the input units, so a stretched column changed the iteration count and moved the result in the last significant figures; it now judges convergence in the fitting space. And the in-fold column mean is computed once per fold rather than twice, since the null model needs it whether or not the fold also scales.

`scale_inside_folds=False`, the opt-out for callers who scale their own block, keeps the centred total sum of squares as its reference and is unchanged. Two new fields make this class of failure visible next time: `q2_per_variable`, each column's own `Q2` beside the pooled figure, and `press_input_units`, the curve in the units the caller passed, for comparing prediction error against instrument error.

One existing test changed as a consequence rather than by choice. `test_pca_select_n_components_n_repeats_narrows_se` asserted that every one of eight components narrows its standard error when repeats go from 1 to 8. Dividing each fold's error by that fold's own estimated standard deviations adds fold-to-fold variance, and an SE built from five folds already carries a relative sampling error near 35%, so the per-component form was a sampling accident rather than a property. It now checks the median narrowing, measured at 0.25 to 0.58 across twelve seeds against the expected 1/sqrt(8) = 0.35, keeps a per-component bound that still catches a real blow-up, and additionally pins that the recommendation does not move.

`r2y_validated["total"]` in PLS is variance-weighted across Y variables for the same reason. It bites rarely, since `M` is usually 1, and the per-variable entries beside it are already right. Noted in #546 as separable and left alone here.

## Downstream

- kgdunn/figures#90: `pca/q2-across-packages.png` is computed live from the library, so it changes. Done and green on the paired branch, and it does **not** have to wait for this release: the script tells "too old to reproduce this figure" apart from "regression" by version, and below 1.80.0 it skips that one figure with a message rather than overwriting a correct PNG with a wrong one.
- kgdunn/pid-book#286: the book section quotes the curve. Deliberately **not** pushed, because the book's CI gate runs against the PyPI release and would go red for a change that is correct. That issue carries the exact replacement numbers, a table of every number that moves, and the ordering.

## Test plan

- [x] `uv run pytest`: **3096 passed**, 3 skipped, coverage 94.05% (gate 92%)
- [x] `ruff check .` and `ruff format --check .`
- [x] `mypy src/process_improve`
- [x] Codecov: all modified and coverable lines covered
- [x] New tests for #546: `Q2` unmoved when one column is multiplied by 1000; LDPE raw and pre-scaled agree and turn over at two components; `q2_per_variable` separates a noise column from the structured ones; a flat column gets `NaN` rather than a spurious zero; `scale_inside_folds=False` still measures in input units against the centred sum of squares; two degenerate blocks (a matrix small enough to leave a column one in-fold cell, and a matrix with no variation at all) return `NaN` answers without raising and without a numpy warning
- [x] New tests for #542 (adaptive T2 limit) and #545 (leverage and Cook's distance against statsmodels for one, two and three predictors, without an intercept, the hat-trace property, a high-leverage row and a saturated fit)
- [x] The `docs/user_guide/cross_validation.rst` page gained a section on what PRESS is measured in, since that is now a thing a reader has to know to read the number

## Checklist

- [x] Version bumped in `pyproject.toml` (MINOR: behavioural change to `select_n_components`, plus `leverage_` / `influence_` gaining multiple-regression support)
- [x] `CITATION.cff` version and date in the same commit
- [x] Tests added
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated, and says plainly which returned values change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxH1kx9oxBt6c7KKXZJufq