### PR TITLE
Build the mid-course prediction interval at the decision point; add MidCourseCorrector.predict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,45 @@ those changes.
 
 ## [Unreleased]
 
+## [1.80.0] - 2026-09-05
+
+### Added
+
+- `MidCourseCorrector.predict`: the monitoring question at a decision point.
+  Predicts the final quality of a running batch from its initial conditions,
+  the samples recorded so far and the planned remaining schedule, with a
+  prediction interval built from the model's error *at that decision point*
+  (`limits_at(k).rmse_k`: the training batches re-projected under the same
+  missingness pattern, against their measured quality), the SPE validity
+  statistics of the batch so far, and the condition number of the
+  score-estimation operator. `limits_at` also reports `rmse_k` and the two
+  operators' condition numbers.
+- `evaluate_control_policies` records each batch's no-change prediction and
+  interval half-width at the first decision point.
+
+### Changed
+
+- The no-correction dead band of `MidCourseCorrector.correct` is measured
+  against the prediction interval at the decision point (from `predict`),
+  not against the full-row training RMSE. Early decision points, where the
+  score estimate rests on few observed columns and can be ill-conditioned,
+  are now held to a correspondingly wider band; the old interval could not see
+  this and let nonsensical early projections trigger harmful corrections. The
+  no-change prediction and the movement penalty now use the currently planned
+  remainder (the implemented schedule after an earlier correction) rather than
+  always the nominal schedule. `correct` reports `y_hat_no_change`,
+  `half_width` and `condition_number` on every outcome. With the interval now
+  calibrated at the decision point, `evaluate_control_policies` defaults to
+  `dead_band=1.0` (the class default: correct only when the whole interval
+  falls short of the target) instead of the 2.5 that compensated for the old
+  interval. A corrector built without `y_target` can `predict` but not
+  `correct` (the target check moved from the constructor to `correct`).
+
+### Fixed
+
+- `midcourse_correction` no longer fails with `n_knots` set when a tag has a
+  single remaining free sample (the last decision point before the batch ends).
+
 ## [1.79.0] - 2026-09-04
 
 ### Changed
@@ -4030,7 +4069,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.79.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.80.0...HEAD
+[1.80.0]: https://github.com/kgdunn/process-improve/compare/v1.79.0...v1.80.0
 [1.79.0]: https://github.com/kgdunn/process-improve/compare/v1.78.0...v1.79.0
 [1.78.0]: https://github.com/kgdunn/process-improve/compare/v1.77.0...v1.78.0
 [1.77.0]: https://github.com/kgdunn/process-improve/compare/v1.76.0...v1.77.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.79.0
-date-released: "2026-09-04"
+version: 1.80.0
+date-released: "2026-09-05"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/docs/user_guide/batch_control.rst
+++ b/docs/user_guide/batch_control.rst
@@ -35,12 +35,18 @@ The pieces
   is a quadratic program; the hard SPE and T2 caps are quadratic constraints,
   handled by an outer iteration on their penalty weights.
 - :class:`~process_improve.batch.control.MidCourseCorrector` wraps the
-  decision-point workflow: the SPE validity gate (an out-of-family batch is
+  decision-point workflow. Its ``predict`` method answers the monitoring
+  question at a decision point: the predicted final quality with a
+  prediction interval built from the model's error *at that decision point*
+  (the training batches re-projected under the same missingness pattern,
+  against their measured quality), the SPE of the batch so far against its
+  limit, and the condition number of the score estimator. Its ``correct``
+  method adds the decision: the SPE validity gate (an out-of-family batch is
   not corrected, following Flores-Cerrillo and MacGregor, 2004), the
   no-correction dead band (correct only when the projected shortfall is
-  significant against the model's prediction interval, the practical lesson
-  of Yabuki and MacGregor, 1997), and per-decision-point limits built by
-  re-projecting the training batches under the same missingness pattern
+  significant against that interval, the practical lesson of Yabuki and
+  MacGregor, 1997; the default of 1.0 asks that the whole interval fall
+  short of the target), and per-decision-point limits built the same way
   (Garcia-Munoz, Kourti and MacGregor, 2004).
 - :func:`~process_improve.batch.control.evaluate_control_policies` runs the
   whole comparison end to end.

--- a/docs/user_guide/batch_control.rst
+++ b/docs/user_guide/batch_control.rst
@@ -60,7 +60,7 @@ that depends on the feed class (warmer mid-batch rescues a slow batch and
 hurts a fast one), so the evaluation fits one model per feed class and
 assigns a fresh batch to the nearest class centroid in standardised Z; with
 the class ranges overlapping along the feed-quality axis that assignment is
-right about 80% of the time, and a miss hands the batch the neighbouring
+right about 85% of the time, and a miss hands the batch the neighbouring
 range's model.
 
 The executed comparison
@@ -84,25 +84,25 @@ seed 0; about seven minutes, dominated by the two ceiling policies):
 Policy           Mean    Sd      Min     Max
 ===============  ======  ======  ======  ======
 replay           7.507   1.198   3.655   8.925
-midcourse        7.709   0.781   5.717   8.925
-oracle-from-k    7.828   0.631   6.108   8.925
+midcourse        7.746   0.782   5.717   8.925
+oracle-from-k    7.866   0.626   6.108   8.925
 adapted          7.824   1.013   4.573   9.309
 ===============  ======  ======  ======  ======
 
-Four of the forty batches were corrected, all in the poorest feed class;
-thirty-five were left alone by the dead band and one was stopped by the SPE
+Five of the forty batches were corrected, all in the poorest feed class;
+thirty-four were left alone by the dead band and one was stopped by the SPE
 validity gate. Reading the table:
 
-- The corrected batches gained between +1.53 and +2.67 g/L, mean +2.02 g/L,
+- The corrected batches gained between +1.48 and +2.67 g/L, mean +1.92 g/L,
   and none was harmed. The worst batch in the campaign rose from 3.66 to
   5.79 g/L.
 - The campaign standard deviation fell from 1.20 to 0.78 g/L, a 35%
-  reduction, with the mean up 0.20 g/L: mid-course correction works on the
+  reduction, with the mean up 0.24 g/L: mid-course correction works on the
   low tail, which is where the money is when the target is a floor.
 - The **oracle-from-k** row re-optimises the remaining schedule of those
   same corrected batches against the simulator itself (the true process) at
   the same decision point: the ceiling for any mid-course scheme there. The
-  data-driven correction captured 63% of the oracle's mean improvement; the
+  data-driven correction captured 67% of the oracle's mean improvement; the
   rest is the price of an empirical model confined to the region its
   history explored.
 - The **adapted** row runs every batch on the true optimal schedule for its
@@ -114,11 +114,11 @@ validity gate. Reading the table:
   address the two different variance shares that
   :func:`~process_improve.simulation.variance_decomposition` separates.
 
-The corrector's predictions were conservative: for the four corrected
-batches it predicted 5.0 to 6.7 g/L and the executed titers came out 5.7 to
-7.7 g/L. A latent-variable prediction regresses toward the mean, so a batch
-deep in the tail is predicted less deep; the correction direction still
-held.
+The corrector's predictions were conservative: for the five corrected
+batches it predicted 5.0 to 6.9 g/L and the executed titers came out 5.7 to
+8.5 g/L (four gains understated, one overstated by 0.1 g/L). A
+latent-variable prediction regresses toward the mean, so a batch deep in the
+tail is predicted less deep; the correction direction still held.
 
 Where to put the decision point
 -------------------------------
@@ -129,21 +129,24 @@ mean executed gain over the batches corrected at that point):
 =========  ====  ==============  ===============
 Sample     Day   Corrected       Mean gain [g/L]
 =========  ====  ==============  ===============
-4          2.0   21 (8 harmed)   +0.32
-6          3.0   8 (3 harmed)    +0.82
-8          4.0   4 (0 harmed)    +2.02
-10         5.0   6 (0 harmed)    +0.67
-12         6.0   7 (7 harmed)    -0.05
-14         7.0   7 (7 harmed)    -0.28
+4          2.0   5 (1 harmed)    +0.93
+6          3.0   6 (0 harmed)    +1.46
+8          4.0   5 (0 harmed)    +1.92
+10         5.0   7 (0 harmed)    +0.63
+12         6.0   8 (8 harmed)    -0.09
+14         7.0   8 (8 harmed)    -0.28
 =========  ====  ==============  ===============
 
 The window is real and it is in the middle of the batch. Too early, the
-projections are still uncertain, so the dead band passes batches that did
-not need correcting and the model misdirects some of them. Too late, the
-biology has already decided: the remaining schedule has almost no leverage,
-and small model errors turn corrections into damage. On this process the
-useful window is days 4 to 5, just after the growth phase reveals which
-batches are behind.
+projections are still uncertain; the interval at the decision point carries
+that, so the dead band admits only the clearest shortfalls (the class A
+batches, whose estimator is ill-conditioned at day 2, arrive with intervals
+hundreds of g/L wide and are never corrected there), and the gain is about
+half of the peak. Too late, the biology has already decided: the remaining
+schedule has almost no leverage, and small model errors turn corrections
+into damage. On this process the useful window is days 3 to 5, with the
+largest gain at day 4, just after the growth phase reveals which batches are
+behind.
 
 Practical notes
 ---------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.79.0"
+version = "1.80.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/batch/_batch_pls.py
+++ b/src/process_improve/batch/_batch_pls.py
@@ -227,6 +227,10 @@ class BatchPLS(RegressorMixin, BaseEstimator):
         # point's missingness pattern to build time-varying SPE and T2 limits
         # (Garcia-Munoz, Kourti and MacGregor, 2004).
         self._x_scaled_training = x_mcuv
+        # The scaled Y block is kept for the same reason: the corrector needs
+        # the training batches' quality to measure the prediction error of the
+        # model at each decision point (a time-varying prediction interval).
+        self._y_scaled_training = y_mcuv
         self._expose_fitted_attributes(wide, x_scaler, y_scaler)
 
         first_batch = X[next(iter(X.keys()))]

--- a/src/process_improve/batch/control.py
+++ b/src/process_improve/batch/control.py
@@ -32,7 +32,9 @@ movement-suppression term, the soft T2 term, and the SPE check on the
 measurements so far that gates whether a correction is computed at all;
 Yabuki and MacGregor (1997) give the no-correction dead band, their
 "no-control region"; Garcia-Munoz, Kourti and MacGregor (2004) give the
-per-decision-point score covariance and limits; Arteaga and Ferrer (2002)
+per-decision-point score covariance and limits, and the prediction interval
+at a decision point is built in the same spirit, from the training batches
+re-projected under that point's missingness pattern; Arteaga and Ferrer (2002)
 give the trimmed score regression used to estimate the scores of a partially
 observed row, which Golshan et al. (2010) also apply in the LV-MPC setting.
 
@@ -480,7 +482,10 @@ def midcourse_correction(  # noqa: PLR0913, PLR0912, PLR0915, C901
         for positions_in_free in by_tag.values():
             ordered = sorted(positions_in_free, key=lambda j: free_labels[j][1])
             order.extend(ordered)
-            blocks.append(_knot_matrix(len(ordered), min(n_knots, len(ordered))))
+            # A tag with a single remaining sample has nothing to interpolate
+            # (the last decision point before the batch ends); it keeps its
+            # one decision variable.
+            blocks.append(_knot_matrix(len(ordered), min(n_knots, len(ordered))) if len(ordered) >= 2 else np.eye(1))
         permute = np.zeros((n_free, n_free))
         for row_pos, j in enumerate(order):
             permute[j, row_pos] = 1.0
@@ -631,12 +636,15 @@ def midcourse_correction(  # noqa: PLR0913, PLR0912, PLR0915, C901
 class MidCourseCorrector:
     """Decision-point workflow around :func:`midcourse_correction`.
 
-    Holds the model, the nominal schedule and the tuning, and at each decision
-    point: checks the batch-so-far against the model (the SPE validity gate of
-    Flores-Cerrillo and MacGregor, 2004), applies the no-correction dead band
-    (Yabuki and MacGregor, 1997) in target mode, builds the per-decision-point
-    reference limits (Garcia-Munoz et al., 2004), solves the QP, and returns
-    the full corrected schedule ready to implement (or to hand to
+    Holds the model, the nominal schedule and the tuning. :meth:`predict`
+    answers the monitoring question at a decision point (the predicted final
+    quality with its interval, and the validity statistics of the batch so
+    far). :meth:`correct` adds the decision: it checks the batch-so-far
+    against the model (the SPE validity gate of Flores-Cerrillo and
+    MacGregor, 2004), applies the no-correction dead band (Yabuki and
+    MacGregor, 1997) in target mode, builds the per-decision-point reference
+    limits (Garcia-Munoz et al., 2004), solves the QP, and returns the full
+    corrected schedule ready to implement (or to hand to
     :meth:`process_improve.simulation.BioreactorSimulator.simulate_batch`).
 
     Parameters
@@ -653,7 +661,10 @@ class MidCourseCorrector:
         tag is a response, treated as missing after the decision point.
     mode : {"target", "maximize"}, default="target"
     y_target : Series, dict, or float, optional
-        Required for ``mode="target"``.
+        Required by :meth:`correct` in ``mode="target"``. A corrector built
+        with only ``model``, ``nominal_schedule`` and ``mv_tags`` can
+        :meth:`predict` (the monitoring question needs no target) but not
+        correct.
     weights, bounds, rate_limits, method, ridge, n_knots
         Passed through to :func:`midcourse_correction`.
     spe_cap, t2_cap : float, "limit", or None, default="limit"
@@ -668,6 +679,10 @@ class MidCourseCorrector:
         Multiplier on the prediction-interval half-width: in target mode the
         correction is skipped while the no-change prediction lies within
         ``dead_band`` half-widths of the target for every quality variable.
+        The half-width is the interval *at the decision point* (see
+        :meth:`predict`): it carries the model's prediction error under that
+        point's missingness pattern, so early decision points, where the
+        estimate rests on few observed columns, are held to a wider band.
         Set to 0.0 to correct at every decision point. Ignored in maximize
         mode.
     target_side : {"both", "below", "above"}, default="both"
@@ -705,8 +720,6 @@ class MidCourseCorrector:
             raise ValueError("MidCourseCorrector requires a model fitted with group_by_batch=False.")
         if mode not in _MODES:
             raise ValueError(f"mode must be one of {list(_MODES)}; got {mode!r}.")
-        if mode == "target" and y_target is None:
-            raise ValueError("y_target is required when mode='target'.")
         unknown_tags = [t for t in mv_tags if t not in model.tag_names_]
         if unknown_tags:
             raise ValueError(f"mv_tags contains tags the model does not carry: {unknown_tags}.")
@@ -771,7 +784,11 @@ class MidCourseCorrector:
         and the F-distribution T2 limit on the candidate-pattern score
         estimates with their own covariance (Garcia-Munoz et al., 2004).
 
-        Results are cached per ``k``.
+        Also returned: ``rmse_k`` (Series over the targets, original units),
+        the prediction error of the model at this decision point, from the
+        candidate-pattern estimates of the training batches; and the
+        condition numbers of the two pattern operators. Results are cached
+        per ``k``.
         """
         if k in self._limit_cache:
             return self._limit_cache[k]
@@ -797,11 +814,29 @@ class MidCourseCorrector:
         score_cov = np.cov(candidate.scores, rowvar=False, ddof=1)
         score_cov = np.atleast_2d(score_cov)
         t2_limit = float((A * (n**2 - 1)) / (n * (n - A)) * f_dist.ppf(self.conf_level, A, n - A))
+
+        # The prediction error of the model *at this decision point*: the
+        # quality predicted from the candidate-pattern score estimates of the
+        # training batches, against their measured quality, on the same
+        # N - A - 1 degrees of freedom as the full-row training RMSE that
+        # PLS.prediction_interval uses. Early in the batch the estimate rests
+        # on few observed columns and this error can be much larger than the
+        # full-row RMSE (orders of magnitude when the restricted estimator is
+        # ill-conditioned); it is what the prediction interval, and hence the
+        # dead band, must carry at that decision point.
+        y_loadings = np.asarray(self.model.y_loadings_, dtype=float)
+        y_scaled = self.model._y_scaled_training.to_numpy(dtype=float)
+        residual = candidate.scores @ y_loadings.T - y_scaled
+        df = max(n - A - 1, 1)
+        rmse_k = np.sqrt(np.sum(residual**2, axis=0) / df) * self.model.y_scale_.to_numpy(dtype=float)
         result = Bunch(
             spe_limit_monitor=float(spe_calculation(monitor.spe, conf_level=self.conf_level)),
             spe_limit_candidate=float(spe_calculation(candidate.spe, conf_level=self.conf_level)),
             t2_limit=t2_limit,
             score_covariance=score_cov,
+            rmse_k=pd.Series(rmse_k, index=self.model.target_names_, name="rmse_k"),
+            condition_number_monitor=float(monitor.condition_number[0]),
+            condition_number_candidate=float(candidate.condition_number[0]),
         )
         self._limit_cache[k] = result
         return result
@@ -835,7 +870,120 @@ class MidCourseCorrector:
                 entries[(tag, s)] = float(batch_so_far.iloc[s][tag])
         return pd.Series(entries)
 
-    def correct(  # noqa: C901, PLR0912, PLR0915 - the decision-point workflow is one narrative
+    def predict(
+        self,
+        batch_so_far: pd.DataFrame,
+        *,
+        initial_conditions: pd.Series | pd.DataFrame | None = None,
+        schedule: pd.DataFrame | None = None,
+        k: int | None = None,
+    ) -> Bunch:
+        """Predict the final quality of a running batch at decision point ``k``.
+
+        The monitoring question "where is this batch heading if nothing more
+        is changed": the initial conditions and the samples recorded so far
+        are known, the remaining manipulated-variable samples are taken from
+        ``schedule`` (the nominal schedule by default), and the remaining
+        response samples are missing and estimated. The prediction interval
+        uses the model's prediction error *at this decision point*
+        (``limits_at(k).rmse_k``) with the leverage of the estimated scores,
+        so it is wide early in the batch, when the estimate rests on few
+        observed columns, and narrows as the batch runs.
+
+        Parameters
+        ----------
+        batch_so_far : pd.DataFrame
+            The recorded tag trajectories up to the decision point: the first
+            ``k`` samples, columns = the model's tags.
+        initial_conditions : pd.Series or pd.DataFrame, optional
+            The batch's Z values; required if the model was fitted with a Z
+            block.
+        schedule : pd.DataFrame, optional
+            The setpoint schedule whose remaining rows are assumed (same
+            layout as ``nominal_schedule``). Defaults to the nominal schedule.
+        k : int, optional
+            The decision point (number of completed samples). Defaults to
+            ``len(batch_so_far)``. At ``k == n_timesteps_`` the row is
+            complete and the prediction equals the model's ordinary one.
+
+        Returns
+        -------
+        result : sklearn.utils.Bunch
+            With keys ``y_hat``, ``half_width``, ``lower`` and ``upper``
+            (Series over the targets, original units; the interval is at
+            ``conf_level``), ``spe_so_far`` and ``spe_limit_monitor`` (the
+            validity check on the measurements so far), ``in_control``
+            (bool, ``spe_so_far <= spe_limit_monitor``), ``t2`` and
+            ``t2_limit`` (the candidate row against the per-decision-point
+            score covariance), ``condition_number`` (of the candidate-pattern
+            operator; a very large value means the estimate at this decision
+            point is not trustworthy, whatever the batch looks like), and
+            ``k``.
+        """
+        from .._linalg import safe_inverse  # noqa: PLC0415
+
+        model = self.model
+        if k is None:
+            k = len(batch_so_far)
+        if not 1 <= k <= model.n_timesteps_:
+            raise ValueError(f"k must lie in [1, {model.n_timesteps_}]; got {k}.")
+        if len(batch_so_far) < k:
+            raise ValueError(f"batch_so_far has {len(batch_so_far)} samples but k={k} were requested.")
+        schedule = schedule if schedule is not None else self.nominal_schedule
+        if schedule.shape[0] != model.n_timesteps_:
+            raise ValueError(f"schedule must have {model.n_timesteps_} rows; got {schedule.shape[0]}.")
+
+        limits = self.limits_at(k)
+        masks = self._masks_at(k)
+        observed = self._observed_series(batch_so_far, initial_conditions, k)
+        features = pd.Index(model.feature_columns_)
+        center = model.center_.to_numpy(dtype=float)
+        scale = model.scale_.to_numpy(dtype=float)
+        loadings = model.x_loadings_.to_numpy(dtype=float)
+        guide = model.direct_weights_.to_numpy(dtype=float)
+        variances = np.asarray(model.explained_variance_, dtype=float)
+
+        row = np.full(len(features), np.nan)
+        positions = features.get_indexer(observed.index)
+        row[positions] = (observed.to_numpy(dtype=float) - center[positions]) / scale[positions]
+        so_far = project_rows(loadings, guide, variances, row[None, :], method=self.method, ridge=self.ridge)
+        spe_so_far = float(so_far.spe[0])
+
+        candidate = row.copy()
+        free_positions = np.flatnonzero(masks.free)
+        if free_positions.size:
+            free_labels = list(features[masks.free])
+            planned = np.array([float(schedule.iloc[s][tag]) for (tag, s) in free_labels])
+            candidate[free_positions] = (planned - center[free_positions]) / scale[free_positions]
+        projected = project_rows(loadings, guide, variances, candidate[None, :], method=self.method, ridge=self.ridge)
+        scores = projected.scores[0]
+        s_inv = safe_inverse(limits.score_covariance, what="score_covariance")
+        t2 = float(scores @ s_inv @ scores)
+
+        y_loadings = np.asarray(model.y_loadings_, dtype=float)
+        y_hat = model.y_center_.to_numpy(dtype=float) + model.y_scale_.to_numpy(dtype=float) * (y_loadings @ scores)
+        n = model.n_samples_
+        df = max(n - int(model.n_components) - 1, 1)
+        t_crit = t_dist.ppf(1 - (1 - self.conf_level) / 2, df)
+        leverage = 1.0 / n + t2 / (n - 1)
+        half_width = t_crit * np.sqrt(1.0 + leverage) * limits.rmse_k.to_numpy(dtype=float)
+        targets = model.target_names_
+        return Bunch(
+            y_hat=pd.Series(y_hat, index=targets, name="y_hat"),
+            half_width=pd.Series(half_width, index=targets, name="half_width"),
+            lower=pd.Series(y_hat - half_width, index=targets, name="lower"),
+            upper=pd.Series(y_hat + half_width, index=targets, name="upper"),
+            conf_level=self.conf_level,
+            spe_so_far=spe_so_far,
+            spe_limit_monitor=limits.spe_limit_monitor,
+            in_control=bool(spe_so_far <= limits.spe_limit_monitor),
+            t2=t2,
+            t2_limit=limits.t2_limit,
+            condition_number=float(projected.condition_number[0]),
+            k=k,
+        )
+
+    def correct(  # noqa: C901, PLR0912 - the decision-point workflow is one narrative
         self,
         batch_so_far: pd.DataFrame,
         *,
@@ -870,13 +1018,20 @@ class MidCourseCorrector:
             ``reason`` (``"corrected"``, ``"spe_gate"``, ``"dead_band"`` or
             ``"batch_complete"``), ``k``, ``spe_so_far`` and
             ``spe_limit_monitor`` (the validity gate), ``y_hat_no_change``
-            and, in target mode, ``dead_band_margin`` (Series; deviation of
-            the no-change prediction from the target in units of the
-            prediction-interval half-width), plus ``correction`` (the full
+            and ``half_width`` (the prediction and its interval half-width
+            at this decision point, from :meth:`predict`),
+            ``condition_number`` (of the candidate-pattern operator), in
+            target mode ``dead_band_margin`` (Series; deviation of the
+            no-change prediction from the target in units of the
+            half-width), plus ``y_hat`` and ``correction`` (the full
             :func:`midcourse_correction` Bunch) when a correction was
             computed.
         """
         model = self.model
+        if self.mode == "target" and self.y_target is None:
+            raise ValueError(
+                "y_target is required to correct in mode='target' (a corrector without one can only predict)."
+            )
         if k is None:
             k = len(batch_so_far)
         if not 1 <= k <= model.n_timesteps_:
@@ -892,36 +1047,29 @@ class MidCourseCorrector:
         limits = self.limits_at(k)
         masks = self._masks_at(k)
         observed = self._observed_series(batch_so_far, initial_conditions, k)
-
-        # --- SPE validity gate on the batch so far -------------------------
         features = pd.Index(model.feature_columns_)
-        center = model.center_.to_numpy(dtype=float)
-        scale = model.scale_.to_numpy(dtype=float)
-        row = np.full(len(features), np.nan)
-        positions = features.get_indexer(observed.index)
-        row[positions] = (observed.to_numpy(dtype=float) - center[positions]) / scale[positions]
-        so_far = project_rows(
-            model.x_loadings_.to_numpy(dtype=float),
-            model.direct_weights_.to_numpy(dtype=float),
-            np.asarray(model.explained_variance_, dtype=float),
-            row[None, :],
-            method=self.method,
-            ridge=self.ridge,
-        )
-        spe_so_far = float(so_far.spe[0])
-        if spe_so_far > limits.spe_limit_monitor:
-            return Bunch(
-                schedule=schedule,
-                corrected=False,
-                reason="spe_gate",
-                k=k,
-                spe_so_far=spe_so_far,
-                spe_limit_monitor=limits.spe_limit_monitor,
-            )
 
-        # --- Assemble the QP inputs ---------------------------------------
+        # --- The no-change prediction, and the SPE validity gate on the
+        # batch so far. The prediction assumes the currently planned
+        # remainder (the implemented schedule's future rows), which is the
+        # nominal schedule unless an earlier decision point changed it. ------
+        prediction = self.predict(batch_so_far, initial_conditions=initial_conditions, schedule=schedule, k=k)
+        spe_so_far = prediction.spe_so_far
+        common = {
+            "k": k,
+            "spe_so_far": spe_so_far,
+            "spe_limit_monitor": limits.spe_limit_monitor,
+            "y_hat_no_change": prediction.y_hat,
+            "half_width": prediction.half_width,
+            "condition_number": prediction.condition_number,
+        }
+        if spe_so_far > limits.spe_limit_monitor:
+            return Bunch(schedule=schedule, corrected=False, reason="spe_gate", **common)
+
+        # --- Assemble the QP inputs. The movement penalty is measured from
+        # the currently planned remainder, for the same reason. ---------------
         free_labels = list(features[masks.free])
-        nominal_remaining = pd.Series({(tag, s): float(self.nominal_schedule.iloc[s][tag]) for (tag, s) in free_labels})
+        nominal_remaining = pd.Series({(tag, s): float(schedule.iloc[s][tag]) for (tag, s) in free_labels})
         seam = {tag: float(schedule.iloc[k - 1][tag]) for tag in self.mv_tags} if k > 0 else None
         caps: dict[str, float | None] = {}
         for name, setting, resolved in (
@@ -936,28 +1084,12 @@ class MidCourseCorrector:
                 caps[name] = float(typing.cast("float", setting))
 
         # --- Dead band (target mode): correct only when the projected
-        # deviation is significant against the prediction interval. ---------
+        # deviation is significant against the prediction interval at this
+        # decision point. ----------------------------------------------------
         dead_band_margin = None
         if self.mode == "target" and (self.dead_band > 0 or self.target_side != "both"):
-            probe = midcourse_correction(
-                model,
-                observed=observed,
-                free_columns=free_labels,
-                mode="target",
-                y_target=self.y_target,
-                weights={"target": 0.0, "movement": 1.0},
-                nominal_remaining=nominal_remaining,
-                score_covariance=limits.score_covariance,
-                method=self.method,
-                ridge=self.ridge,
-            )
-            y0 = probe.y_hat_no_change
-            n = model.n_samples_
-            df = max(n - int(model.n_components) - 1, 1)
-            t_crit = t_dist.ppf(1 - (1 - self.conf_level) / 2, df)
-            leverage = 1.0 / n + probe.t2 / (n - 1)
-            error_std = model.rmse_.iloc[:, -1].to_numpy(dtype=float)
-            half_width = t_crit * np.sqrt(1.0 + leverage) * error_std
+            y0 = prediction.y_hat
+            half_width = prediction.half_width.to_numpy(dtype=float)
             target = pd.Series(self.y_target) if not isinstance(self.y_target, (int, float)) else None
             target_values = (
                 target.reindex(model.target_names_).to_numpy(dtype=float)
@@ -974,14 +1106,7 @@ class MidCourseCorrector:
             dead_band_margin = pd.Series(deviation / half_width, index=model.target_names_, name="dead_band_margin")
             if bool((deviation <= self.dead_band * half_width).all()):
                 return Bunch(
-                    schedule=schedule,
-                    corrected=False,
-                    reason="dead_band",
-                    k=k,
-                    spe_so_far=spe_so_far,
-                    spe_limit_monitor=limits.spe_limit_monitor,
-                    y_hat_no_change=y0,
-                    dead_band_margin=dead_band_margin,
+                    schedule=schedule, corrected=False, reason="dead_band", dead_band_margin=dead_band_margin, **common
                 )
 
         result = midcourse_correction(
@@ -1009,15 +1134,12 @@ class MidCourseCorrector:
             schedule=schedule,
             corrected=True,
             reason="corrected",
-            k=k,
-            spe_so_far=spe_so_far,
-            spe_limit_monitor=limits.spe_limit_monitor,
             spe_limit_candidate=limits.spe_limit_candidate,
             t2_limit=limits.t2_limit,
             y_hat=result.y_hat,
-            y_hat_no_change=result.y_hat_no_change,
             dead_band_margin=dead_band_margin,
             correction=result,
+            **common,
         )
 
 
@@ -1067,7 +1189,7 @@ def _oracle_remaining(  # noqa: PLR0913 - explicit oracle inputs
     return float(-min(first.fun, second.fun))
 
 
-def evaluate_control_policies(  # noqa: PLR0913, PLR0915, C901 - one executed comparison, kept linear
+def evaluate_control_policies(  # noqa: PLR0912, PLR0913, PLR0915, C901 - one executed comparison, kept linear
     simulator: object,
     *,
     y_target: float,
@@ -1077,7 +1199,7 @@ def evaluate_control_policies(  # noqa: PLR0913, PLR0915, C901 - one executed co
     n_components: int = 4,
     decision_points: tuple[int, ...] = (8,),
     target_side: str = "below",
-    dead_band: float = 2.5,
+    dead_band: float = 1.0,
     weights: dict | None = None,
     bounds: dict | None = None,
     rate_limits: dict | None = None,
@@ -1172,7 +1294,9 @@ def evaluate_control_policies(  # noqa: PLR0913, PLR0915, C901 - one executed co
         min and max titer), ``batches`` (DataFrame: per-batch replay /
         mid-course / adapted / oracle titers, the assigned and true feed
         class, whether and why each batch was or was not corrected, the
-        decision point used, and the corrector's predicted quality),
+        decision point used, the corrector's predicted quality, and the
+        no-change prediction with its interval half-width at the first
+        decision point),
         ``n_corrected``, ``n_harmed`` (corrected batches whose executed
         titer fell more than 0.01 below replay), and ``models`` (per-class
         fit R2).
@@ -1268,6 +1392,8 @@ def evaluate_control_policies(  # noqa: PLR0913, PLR0915, C901 - one executed co
         reason = None
         first_k = None
         y_hat_predicted = np.nan
+        y_hat_no_change = np.nan
+        half_width = np.nan
         current = base
         for k in decision_points:
             outcome = corrector.correct(
@@ -1276,6 +1402,9 @@ def evaluate_control_policies(  # noqa: PLR0913, PLR0915, C901 - one executed co
                 implemented_schedule=schedule,
                 k=int(k),
             )
+            if np.isnan(y_hat_no_change) and "y_hat_no_change" in outcome:
+                y_hat_no_change = float(outcome.y_hat_no_change.iloc[0])
+                half_width = float(outcome.half_width.iloc[0])
             reason = outcome.reason if reason is None or not corrected else reason
             if outcome.corrected:
                 schedule = outcome.schedule
@@ -1298,6 +1427,8 @@ def evaluate_control_policies(  # noqa: PLR0913, PLR0915, C901 - one executed co
             "reason": reason,
             "decision_point": first_k,
             "y_hat_predicted": y_hat_predicted,
+            "y_hat_no_change": y_hat_no_change,
+            "half_width": half_width,
         }
         if include_adapted:
             best = simulator.optimal_trajectory(  # type: ignore[attr-defined]

--- a/src/process_improve/simulation/tools.py
+++ b/src/process_improve/simulation/tools.py
@@ -681,12 +681,13 @@ class CorrectBatchMidcourseInput(BaseModel):
         ),
     )
     dead_band: float = Field(
-        2.5,
+        1.0,
         ge=0.0,
         le=10.0,
         description=(
-            "No-correction dead band in prediction-interval half-widths: correct only when the projected "
-            "shortfall is significant (Yabuki and MacGregor's lesson; 0 corrects every below-target batch)."
+            "No-correction dead band in half-widths of the prediction interval at the decision point: 1.0 corrects "
+            "only when the whole interval falls short of the target (Yabuki and MacGregor's no-control region); "
+            "0 corrects every below-target batch."
         ),
     )
     random_state: int = Field(0, ge=0, le=2**31 - 1, description="Seed; the same seed reproduces everything.")
@@ -784,7 +785,10 @@ class EvaluateBatchControlPolicyInput(BaseModel):
     )
     decision_point: int = Field(8, ge=1, le=19, description="Sample index of the decision point.")
     dead_band: float = Field(
-        2.5, ge=0.0, le=10.0, description="No-correction dead band in prediction-interval half-widths."
+        1.0,
+        ge=0.0,
+        le=10.0,
+        description="No-correction dead band in half-widths of the prediction interval at the decision point.",
     )
     include_ceilings: bool = Field(
         default=False,

--- a/tests/batch/test_batch_control.py
+++ b/tests/batch/test_batch_control.py
@@ -361,14 +361,17 @@ def test_corrector_validation_errors(fitted: BatchPLS) -> None:
     nominal = pd.DataFrame({"u": np.zeros(fitted.n_timesteps_)})
     with pytest.raises(ValueError, match="mv_tags contains tags"):
         MidCourseCorrector(fitted, nominal, mv_tags=["nope"], y_target=0.0)
+    batches, _ = _synthetic_batches()
+    # No target: the monitoring question is answered, the decision is refused.
+    watcher = MidCourseCorrector(fitted, nominal, mv_tags=["u"])
+    assert float(watcher.predict(batches["b0"].iloc[:4], k=4).half_width.iloc[0]) > 0
     with pytest.raises(ValueError, match="y_target is required"):
-        MidCourseCorrector(fitted, nominal, mv_tags=["u"])
+        watcher.correct(batches["b0"].iloc[:4], k=4)
     with pytest.raises(ValueError, match="target_side must be"):
         MidCourseCorrector(fitted, nominal, mv_tags=["u"], y_target=0.0, target_side="sideways")
     with pytest.raises(ValueError, match=r"rows \(one per aligned sample\)"):
         MidCourseCorrector(fitted, nominal.iloc[:3], mv_tags=["u"], y_target=0.0)
     corrector = MidCourseCorrector(fitted, nominal, mv_tags=["u"], y_target=0.0)
-    batches, _ = _synthetic_batches()
     with pytest.raises(ValueError, match="k must lie in"):
         corrector.correct(batches["b0"], k=0)
 
@@ -410,7 +413,7 @@ def test_executed_correction_gains_on_simulator() -> None:
             rate_limits={"temperature": 3.0, "pH": 0.5},
             spe_cap="limit",
             t2_cap="limit",
-            dead_band=2.5,
+            dead_band=1.0,
             target_side="below",
             n_knots=4,
         )
@@ -468,3 +471,88 @@ def test_evaluate_control_policies_structure() -> None:
         random_state=0,
     )
     pd.testing.assert_frame_equal(result.batches, again.batches)
+
+
+def test_limits_carry_decision_point_error_and_conditioning(corrector: MidCourseCorrector) -> None:
+    """rmse_k is the model's error under the decision point's pattern; at the full row it is the training RMSE."""
+    model = corrector.model
+    T = model.n_timesteps_
+    # k=1 observes two columns for three components: the estimator is singular
+    # there, by construction. Two samples are the earliest usable point.
+    early, full = corrector.limits_at(2), corrector.limits_at(T)
+    assert np.all(np.isfinite(early.rmse_k))
+    assert float(early.rmse_k.iloc[0]) > 0
+    assert early.condition_number_candidate >= 1.0
+    assert early.condition_number_monitor >= 1.0
+    # With everything observed the candidate pattern is the complete row, so the
+    # error equals the full-row training RMSE on N - A - 1 degrees of freedom.
+    n, A = model.n_samples_, int(model.n_components)
+    expected = float(model.rmse_.iloc[0, -1]) * np.sqrt(n / (n - A - 1))
+    assert abs(float(full.rmse_k.iloc[0]) - expected) < 1e-8
+    # Less of the batch observed cannot make the model's own fit better.
+    assert float(early.rmse_k.iloc[0]) > float(full.rmse_k.iloc[0])
+
+
+def test_predict_is_the_no_change_prediction_and_narrows(corrector: MidCourseCorrector) -> None:
+    """predict() matches correct()'s no-change prediction, widens early, and equals predict() at the end."""
+    batches, _ = _synthetic_batches()
+    bid = "b7"
+    batch = batches[bid]
+    model = corrector.model
+    T = model.n_timesteps_
+    early = corrector.predict(batch.iloc[:2], k=2)
+    late = corrector.predict(batch.iloc[:T], k=T)
+    assert float(early.half_width.iloc[0]) > float(late.half_width.iloc[0])
+    assert float(early.lower.iloc[0]) < float(early.y_hat.iloc[0]) < float(early.upper.iloc[0])
+    assert early.in_control
+    assert early.condition_number >= 1.0
+    # The complete row: the same prediction as the model's ordinary predict().
+    ordinary = model.predict({bid: batch})
+    assert abs(float(late.y_hat.iloc[0]) - float(ordinary.y_hat.iloc[0, 0])) < 1e-8
+    # correct() reports predict()'s numbers, whatever it decides.
+    out = corrector.correct(batch.iloc[:4], k=4)
+    same = corrector.predict(batch.iloc[:4], k=4)
+    assert abs(float(out.y_hat_no_change.iloc[0]) - float(same.y_hat.iloc[0])) < 1e-10
+    assert abs(float(out.half_width.iloc[0]) - float(same.half_width.iloc[0])) < 1e-10
+    assert out.condition_number == same.condition_number
+    with pytest.raises(ValueError, match="k must lie in"):
+        corrector.predict(batch, k=T + 1)
+    with pytest.raises(ValueError, match="schedule must have"):
+        corrector.predict(batch.iloc[:4], schedule=corrector.nominal_schedule.iloc[:3], k=4)
+
+
+def test_predict_uses_the_planned_schedule(corrector: MidCourseCorrector) -> None:
+    """A different remaining schedule changes the prediction; the past rows do not matter to it."""
+    batches, _ = _synthetic_batches()
+    batch = batches["b7"]
+    k = 4
+    nominal = corrector.predict(batch.iloc[:k], k=k)
+    moved = corrector.nominal_schedule.copy()
+    moved.iloc[k:, 0] = 0.5
+    with_move = corrector.predict(batch.iloc[:k], schedule=moved, k=k)
+    assert abs(float(with_move.y_hat.iloc[0]) - float(nominal.y_hat.iloc[0])) > 1e-3
+    past_only = moved.copy()
+    past_only.iloc[k:, 0] = corrector.nominal_schedule.iloc[k:, 0]
+    past_only.iloc[:k, 0] = 9.0
+    unchanged = corrector.predict(batch.iloc[:k], schedule=past_only, k=k)
+    assert abs(float(unchanged.y_hat.iloc[0]) - float(nominal.y_hat.iloc[0])) < 1e-12
+
+
+def test_correct_at_penultimate_sample_with_knots(fitted: BatchPLS) -> None:
+    """One remaining free sample cannot carry a knot basis; the correction still runs."""
+    nominal = pd.DataFrame({"u": np.zeros(fitted.n_timesteps_)})
+    knotted = MidCourseCorrector(
+        fitted,
+        nominal,
+        mv_tags=["u"],
+        mode="target",
+        y_target=0.5,
+        dead_band=0.0,
+        n_knots=4,
+        weights={"target": 5.0, "movement": 1e-3},
+    )
+    batches, _ = _synthetic_batches()
+    T = fitted.n_timesteps_
+    out = knotted.correct(batches["b5"].iloc[: T - 1], k=T - 1)
+    assert out.reason in ("corrected", "dead_band")
+    assert out.schedule.shape[0] == T

--- a/tests/batch/test_batch_control.py
+++ b/tests/batch/test_batch_control.py
@@ -515,8 +515,14 @@ def test_predict_is_the_no_change_prediction_and_narrows(corrector: MidCourseCor
     assert abs(float(out.y_hat_no_change.iloc[0]) - float(same.y_hat.iloc[0])) < 1e-10
     assert abs(float(out.half_width.iloc[0]) - float(same.half_width.iloc[0])) < 1e-10
     assert out.condition_number == same.condition_number
+    # k defaults to the number of samples handed in.
+    default_k = corrector.predict(batch.iloc[:4])
+    assert default_k.k == 4
+    assert abs(float(default_k.y_hat.iloc[0]) - float(same.y_hat.iloc[0])) < 1e-12
     with pytest.raises(ValueError, match="k must lie in"):
         corrector.predict(batch, k=T + 1)
+    with pytest.raises(ValueError, match="batch_so_far has 3 samples"):
+        corrector.predict(batch.iloc[:3], k=4)
     with pytest.raises(ValueError, match="schedule must have"):
         corrector.predict(batch.iloc[:4], schedule=corrector.nominal_schedule.iloc[:3], k=4)
 


### PR DESCRIPTION
Follow-up to #516, found while reworking the book chapter (kgdunn/pid-book#272) around *when* and *how* to apply mid-course correction.

**The problem.** `MidCourseCorrector`'s dead band compared the projected shortfall with a prediction interval built from the model's full-row training RMSE. That interval cannot see that a score estimate resting on a few observed columns is far less certain than one resting on the whole row, nor that the restricted trimmed-score-regression estimator can be ill-conditioned early in the batch. Measured on the chapter's bioreactor: class A's estimator has a condition number near 8e5 at day 2 (a few hundred from day 4 on) and projects batches that finish at 8 g/L to -140 g/L, and the old interval declared those projections precise. The harmful early corrections in the decision-day sweep came from exactly this. On 40 held-out batches the old 95% interval covered about 70% of outcomes even at the decision point that matters.

**The fix.**
- `limits_at(k)` now also measures the model's prediction error *at the decision point* (`rmse_k`): the training batches re-projected under the candidate pattern, their predicted quality against their measured quality, on N - A - 1 degrees of freedom (the same construction as `PLS.prediction_interval`; at the full row it equals the training RMSE). It also reports the condition numbers of the monitoring and candidate operators.
- New public `MidCourseCorrector.predict(batch_so_far, initial_conditions=, schedule=, k=)`: the monitoring question at a decision point. Returns the prediction with its interval at that point, the SPE of the batch so far against its limit (`in_control`), the candidate row's T2 against the per-decision-point covariance, and the condition number. A corrector built with only the model, the nominal schedule and `mv_tags` can predict but not correct (the `y_target` check moved from the constructor to `correct`).
- `correct()` builds both gates on `predict()` and reports `y_hat_no_change`, `half_width` and `condition_number` on every outcome. The no-change prediction and the movement penalty use the currently planned remainder (the implemented schedule after an earlier decision point) rather than always the nominal schedule.
- `evaluate_control_policies` and the two agent tools default to `dead_band=1.0` (the class default: correct only when the whole interval falls short of the target) instead of the 2.5 that compensated for the old interval; the evaluation records each batch's no-change prediction and half-width.
- Bug fix: `midcourse_correction` no longer fails with `n_knots` set when a tag has a single remaining free sample (the last decision point before the batch ends).
- The user guide's headline table, sweep table and decision-point window are re-measured under the new dead band (five corrected, none harmed; window days 3 to 5).

**Measured.** With the new interval, on the 40 held-out test batches of the chapter's seed chain, the 95% interval's coverage is 0.95, 0.97, 0.98, 1.00, 0.95 at days 1 to 5 (0.80 by day 9, where the model under-predicts replay batches by about 0.6 g/L). The funnel of one poor batch narrows from +/-4.0 g/L at day 0.5 to +/-1.75 at day 4, where the old interval was flat at about +/-0.85.

**Version.** 1.79.1 -> 1.80.0 (a new public method and a behavioural change of the dead band). `main` took 1.79.0 for #539 and 1.79.1 for #547 while this branch was open: the branch was restarted from `main` after #516's squash merge, and #547 was merged in afterwards; `CITATION.cff` and the changelog are synced to 1.80.0, with the 1.80.0 section above the 1.79.1 entry.

**Gates.** `ruff check .` and `ruff format --check .` clean; `mypy src/process_improve` clean; `tests/batch/` (142 tests) and the two slow executed-simulator tests in `test_batch_control.py` pass on the merged branch.

Companion PRs: kgdunn/figures#83 (figures regenerated with this package) and kgdunn/pid-book#272 (the chapter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZAyiPT8xURSdi24yFKCra