### PR TITLE
Docs: describe the ekf scheme and selection rules the PCA selector actually uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ those changes.
 
 ## [Unreleased]
 
+## [1.79.1] - 2026-09-05
+
+### Documentation
+
+- The cross-validation user guide described `PCA.select_n_components` as K-fold
+  PRESS with Wold's criterion, which it has not been since the element-wise
+  k-fold (ekf) rebuild, and its example passed the deprecated `threshold=0.95`,
+  so a reader who copied it was answered with a `DeprecationWarning`. The page
+  now describes the ekf scheme (cells held out, not rows, and why that matters),
+  lists the keys the result actually carries, and has a table of the four
+  selection rules, including which of them is the closest equivalent to the
+  retired `threshold`. The stale Wold's-criterion cross-references in the PCA
+  and PLS guides are corrected in the same way, as is the PLS claim that
+  `n_components` is the lowest-RMSECV count: the default has been the 1-SE rule
+  since 1.28.
+- The `pca-food-texture` and `pca-spectral-data` case-study notebooks passed a
+  pre-scaled `X` to `PCA.select_n_components`, so every rendered build showed
+  the pre-scaled `SpecificationWarning` added in 1.79.0. They now pass the raw
+  block to the selector and keep the scaled block for fitting the model, which
+  is the same shape as the rest of the documentation. The recommended component
+  count is unchanged in both (2 and 5).
+
 ## [1.79.0] - 2026-09-04
 
 ### Changed
@@ -4030,7 +4052,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.79.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.79.1...HEAD
+[1.79.1]: https://github.com/kgdunn/process-improve/compare/v1.79.0...v1.79.1
 [1.79.0]: https://github.com/kgdunn/process-improve/compare/v1.78.0...v1.79.0
 [1.78.0]: https://github.com/kgdunn/process-improve/compare/v1.77.0...v1.78.0
 [1.77.0]: https://github.com/kgdunn/process-improve/compare/v1.76.0...v1.77.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.79.0
-date-released: "2026-09-04"
+version: 1.79.1
+date-released: "2026-09-05"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/docs/user_guide/case_studies/latent-variable-modelling/pca-food-texture.ipynb
+++ b/docs/user_guide/case_studies/latent-variable-modelling/pca-food-texture.ipynb
@@ -61,7 +61,13 @@
    "source": [
     "The five variables span very different ranges (oil percentage is in the teens, density is in the thousands, the rest are unitless sensory scores). Without scaling, density would dominate the model purely through its variance.\n",
     "\n",
-    "## Preprocess and fit"
+    "## Preprocess and fit\n",
+    "\n",
+    "Two different inputs, deliberately. `PCA.select_n_components` gets the\n",
+    "**raw** `foods`: it cross-validates by holding out individual cells, and its\n",
+    "default `scale_inside_folds=True` fits the scaling separately inside each\n",
+    "fold so that a held-out cell never influences its own prediction. The model\n",
+    "itself is then fitted on the autoscaled `X`."
    ]
   },
   {
@@ -72,7 +78,7 @@
    "source": [
     "X = MCUVScaler().fit_transform(foods)\n",
     "\n",
-    "selection = PCA.select_n_components(X, max_components=4, cv=5)\n",
+    "selection = PCA.select_n_components(foods, max_components=4, cv=5)\n",
     "print(f\"Recommended A = {selection.n_components}\")\n",
     "selection.press_ratio.round(3)"
    ]

--- a/docs/user_guide/case_studies/latent-variable-modelling/pca-spectral-data.ipynb
+++ b/docs/user_guide/case_studies/latent-variable-modelling/pca-spectral-data.ipynb
@@ -109,10 +109,17 @@
    "source": [
     "## Choose the number of components\n",
     "\n",
-    "`PCA.select_n_components` runs k-fold cross-validation and applies Wold's\n",
-    "criterion to the per-component PRESS values. We cap the search at eight\n",
-    "components and use three folds to keep the build time of these docs short;\n",
-    "for a real analysis use the defaults."
+    "`PCA.select_n_components` holds out individual cells of the matrix\n",
+    "(element-wise k-fold cross-validation), predicts each one from a model that\n",
+    "never saw its value, and recommends the component count with the lowest\n",
+    "cross-validated PRESS. We cap the search at eight components and use three\n",
+    "element-folds to keep the build time of these docs short; for a real\n",
+    "analysis use the defaults.\n",
+    "\n",
+    "The **raw** spectra go in here, not the scaled `X`. The default\n",
+    "`scale_inside_folds=True` fits the centring and scaling separately inside\n",
+    "every fold, which is what keeps a held-out cell out of its own\n",
+    "prediction."
    ]
   },
   {
@@ -121,7 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "selection = PCA.select_n_components(X, max_components=8, cv=3)\n",
+    "selection = PCA.select_n_components(spectra, max_components=8, cv=3)\n",
     "print(f\"Recommended A = {selection.n_components}\")\n",
     "selection.press_ratio.round(3)"
    ]

--- a/docs/user_guide/cross_validation.rst
+++ b/docs/user_guide/cross_validation.rst
@@ -3,7 +3,8 @@ Cross-Validation
 
 Cross-validation is used for two purposes in multivariate analysis:
 
-1. **Component selection** - choosing the right number of components (PCA).
+1. **Component selection** - choosing the right number of components, for
+   both PCA and PLS.
 2. **Coefficient uncertainty** - obtaining error bars for PLS beta
    coefficients.
 
@@ -13,18 +14,28 @@ Selecting the Number of Components
 Choosing the right number of components is critical. Too few components
 underfit (miss important structure), too many overfit (model noise).
 
-PRESS Cross-Validation
------------------------
+Element-wise Cross-Validation (PCA)
+-----------------------------------
 
-The ``PCA.select_n_components()`` class method uses Predicted Residual Error
-Sum of Squares (PRESS) with K-fold cross-validation:
+``PCA.select_n_components()`` evaluates every component count from 1 to
+``max_components``, measures the Predicted Residual Error Sum of Squares
+(PRESS) of each, and recommends one. The default scheme is the
+**element-wise k-fold** (ekf) algorithm of Bro et al. (2008):
 
-1. For each candidate number of components (1, 2, ..., max):
-   - Split data into K folds
-   - Fit PCA on K-1 folds, predict the held-out fold
-   - Compute prediction error (PRESS)
-2. Apply **Wold's criterion**: stop when adding a component does not
-   meaningfully reduce PRESS (ratio > threshold)
+1. Split the individual *cells* of ``X`` into K folds, so that every cell is
+   held out exactly once.
+2. For each fold and each component count: mask that fold's cells, impute
+   them EM-style from a model fitted on the cells that remain, and add the
+   squared error of those predictions to PRESS.
+3. Recommend a component count from the PRESS curve using
+   ``selection_rule``.
+
+Holding out individual cells, rather than whole rows, is what keeps a
+prediction independent of the value being predicted. Under the legacy
+``cv_scheme="row_wise"`` scheme a held-out row flows back through
+``transform()`` into its own prediction, so PRESS shrinks monotonically and
+the recommendation tends to run to ``max_components``. That scheme is kept
+for backwards compatibility and emits a ``SpecificationWarning``.
 
 .. code-block:: python
 
@@ -36,30 +47,65 @@ Sum of Squares (PRESS) with K-fold cross-validation:
    result = PCA.select_n_components(
        X,
        max_components=10,
-       cv=7,  # 7-fold cross-validation
-       threshold=0.95,  # Wold's criterion threshold
+       cv=7,  # 7 element-folds
    )
 
    print(f"Recommended components: {result.n_components}")
-   print(f"PRESS values: {result.press}")
-   print(f"PRESS ratios: {result.press_ratio}")
+   print(result.press)  # PRESS per component count
+   print(result.q2)     # cross-validated R2 of X
 
 The result is a ``Bunch`` with:
 
 - ``n_components``: recommended number of components
-- ``press``: PRESS value for each number of components
-- ``press_ratio``: ratio ``PRESS_a / PRESS_{a-1}`` (values > threshold suggest overfitting)
-- ``cv_scores``: raw cross-validation scores per fold
+- ``press``: PRESS for each number of components
+- ``q2``: cross-validated :math:`R^2_X` per component count, on the same
+  scale as the calibration ``r2_cumulative_`` of a fitted model
+- ``per_fold_press``, ``se_press`` and ``q2_se``: the per-fold PRESS
+  contributions and the standard error built from them, which is what the
+  1-SE rule needs
+- ``press_ratio``: the ratio ``PRESS_a / PRESS_{a-1}``, for inspection
+- ``cv_scores``: per-fold scores (an alias of ``per_fold_press`` under ekf)
+- ``cv_scheme`` and ``selection_rule``: which scheme and rule were used
 
-Wold's Criterion
------------------
+``n_repeats`` runs the whole pass again with a fresh fold permutation.
+Each repeat still covers every cell exactly once; more repeats narrow
+``se_press``, which helps when the 1-SE rule sits on a borderline.
 
-The default threshold of 0.95 means: stop adding components when the PRESS
-ratio exceeds 0.95. A ratio close to 1.0 means the new component barely
-improves prediction - it is likely fitting noise.
+Selection Rules
+----------------
 
-Lower thresholds (e.g., 0.90) are more conservative (fewer components).
-Higher thresholds (e.g., 0.98) are more liberal (more components).
+``selection_rule`` decides which count is recommended from the error curve.
+PCA defaults to ``"min"``; PLS defaults to ``"1se"``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Rule
+     - Recommends
+   * - ``"min"``
+     - The component count with the lowest cross-validated error. This is
+       the GlobalMin criterion that Bro et al. pair with ekf.
+   * - ``"1se"``
+     - The smallest count whose error is within one standard error of that
+       minimum, so it is never less parsimonious than ``"min"``.
+   * - ``"q2_increment"``
+     - Keeps a component only while it lifts the cumulative :math:`Q^2` by
+       at least ``min_q2_increase`` (default 0.01), and stops at the first
+       one that does not. A Wold's-R-style heuristic: cheap, but the
+       threshold is absolute and hand-tuned.
+   * - ``"randomization"``
+     - PLS only. Van der Voet's (1994) permutation test: the smallest model
+       whose predictive ability is statistically indistinguishable from the
+       lowest-RMSECV one, at significance level ``alpha``.
+
+.. note::
+
+   The original Wold PRESS-ratio cutoff, the ``threshold`` argument of
+   ``PCA.select_n_components``, is deprecated: passing it emits a
+   ``DeprecationWarning`` and the value is ignored. Use
+   ``selection_rule="q2_increment"``, tuned with ``min_q2_increase``, for a
+   comparable preference for parsimony.
 
 PLS Component Selection
 ------------------------
@@ -92,14 +138,21 @@ full dataset into every fold, and a warning says so.
 
 The result is a ``Bunch`` with:
 
-- ``n_components``: recommended count, the one with the lowest overall RMSECV
+- ``n_components``: recommended count, chosen by ``selection_rule`` (the
+  1-SE rule by default, not the lowest RMSECV; see `Selection Rules`_)
 - ``rmsecv``: root-mean-square error of cross-validation, per Y variable and overall
+- ``se_rmsecv`` / ``q2_se``: the standard error of that curve, on the RMSECV
+  and the :math:`Q^2` scale respectively
 - ``r2y_validated`` / ``r2x_validated``: validated explained variance, per variable and overall
 - ``press``: overall Y prediction error sum of squares per component count
 - ``cv_predictions``: out-of-fold Y predictions at the recommended count
+- ``selection_rule``: the rule that produced ``n_components``
 
 The ``cv`` argument accepts an integer (K-fold) or any scikit-learn splitter
-object, such as ``KFold`` or ``LeaveOneOut``.
+object, such as ``KFold`` or ``LeaveOneOut``. When it is an integer, the
+split is repeated ``n_repeats`` times (10 by default) with a fresh shuffle,
+which is what gives the 1-SE rule a usable standard error. A splitter object
+is used as-is and ``n_repeats`` is then ignored.
 
 PLS Beta Coefficient Error Bars
 --------------------------------

--- a/docs/user_guide/pca.rst
+++ b/docs/user_guide/pca.rst
@@ -343,9 +343,11 @@ stop. The cross-validated Q² metric *decreases* once the model begins
 fitting noise rather than systematic structure. The point where Q² stops
 improving indicates the useful number of components.
 
-Use ``PCA.select_n_components()`` for automated selection via PRESS
-cross-validation with Wold's criterion (see :doc:`cross_validation` for
-details). Remember that the answer is never exact - examine one or two
+Use ``PCA.select_n_components()`` for automated selection. It cross-validates
+by holding out individual cells of ``X`` (the element-wise k-fold scheme) and
+recommends the component count with the lowest cross-validated PRESS; other
+selection rules are available (see :doc:`cross_validation` for details).
+Remember that the answer is never exact - examine one or two
 components beyond and before the suggestion, and consider the interpretability
 of each additional component in the context of your application.
 

--- a/docs/user_guide/pls.rst
+++ b/docs/user_guide/pls.rst
@@ -173,8 +173,11 @@ because PLS can overfit more aggressively: it will find directions that
 correlate X with Y in the training data even if those correlations are
 spurious. Cross-validation is essential.
 
-The same PRESS / Wold's criterion approach described in
-:doc:`cross_validation` applies. A practical check: if the training R² is
+``PLS.select_n_components()`` handles this: it reports RMSECV per component
+count from repeated K-fold cross-validation and, by default, applies the
+1-SE rule, which prefers the smallest model whose error is within one
+standard error of the best (see :doc:`cross_validation`). A practical check:
+if the training R² is
 much higher than the test-set R² (gap > 0.15–0.20), overfitting is likely
 and you should reduce the number of components.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.79.0"
+version = "1.79.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Follow-up to #539, fixing the documentation staleness that PR flagged but left out of scope. Docs only: no source change.

- **`docs/user_guide/cross_validation.rst`** described `PCA.select_n_components` as K-fold PRESS with Wold's criterion, which it has not been since the element-wise k-fold (ekf) rebuild, and its example passed the deprecated `threshold=0.95`, so a reader who copied it was answered with a `DeprecationWarning`. The page now describes the ekf scheme (cells held out rather than whole rows, and why that independence matters), lists the keys the result actually carries (`q2`, `se_press`, `q2_se`, `cv_scheme`, ...), and replaces the "Wold's Criterion" section with a table of the four selection rules, naming `q2_increment` as the closest equivalent to the retired `threshold`.
- **`docs/user_guide/pca.rst`** and **`docs/user_guide/pls.rst`** carried the same stale "PRESS / Wold's criterion" cross-reference; both corrected. The PLS page also claimed `n_components` is the lowest-RMSECV count, but the default has been the 1-SE rule since 1.28.
- **`pca-food-texture.ipynb`** and **`pca-spectral-data.ipynb`** passed a pre-scaled `X` to `PCA.select_n_components`, so every rendered build displayed the pre-scaled `SpecificationWarning` that #539 added. They now pass the raw block to the selector and keep the scaled block for fitting the model, matching the rest of the docs.

## Test plan

- [x] Both notebooks executed end-to-end with `jupyter nbconvert --execute`: no errors, and **no warnings in any cell output**. The recommended component count is unchanged (2 for food-texture, 5 for spectral-data), so the surrounding narrative still holds.
- [x] Notebook edits preserve the on-disk format: `source` stays a list of lines, the trailing newline is kept, and the per-cell key structure is byte-identical to `main` (verified by JSON round-trip producing an empty diff before editing).
- [x] Sphinx build: no warnings on `cross_validation.rst`, `pca.rst` or `pls.rst`. The `Selection Rules` cross-reference resolves, and `threshold=0.95` no longer appears in the rendered page. (Notebooks were excluded from the local build only because pandoc is not installed in the sandbox; CI builds them.)
- [x] `ruff check .` and `ruff format --check .` clean.
- [x] Every claim in the new prose checked against the source: `cv_scheme="ekf"` default, `selection_rule="min"` for PCA and `"1se"` for PLS, `min_q2_increase=0.01`, the `n_repeats=10` default on PLS integer `cv`, and the returned Bunch keys.

## Checklist

- [x] Version bumped in `pyproject.toml` (PATCH, 1.79.1: documentation only), `CITATION.cff` in sync
- [x] Tests added or updated where relevant (none needed: no source change)
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkLrfRbhDPfgXPcS7ttvYq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkLrfRbhDPfgXPcS7ttvYq)_