### PR TITLE
fix: raise ValueError, not a stripped assert, when PLS.fit_transform gets no Y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ those changes.
 
 ## [Unreleased]
 
+## [1.81.2] - 2026-09-07
+
+### Fixed
+
+- `PLS.fit_transform` now raises `ValueError` when called without `Y`, instead
+  of tripping a bare `assert`. `Y` carries a `None` default only to match
+  sklearn's `fit_transform(X, y=None)` signature; under `python -O` the assert
+  was stripped and the call instead failed inside `fit` with
+  `ValueError: at least one array or dtype is required`, which named neither
+  `Y` nor `fit_transform`. This is a caller-contract violation, so it follows
+  case 1 of `docs/development/error_handling.rst`. Callers catching
+  `AssertionError` here should catch `ValueError` instead.
+
 ## [1.81.1] - 2026-09-07
 
 ### Changed
@@ -4271,7 +4284,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.81.1...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.81.2...HEAD
+[1.81.2]: https://github.com/kgdunn/process-improve/compare/v1.81.1...v1.81.2
 [1.81.1]: https://github.com/kgdunn/process-improve/compare/v1.81.0...v1.81.1
 [1.81.0]: https://github.com/kgdunn/process-improve/compare/v1.80.0...v1.81.0
 [1.80.0]: https://github.com/kgdunn/process-improve/compare/v1.79.1...v1.80.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.81.1
+version: 1.81.2
 date-released: "2026-09-07"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.81.1"
+version = "1.81.2"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pls.py
+++ b/src/process_improve/multivariate/_pls.py
@@ -971,16 +971,19 @@ class PLS(_LatentVariableModel, RegressorMixin, TransformerMixin, BaseEstimator)
         Y : array-like of shape (n_samples, n_targets)
             Required despite the ``None`` default: the default is present only
             for signature-compatibility with the sklearn ``fit_transform``
-            protocol, and PLS cannot be fitted without responses. The check is
-            an ``assert``, so omitting ``Y`` raises :class:`AssertionError`
-            under default Python; under ``python -O`` the assert is stripped
-            and the call fails further down in :meth:`fit` instead.
+            protocol, and PLS cannot be fitted without responses. Omitting
+            ``Y`` raises :class:`ValueError`, under ``python -O`` as well.
 
         Returns
         -------
         X_scores : pd.DataFrame of shape (n_samples, n_components)
         """
-        assert Y is not None, "PLS requires Y to be supplied to fit_transform."
+        if Y is None:
+            raise ValueError(
+                "Y is required by PLS.fit_transform; got None. The None default exists only to "
+                "match the sklearn fit_transform(X, y=None) signature, and PLS cannot be fitted "
+                "without responses. Pass the response block, e.g. model.fit_transform(X, Y)."
+            )
         self.fit(X, Y)
         return self.scores_
 

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -4439,6 +4439,35 @@ def test_pca_fit_transform() -> None:
     np.testing.assert_allclose(scores.values, model.scores_.values, atol=1e-10)
 
 
+def test_pls_fit_transform_without_y_raises_value_error() -> None:
+    """ENG-11 / #293 case 1: the missing-Y check must survive ``python -O``.
+
+    ``Y`` carries a ``None`` default only to match sklearn's
+    ``fit_transform(X, y=None)`` signature. The check used to be an ``assert``,
+    which ``python -O`` strips: the call then reached ``fit`` and died with
+    ``ValueError: at least one array or dtype is required`` from inside
+    sklearn, far from the argument the caller got wrong. It is a caller-contract
+    violation, so it raises ``ValueError`` up front and names ``Y``.
+    """
+    rng = np.random.default_rng(42)
+    X = MCUVScaler().fit_transform(pd.DataFrame(rng.standard_normal((20, 4))))
+
+    with pytest.raises(ValueError, match=r"Y is required by PLS\.fit_transform"):
+        PLS(n_components=2).fit_transform(X)
+
+
+def test_pls_fit_transform_with_y_matches_fit() -> None:
+    """The happy path is unchanged: fit_transform equals fit() then ``scores_``."""
+    rng = np.random.default_rng(42)
+    X = MCUVScaler().fit_transform(pd.DataFrame(rng.standard_normal((20, 4))))
+    Y = pd.DataFrame({"y": X.values @ rng.standard_normal(4)})
+
+    scores = PLS(n_components=2).fit_transform(X, Y)
+    model = PLS(n_components=2).fit(X, Y)
+
+    np.testing.assert_allclose(scores.values, model.scores_.values, atol=1e-10)
+
+
 def test_ellipse_coordinates_basic() -> None:
     """ellipse_coordinates should return x, y arrays forming a closed ellipse."""
     scaling = pd.Series([2.0, 1.5, 1.0])


### PR DESCRIPTION
## Summary

- `PLS.fit_transform` guarded its required `Y` with a bare `assert`. `python -O` strips it, so the call reached `fit` and died with `ValueError: at least one array or dtype is required` raised from inside sklearn: a message naming neither `Y` nor `fit_transform`. This repo runs the whole suite under `-O` (`test-under-dash-O`), so that path is real, not hypothetical.
- A missing required argument is a caller-contract violation, which `docs/development/error_handling.rst` case 1 covers, and that section warns about this exact failure mode by name: "*asserts are stripped by `python -O`; the check silently disappears in optimised deployments, and the bug surfaces miles downstream*". Replaced with a `ValueError` that names the argument and shows the fix.
- Follow-up to #548, which documented this sharp edge rather than changing behaviour.

## Why `ValueError`, and why PATCH

This mirrors **SEC-13 (#261)**, which replaced the same kind of `-O`-strippable assert in `find_reference_batch` for the same reason and shipped as a PATCH under `### Fixed` (`1.24.5 -> 1.24.6`).

Per `CONTRIBUTING.md`, "a documented bug is fixed" is explicitly **not** a breaking change, and the breaking case is a documented behaviour changed *silently*. This one is in the changelog with an explicit note for anyone catching `AssertionError`. The `AssertionError` was never described anywhere outside the docstring added in #548 yesterday, so nothing in a shipped doc or notebook relied on it.

## Scope

One line of behaviour. `_pls.py` has three other asserts (`X_orig`/`Y_orig` not None, the two `isinstance` checks after `validate_data`); those are internal invariants, case 2 of the same policy, and are left alone.

```python
# before: stripped under -O
assert Y is not None, "PLS requires Y to be supplied to fit_transform."

# after
if Y is None:
    raise ValueError(
        "Y is required by PLS.fit_transform; got None. The None default exists only to "
        "match the sklearn fit_transform(X, y=None) signature, and PLS cannot be fitted "
        "without responses. Pass the response block, e.g. model.fit_transform(X, Y)."
    )
```

## Test plan

- [x] `test_pls_fit_transform_without_y_raises_value_error` asserts the exception text, as case 1 of the policy requires. Verified it is a real regression guard, not a tautology: restoring the old `assert` and running under `python -O` makes it **fail** (`DID NOT RAISE`), and the fix makes it pass again.
- [x] `test_pls_fit_transform_with_y_matches_fit` pins the unchanged happy path (`fit_transform(X, Y)` equals `fit()` then `scores_`).
- [x] Both pass under plain `python` **and** `python -O`. Before this change the behaviour differed between the two; now it does not.
- [x] Full `pytest` suite: **3173 passed, 41 skipped** (up 2, the new tests). Every skip is this sandbox's network policy blocking the `openmv.net` sample datasets.
- [x] `ruff check .` - all checks passed
- [x] `ruff format --check .` - 319 files already formatted
- [x] `mypy src/process_improve` - no issues found in 163 source files

## Checklist

- [x] Version bumped in `pyproject.toml` - PATCH, `1.81.1 -> 1.81.2`
- [x] Tests added or updated where relevant - two, above
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated - `[1.81.2]` under `### Fixed`, with `CITATION.cff` `version:` and `date-released:` kept in step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CrGZxKkz6wVQHZn8cUKCq

---
_Generated by [Claude Code](https://claude.ai/code/session_016CrGZxKkz6wVQHZn8cUKCq)_