### PR TITLE
Three more ways to choose a PCA component count, and retire the fourth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,11 @@ those changes.
   is held out in folds that could disagree, so `selection_rule="1se"` has
   nothing to work with. Both leverage schemes are first-order approximations
   that degrade as the components approach the variables; the docstring says so
-  and a test pins it.
+  and a test pins it. Once every cell's leverage reaches one there is nothing
+  left to measure, and both report `NaN` rather than a number: totalling an
+  empty set would give zero error, which reads as a flawless model and would
+  win the selection outright. Where only some cells are dropped, the criterion
+  and the reference it is divided by cover the same cells.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@ those changes.
     `FactoMineR` and `missMDA`.
 
   All three factorise the matrix directly, so they raise a clear `ValueError`
-  on a block with missing cells and they ignore `scale_inside_folds`,
+  on a block with missing cells, naming how many there are and whether they sit
+  in one column (drop it and keep every row) or are scattered (they cannot be
+  dropped that way), and they ignore `scale_inside_folds`,
   `n_repeats`, `n_iter` and `tol`. They report no per-fold spread, since none
   is held out in folds that could disagree, so `selection_rule="1se"` has
   nothing to work with. Both leverage schemes are first-order approximations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,50 @@ those changes.
 
 ## [Unreleased]
 
+## [1.84.0] - 2026-09-10
+
+### Added
+
+- **`PCA.select_n_components` gains three cross-validation schemes**, so the
+  component count can be chosen the way the rest of the field chooses it.
+  A survey of what other packages implement prompted all three.
+
+  - `cv_scheme="ek"` is the two-model scheme of Eastment and Krzanowski (1982):
+    an element is predicted by a score from a model without its column and a
+    loading from a model without its row, so it enters neither decomposition.
+    This is what Simca-P reports as its PCA `Q2` and what
+    `pcaMethods::Q2` computes by default in R, so it is the scheme to use when
+    a number has to line up with either. Costs `2 * n_folds` decompositions.
+  - `cv_scheme="sacv"` is the leave-one-cell-out criterion of Josse and Husson
+    (2012), approximated without refitting anything: each residual is inflated
+    by the leverage of the cell that produced it, `(1 - 1/n - a_i)(1 - b_j)`,
+    the same device that turns a regression residual into its leave-one-out
+    counterpart. One decomposition in total, and on a rank-3 block it picks the
+    same count as the element-wise scheme and stays within five points of its
+    curve through the optimum.
+  - `cv_scheme="gcv"` replaces the two leverages with one averaged constant.
+    Blunter, and it keeps more components. These two are the defaults in
+    `FactoMineR` and `missMDA`.
+
+  All three factorise the matrix directly, so they raise a clear `ValueError`
+  on a block with missing cells and they ignore `scale_inside_folds`,
+  `n_repeats`, `n_iter` and `tol`. They report no per-fold spread, since none
+  is held out in folds that could disagree, so `selection_rule="1se"` has
+  nothing to work with. Both leverage schemes are first-order approximations
+  that degrade as the components approach the variables; the docstring says so
+  and a test pins it.
+
+### Deprecated
+
+- **`cv_scheme="row_wise"` is deprecated and will be removed in 2.0.** It now
+  emits a `DeprecationWarning` alongside the existing `SpecificationWarning`.
+  It measures how well a held-out row reproduces itself, which is a
+  compression error rather than a prediction error: the row supplies the
+  scores that rebuild it, so PRESS falls monotonically and reaches zero once
+  the components equal the variables. It cannot select a component count.
+  `mdatools` removed the equivalent from its own PCA and said publicly that it
+  had been a mistake. Use `"ekf"`, `"ek"`, `"sacv"` or `"gcv"`.
+
 ## [1.83.2] - 2026-09-09
 
 ### Fixed
@@ -4362,7 +4406,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.83.2...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.84.0...HEAD
+[1.84.0]: https://github.com/kgdunn/process-improve/compare/v1.83.2...v1.84.0
 [1.83.2]: https://github.com/kgdunn/process-improve/compare/v1.83.1...v1.83.2
 [1.83.1]: https://github.com/kgdunn/process-improve/compare/v1.83.0...v1.83.1
 [1.83.0]: https://github.com/kgdunn/process-improve/compare/v1.82.0...v1.83.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.83.2
-date-released: "2026-09-09"
+version: 1.84.0
+date-released: "2026-09-10"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/docs/user_guide/cross_validation.rst
+++ b/docs/user_guide/cross_validation.rst
@@ -31,11 +31,57 @@ Element-wise Cross-Validation (PCA)
    ``selection_rule``.
 
 Holding out individual cells, rather than whole rows, is what keeps a
-prediction independent of the value being predicted. Under the legacy
+prediction independent of the value being predicted. Under the deprecated
 ``cv_scheme="row_wise"`` scheme a held-out row flows back through
 ``transform()`` into its own prediction, so PRESS shrinks monotonically and
-the recommendation tends to run to ``max_components``. That scheme is kept
-for backwards compatibility and emits a ``SpecificationWarning``.
+reaches zero once the components equal the variables. It measures compression
+rather than prediction and cannot select a component count. It is kept for one
+more release cycle and emits a ``DeprecationWarning``; it will be removed in
+2.0.
+
+Choosing among the schemes
+--------------------------
+
+Four schemes keep the prediction independent of the value predicted. They
+differ in what they hold out and what they cost.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 34 30 24
+
+   * - ``cv_scheme``
+     - What is held out
+     - Cost
+     - Use it when
+   * - ``"ekf"``
+     - Scattered cells, imputed by EM from a model that never saw them
+     - ``n_folds * n_repeats * max_components`` decompositions
+     - The default. The only one that takes a block with missing cells.
+   * - ``"ek"``
+     - Nothing directly: a score comes from a model without the cell's
+       column, a loading from a model without its row
+     - ``2 * n_folds`` decompositions
+     - A number has to line up with Simca-P or with ``pcaMethods::Q2``.
+   * - ``"sacv"``
+     - Nothing. Each residual is inflated by the leverage of the cell that
+       produced it, approximating leave-one-cell-out
+     - One decomposition
+     - The block is large and ``"ekf"`` is too slow.
+   * - ``"gcv"``
+     - Nothing. One averaged leverage instead of one per cell
+     - One decomposition
+     - Comparing against ``FactoMineR`` or ``missMDA``, whose default it is.
+
+The three new schemes factorise the matrix directly, so they raise on a block
+with missing cells, and they ignore ``scale_inside_folds``, ``n_repeats``,
+``n_iter`` and ``tol``. They hold nothing out in folds that could disagree, so
+they report no per-fold spread and ``selection_rule="1se"`` has nothing to work
+with.
+
+Both leverage schemes are first-order approximations that degrade as the
+component count approaches the number of variables, because a column's leverage
+approaches one and the divisor approaches zero with it. Read them well below
+that ceiling; ``FactoMineR`` defaults to five components for the same reason.
 
 .. code-block:: python
 

--- a/docs/user_guide/cross_validation.rst
+++ b/docs/user_guide/cross_validation.rst
@@ -83,6 +83,16 @@ component count approaches the number of variables, because a column's leverage
 approaches one and the divisor approaches zero with it. Read them well below
 that ceiling; ``FactoMineR`` defaults to five components for the same reason.
 
+They also lean on the residual having something left in it. On the LDPE data
+of 54 rows and 19 variables, whose fit reaches 99.98% by eleven components,
+``"ekf"`` and ``"ek"`` both turn over at two components, which is where Simca-P
+turns over on the same data. Neither ``"sacv"`` nor ``"gcv"`` turns over at all
+within the first five: their curves rise at every count, so the number they
+return is the largest one evaluated rather than an optimum. Any scheme that
+does that now says so, through a :class:`SpecificationWarning`. Treat the
+warning as the answer: the criterion failed on that data, and a scheme that
+holds values out should be used instead.
+
 .. code-block:: python
 
    from process_improve.multivariate.methods import PCA

--- a/docs/user_guide/cross_validation.rst
+++ b/docs/user_guide/cross_validation.rst
@@ -82,6 +82,8 @@ Both leverage schemes are first-order approximations that degrade as the
 component count approaches the number of variables, because a column's leverage
 approaches one and the divisor approaches zero with it. Read them well below
 that ceiling; ``FactoMineR`` defaults to five components for the same reason.
+At the ceiling itself no cell has a defined leave-one-out residual at all, and
+both schemes report ``NaN`` rather than a number there.
 
 They also lean on the residual having something left in it. On the LDPE data
 of 54 rows and 19 variables, whose fit reaches 99.98% by eleven components,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.83.2"
+version = "1.84.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -2004,20 +2004,16 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         # residual they inflate has almost nothing left in it.
         evaluated = q2.to_numpy()[~np.isnan(q2.to_numpy())]
         if evaluated.size > 1 and np.all(np.diff(evaluated) > 0) and int(recommended) == max_components:
-            # A scheme that already holds data out has nothing better to switch
-            # to, so it is only told to widen the range; the others are told
-            # both, since a criterion that never turns over is the failure mode
-            # they share.
-            alternatives = [name for name in ("ekf", "ek") if name != cv_scheme]
-            remedy = "Evaluate more components"
-            if alternatives:
-                joined = " or ".join(f"cv_scheme={name!r}" for name in alternatives)
-                remedy += f", or use a scheme that holds data out ({joined})"
+            # Name the schemes that hold data out, less whichever is running:
+            # pointing a caller back at the scheme being warned about is no
+            # remedy. One of the two always survives, since a scheme cannot be
+            # both.
+            alternatives = " or ".join(f"cv_scheme={name!r}" for name in ("ekf", "ek") if name != cv_scheme)
             warnings.warn(
                 f"cv_scheme={cv_scheme!r} did not turn over: its Q2 rises at every one of the "
                 f"{evaluated.size} component counts it could evaluate, so {recommended} is the "
-                f"largest count tried rather than an optimum. {remedy}, before reading this as "
-                "an answer.",
+                f"largest count tried rather than an optimum. Evaluate more components, or use "
+                f"a scheme that holds data out ({alternatives}), before reading this as an answer.",
                 SpecificationWarning,
                 stacklevel=2,
             )

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -363,11 +363,24 @@ def _preprocess_for_cell_schemes(X: np.ndarray, scheme: str) -> np.ndarray:
         If ``X`` holds missing cells. These schemes factorise ``X`` directly,
         and an SVD cannot see a NaN.
     """
-    if np.isnan(X).any():
+    per_column = np.isnan(X).sum(axis=0)
+    n_missing = int(per_column.sum())
+    if n_missing:
+        # Where the misses sit decides what to do about them, so say. A block whose
+        # gaps are one column's is repaired by dropping that column, keeping every
+        # row; one whose gaps are scattered is not.
+        worst = int(np.argmax(per_column))
+        share = int(per_column[worst])
+        where = (
+            f"{share} of them in column {worst}"
+            if share > n_missing / 2
+            else f"spread over {int((per_column > 0).sum())} columns"
+        )
         raise ValueError(
             f"cv_scheme={scheme!r} cannot take a block with missing cells, because it "
-            "factorises the matrix directly. Use cv_scheme='ekf', which imputes an "
-            "unmeasured cell alongside the held-out ones and never scores it."
+            f"factorises the matrix directly. This block has {n_missing} of {X.size}, "
+            f"{where}. Use cv_scheme='ekf', which imputes an unmeasured cell alongside "
+            "the held-out ones and never scores it, or drop what is missing first."
         )
     centre = X.mean(axis=0)
     spread = X.std(axis=0, ddof=1)

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -335,6 +335,269 @@ def _ekf_null_reference(
     return float(centred_ss.sum()), centred_ss
 
 
+def _preprocess_for_cell_schemes(X: np.ndarray, scheme: str) -> np.ndarray:
+    """Mean-centre and unit-variance scale the whole matrix, once.
+
+    The schemes below are the classical ones, and all of them are defined on a
+    single preprocessed matrix rather than on per-fold constants: there are no
+    folds to fit constants on in ``"sacv"`` and ``"gcv"``, and the two SVD
+    families of ``"ek"`` are both taken from the same preprocessed matrix. That
+    is what ``FactoMineR`` and ``pcaMethods`` do, so a number computed here is
+    comparable with theirs.
+
+    Parameters
+    ----------
+    X : np.ndarray of shape (n_samples, n_features)
+        Raw data matrix. Missing cells are not supported by these schemes.
+    scheme : str
+        Name of the calling scheme, used only in the error message.
+
+    Returns
+    -------
+    np.ndarray
+        The centred, unit-variance scaled matrix.
+
+    Raises
+    ------
+    ValueError
+        If ``X`` holds missing cells. These schemes factorise ``X`` directly,
+        and an SVD cannot see a NaN.
+    """
+    if np.isnan(X).any():
+        raise ValueError(
+            f"cv_scheme={scheme!r} cannot take a block with missing cells, because it "
+            "factorises the matrix directly. Use cv_scheme='ekf', which imputes an "
+            "unmeasured cell alongside the held-out ones and never scores it."
+        )
+    centre = X.mean(axis=0)
+    spread = X.std(axis=0, ddof=1)
+    spread[spread < epsqrt] = 1.0
+    return (X - centre) / spread
+
+
+def _leverage_corrected_press(
+    X: np.ndarray,
+    max_components: int,
+    *,
+    method: typing.Literal["sacv", "gcv"],
+) -> tuple[np.ndarray, np.ndarray, float, np.ndarray]:
+    r"""Leave-one-cell-out prediction error, approximated without refitting anything.
+
+    Holding out one cell at a time and refitting costs :math:`n \times p` fits per
+    component count. Josse and Husson (2012) avoid all of them: fit once, then
+    inflate the ordinary residual by the leverage of the cell that produced it,
+    the same device that turns a regression residual into its
+    leave-one-out counterpart via :math:`e_i / (1 - h_{ii})`.
+
+    With :math:`\mathbf{U}`, :math:`\mathbf{V}` the first ``a`` left and right
+    singular vectors, the row and column leverages are
+    :math:`a_i = \sum_k u_{ik}^2` and :math:`b_j = \sum_k v_{jk}^2`, and
+
+    - ``"sacv"`` divides each residual by :math:`(1 - 1/n - a_i)(1 - b_j)`,
+      cell by cell. This is the *smoothing approximation* of the
+      cross-validation criterion.
+    - ``"gcv"`` replaces both leverages by one averaged constant,
+      :math:`np / [(n - 1)p - a(n + p - a - 1)]`, where the subtracted term
+      counts the free parameters of a centred rank-``a`` bilinear model. This
+      is *generalised* cross-validation, and it is the cheaper, blunter cousin.
+
+    Neither holds any data out. They correct the circularity analytically
+    instead, which is why they cost one SVD in total rather than one per fold.
+
+    Both are first-order approximations and both degrade as ``a`` approaches
+    the number of variables. A column's leverage is the share of its variance
+    inside the retained subspace, so it reaches one when the components reach
+    the variables, and the divisor reaches zero with it. Read these criteria
+    over a component count well below the number of variables; ``FactoMineR``
+    defaults to five for the same reason.
+
+    Parameters
+    ----------
+    X : np.ndarray of shape (n_samples, n_features)
+        Data matrix, already centred and scaled.
+    max_components : int
+        Largest component count to evaluate; the criterion is returned for
+        ``1 .. max_components``.
+    method : {"sacv", "gcv"}
+        Which of the two corrections to apply.
+
+    Returns
+    -------
+    press : np.ndarray of shape (max_components,)
+        The corrected sum of squared residuals per component count.
+    per_column_press : np.ndarray of shape (max_components, n_features)
+        The same total, split by variable.
+    null_model_ss : float
+        What predicting every cell by its column mean gets wrong. Since ``X``
+        arrives centred, that is its total sum of squares.
+    per_column_null_ss : np.ndarray of shape (n_features,)
+        That reference, split by variable.
+
+    References
+    ----------
+    Josse, J., & Husson, F. (2012). Selecting the number of components in
+    principal component analysis using cross-validation approximations.
+    *Computational Statistics & Data Analysis*, 56(6), 1869-1879.
+    """
+    n, p = X.shape
+    U, S, Vt = np.linalg.svd(X, full_matrices=False)
+    press = np.full(max_components, np.nan)
+    per_column_press = np.full((max_components, p), np.nan)
+
+    for a in range(1, max_components + 1):
+        rank = min(a, S.shape[0])
+        residual = X - (U[:, :rank] * S[:rank]) @ Vt[:rank]
+        if method == "sacv":
+            row_leverage = np.sum(U[:, :rank] ** 2, axis=1)
+            column_leverage = np.sum(Vt[:rank] ** 2, axis=0)
+            denominator = np.outer(1.0 - 1.0 / n - row_leverage, 1.0 - column_leverage)
+            # A cell whose leverage reaches one is reconstructed entirely by
+            # itself, so its leave-one-out residual is not defined. Drop it
+            # rather than let a division by ~0 dominate the total.
+            usable = denominator > epsqrt
+            corrected = np.where(usable, residual / np.where(usable, denominator, 1.0), np.nan)
+        else:
+            remaining = (n - 1) * p - a * (n + p - a - 1)
+            if remaining <= 0:
+                # More free parameters than degrees of freedom: the criterion
+                # has nothing left to measure against.
+                continue
+            corrected = residual * (n * p / remaining)
+        press[a - 1] = float(np.nansum(corrected**2))
+        per_column_press[a - 1] = np.nansum(corrected**2, axis=0)
+
+    return press, per_column_press, float(np.sum(X**2)), np.sum(X**2, axis=0)
+
+
+def _eastment_krzanowski_press(
+    X: np.ndarray,
+    max_components: int,
+    *,
+    n_folds: int,
+    random_state: int | None = None,
+) -> tuple[np.ndarray, np.ndarray, float, np.ndarray]:
+    r"""Cross-validated prediction error by the two-model scheme of Eastment and Krzanowski.
+
+    An element is predicted by a score taken from a model that never saw its
+    **column** and a loading taken from a model that never saw its **row**, so
+    :math:`x_{ij}` enters neither decomposition:
+
+    .. math::
+        \hat{x}_{ij} = \sum_{k=1}^{a} u^{(-j)}_{ik}\sqrt{d^{(-j)}_k}\,
+                       \sqrt{d^{(-i)}_k}\, v^{(-i)}_{jk}
+
+    This is what Simca-P reports as its PCA :math:`Q^2`, and what
+    ``pcaMethods::Q2(type = "krzanowski")`` computes in R, so it is the scheme
+    to use when a number has to line up with either of those.
+
+    Rows and columns are each split into ``n_folds`` groups rather than deleted
+    one at a time, which costs ``2 * n_folds`` decompositions instead of
+    ``n + p``. The sign of every fold model's singular vectors is aligned to the
+    full-data fit, because an SVD fixes each vector only up to sign and two fold
+    models must agree before their product means anything.
+
+    One caveat, which the classical scheme and the reference implementations
+    share: centring and scaling are fitted once on the whole matrix, so a cell
+    reaches the fold models through its own column's centre and spread even
+    though it is absent from both decompositions. That path is of order
+    :math:`1/n` and vanishes as rows are added, but it is not nothing, and it is
+    why this scheme is not offered as the default. ``"ekf"`` fits its constants
+    inside each fold and has no such path.
+
+    Parameters
+    ----------
+    X : np.ndarray of shape (n_samples, n_features)
+        Data matrix, already centred and scaled, with no missing cells.
+    max_components : int
+        Largest component count to evaluate.
+    n_folds : int
+        Number of row groups, and of column groups.
+    random_state : int, optional
+        Seed for the row and column permutations.
+
+    Returns
+    -------
+    press : np.ndarray of shape (max_components,)
+        Prediction error sum of squares per component count.
+    per_column_press : np.ndarray of shape (max_components, n_features)
+        The same total, split by variable.
+    null_model_ss : float
+        What predicting every cell by its column mean gets wrong.
+    per_column_null_ss : np.ndarray of shape (n_features,)
+        That reference, split by variable.
+
+    References
+    ----------
+    Eastment, H. T., & Krzanowski, W. J. (1982). Cross-validatory choice of the
+    number of components from a principal component analysis. *Technometrics*,
+    24(1), 73-77.
+    """
+    n, p = X.shape
+    rng = np.random.default_rng(random_state)
+    row_group = np.array_split(rng.permutation(n), n_folds)
+    column_group = np.array_split(rng.permutation(p), n_folds)
+
+    _, _, Vt_full = np.linalg.svd(X, full_matrices=False)
+    U_full, _, _ = np.linalg.svd(X, full_matrices=False)
+
+    def aligned(vectors: np.ndarray, reference: np.ndarray) -> np.ndarray:
+        """Flip each column whose direction opposes the full-data fit."""
+        width = min(vectors.shape[1], reference.shape[1])
+        signs = np.sign(np.sum(vectors[:, :width] * reference[:, :width], axis=0))
+        signs[signs == 0] = 1.0
+        return vectors[:, :width] * signs
+
+    # Loadings from models that never saw the rows of their group.
+    loadings: list[np.ndarray] = []
+    row_singular: list[np.ndarray] = []
+    for rows in row_group:
+        kept = np.setdiff1d(np.arange(n), rows)
+        _, S_r, Vt_r = np.linalg.svd(X[kept], full_matrices=False)
+        loadings.append(aligned(Vt_r.T, Vt_full.T))
+        row_singular.append(S_r)
+
+    # Scores from models that never saw the columns of their group.
+    scores: list[np.ndarray] = []
+    column_singular: list[np.ndarray] = []
+    for columns in column_group:
+        kept = np.setdiff1d(np.arange(p), columns)
+        U_c, S_c, _ = np.linalg.svd(X[:, kept], full_matrices=False)
+        scores.append(aligned(U_c, U_full))
+        column_singular.append(S_c)
+
+    available = min(
+        *(v.shape[1] for v in loadings),
+        *(u.shape[1] for u in scores),
+        *(s.size for s in row_singular),
+        *(s.size for s in column_singular),
+    )
+    if available < max_components:
+        warnings.warn(
+            f"cv_scheme='ek' can evaluate at most {available} component(s) with "
+            f"{n_folds} folds on a {n} by {p} block, not {max_components}: each fold "
+            "model is fitted on fewer rows or columns than the whole. Component counts "
+            "above that are reported as NaN. Use fewer folds to evaluate more.",
+            SpecificationWarning,
+            stacklevel=2,
+        )
+
+    press = np.full(max_components, np.nan)
+    per_column_press = np.full((max_components, p), np.nan)
+    usable = min(available, max_components)
+    for a in range(1, usable + 1):
+        prediction = np.zeros_like(X)
+        for rows, V_r, S_r in zip(row_group, loadings, row_singular, strict=True):
+            for columns, U_c, S_c in zip(column_group, scores, column_singular, strict=True):
+                block = np.ix_(rows, columns)
+                weight = np.sqrt(S_c[:a]) * np.sqrt(S_r[:a])
+                prediction[block] = (U_c[rows, :a] * weight) @ V_r[columns, :a].T
+        squared = (X - prediction) ** 2
+        press[a - 1] = float(np.sum(squared))
+        per_column_press[a - 1] = np.sum(squared, axis=0)
+
+    return press, per_column_press, float(np.sum(X**2)), np.sum(X**2, axis=0)
+
+
 class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
     """Principal Component Analysis with support for missing data.
 
@@ -1302,13 +1565,13 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         )
 
     @classmethod
-    def select_n_components(  # noqa: PLR0913, PLR0915, C901
+    def select_n_components(  # noqa: PLR0913, PLR0915, PLR0912, C901
         cls,
         X: DataMatrix,
         *,
         max_components: int | None = None,
         cv: int | BaseCrossValidator = 5,
-        cv_scheme: typing.Literal["row_wise", "ekf"] = "ekf",
+        cv_scheme: typing.Literal["ekf", "ek", "sacv", "gcv", "row_wise"] = "ekf",
         n_repeats: int = 1,
         selection_rule: SelectionRule = "min",
         min_q2_increase: float = Q2_MIN_INCREMENT,
@@ -1344,14 +1607,45 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             ``min(n_samples - 1, n_features)``.
         cv : int or sklearn CV splitter, default 5
             For ``cv_scheme="ekf"``: the integer number of element-folds
-            (splitter objects are ignored). For ``cv_scheme="row_wise"``:
+            (splitter objects are ignored). For ``cv_scheme="ek"``: the number
+            of row groups, and of column groups. For ``cv_scheme="row_wise"``:
             either an integer K (fed to ``KFold``) or any sklearn splitter.
-        cv_scheme : {"ekf", "row_wise"}, default "ekf"
-            ``"ekf"`` is the element-wise k-fold scheme of Bro et al. 2008
-            with EM imputation; the research-recommended default. The legacy
-            ``"row_wise"`` scheme is preserved for back-compat but emits a
-            :class:`SpecificationWarning` because it over-selects (see the
-            warning admonition below).
+            Ignored by ``"sacv"`` and ``"gcv"``, which hold nothing out.
+        cv_scheme : {"ekf", "ek", "sacv", "gcv", "row_wise"}, default "ekf"
+            How a held-out value is produced. Every one of these except
+            ``"row_wise"`` keeps the prediction independent of the value being
+            predicted; they differ in what they hold out and what they cost.
+
+            - ``"ekf"``, the default: element-wise k-fold with EM imputation.
+              Scattered cells are held out and each is imputed from a model
+              that never saw it. Fits its centring and scaling inside every
+              fold, and is the only scheme here that takes a block with
+              missing cells. Cost: ``n_folds * n_repeats * max_components``
+              decompositions.
+            - ``"ek"``: the two-model scheme of Eastment and Krzanowski
+              (1982). An element is predicted by a score from a model without
+              its column and a loading from a model without its row. This is
+              what Simca-P reports and what ``pcaMethods::Q2`` computes by
+              default, so use it when a number has to line up with either.
+              Cost: ``2 * n_folds`` decompositions.
+            - ``"sacv"``: leave-one-cell-out, approximated by inflating each
+              residual by the leverage of the cell that produced it, after
+              Josse and Husson (2012). The cheap version of holding cells out
+              one at a time. Cost: one decomposition.
+            - ``"gcv"``: the same idea with a single averaged leverage instead
+              of one per cell. Blunter, and it tends to keep more components.
+              Cost: one decomposition. This and ``"sacv"`` are the defaults in
+              ``FactoMineR`` and ``missMDA``.
+            - ``"row_wise"``: **deprecated, removed in 2.0.** See the warning
+              admonition below.
+
+            ``"ek"``, ``"sacv"`` and ``"gcv"`` factorise the matrix directly,
+            so they raise on a block with missing cells and they ignore
+            ``scale_inside_folds``, ``n_repeats``, ``n_iter`` and ``tol``.
+            They also report no per-fold spread, so ``selection_rule="1se"``
+            has nothing to work with; ``"min"`` takes the global optimum,
+            where ``FactoMineR`` instead stops at the first local worsening,
+            which can return a smaller count on the same data.
         n_repeats : int, default 1
             Repeat the ekf pass with a fresh random fold permutation this
             many times. Each repeat covers every cell exactly once;
@@ -1476,15 +1770,25 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         with the element-wise k-fold (ekf) algorithm: theoretical aspects.
         *J. Chemometrics*, 26(7), 361-373.
 
+        Eastment, H. T., & Krzanowski, W. J. (1982). Cross-validatory choice
+        of the number of components from a principal component analysis.
+        *Technometrics*, 24(1), 73-77.
+
+        Josse, J., & Husson, F. (2012). Selecting the number of components in
+        principal component analysis using cross-validation approximations.
+        *Computational Statistics & Data Analysis*, 56(6), 1869-1879.
+
         .. warning::
 
-           ``cv_scheme="row_wise"`` is preserved only for back-compat and
-           emits a :class:`SpecificationWarning`. It suffers from the
-           *trivial-fit* problem: holding out whole rows and projecting them
-           back via :meth:`transform` lets the held-out row's own values
-           reach its prediction, so PRESS shrinks monotonically with the
-           component count and the recommendation tends to run to the
-           maximum. Prefer the default ``"ekf"``.
+           ``cv_scheme="row_wise"`` is **deprecated since 1.84 and will be
+           removed in 2.0**. It emits a :class:`DeprecationWarning` and a
+           :class:`SpecificationWarning`. It suffers from the *trivial-fit*
+           problem: holding out whole rows and projecting them back via
+           :meth:`transform` lets the held-out row's own values reach its
+           prediction, so PRESS shrinks monotonically with the component
+           count and reaches zero once the components equal the variables.
+           It measures compression, not prediction, and cannot select a
+           component count. Use ``"ekf"``, ``"ek"``, ``"sacv"`` or ``"gcv"``.
         """
         if threshold is not None:
             warnings.warn(
@@ -1548,7 +1852,40 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             safe_null = np.where(per_column_null_ss > epsqrt, per_column_null_ss, np.nan)
             per_variable = 1.0 - ekf.per_column_press / safe_null
             q2_per_variable = pd.DataFrame(per_variable, index=component_index, columns=list(X.columns))
+        elif cv_scheme in {"ek", "sacv", "gcv"}:
+            Z = _preprocess_for_cell_schemes(X_arr, cv_scheme)
+            if cv_scheme == "ek":
+                n_folds = cv if isinstance(cv, int) else 5
+                raw_press, raw_per_column, null_model_ss, per_column_null = _eastment_krzanowski_press(
+                    Z, max_components, n_folds=n_folds, random_state=random_state
+                )
+            else:
+                raw_press, raw_per_column, null_model_ss, per_column_null = _leverage_corrected_press(
+                    Z, max_components, method=cv_scheme
+                )
+            press = pd.Series(raw_press, index=component_index, name="PRESS")
+            # None of these three splits the data into folds that could disagree:
+            # "ek" pools every cell into one total, and the other two hold nothing
+            # out at all. A per-fold spread would be fabricated, so it is absent
+            # rather than zero, and the 1-SE rule has nothing to work with.
+            per_fold_press = pd.DataFrame(np.nan, index=component_index, columns=["fold_1"])
+            cv_scores = per_fold_press
+            press_input_units = press.rename("PRESS (input units)")
+            q2 = 1.0 - press / null_model_ss if null_model_ss > epsqrt else press * np.nan
+            safe_null = np.where(per_column_null > epsqrt, per_column_null, np.nan)
+            q2_per_variable = pd.DataFrame(
+                1.0 - raw_per_column / safe_null, index=component_index, columns=list(X.columns)
+            )
         elif cv_scheme == "row_wise":
+            warnings.warn(
+                "cv_scheme='row_wise' is deprecated and will be removed in 2.0. It "
+                "measures how well a held-out row reproduces itself, which is a "
+                "compression error rather than a prediction error, so it cannot pick "
+                "a component count. Use the default cv_scheme='ekf', or 'ek', 'sacv' "
+                "or 'gcv'.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             warnings.warn(
                 "cv_scheme='row_wise' uses the legacy whole-row CV scheme that "
                 "Bro et al. 2008 flagged as invalid: held-out row values flow "
@@ -1581,7 +1918,9 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             press_input_units = press.rename("PRESS (input units)")
             q2_per_variable = pd.DataFrame(np.nan, index=component_index, columns=list(X.columns))
         else:
-            raise ValueError(f"Unknown cv_scheme {cv_scheme!r}; expected 'ekf' or 'row_wise'.")
+            raise ValueError(
+                f"Unknown cv_scheme {cv_scheme!r}; expected one of 'ekf', 'ek', 'sacv', 'gcv' or 'row_wise'."
+            )
 
         q2 = q2.rename("Q2")
         q2.index = component_index

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -443,10 +443,12 @@ def _leverage_corrected_press(
     U, S, Vt = np.linalg.svd(X, full_matrices=False)
     press = np.full(max_components, np.nan)
     per_column_press = np.full((max_components, p), np.nan)
+    null_ss = np.sum(X**2, axis=0)
 
     for a in range(1, max_components + 1):
         rank = min(a, S.shape[0])
         residual = X - (U[:, :rank] * S[:rank]) @ Vt[:rank]
+        scored = np.ones_like(residual, dtype=bool)
         if method == "sacv":
             row_leverage = np.sum(U[:, :rank] ** 2, axis=1)
             column_leverage = np.sum(Vt[:rank] ** 2, axis=0)
@@ -454,8 +456,14 @@ def _leverage_corrected_press(
             # A cell whose leverage reaches one is reconstructed entirely by
             # itself, so its leave-one-out residual is not defined. Drop it
             # rather than let a division by ~0 dominate the total.
-            usable = denominator > epsqrt
-            corrected = np.where(usable, residual / np.where(usable, denominator, 1.0), np.nan)
+            scored = denominator > epsqrt
+            if not scored.any():
+                # Nothing is left to measure. Summing an empty total would
+                # report zero error, which reads as a perfect fit and would win
+                # the selection outright. Report nothing instead, as the
+                # generalised criterion does when its own guard fires.
+                continue
+            corrected = np.where(scored, residual / np.where(scored, denominator, 1.0), 0.0)
         else:
             remaining = (n - 1) * p - a * (n + p - a - 1)
             if remaining <= 0:
@@ -463,10 +471,16 @@ def _leverage_corrected_press(
                 # has nothing left to measure against.
                 continue
             corrected = residual * (n * p / remaining)
-        press[a - 1] = float(np.nansum(corrected**2))
-        per_column_press[a - 1] = np.nansum(corrected**2, axis=0)
+        # Both totals must cover the same cells. Where some were dropped, the
+        # error is rescaled onto the whole block, so that dividing it by the
+        # block's own sum of squares gives the criterion over the cells that
+        # were actually scored.
+        scored_null = np.sum(np.where(scored, X**2, 0.0), axis=0)
+        inflate = np.divide(null_ss, scored_null, out=np.ones_like(null_ss), where=scored_null > epsqrt)
+        per_column_press[a - 1] = np.sum(corrected**2, axis=0) * inflate
+        press[a - 1] = float(np.sum(per_column_press[a - 1]))
 
-    return press, per_column_press, float(np.sum(X**2)), np.sum(X**2, axis=0)
+    return press, per_column_press, float(np.sum(X**2)), null_ss
 
 
 def _eastment_krzanowski_press(
@@ -1977,11 +1991,20 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
         # residual they inflate has almost nothing left in it.
         evaluated = q2.to_numpy()[~np.isnan(q2.to_numpy())]
         if evaluated.size > 1 and np.all(np.diff(evaluated) > 0) and int(recommended) == max_components:
+            # A scheme that already holds data out has nothing better to switch
+            # to, so it is only told to widen the range; the others are told
+            # both, since a criterion that never turns over is the failure mode
+            # they share.
+            alternatives = [name for name in ("ekf", "ek") if name != cv_scheme]
+            remedy = "Evaluate more components"
+            if alternatives:
+                joined = " or ".join(f"cv_scheme={name!r}" for name in alternatives)
+                remedy += f", or use a scheme that holds data out ({joined})"
             warnings.warn(
                 f"cv_scheme={cv_scheme!r} did not turn over: its Q2 rises at every one of the "
-                f"{max_components} component counts evaluated, so {recommended} is the largest "
-                "count tried rather than an optimum. Evaluate more components, or use a scheme "
-                "that holds data out (cv_scheme='ekf' or 'ek'), before reading this as an answer.",
+                f"{evaluated.size} component counts it could evaluate, so {recommended} is the "
+                f"largest count tried rather than an optimum. {remedy}, before reading this as "
+                "an answer.",
                 SpecificationWarning,
                 stacklevel=2,
             )

--- a/src/process_improve/multivariate/_pca.py
+++ b/src/process_improve/multivariate/_pca.py
@@ -1968,6 +1968,24 @@ class PCA(_LatentVariableModel, TransformerMixin, BaseEstimator):
             min_q2_increase=min_q2_increase,
         )
 
+        # A criterion that never turns over has not found an optimum: it has run
+        # out of components to evaluate. The count returned is then the largest
+        # one tried rather than an answer, and saying so is the difference
+        # between a recommendation and a number. This is the failure mode that
+        # makes cv_scheme="row_wise" useless, and the leverage approximations
+        # can fall into it too on data whose R2 approaches one, where the
+        # residual they inflate has almost nothing left in it.
+        evaluated = q2.to_numpy()[~np.isnan(q2.to_numpy())]
+        if evaluated.size > 1 and np.all(np.diff(evaluated) > 0) and int(recommended) == max_components:
+            warnings.warn(
+                f"cv_scheme={cv_scheme!r} did not turn over: its Q2 rises at every one of the "
+                f"{max_components} component counts evaluated, so {recommended} is the largest "
+                "count tried rather than an optimum. Evaluate more components, or use a scheme "
+                "that holds data out (cv_scheme='ekf' or 'ek'), before reading this as an answer.",
+                SpecificationWarning,
+                stacklevel=2,
+            )
+
         consensus_fields: dict[str, object] = {}
         if return_consensus:
             # Two cheap cross-checks: Minka's PPCA MLE (mean-centred input,

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -5349,3 +5349,123 @@ def test_vip_raises_without_weights_or_loadings() -> None:
 
     with pytest.raises(ValueError, match="x_weights_"):
         vip(_FakeFitted())
+
+
+# --------------------------------------------------------------------------
+# The cell-wise cross-validation schemes added in 1.84: "ek", "sacv", "gcv".
+# --------------------------------------------------------------------------
+
+
+def _known_rank_block(seed: int = 0, n: int = 100, k: int = 12, rank: int = 3) -> pd.DataFrame:
+    """Build a block whose true rank is known, so a criterion can be judged right or wrong."""
+    rng = np.random.default_rng(seed)
+    scores = rng.standard_normal((n, rank)) * np.array([6.0, 4.0, 2.5])
+    return pd.DataFrame(scores @ rng.standard_normal((rank, k)) + rng.standard_normal((n, k)))
+
+
+@pytest.mark.parametrize("scheme", ["ek", "sacv", "gcv"])
+def test_cell_schemes_return_the_documented_bunch(scheme: str) -> None:
+    """Each new scheme fills the same Bunch, and reports no fabricated fold spread."""
+    X = _known_rank_block()
+    result = PCA.select_n_components(X, max_components=6, cv=5, cv_scheme=scheme, random_state=0)
+
+    assert result.cv_scheme == scheme
+    assert list(result.q2.index) == list(range(1, 7))
+    assert result.q2_per_variable.shape == (6, X.shape[1])
+    # Nothing is held out in folds that could disagree, so the spread is absent
+    # rather than zero: a zero would let the 1-SE rule read a false certainty.
+    assert result.per_fold_press.isna().to_numpy().all()
+    assert np.isnan(result.se_press.to_numpy()).all()
+
+
+def test_sacv_tracks_the_element_wise_scheme_it_approximates() -> None:
+    """The leverage correction stands in for holding cells out, over the range that is read."""
+    X = _known_rank_block()
+    ekf = PCA.select_n_components(X, max_components=8, cv=7, n_repeats=10, random_state=0)
+    sacv = PCA.select_n_components(X, max_components=8, cv_scheme="sacv", random_state=0)
+
+    # Same answer, for one decomposition instead of 560.
+    assert int(np.nanargmax(sacv.q2.to_numpy())) == int(np.nanargmax(ekf.q2.to_numpy())) == 2
+    # And the same curve, within five points, through the optimum and past it.
+    assert np.nanmax(np.abs(sacv.q2.to_numpy()[:5] - ekf.q2.to_numpy()[:5])) < 0.05
+
+
+def test_sacv_degrades_as_the_components_approach_the_variables() -> None:
+    """The trap in the leverage correction, pinned so nobody meets it unawares.
+
+    A column's leverage is the share of its variance inside the retained
+    subspace, and it reaches one when the components reach the variables. The
+    divisor goes to zero with it, so the corrected residual blows up. On a
+    12-variable block the approximation is faithful to about half that many
+    components and unusable near the top.
+    """
+    X = _known_rank_block(n=100, k=12)
+    ekf = PCA.select_n_components(X, max_components=8, cv=7, n_repeats=10, random_state=0).q2.to_numpy()
+    sacv = PCA.select_n_components(X, max_components=8, cv_scheme="sacv", random_state=0).q2.to_numpy()
+
+    assert np.max(np.abs(sacv[:6] - ekf[:6])) < 0.05
+    assert np.abs(sacv[7] - ekf[7]) > 0.5
+
+
+def test_cell_schemes_find_the_true_rank_where_the_row_wise_one_cannot() -> None:
+    """The point of all of this: an interior optimum exists, and row_wise has none."""
+    X = _known_rank_block()
+    for scheme in ("ekf", "sacv"):
+        kwargs = {"n_repeats": 10} if scheme == "ekf" else {}
+        result = PCA.select_n_components(X, max_components=11, cv=7, cv_scheme=scheme, random_state=0, **kwargs)
+        assert int(np.nanargmax(result.q2.to_numpy())) + 1 == 3, scheme
+
+    with pytest.warns((SpecificationWarning, DeprecationWarning)):
+        legacy = PCA.select_n_components(X, max_components=11, cv=7, cv_scheme="row_wise", random_state=0)
+    assert np.all(np.diff(legacy.q2.to_numpy()) > 0)
+
+
+def test_ek_never_lets_a_cell_reach_the_model_that_predicts_it() -> None:
+    """Eastment-Krzanowski's defining property, checked rather than assumed.
+
+    A cell sits in one row group and one column group. The scores come from a
+    decomposition that dropped its column, so perturbing the cell cannot move
+    them. Preprocessing is fitted on the whole matrix, as in the classical
+    scheme, so the loadings shift only through its column's centre and spread.
+    """
+    from process_improve.multivariate._pca import _preprocess_for_cell_schemes
+
+    rng = np.random.default_rng(1)
+    n, k = 40, 8
+    X = (rng.standard_normal((n, 3)) * np.array([5.0, 3.0, 1.5])) @ rng.standard_normal((3, k))
+    X += rng.standard_normal((n, k))
+
+    kept_columns = np.setdiff1d(np.arange(k), np.arange(0, k, 2))
+    scores_before, _, _ = np.linalg.svd(_preprocess_for_cell_schemes(X, "ek")[:, kept_columns], full_matrices=False)
+
+    moved = X.copy()
+    moved[0, 0] += 1000.0  # a cell inside the dropped column group
+    scores_after, _, _ = np.linalg.svd(_preprocess_for_cell_schemes(moved, "ek")[:, kept_columns], full_matrices=False)
+    assert np.abs(np.abs(scores_before) - np.abs(scores_after)).max() < 1e-12
+
+
+def test_cell_schemes_refuse_a_block_with_missing_cells() -> None:
+    """They factorise X directly, so they must say so rather than fail inside an SVD."""
+    X = _known_rank_block().copy()
+    X.iloc[0, 0] = np.nan
+    for scheme in ("ek", "sacv", "gcv"):
+        with pytest.raises(ValueError, match="missing cells"):
+            PCA.select_n_components(X, max_components=3, cv=5, cv_scheme=scheme)
+    # The default scheme does take it, which is the reason to reach for it.
+    assert PCA.select_n_components(X, max_components=3, cv=5, random_state=0).q2.notna().all()
+
+
+def test_ek_warns_when_the_folds_cannot_reach_the_requested_components() -> None:
+    """Each fold model is fitted on fewer rows or columns, so it saturates early."""
+    X = _known_rank_block(n=30, k=8)
+    with pytest.warns(SpecificationWarning, match="can evaluate at most"):
+        result = PCA.select_n_components(X, max_components=7, cv=7, cv_scheme="ek", random_state=0)
+    assert result.q2.isna().any()
+
+
+def test_row_wise_is_deprecated_for_removal() -> None:
+    """The announce phase of the deprecation schedule: it still works, and it says so."""
+    X = _known_rank_block(n=40, k=6)
+    with pytest.warns(DeprecationWarning, match="removed in 2.0"):
+        result = PCA.select_n_components(X, max_components=4, cv=5, cv_scheme="row_wise", random_state=0)
+    assert result.cv_scheme == "row_wise"

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -23,7 +23,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils import Bunch
 
-from process_improve.multivariate._pca import _pca_ekf_press
+from process_improve.multivariate._pca import _leverage_corrected_press, _pca_ekf_press
 from process_improve.multivariate.methods import (
     PCA,
     PLS,
@@ -5472,6 +5472,65 @@ def test_row_wise_is_deprecated_for_removal() -> None:
     with pytest.warns(DeprecationWarning, match="removed in 2.0"):
         result = PCA.select_n_components(X, max_components=4, cv=5, cv_scheme="row_wise", random_state=0)
     assert result.cv_scheme == "row_wise"
+
+
+def test_sacv_reports_nothing_rather_than_a_perfect_score_at_the_top() -> None:
+    """The counterpart of the generalised criterion's guard, on the smoothing one.
+
+    Once the components reach the variables every column leverage is one, so
+    every cell is dropped as undefined. Totalling an empty set gives zero error,
+    which reads as a flawless model and wins the selection outright. It must
+    come back as NaN, the way the generalised criterion already does.
+    """
+    n, p = 40, 5
+    X = _known_rank_block(n=n, k=p, rank=2)
+    result = PCA.select_n_components(X, max_components=p, cv_scheme="sacv", random_state=0)
+    q2 = result.q2.to_numpy()
+
+    assert np.isnan(q2[p - 1]), "the component count that equals the variable count means nothing"
+    assert np.isfinite(q2[: p - 1]).all()
+    assert int(result.n_components) < p
+
+
+def test_leverage_criterion_scores_the_same_cells_it_divides_by() -> None:
+    """A dropped cell leaves both totals, not just the error.
+
+    A cell whose leverage reaches one is not scored, so its share of the block's
+    variance must leave the reference too. Otherwise the criterion is an error
+    over part of the block against a null over all of it, which flatters the
+    model in proportion to how many cells were dropped.
+    """
+    n, p, components = 30, 8, 4
+    X = _known_rank_block(n=n, k=p, rank=3)
+    Z = MCUVScaler().fit_transform(X).to_numpy()
+    press, per_column, null_ss, per_column_null = _leverage_corrected_press(Z, components, method="sacv")
+
+    # Nothing is dropped at this shape, so the rescaling must be the identity and
+    # the totals must agree with a direct calculation of the same quantity.
+    assert np.isclose(null_ss, float(np.sum(Z**2)))
+    assert np.allclose(per_column_null, np.sum(Z**2, axis=0))
+    assert np.allclose(press, per_column.sum(axis=1))
+    U, S, Vt = np.linalg.svd(Z, full_matrices=False)
+    for a in range(1, components + 1):
+        residual = Z - (U[:, :a] * S[:a]) @ Vt[:a]
+        denominator = np.outer(1.0 - 1.0 / n - np.sum(U[:, :a] ** 2, axis=1), 1.0 - np.sum(Vt[:a] ** 2, axis=0))
+        assert (denominator > 0).all(), "pick a shape where no cell is dropped"
+        assert np.isclose(press[a - 1], float(np.sum((residual / denominator) ** 2)))
+
+
+def test_the_no_optimum_warning_names_a_scheme_other_than_the_one_in_use() -> None:
+    """Told that a criterion never turned over, the reader needs somewhere to go.
+
+    The remedy used to name both element-wise schemes whatever was running, so a
+    caller already using one was pointed back at it.
+    """
+    X = _known_rank_block(n=60, k=8)
+    for scheme, expected, forbidden in (("ekf", "'ek'", "cv_scheme='ekf' or"), ("ek", "'ekf'", "or cv_scheme='ek'")):
+        with pytest.warns(SpecificationWarning, match="did not turn over") as caught:
+            PCA.select_n_components(X, max_components=3, cv=5, cv_scheme=scheme, random_state=0)
+        message = next(str(w.message) for w in caught if "did not turn over" in str(w.message))
+        assert expected in message
+        assert forbidden not in message
 
 
 def test_gcv_reports_nothing_once_the_parameters_outnumber_the_data() -> None:

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -5492,3 +5492,27 @@ def test_gcv_reports_nothing_once_the_parameters_outnumber_the_data() -> None:
     assert exhausted.any(), "pick a shape where the guard actually fires"
     assert np.isnan(result.q2.to_numpy()[exhausted]).all()
     assert np.isfinite(result.q2.to_numpy()[~exhausted]).all()
+
+
+def test_a_criterion_that_never_turns_over_says_so() -> None:
+    """A count that is just the largest one tried is not a recommendation.
+
+    The leverage approximations inflate a residual, and on data whose fit
+    approaches one there is almost nothing left in that residual to inflate, so
+    the criterion can rise at every component count. That is the same failure
+    that makes the row-wise scheme useless, and it has to be visible.
+    """
+    rng = np.random.default_rng(3)
+    n, k = 54, 12
+    # Structure at many components and very little noise: R2 reaches ~1 early.
+    X = pd.DataFrame(rng.standard_normal((n, 8)) @ rng.standard_normal((8, k)) + 0.01 * rng.standard_normal((n, k)))
+
+    with pytest.warns(SpecificationWarning, match="did not turn over"):
+        result = PCA.select_n_components(X, max_components=6, cv_scheme="gcv", random_state=0)
+    assert result.n_components == 6
+
+    # The schemes that hold data out are not warned about on data where they do
+    # turn over, so the warning is a signal and not noise.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SpecificationWarning)
+        PCA.select_n_components(_known_rank_block(), max_components=8, cv=7, n_repeats=5, random_state=0)

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -5458,6 +5458,25 @@ def test_cell_schemes_refuse_a_block_with_missing_cells() -> None:
     assert PCA.select_n_components(X, max_components=3, cv=5, random_state=0).q2.notna().all()
 
 
+def test_the_missing_cell_refusal_says_how_many_and_where() -> None:
+    """Where the gaps sit decides what to do about them, so the message says.
+
+    A block whose misses are all in one column is repaired by dropping that
+    column, keeping every row; one whose misses are scattered is not. Both were
+    the choice faced on a real quality block, so the error names which it is.
+    """
+    X = _known_rank_block(n=40, k=6).copy()
+    X.iloc[:9, 2] = np.nan
+    X.iloc[0, 0] = np.nan
+    with pytest.raises(ValueError, match=r"10 of 240, 9 of them in column 2"):
+        PCA.select_n_components(X, max_components=3, cv=5, cv_scheme="sacv")
+
+    scattered = _known_rank_block(n=40, k=6).copy()
+    scattered.iloc[0, 0] = scattered.iloc[1, 3] = scattered.iloc[2, 5] = np.nan
+    with pytest.raises(ValueError, match=r"3 of 240, spread over 3 columns"):
+        PCA.select_n_components(scattered, max_components=3, cv=5, cv_scheme="ek")
+
+
 def test_ek_warns_when_the_folds_cannot_reach_the_requested_components() -> None:
     """Each fold model is fitted on fewer rows or columns, so it saturates early."""
     X = _known_rank_block(n=30, k=8)

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -5359,7 +5359,10 @@ def test_vip_raises_without_weights_or_loadings() -> None:
 def _known_rank_block(seed: int = 0, n: int = 100, k: int = 12, rank: int = 3) -> pd.DataFrame:
     """Build a block whose true rank is known, so a criterion can be judged right or wrong."""
     rng = np.random.default_rng(seed)
-    scores = rng.standard_normal((n, rank)) * np.array([6.0, 4.0, 2.5])
+    # A fixed, decreasing set of component sizes, sliced to the rank asked for, so
+    # that the default rank of three keeps the values the other tests are pinned to.
+    spread = np.array([6.0, 4.0, 2.5, 1.8, 1.2])[:rank]
+    scores = rng.standard_normal((n, rank)) * spread
     return pd.DataFrame(scores @ rng.standard_normal((rank, k)) + rng.standard_normal((n, k)))
 
 
@@ -5469,3 +5472,23 @@ def test_row_wise_is_deprecated_for_removal() -> None:
     with pytest.warns(DeprecationWarning, match="removed in 2.0"):
         result = PCA.select_n_components(X, max_components=4, cv=5, cv_scheme="row_wise", random_state=0)
     assert result.cv_scheme == "row_wise"
+
+
+def test_gcv_reports_nothing_once_the_parameters_outnumber_the_data() -> None:
+    """The guard on the generalised criterion, exercised rather than assumed.
+
+    A rank-``a`` bilinear model spends ``a(n + p - a - 1)`` free parameters. Once
+    that reaches the ``(n - 1)p`` degrees of freedom available, the inflation
+    factor has a non-positive denominator and the criterion means nothing. It
+    must come back as NaN rather than as a number with the wrong sign.
+    """
+    n, p = 20, 6
+    X = _known_rank_block(n=n, k=p, rank=2)
+    result = PCA.select_n_components(X, max_components=p, cv_scheme="gcv", random_state=0)
+
+    spent = np.array([a * (n + p - a - 1) for a in range(1, p + 1)])
+    available = (n - 1) * p
+    exhausted = spent >= available
+    assert exhausted.any(), "pick a shape where the guard actually fires"
+    assert np.isnan(result.q2.to_numpy()[exhausted]).all()
+    assert np.isfinite(result.q2.to_numpy()[~exhausted]).all()

--- a/tests/test_multivariate_centring_traps.py
+++ b/tests/test_multivariate_centring_traps.py
@@ -233,14 +233,19 @@ class TestPreScaledInsideFoldsWarningPCA:
         with _no_specification_warning():
             PCA.select_n_components(raw, max_components=4, cv=5, random_state=0)
 
-    def test_row_wise_ignores_the_flag_and_so_does_the_warning(self) -> None:
-        """``row_wise`` warns about itself only; the flag it ignores earns no second warning."""
+    def test_row_wise_ignores_the_flag_and_so_earns_no_scaling_warning(self) -> None:
+        """``row_wise`` ignores ``scale_inside_folds``, so the flag it ignores earns no warning.
+
+        It does earn two warnings of its own: that it is deprecated, and that its
+        criterion never turns over, which is the whole reason it is going. Neither
+        is about scaling, and that is what this test is guarding.
+        """
         _raw, autoscale, _pareto = self._blocks(self._UNEQUAL_SPREADS)
         with pytest.warns(SpecificationWarning) as record:
             PCA.select_n_components(autoscale, max_components=4, cv=5, cv_scheme="row_wise", random_state=0)
         messages = [str(w.message) for w in record if issubclass(w.category, SpecificationWarning)]
-        assert len(messages) == 1
-        assert "row_wise" in messages[0]
+        assert any("row_wise" in message for message in messages)
+        assert not any("scale_inside_folds" in message for message in messages)
 
     def test_two_deliberate_scalings_collapse_inside_folds(self) -> None:
         """The behaviour the warning is about: in-fold standardisation undoes the caller's scaling.


### PR DESCRIPTION
A survey of how other packages cross-validate a PCA turned up two schemes worth having and one worth removing. All three changes are on `PCA.select_n_components`.

## Added

**`cv_scheme="ek"`, the two-model scheme of Eastment and Krzanowski (1982).** An element is predicted by a score from a decomposition that dropped its column and a loading from one that dropped its row, so it enters neither. This is what Simca-P reports as its PCA `Q2` and what `pcaMethods::Q2` computes by default in R, so it is the scheme to reach for when a number has to line up with either. Rows and columns are each split into `cv` groups rather than deleted one at a time, costing `2 * n_folds` decompositions instead of `n + p`, and every fold model's singular vectors are sign-aligned to the full-data fit.

One leak is documented rather than hidden. Centring and scaling are fitted once on the whole matrix, as in the classical scheme and in the reference implementations, so a cell reaches the fold models through its own column's centre and spread even though it is absent from both decompositions. That path is of order `1/n`. It is why this is an option and not the default.

**`cv_scheme="sacv"` and `cv_scheme="gcv"`, the leverage corrections of Josse and Husson (2012).** These get leave-one-cell-out without refitting anything: inflate each residual by the leverage of the cell that produced it, `(1 - 1/n - a_i)(1 - b_j)`, the same device that turns a regression residual into its leave-one-out counterpart via `e_i / (1 - h_ii)`. `"gcv"` replaces the two leverages with one averaged constant and is blunter. Both are the defaults in `FactoMineR` and `missMDA`.

The point is cost. On a 100 by 12 block, `"sacv"` costs one decomposition against 560 for the element-wise scheme, picks the same component count, and stays within five points of its curve through the optimum:

| Components | `ekf` | `sacv` |
|---|---|---|
| 2 | 0.786 | 0.791 |
| 3 | **0.883** | **0.891** |
| 4 | 0.821 | 0.845 |
| 8 | 0.549 | −0.044 |

The last row is the trap, and it is pinned by a test. Both leverage schemes are first-order approximations that degrade as the components approach the variables, because a column's leverage is the share of its variance inside the retained subspace and reaches one when the components reach the variables. The divisor goes to zero with it. The docstring and the user guide say to read them well below that ceiling, which is why `FactoMineR` defaults to five.

All three factorise the matrix directly, so they raise a clear `ValueError` on a block with missing cells and point at `"ekf"`, which imputes an unmeasured cell alongside the held-out ones and never scores it. The refusal names how many cells are missing and whether one column holds them, because that decides the repair: on the FMC dryer's quality block 18 of the 19 sit in one attribute, so dropping that column keeps all 46 batches where dropping the incomplete rows would cost 19 of them. A block whose gaps are scattered has no such repair, and the message says which case it is. The three schemes also ignore `scale_inside_folds`, `n_repeats`, `n_iter` and `tol`, and they report no per-fold spread, since nothing is held out in folds that could disagree. A fabricated zero there would let the 1-SE rule read a false certainty, so the field is `NaN` instead.

## Deprecated

**`cv_scheme="row_wise"` now emits a `DeprecationWarning` and will be removed in 2.0**, following `docs/development/deprecation_policy.rst`. It measures how well a held-out row reproduces itself: the row supplies the scores that rebuild it, so PRESS falls monotonically and reaches exactly zero once the components equal the variables. That is a compression error, not a prediction error, and it cannot select a component count. `mdatools` removed the equivalent from its own PCA and said in its release notes that it "was a bad idea from the beginning". The existing `SpecificationWarning` still fires alongside.

The FMC quality block shows it plainly. On its complete 46 by 6 sub-block the row-wise scheme climbs -0.11, 0.93, 0.95, 0.97, 0.999, 1.000 and recommends six components, the number of attributes; `"ekf"` on the same block recommends one.

## Fixed

**The leverage criterion could report a perfect score on an empty total.** Found by running every scheme over the whole component range on the FMC quality block, which is narrow enough (six to eight attributes) to reach the ceiling. Once the components reach the variables every column leverage is one, so the guard in `"sacv"` drops every cell as undefined. `np.nansum` of an all-NaN array is `0.0`, not `NaN`, so PRESS came back as zero and `Q2` as exactly `1.000`, which then won the selection outright: six components on a 46 by 6 block and eight on a 27 by 8 one, the worst answers available. `"gcv"` already guarded its own version of this; `"sacv"` did not. It now reports `NaN` there, and recommends 1 and 2 on those two blocks.

Where only *some* cells are dropped, the criterion and the reference it is divided by now cover the same cells. The previous code compared an error over part of the block against a null over all of it, which flatters the model in proportion to how many cells were dropped. Nothing is dropped early on real data, so no published number moves; a high-leverage outlying row is what reaches this path.

**The no-optimum warning named the scheme it was warning about.** Its remedy listed both element-wise schemes whatever was running, so a caller already using `"ekf"` was told to use `"ekf"`. It now names only the alternatives, and says how many component counts it could actually evaluate rather than how many were asked for. The guard that built that remedy conditionally has gone with it: the list is the two schemes less whichever is running, so one always survives.

## Why the default did not change

The likelihood route that scikit-learn takes is elegant and immune to the circularity, but it assumes isotropic noise. On a rank-3 block with the noise ramped from 0.3 to 3.0 across the variables, which is ordinary for a plant with sensors of differing quality, the cross-validated log-likelihood and Minka's estimate both take ten or eleven components across five seeds while the element-wise scheme takes three every time. `"ekf"` stays the default.

Two datasets since bore that out from the other side. On LDPE, `"ekf"` and `"ek"` both turn over at two components as Simca-P does (correlation with the recorded Simca-P curve +0.86 and +0.65 over the first eight counts), while `"sacv"` and `"gcv"` do not turn over at all there, because the fit reaches 99.98% and the residual they inflate has nothing left in it. On the FMC quality block, whose 19 missing cells are the ordinary case for plant data, `"ekf"` is the only one of the four that will run at all.

## Verification

- `uv run pytest`: **3235 passed, 3 skipped**, coverage 94.20% against the 92% gate. (An earlier revision of this description said 3234; that was the count before the last test landed.)
- Fourteen new tests, including the defining property of the Eastment-Krzanowski scheme checked rather than assumed: perturb a cell by 1000 and the scores from the decomposition that dropped its column move by less than 1e-12; and the two guards above, each pinned on a shape where it fires.
- `ruff check .`, `ruff format --check .` and `mypy src/process_improve` all clean on the current head.
- The strict Sphinx docs build (`-W`) succeeds.
- `CHANGELOG.md`, `pyproject.toml` and `CITATION.cff` all at 1.84.0, dated 2026-09-10, a MINOR bump for new features. The fixes above are to code this PR itself adds, so they are folded into that entry rather than bumping again.
- No lock file staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXthGpHLQFfGubBiKFtGAE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXthGpHLQFfGubBiKFtGAE)_