### PR TITLE
Cross-validate a multi-block PLS by holding out rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ those changes.
 
 ## [Unreleased]
 
+## [1.85.0] - 2026-09-11
+
+### Added
+
+- **`MBPLS.select_n_components`**, cross-validation for a multi-block PLS.
+  Whole rows are held out, as for `PLS.select_n_components`, and the argument
+  that makes that sound is untouched by there being several X-blocks: a
+  held-out row's super score is computed from its X-blocks alone, so its Y
+  never reaches its own prediction. Each block is centred and scaled inside
+  `fit`, on the training rows only.
+
+  PRESS and the "predict the mean" reference are both taken on the original Y
+  scale, and the reference is weighted by how often each row is actually held
+  out, so a splitter that tests some rows more than others is handled exactly.
+  Both choices match `PLS.select_n_components`, which is what lets a multi-block
+  row and a single-block row be read in the same column.
+
+  One model is fitted per fold and per component count, because hierarchical
+  NIPALS deflation means an `a`-component model cannot be recovered from an
+  `A`-component one. The cost is `cv * n_repeats * max_components` fits.
+
+  Note that a fitted model's `r2_y_cumulative_` is computed on the scaled Y,
+  where every target carries equal weight, while the returned `r2y_validated`
+  is on the original Y scale. On targets of unequal spread the two differ
+  widely, and they are not comparable with each other.
+
 ## [1.84.0] - 2026-09-10
 
 ### Added
@@ -4412,7 +4438,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.84.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.85.0...HEAD
+[1.85.0]: https://github.com/kgdunn/process-improve/compare/v1.84.0...v1.85.0
 [1.84.0]: https://github.com/kgdunn/process-improve/compare/v1.83.2...v1.84.0
 [1.83.2]: https://github.com/kgdunn/process-improve/compare/v1.83.1...v1.83.2
 [1.83.1]: https://github.com/kgdunn/process-improve/compare/v1.83.0...v1.83.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.84.0
-date-released: "2026-09-10"
+version: 1.85.0
+date-released: "2026-09-11"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/docs/api/multivariate.rst
+++ b/docs/api/multivariate.rst
@@ -40,7 +40,7 @@ loop, so blocks of unequal width contribute fairly to the consensus
 super-score.
 
 .. autoclass:: MBPLS
-   :members: fit, transform, predict, spe_contributions,
+   :members: fit, transform, predict, select_n_components, spe_contributions,
              block_spe_limit, super_spe_limit, display_results,
              super_score_plot, super_weights_bar_plot,
              predictions_vs_observed_plot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.84.0"
+version = "1.85.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/multivariate/_mbpls.py
+++ b/src/process_improve/multivariate/_mbpls.py
@@ -17,12 +17,20 @@ from collections.abc import Sequence
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, RegressorMixin, _fit_context
+from sklearn.model_selection import BaseCrossValidator, KFold, RepeatedKFold
 from sklearn.utils import Bunch
 from sklearn.utils.validation import check_is_fitted
 
 from ..visualization.themes import REFERENCE_LINE_COLOR
 from ._base import _HotellingsT2LimitMixin
-from ._common import SpecificationWarning, _nz, _scale_block_contributions, epsqrt
+from ._common import (
+    SelectionRule,
+    SpecificationWarning,
+    _nz,
+    _scale_block_contributions,
+    _select_n_components,
+    epsqrt,
+)
 from ._diagnostics import _select_rows
 from ._limits import spe_calculation
 from ._nipals import quick_regress, ssq
@@ -1024,6 +1032,195 @@ class MBPLS(_HotellingsT2LimitMixin, RegressorMixin, BaseEstimator):
         """
         check_is_fitted(self, "super_weights_")
         return self._project(X)
+
+    @classmethod
+    def select_n_components(  # noqa: PLR0913, PLR0915
+        cls,
+        X: dict[str, pd.DataFrame],
+        y: pd.DataFrame,
+        *,
+        max_components: int | None = None,
+        cv: int | BaseCrossValidator = 5,
+        n_repeats: int | None = None,
+        random_state: int | None = None,
+        selection_rule: SelectionRule = "1se",
+        **mbpls_kwargs,
+    ) -> Bunch:
+        """Select the number of multi-block PLS components by cross-validation.
+
+        Whole rows are held out. The super score of a held-out row is computed
+        from its X-blocks alone and its Y is what the model predicts, so the
+        value being predicted never enters its own prediction. That is the same
+        argument that makes row-wise cross-validation sound for a single-block
+        :meth:`PLS.select_n_components`, and it is unaffected by there being
+        several X-blocks.
+
+        Each block is centred and scaled inside :meth:`fit`, on the training
+        rows only, so the fold statistics never see the held-out rows.
+
+        One model is fitted per fold **and** per component count, because the
+        hierarchical NIPALS deflation means an ``a``-component model is not
+        recoverable from an ``A``-component one. The cost is
+        ``cv * n_repeats * max_components`` fits.
+
+        Parameters
+        ----------
+        X : dict[str, pd.DataFrame]
+            X-blocks, keyed by block name, all sharing ``y``'s row index.
+        y : pd.DataFrame
+            Y-block, one row per observation.
+        max_components : int, optional
+            Largest component count to evaluate. Defaults to the largest the
+            smallest training fold supports, capped at the total width of the
+            X-blocks.
+        cv : int or sklearn CV splitter, default 5
+            An integer is used as the ``n_splits`` of a shuffled
+            :class:`~sklearn.model_selection.KFold`, or of a
+            :class:`~sklearn.model_selection.RepeatedKFold` when
+            ``n_repeats > 1``. A splitter object is used as given, and
+            ``n_repeats`` is then ignored.
+        n_repeats : int, optional
+            How many times to repeat the split with a fresh shuffle. Resolved
+            to 10 when ``cv`` is an integer; pass 1 to disable repeats.
+        random_state : int, optional
+            Seed for the shuffling. Ignored when ``cv`` is a splitter.
+        selection_rule : {"1se", "min", "q2_increment"}, default "1se"
+            How ``n_components`` is chosen from the curve. See
+            :data:`~process_improve.multivariate._common.SelectionRule`.
+            ``"randomization"`` is not offered here.
+        **mbpls_kwargs
+            Passed to every :class:`MBPLS` fitted, for instance ``tol`` or
+            ``algorithm``.
+
+        Returns
+        -------
+        sklearn.utils.Bunch
+            With ``n_components`` (int), ``rmsecv`` and ``se_rmsecv`` (Series
+            indexed ``1..A``), ``per_fold_rmsecv`` (DataFrame, components by
+            fold), ``press`` (Series), ``r2y_validated`` (DataFrame with one
+            column per target plus ``"total"``), ``cv_predictions`` (DataFrame
+            of the held-out predictions of the recommended model, averaged
+            over repeats) and ``selection_rule``.
+
+        Raises
+        ------
+        ValueError
+            If ``X`` is not a non-empty dict of frames sharing ``y``'s index,
+            or if no component count could be evaluated.
+
+        Examples
+        --------
+        >>> import numpy as np, pandas as pd
+        >>> from process_improve.multivariate.methods import MBPLS
+        >>> rng = np.random.default_rng(0)
+        >>> t = rng.standard_normal((40, 2))
+        >>> blocks = {
+        ...     "a": pd.DataFrame(t @ rng.standard_normal((2, 5)) + rng.standard_normal((40, 5)) * 0.3),
+        ...     "b": pd.DataFrame(t @ rng.standard_normal((2, 4)) + rng.standard_normal((40, 4)) * 0.3),
+        ... }
+        >>> Y = pd.DataFrame(t @ rng.standard_normal((2, 2)) + rng.standard_normal((40, 2)) * 0.3)
+        >>> out = MBPLS.select_n_components(blocks, Y, max_components=3, cv=5, n_repeats=2, random_state=0)
+        >>> 1 <= out.n_components <= 3
+        True
+        """
+        if not isinstance(X, dict):
+            raise TypeError(f"X must be a dict of DataFrames, one per block; got {type(X).__name__}.")
+        if not X:
+            raise ValueError("X must hold at least one block.")
+        y = pd.DataFrame(y)
+        for name, block in X.items():
+            if not isinstance(block, pd.DataFrame):
+                raise TypeError(f"Block {name!r} must be a pandas DataFrame; got {type(block).__name__}.")
+            if len(block) != len(y):
+                raise ValueError(f"Block {name!r} has {len(block)} rows; y has {len(y)}.")
+        n_samples = len(y)
+        total_width = sum(block.shape[1] for block in X.values())
+
+        if isinstance(cv, int):
+            repeats = 10 if n_repeats is None else int(n_repeats)
+            splitter: BaseCrossValidator = (
+                KFold(cv, shuffle=True, random_state=random_state)
+                if repeats == 1
+                else RepeatedKFold(n_splits=cv, n_repeats=repeats, random_state=random_state)
+            )
+            n_splits = cv
+        else:
+            splitter, repeats, n_splits = cv, 1, cv.get_n_splits(y)
+
+        splits = list(splitter.split(y))
+        smallest_train = min(len(train) for train, _ in splits)
+        ceiling = max(1, min(smallest_train - 1, total_width))
+        A = ceiling if max_components is None else min(int(max_components), ceiling)
+        if A < 1:
+            raise ValueError("No component count could be evaluated; the folds are too small.")
+
+        component_index = pd.Index(range(1, A + 1), name="n_components")
+        targets = list(y.columns)
+        press = np.zeros((A, len(targets)))
+        per_fold = np.full((A, len(splits)), np.nan)
+        gathered: dict[int, list[pd.DataFrame]] = {a: [] for a in component_index}
+        tested = np.zeros(n_samples)  # how often each row is held out, which need not be uniform
+
+        for fold, (train, test) in enumerate(splits):
+            tested[test] += 1.0
+            tr, te = y.index[train], y.index[test]
+            train_blocks = {name: block.iloc[train] for name, block in X.items()}
+            test_blocks = {name: block.iloc[test] for name, block in X.items()}
+            for a in component_index:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", SpecificationWarning)
+                    model = cls(n_components=a, **mbpls_kwargs).fit(train_blocks, y.loc[tr])
+                    predicted = model.diagnose(test_blocks).predictions
+                residual = y.loc[te].to_numpy(dtype=float) - np.asarray(predicted, dtype=float)
+                press[a - 1] += np.nansum(residual**2, axis=0)
+                per_fold[a - 1, fold] = float(np.sqrt(np.nanmean(residual**2)))
+                gathered[a].append(pd.DataFrame(predicted, index=te, columns=targets))
+
+        # Weight the "predict the mean" reference by the same per-row coverage that
+        # built PRESS, so each row counts in the denominator exactly as often as it
+        # counted in the numerator. A splitter that tests some rows more than others,
+        # or not at all, is then handled exactly rather than by a flat repeat count.
+        # This is what PLS.select_n_components does, and both sides are on the
+        # original Y scale, so the two are directly comparable.
+        values = y.to_numpy(dtype=float)
+        centred_sq = (values - np.nanmean(values, axis=0)) ** 2
+        tss = np.nansum(tested[:, None] * centred_sq, axis=0)
+        per_target = np.where(tss > 0, 1.0 - press / np.where(tss > 0, tss, 1.0), np.nan)
+        total = np.where(tss.sum() > 0, 1.0 - press.sum(axis=1) / tss.sum(), np.nan)
+
+        n_predicted = float(tested.sum())
+        rmsecv = pd.Series(
+            np.sqrt(press.sum(axis=1) / max(n_predicted * len(targets), 1.0)), index=component_index, name="RMSECV"
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            se = np.nanstd(per_fold, axis=1, ddof=1) / np.sqrt(np.maximum(1, np.sum(~np.isnan(per_fold), axis=1)))
+        se_rmsecv = pd.Series(se, index=component_index, name="SE of RMSECV")
+        r2y_validated = pd.DataFrame(
+            np.column_stack([per_target, total]), index=component_index, columns=[*targets, "total"]
+        )
+
+        recommended = _select_n_components(
+            selection_rule,
+            mean_error=rmsecv.to_numpy(),
+            se_error=se_rmsecv.to_numpy(),
+            q2_cumulative=r2y_validated["total"].to_numpy(),
+        )
+        held_out = pd.concat(gathered[recommended]).groupby(level=0).mean().reindex(y.index)
+
+        return Bunch(
+            n_components=int(recommended),
+            rmsecv=rmsecv,
+            se_rmsecv=se_rmsecv,
+            per_fold_rmsecv=pd.DataFrame(
+                per_fold, index=component_index, columns=[f"fold_{i + 1}" for i in range(len(splits))]
+            ),
+            press=pd.Series(press.sum(axis=1), index=component_index, name="PRESS"),
+            r2y_validated=r2y_validated,
+            cv_predictions=held_out,
+            selection_rule=selection_rule,
+            n_splits=n_splits,
+        )
 
     def predict(self, X: dict[str, pd.DataFrame]) -> Bunch:
         """Forward to :meth:`diagnose`; emits a :class:`DeprecationWarning`.

--- a/src/process_improve/multivariate/_mbpls.py
+++ b/src/process_improve/multivariate/_mbpls.py
@@ -1147,12 +1147,15 @@ class MBPLS(_HotellingsT2LimitMixin, RegressorMixin, BaseEstimator):
         else:
             splitter, repeats, n_splits = cv, 1, cv.get_n_splits(y)
 
+        if max_components is not None and int(max_components) < 1:
+            raise ValueError(f"max_components must be at least 1; got {max_components}.")
+
         splits = list(splitter.split(y))
         smallest_train = min(len(train) for train, _ in splits)
+        # At least one component is always evaluated: a fold too small to support more
+        # still supports one, and reporting nothing would hide that from the caller.
         ceiling = max(1, min(smallest_train - 1, total_width))
         A = ceiling if max_components is None else min(int(max_components), ceiling)
-        if A < 1:
-            raise ValueError("No component count could be evaluated; the folds are too small.")
 
         component_index = pd.Index(range(1, A + 1), name="n_components")
         targets = list(y.columns)

--- a/tests/test_mbpls_cross_validation.py
+++ b/tests/test_mbpls_cross_validation.py
@@ -1,0 +1,132 @@
+"""Cross-validating a multi-block PLS by holding out rows.
+
+The scheme is the same one :meth:`PLS.select_n_components` uses, and it is sound
+here for the same reason: a held-out row's super score comes from its X-blocks
+alone, so its Y never contributes to its own prediction. Having several X-blocks
+does not touch that argument.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.model_selection import KFold
+
+from process_improve.multivariate.methods import MBPLS
+
+
+def _two_block_data(seed: int = 0, n: int = 60, rank: int = 2) -> tuple[dict[str, pd.DataFrame], pd.DataFrame]:
+    """Two X-blocks and a Y block driven by the same `rank` latent variables."""
+    rng = np.random.default_rng(seed)
+    scores = rng.standard_normal((n, rank)) * np.array([5.0, 3.0, 1.5])[:rank]
+    blocks = {
+        "wide": pd.DataFrame(scores @ rng.standard_normal((rank, 8)) + rng.standard_normal((n, 8)) * 0.4),
+        "narrow": pd.DataFrame(scores @ rng.standard_normal((rank, 3)) + rng.standard_normal((n, 3)) * 0.4),
+    }
+    y = pd.DataFrame(scores @ rng.standard_normal((rank, 2)) + rng.standard_normal((n, 2)) * 0.4)
+    return blocks, y
+
+
+def test_returns_the_documented_bunch() -> None:
+    """Every field the docstring promises, with the shapes it promises."""
+    blocks, y = _two_block_data()
+    out = MBPLS.select_n_components(blocks, y, max_components=4, cv=5, n_repeats=2, random_state=0)
+
+    assert list(out.rmsecv.index) == [1, 2, 3, 4]
+    assert out.rmsecv.index.name == "n_components"
+    assert out.se_rmsecv.shape == (4,)
+    assert out.per_fold_rmsecv.shape == (4, 10)  # five folds, twice over
+    assert list(out.r2y_validated.columns) == [*y.columns, "total"]
+    assert out.cv_predictions.shape == y.shape
+    assert out.selection_rule == "1se"
+    assert 1 <= out.n_components <= 4
+
+
+def test_holding_out_rows_costs_something() -> None:
+    """The defining property: a held-out row is predicted worse than a fitted one.
+
+    If the held-out Y were reaching its own prediction, the cross-validated value
+    could match or beat the fit. It must not.
+
+    The baseline is the fitted model's own predictions on the original Y scale,
+    which is what the validated value is built from. It is deliberately not
+    ``r2_y_cumulative_``: that is computed on the scaled Y, where every target
+    carries equal weight, so the two are on different footings and differ by a
+    wide margin on data whose targets have unequal spread.
+    """
+    blocks, y = _two_block_data()
+    out = MBPLS.select_n_components(blocks, y, max_components=3, cv=5, n_repeats=2, random_state=0)
+    values = y.to_numpy(dtype=float)
+    tss = float(((values - values.mean(axis=0)) ** 2).sum())
+
+    for a in (1, 2, 3):
+        fitted = MBPLS(n_components=a).fit(blocks, y)
+        predicted = np.asarray(fitted.diagnose(blocks).predictions, dtype=float)
+        fitted_r2 = 1.0 - float(((values - predicted) ** 2).sum()) / tss
+        validated = float(out.r2y_validated["total"].loc[a])
+        assert validated < fitted_r2, f"{a} components: validated {validated} beat the fit {fitted_r2}"
+        assert validated > 0, "the blocks do carry signal, so the model must beat the mean"
+
+
+def test_finds_the_rank_the_blocks_carry() -> None:
+    """Two latent variables generated the data, and the curve should say so."""
+    blocks, y = _two_block_data(rank=2)
+    out = MBPLS.select_n_components(blocks, y, max_components=5, cv=5, n_repeats=3, random_state=0)
+    gains = np.diff([0.0, *out.r2y_validated["total"].tolist()])
+
+    assert out.n_components <= 3
+    assert gains[0] > 0.3, "the first component carries most of it"
+    assert gains[2] < 0.02, "a third component adds nothing the blocks support"
+
+
+def test_repeatable_and_seed_sensitive() -> None:
+    """The same seed gives the same curve; a different one moves it."""
+    blocks, y = _two_block_data()
+    kwargs = {"max_components": 3, "cv": 5, "n_repeats": 2}
+    first = MBPLS.select_n_components(blocks, y, random_state=0, **kwargs)
+    again = MBPLS.select_n_components(blocks, y, random_state=0, **kwargs)
+    other = MBPLS.select_n_components(blocks, y, random_state=7, **kwargs)
+
+    assert np.allclose(first.rmsecv, again.rmsecv)
+    assert not np.allclose(first.per_fold_rmsecv.to_numpy(), other.per_fold_rmsecv.to_numpy())
+
+
+def test_accepts_a_splitter_and_ignores_n_repeats() -> None:
+    """A pre-built splitter is used as given, as it is for PLS."""
+    blocks, y = _two_block_data()
+    out = MBPLS.select_n_components(blocks, y, max_components=2, cv=KFold(4), n_repeats=9, random_state=0)
+
+    assert out.per_fold_rmsecv.shape == (2, 4), "four folds, not four times nine"
+
+
+def test_component_count_capped_by_the_smallest_fold() -> None:
+    """More components than a training fold can support are not evaluated."""
+    blocks, y = _two_block_data(n=12)
+    out = MBPLS.select_n_components(blocks, y, max_components=50, cv=4, n_repeats=1, random_state=0)
+
+    smallest_train = 12 - 12 // 4
+    assert len(out.rmsecv) <= smallest_train - 1
+
+
+@pytest.mark.parametrize(
+    ("blocks", "error", "message"),
+    [
+        ([], TypeError, r"dict of DataFrames.*got list"),
+        ({}, ValueError, "at least one block"),
+        ({"a": np.zeros((10, 3))}, TypeError, r"'a' must be a pandas DataFrame; got ndarray"),
+    ],
+)
+def test_rejects_malformed_blocks(blocks: object, error: type[Exception], message: str) -> None:
+    """A wrong type raises TypeError and a wrong value ValueError, each naming what arrived."""
+    _, y = _two_block_data(n=10)
+    with pytest.raises(error, match=message):
+        MBPLS.select_n_components(blocks, y, max_components=1, cv=2)
+
+
+def test_rejects_a_block_of_the_wrong_length() -> None:
+    """A block that does not line up with y is named, with both row counts."""
+    blocks, y = _two_block_data(n=20)
+    blocks["narrow"] = blocks["narrow"].iloc[:15]
+    with pytest.raises(ValueError, match=r"'narrow' has 15 rows; y has 20"):
+        MBPLS.select_n_components(blocks, y, max_components=1, cv=2)

--- a/tests/test_mbpls_cross_validation.py
+++ b/tests/test_mbpls_cross_validation.py
@@ -124,6 +124,17 @@ def test_rejects_malformed_blocks(blocks: object, error: type[Exception], messag
         MBPLS.select_n_components(blocks, y, max_components=1, cv=2)
 
 
+def test_rejects_a_component_count_below_one() -> None:
+    """Asking for no components is the caller's mistake, and the message names it.
+
+    The cap is applied afterwards with ``max(1, ...)``, so a fold too small to support
+    more components still supports one. Zero can only come from the argument.
+    """
+    blocks, y = _two_block_data(n=20)
+    with pytest.raises(ValueError, match=r"max_components must be at least 1; got 0"):
+        MBPLS.select_n_components(blocks, y, max_components=0, cv=2)
+
+
 def test_rejects_a_block_of_the_wrong_length() -> None:
     """A block that does not line up with y is named, with both row counts."""
     blocks, y = _two_block_data(n=20)


### PR DESCRIPTION
`MBPLS` had no `select_n_components`, so the component count of a multi-block model could not be chosen the way a single-block one's is. The gap was in the package, not in the method.

Holding out whole rows is sound for a multi-block PLS for the same reason it is sound for `PLS.select_n_components`: a held-out row's super score is computed from its X-blocks alone, and its Y is what the model predicts, so the value being predicted never enters its own prediction. That is the objection that forces a PCA to hold out cells instead, and having several X-blocks rather than one does not touch it.

## What it does

```python
out = MBPLS.select_n_components({"chem": Zchem, "op": Zop}, Y, max_components=2, cv=7)
out.r2y_validated["total"]   # the validated R2Y per component count
out.n_components             # the recommended count, by the 1-SE rule
```

Returns a `Bunch` of `n_components`, `rmsecv`, `se_rmsecv`, `per_fold_rmsecv`, `press`, `r2y_validated`, `cv_predictions` and `selection_rule`. Each block is centred and scaled inside `fit`, on the training rows only, so the fold statistics never see the held-out rows.

## Two choices that make it comparable with the single-block method

This is the point of having it, so both follow `PLS.select_n_components` exactly:

- **PRESS and the reference are both on the original Y scale.** PLS un-scales its predictions before differencing and takes TSS from the raw Y; so does this. That is what lets a multi-block row and a single-block row be read in the same column.
- **The reference is weighted by per-row coverage**, by how often each row is actually held out, rather than by a flat repeat count. A splitter that tests some rows more than others, or not at all, is then handled exactly.

## Cost

One model is fitted per fold **and** per component count: `cv * n_repeats * max_components` fits. Hierarchical NIPALS deflation means an `a`-component model cannot be recovered from an `A`-component one, so there is no truncation shortcut. The docstring states the cost.

## A trap worth knowing about

A fitted model's `r2_y_cumulative_` is computed on the **scaled** Y, where every target carries equal weight. The returned `r2y_validated` is on the **raw** Y. On targets of unequal spread the two diverge widely: 0.55 against 0.86 at one component on the synthetic block in the tests. They are not comparable with each other, and the changelog says so.

This surfaced as a failing test. `test_holding_out_rows_costs_something` asserts the invariant that matters, that a held-out row is predicted worse than a fitted one, and it originally compared against `r2_y_cumulative_` and failed. The baseline is now the fitted model's own predictions, computed the same way the validated value is, and the test documents why.

## Verification

- **Ten new tests** in `tests/test_mbpls_cross_validation.py`: the documented Bunch and its shapes; the held-out-costs-something invariant at every component count; recovering the rank the blocks carry; repeatability under a seed and sensitivity to a different one; a pre-built splitter being used as given; the component count capped by the smallest training fold; and the input guards, `TypeError` for a wrong type and `ValueError` for a wrong value, each naming what arrived. Slowest is 1.71 s, under the `slow` threshold, so no tier marker.
- `ruff check .`, `ruff format --check .` and `mypy src/process_improve` all clean.
- Full suite: **3243 passed, 3 skipped**. Two dataset tests in `tests/batch/test_sbr_reference.py` erred on a truncated download from openmv.net and pass on re-run (3 passed, 103 s); neither touches this code.
- `CHANGELOG.md`, `pyproject.toml` and `CITATION.cff` at **1.85.0**, dated 2026-09-11, a MINOR bump for a new feature.
- `docs/api/multivariate.rst` lists the new method.
- No lock file staged.

## Context

The FMC quality comparison in the book has empty cross-validated cells on its multi-block rows, and the caption said the package cross-validates a single-block PLS and not a multi-block one, which reads as a property of the method. On those blocks this method gives a validated R2Y of 14.3% and 12.7% over two components and recommends one, against 14.8% and 11.1% for the operating-conditions block alone: joining the two initial-condition blocks buys almost nothing in prediction, though the fit rises from 26.2% to 36.4%.

The book cannot call this until it reaches PyPI, since its blocking CI job runs against the release. kgdunn/pid-book#273 carries the corrected caption in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXthGpHLQFfGubBiKFtGAE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXthGpHLQFfGubBiKFtGAE)_