### PR TITLE
docs: fix docstring/implementation inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ those changes.
 
 ## [Unreleased]
 
+## [1.84.1] - 2026-09-11
+
+### Fixed
+
+- **Docstring corrections across the package** to bring the documented
+  behaviour into line with what the code actually does. No compute behaviour
+  changed; only docstrings were updated.
+
+  - `multivariate/_preprocessing.center()`: the default `func=np.mean`
+    propagates NaN rather than skipping missing data; the docstring now says
+    so and points at `np.nanmean` for the skip-missing behaviour.
+  - `multivariate/_preprocessing.scale()`: same clarification for the default
+    `func=np.std` versus `np.nanstd`.
+  - `sensory/mam.align_scores()`: clarify that the location-only fallback
+    applies to `method="both"`; under `method="scale"` a panelist with an
+    unusable slope is left as-is.
+  - `experiments/augment._augment_replicate`: replace "one or more" with
+    "zero or more (default 1 when `n_additional_runs` is None)".
+  - `multivariate/_diagnostics.observation_contributions()`: note that
+    columns sum to 1 except when the component has zero score variance,
+    in which case the column is all zeros.
+  - `experiments/augment.augment_design()`: clarify that for `replicate`,
+    `n_additional_runs` is the number of complete-design copies added.
+  - `experiments/analysis.analyze_experiment()`: state that only the first
+    response column is analysed when a multi-column DataFrame is passed.
+  - `monitoring/control_charts.psi()`: replace "Huber y-function" with the
+    correct "Huber psi function".
+  - `univariate/metrics.detect_outliers_esd()`: note that the `"cc-robust"`
+    method is not implemented and currently returns empty results.
+  - `monitoring/control_charts.ControlChart.__init__`: document that only
+    `variant="hw"` and `variant="xbar.no.subgroup"` are currently accepted;
+    `variant="cusum"` raises `ValueError`.
+
 ## [1.84.0] - 2026-09-10
 
 ### Added
@@ -4412,7 +4445,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.84.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.84.1...HEAD
+[1.84.1]: https://github.com/kgdunn/process-improve/compare/v1.84.0...v1.84.1
 [1.84.0]: https://github.com/kgdunn/process-improve/compare/v1.83.2...v1.84.0
 [1.83.2]: https://github.com/kgdunn/process-improve/compare/v1.83.1...v1.83.2
 [1.83.1]: https://github.com/kgdunn/process-improve/compare/v1.83.0...v1.83.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.84.0
-date-released: "2026-09-10"
+version: 1.84.1
+date-released: "2026-09-11"
 keywords:
   - chemometrics
   - multivariate analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.84.0"
+version = "1.84.1"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/src/process_improve/experiments/analysis.py
+++ b/src/process_improve/experiments/analysis.py
@@ -165,7 +165,11 @@ def analyze_experiment(  # noqa: PLR0912, PLR0913, PLR0915, C901
         Factor settings per run.  May also contain the response column(s).
     responses : DataFrame, Series, or None
         Response column(s).  If *None*, ``response_column`` must name a
-        column already present in *design_matrix*.
+        column already present in *design_matrix*. When a DataFrame with
+        more than one column is passed, only the first column is analysed;
+        the rest are added to the working frame but ignored by every
+        subsequent step. Use ``response_column`` to pick a specific column
+        explicitly.
     model : str or None
         ``"main_effects"``, ``"interactions"``, ``"quadratic"``, an explicit
         formula, or *None* (defaults to ``"interactions"``).

--- a/src/process_improve/experiments/augment.py
+++ b/src/process_improve/experiments/augment.py
@@ -326,7 +326,12 @@ def _augment_add_center_points(ctx: _AugmentContext) -> dict[str, Any]:
 
 
 def _augment_replicate(ctx: _AugmentContext) -> dict[str, Any]:
-    """Append one or more complete copies of the existing design."""
+    """Append zero or more complete copies of the existing design.
+
+    The number of copies is ``ctx.n_additional_runs`` (default 1 when
+    ``ctx.n_additional_runs`` is ``None``); passing 0 leaves the design
+    unchanged.
+    """
     df = ctx.existing_design[ctx.factor_names].copy()
     n_copies = ctx.n_additional_runs if ctx.n_additional_runs is not None else 1
 
@@ -722,7 +727,10 @@ def augment_design(  # noqa: PLR0913
     n_additional_runs : int or None
         Budget for additional runs.  Interpretation depends on the
         augmentation type (number of center points, number of D-optimal
-        runs, number of replicates, or number of blocks).
+        runs, number of blocks, ...). For ``"replicate"``, this is the
+        number of complete copies of the existing design that are appended
+        (each copy adds ``len(existing_design)`` runs); the default of
+        ``None`` becomes 1 complete copy.
     fold_on : str or None
         For ``"semifold"`` only: which factor to fold on.  If ``None``,
         the best factor is auto-selected.

--- a/src/process_improve/monitoring/control_charts.py
+++ b/src/process_improve/monitoring/control_charts.py
@@ -42,7 +42,7 @@ def rho(x: float, k: float = 2.52) -> float:
 
 def psi(x: float, k: float = 2.0) -> float:
     """
-    Pre-clean based on the Huber y-function.
+    Pre-clean based on the Huber psi function.
 
     Can be interpreted as replacing unexpected high or low values by a more likely value.
     From p 288 of the paper
@@ -63,24 +63,28 @@ class ControlChart:
             Other choice is 'regular' (i.e. not-robust) calculations. User should then ensure that
             no outliers are present in the data.
 
-            variant (str, optional): Many variants of control charts are available. The variant
-                string is compared case-insensitively (it is normalised via ``.strip().lower()``
-                on assignment), so ``'HW'``, ``'hw'``, and ``'Hw'`` are all equivalent.
+            variant (str, optional): Only two variants are currently accepted:
+                ``'hw'`` (the default) and ``'xbar.no.subgroup'``. Any other value,
+                including ``'cusum'``, raises ``ValueError`` at construction time.
+                The variant string is compared case-insensitively (it is normalised
+                via ``.strip().lower()`` on assignment), so ``'HW'``, ``'hw'``, and
+                ``'Hw'`` are all equivalent.
 
                 The default is a Holt-Winters (`'hw'`) chart, with automatic determination of
                 control chart parameters. This chart is a blend of infinite history (CUSUM)
                 charts, and an instantaneous (no history taken into account) Shewhart chart. The
                 exact blend is specified by parameters `ld_1` (lambda 1) and `ld_2` (lambda 2).
 
-                Other variants are:
+                The other accepted variant is:
 
                 'xbar.no.subgroup' [Shewhart chart, with no subgroups]. In other words, each
                 observation is independently plotted on the control chart.
 
                 A pure 'cusum' (CUmulative SUM) chart is a planned future variant but
-                is not currently implemented; the Holt-Winters ('hw') default already
-                blends CUSUM-style infinite history with Shewhart-style
-                instantaneous behaviour via its lambda parameters.
+                is not currently implemented; passing ``variant='cusum'`` raises
+                ``ValueError``. The Holt-Winters ('hw') default already blends
+                CUSUM-style infinite history with Shewhart-style instantaneous
+                behaviour via its lambda parameters.
         """
         self.style = style.strip()
         self.variant = variant.strip().lower()

--- a/src/process_improve/multivariate/_diagnostics.py
+++ b/src/process_improve/multivariate/_diagnostics.py
@@ -457,7 +457,10 @@ def observation_contributions(model: BaseEstimator, n_components: int | None = N
 
     Values lie between 0 and 1 and each column sums to 1, so a contribution
     well above the average :math:`1/N` flags an observation that strongly
-    shapes that component.
+    shapes that component. The exception is a component whose score column
+    has zero variance (``sum(t_{ia}^2) = 0``): the division cannot be
+    computed, so the column is returned as zeros rather than NaN, and its
+    sum is 0 rather than 1.
 
     Note that this is *not* the same diagnostic as the ``score_contributions``
     method, despite the similar name. ``score_contributions`` is *per-variable*
@@ -480,7 +483,8 @@ def observation_contributions(model: BaseEstimator, n_components: int | None = N
     -------
     pd.DataFrame
         Contributions of shape (n_samples, n_components), indexed by sample.
-        Each column sums to 1.
+        Each column sums to 1 except columns for components whose score has
+        zero variance, which are returned as zeros and sum to 0.
 
     Raises
     ------

--- a/src/process_improve/multivariate/_preprocessing.py
+++ b/src/process_improve/multivariate/_preprocessing.py
@@ -173,9 +173,11 @@ def center(
     This specifies the axis along which the centering vector will be calculated if not provided.
     The function is applied along the `axis`: 0=down the columns; 1 = across the rows.
 
-    *Missing values*: The sample mean is computed by taking the sum along the `axis`, skipping
-    any missing data, and dividing by N = number of values which are present. Values which were
-    missing before, are left as missing after.
+    *Missing values*: with the default ``func=np.mean``, any NaN along the reduction axis
+    propagates into the centring vector, so an entire row or column of the returned data can end
+    up NaN. To skip missing entries instead (summing along the `axis`, dividing by the number of
+    values that are present, and leaving pre-existing NaNs as NaNs in the output), pass
+    ``func=np.nanmean``.
 
     Returns
     -------

--- a/src/process_improve/multivariate/_preprocessing.py
+++ b/src/process_improve/multivariate/_preprocessing.py
@@ -241,9 +241,11 @@ def scale(
 
 
     `func` [optional; default=np.std] {a function}
-        The default (np.std) uses NumPy to calculate the standard deviation of
-        the data along the required `axis`, skipping over any missing data, and
-        uses that as `scale`.
+        The default (``np.std``) uses NumPy to calculate the standard deviation
+        of the data along the required `axis` and uses that as `scale`. Any
+        NaN along the reduction axis propagates into the resulting scale
+        vector, so an entire row or column of the returned data can end up
+        NaN. Pass ``func=np.nanstd`` to skip missing entries instead.
 
     `axis` [optional; default=0] {integer}
         Transformations are applied on slices of data.  This specifies the

--- a/src/process_improve/sensory/mam.py
+++ b/src/process_improve/sensory/mam.py
@@ -204,9 +204,16 @@ def align_scores(panel: pd.DataFrame, *, method: AlignMethod = "both", robust: b
     mean offset (so "rates everything high/low" goes away) and the scale lever
     divides by the panelist's scaling coefficient ``beta`` (so a compressor's
     narrow range is stretched toward the panel's). This rescales the whole panel
-    (standard MAM practice), keeping panelists rather than dropping them; a
-    panelist who is flat or anti-correlated with the panel (``beta`` not usable)
-    is left location-corrected only.
+    (standard MAM practice), keeping panelists rather than dropping them.
+
+    When a panelist is flat or anti-correlated with the panel (``beta`` is not
+    finite or below ``_MIN_SLOPE``), the scale lever is skipped for that
+    panelist and the fallback depends on ``method``:
+
+    - ``"both"``: the panelist is left location-corrected only.
+    - ``"scale"``: the panelist is left as-is (no correction applied).
+    - ``"location"``: the slope is not consulted, so the location correction
+      is always applied.
 
     Parameters
     ----------

--- a/src/process_improve/univariate/metrics.py
+++ b/src/process_improve/univariate/metrics.py
@@ -986,7 +986,10 @@ def detect_outliers_esd(
             'cc-robust': Build a robust control-chart for the sequence `x` and
             points should lie outside the +/- 3 sigma limits are considered
             outliers.
-            Not Implemented Yet: left here as an idea for the future, but not confirmed yet.
+            Not Implemented Yet: left here as an idea for the future, but not
+            confirmed yet. Passing ``algorithm='cc-robust'`` (or any other value
+            besides ``'esd'``) silently returns an empty outlier list and an
+            empty details dict; it does not raise.
 
         max_outliers_detected -- The maximum number of outliers that
             should be detected, as required by the algorithms.


### PR DESCRIPTION
## Plan

Docstring-only pass across the package to bring documented behaviour into line with what the code actually does. **No compute behaviour changes** in this PR; every micro-commit updates docstrings (and once, the CHANGELOG / CITATION / version bump).

### Fixes to land

- `src/process_improve/multivariate/_preprocessing.py` `center()`: the default `func=np.mean` propagates NaN, it does not skip missing data. Docstring now says so and points at `np.nanmean` for the skip-missing behaviour.
- `src/process_improve/multivariate/_preprocessing.py` `scale()`: same clarification for the default `func=np.std` vs `np.nanstd`.
- `src/process_improve/sensory/mam.py` `align_scores()`: clarify the location-only fallback applies to `method="both"`; under `method="scale"` a panelist with an unusable slope is left as-is.
- `src/process_improve/experiments/augment.py` `_augment_replicate`: replace "one or more" with "zero or more (default 1 when `n_additional_runs` is None)".
- `src/process_improve/multivariate/_diagnostics.py` `observation_contributions()`: note that columns sum to 1 except when the component has zero score variance (then the column is all zeros).
- `src/process_improve/experiments/augment.py` `augment_design()`: for `replicate`, clarify that `n_additional_runs` is the number of complete-design copies added.
- `src/process_improve/experiments/analysis.py` `analyze_experiment()`: state that only the first response column is analysed when a multi-column DataFrame is passed.
- `src/process_improve/monitoring/control_charts.py` `psi()`: replace "Huber y-function" with "Huber psi function".
- `src/process_improve/univariate/metrics.py` `detect_outliers_esd()`: state that `"cc-robust"` is not implemented (returns empty results).
- `src/process_improve/monitoring/control_charts.py` `ControlChart.__init__`: docstring for `variant` should note that only `'hw'` and `'xbar.no.subgroup'` are currently accepted; `'cusum'` raises `ValueError`.

### Version

Originally `1.84.1`. Main moved to `1.85.0` (#555) while this branch was open, so `1.84.1` is a patch on a version that is no longer the tip. A docstring-only change is still a patch, so this is now **`1.85.1`**, in `pyproject.toml` and `CITATION.cff` (`date-released: 2026-09-11`), with a `## [1.85.1]` section in `CHANGELOG.md` above the `1.85.0` one and a matching compare link in the footer.

### Merge resolution

Main was merged into this branch to clear the conflict. Only the three version-metadata files conflicted; the docstring changes merged untouched. After the merge:

- `ruff check .`, `ruff format --check .` and `mypy src/process_improve` all clean.
- `pytest -m "not slow and not dataset"`: 3051 passed, 3 skipped (the three pre-existing skips).
- Two of the documented claims were checked against the code rather than taken on trust: `ControlChart(variant="cusum")` does raise `ValueError`, and `detect_outliers_esd(x, algorithm="cc-robust")` does return `([], {})` without raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135RHzyoZPWfBSpa2Lukkry

---
_Generated by [Claude Code](https://claude.ai/code/session_0135RHzyoZPWfBSpa2Lukkry)_