### PR TITLE
Close out #198, #197 and #199

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,64 @@ those changes.
 
 ## [Unreleased]
 
+## [1.90.0] - 2026-09-12
+
+### Added
+
+- **`f_rupture` detects change points**, the last unimplemented feature function. It has
+  never had a working body: before 1.85.x it returned `None` for a valid call, and since
+  then it raised `NotImplementedError`. Detection uses PELT from `ruptures`, which is
+  exact, linear in the signal length, and does not need to be told how many change points
+  to look for.
+
+  ```python
+  breaks = f_rupture(data, tags=["DryerTemp"], batch_col="batch_id")
+  counts = breaks.map(len)          # a numeric feature for a model matrix
+  ```
+
+  One `<tag>_rupture` column per tag, each cell a tuple of positions. Unlike the other
+  feature functions the cells are not numeric, because the number of change points varies
+  from batch to batch. The trailing sentinel `ruptures` appends (the signal length, which
+  is not a change point) is stripped, and a signal too short to split or carrying missing
+  data gives an empty tuple rather than raising.
+
+  The default penalty is `log(n)`, the BIC-style choice, not a fixed number: the `rbf`
+  cost is bounded, so the 100.0 of the original sketch is unreachable on a 100-sample
+  signal and finds nothing at all. Measured on a single five-sigma step, `log(n)` recovers
+  the change point exactly at 60, 200 and 1000 samples under both `rbf` and `l2`, and on
+  pure noise reports at most one spurious point. The default model is `rbf` because its
+  cost is scale-free: multiplying a signal by 1000 leaves the result unchanged, where `l2`
+  at the same penalty turned one true change point into 37 spurious ones. (#198)
+
+- **`determine_scaling` accepts `settings["robust_range"]`**, either `"q98-q02"` (the
+  default, unchanged) or `"iqr"`. This answers the question the TODO there posed, whether
+  `f_iqr` would serve as the robust range. It works, but it is not interchangeable: the
+  IQR spans the middle half of a batch against nearly all of it, and because a batch
+  trajectory is not Gaussian the ratio varies by tag, from 1.02 to 4.23 on the dryer data
+  and 1.21 to 2.95 on nylon. Switching re-weights the tags against each other rather than
+  rescaling them together, so it is offered rather than substituted. (#198)
+
+### Changed
+
+- **`ruptures` joins the optional `batch` extra**, for `f_rupture`. The module still
+  imports without it; calling `f_rupture` then raises an `ImportError` naming the extra.
+  (#198)
+
+- **`f_rupture`'s first keyword is now `tags`, not `columns`**, matching every other
+  feature function in the module. The function never returned a value, so no working
+  caller can be affected. (#198)
+
+### Fixed
+
+- **`determine_scaling` no longer silently substitutes 1.0 for a zero range.** A tag that
+  holds one value across a batch got `1.0` as its range and was left unscaled, with
+  nothing said, which `docs/development/error_handling.rst` names as a `warnings.warn`
+  case. One aggregated `UserWarning` per call now names each affected tag and how many
+  batches it affected. On the dryer data with the default `columns_to_align` this reports
+  `batch_id` in 71 of 71 batches, which is worth knowing on its own: the identifier column
+  is swept in as a tag whenever the columns are left unspecified. (#198)
+
+
 ## [1.89.0] - 2026-09-12
 
 ### Added
@@ -4875,7 +4933,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.89.0...HEAD
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.90.0...HEAD
+[1.90.0]: https://github.com/kgdunn/process-improve/compare/v1.89.0...v1.90.0
 [1.89.0]: https://github.com/kgdunn/process-improve/compare/v1.88.0...v1.89.0
 [1.88.0]: https://github.com/kgdunn/process-improve/compare/v1.87.1...v1.88.0
 [1.87.1]: https://github.com/kgdunn/process-improve/compare/v1.87.0...v1.87.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,39 @@ those changes.
 
 ## [Unreleased]
 
-## [1.91.0] - 2026-09-12
+## [1.92.0] - 2026-09-12
 
 ### Added
+
+- **`BatchScaler` wraps the scaling trio as a fit / transform estimator.**
+  `determine_scaling`, `apply_scaling` and `reverse_scaling` remain public and unchanged;
+  this carries the fitted scaling as one object that composes with
+  `sklearn.pipeline.Pipeline` and survives `clone`, the way `MCUVScaler` already does.
+
+  ```python
+  scaler = BatchScaler(columns_to_align=["Temperature"])
+  scaled = scaler.fit_transform(batches)
+  original = scaler.inverse_transform(scaled)
+  ```
+
+  It also accepts the melted-DataFrame input the functions reject: pass
+  `BatchScaler(batch_col="batch_id")` and it splits the frame itself. (#199)
+
+- **`batch_dtw` accepts `settings["batch_weighting"]`**, either `"equal"` (the default,
+  unchanged) or `"huber"`. Under equal weighting one badly aligned batch inflates the
+  summed deviation of whichever variables it misfits and depresses their weights for every
+  other batch. Huber weights each batch by the robust z-score of its `normalized_distance`
+  against the median and MAD of the batch set: weight 1 inside a cutoff of 1.345, falling
+  off as `1 / |z|` beyond it, rescaled to average 1.0.
+
+  Huber rather than a redescending function because it never reaches zero: a downweighted
+  batch pulls the average away from itself and so looks worse next iteration, and a weight
+  that could reach zero would make that a one-way door. Weights are recomputed each
+  iteration and floored, so a batch that recovers is counted again.
+
+  On the dryer data it leaves 53 of 71 batches at full weight and downweights batches 23,
+  48 and 34 hardest, which are exactly the three the `distances` output reports as worst.
+  (#199)
 
 - **`f_rupture` detects change points**, the last unimplemented feature function. It has
   never had a working body: before 1.85.x it returned `None` for a valid call, and since
@@ -4957,8 +4987,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.91.0...HEAD
-[1.91.0]: https://github.com/kgdunn/process-improve/compare/v1.89.0...v1.91.0
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.92.0...HEAD
+[1.92.0]: https://github.com/kgdunn/process-improve/compare/v1.89.0...v1.92.0
 [1.89.0]: https://github.com/kgdunn/process-improve/compare/v1.88.0...v1.89.0
 [1.88.0]: https://github.com/kgdunn/process-improve/compare/v1.87.1...v1.88.0
 [1.87.1]: https://github.com/kgdunn/process-improve/compare/v1.87.0...v1.87.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ those changes.
 
 ## [Unreleased]
 
-## [1.90.0] - 2026-09-12
+## [1.91.0] - 2026-09-12
 
 ### Added
 
@@ -60,6 +60,31 @@ those changes.
 
 ### Fixed
 
+- **Batch identifiers may be of any type**, including strings. `melted_to_dict` never
+  coerced its keys, but two functions downstream assumed every column was numeric, so a
+  string identifier raised `TypeError: Cannot convert [...] to numeric` in
+  `determine_scaling` and then `TypeError: unsupported operand type(s) for /: 'str' and
+  'int'` in `align_with_path`. Two causes, both fixed:
+
+  `determine_scaling` took its per-batch minimum over every column rather than over
+  `columns_to_align`. With integer identifiers this did not raise, but it still returned
+  rows for columns that were never scaled, each carrying a real `Minimum` against a NaN
+  `Range`. `align_with_path` averaged whole rows, so a compression in the warping path
+  averaged the identifier too; with integer identifiers it wrote that mean into the
+  aligned frame, and pandas had already begun warning that assigning a string into the
+  float frame would become an error. Non-numeric columns are now carried through
+  unaveraged, keeping their own dtype. The integer path is unchanged, verified
+  bit-identical in weights, average batch and aligned values. (#197)
+
+- **The resampled percentage axis accepts any resolution.** The target axis came from
+  `np.arange(0, maximum, delta)` while the source axis was rebuilt as `maximum - delta`;
+  those agree only when the delta divides the maximum exactly, so
+  `interpolate_time_axis_delta` of 0.3 or 7 failed a bare `assert`. Under `python -O`,
+  which strips asserts, it extrapolated silently instead. The source axis now takes its
+  endpoints from the target axis, so any delta works. An axis that cannot be built (a
+  non-positive value, or a delta no smaller than the maximum) is rejected up front with a
+  message naming both values. (#197)
+
 - **`determine_scaling` no longer silently substitutes 1.0 for a zero range.** A tag that
   holds one value across a batch got `1.0` as its range and was left unscaled, with
   nothing said, which `docs/development/error_handling.rst` names as a `warnings.warn`
@@ -67,7 +92,6 @@ those changes.
   batches it affected. On the dryer data with the default `columns_to_align` this reports
   `batch_id` in 71 of 71 batches, which is worth knowing on its own: the identifier column
   is swept in as a tag whenever the columns are left unspecified. (#198)
-
 
 ## [1.89.0] - 2026-09-12
 
@@ -4933,8 +4957,8 @@ this entry records them together.
 - Reworked the README with a sharper value proposition and a
   "Why not scikit-learn?" comparison table.
 
-[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.90.0...HEAD
-[1.90.0]: https://github.com/kgdunn/process-improve/compare/v1.89.0...v1.90.0
+[Unreleased]: https://github.com/kgdunn/process-improve/compare/v1.91.0...HEAD
+[1.91.0]: https://github.com/kgdunn/process-improve/compare/v1.89.0...v1.91.0
 [1.89.0]: https://github.com/kgdunn/process-improve/compare/v1.88.0...v1.89.0
 [1.88.0]: https://github.com/kgdunn/process-improve/compare/v1.87.1...v1.88.0
 [1.87.1]: https://github.com/kgdunn/process-improve/compare/v1.87.0...v1.87.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.91.0
+version: 1.92.0
 date-released: "2026-09-12"
 keywords:
   - chemometrics

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.90.0
+version: 1.91.0
 date-released: "2026-09-12"
 keywords:
   - chemometrics

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
 repository-code: "https://github.com/kgdunn/process-improve"
 url: "https://kgdunn.github.io/process-improve/"
 license: MIT
-version: 1.89.0
+version: 1.90.0
 date-released: "2026-09-12"
 keywords:
   - chemometrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.90.0"
+version = "1.91.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.89.0"
+version = "1.90.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "process-improve"
-version = "1.91.0"
+version = "1.92.0"
 description = 'Designed Experiments; Latent Variables (PCA, PLS, multivariate methods with missing data); Process Monitoring; Batch data analysis.'
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,11 @@ expt = [
 ]
 
 # Batch process data analysis: image-IO + Excel readers used by the
-# batch alignment / fixture loaders.
+# batch alignment / fixture loaders, plus change-point detection for
+# ``features.f_rupture``.
 batch = [
     "openpyxl>=3.1.5",
+    "ruptures>=1.1.9",
     "scikit-image>=0.25.2",
 ]
 

--- a/src/process_improve/_extras.py
+++ b/src/process_improve/_extras.py
@@ -6,7 +6,7 @@ optional dependencies behind extras::
 
     pip install 'process-improve[plotting]'    # matplotlib + plotly + seaborn + ridgeplot
     pip install 'process-improve[expt]'        # pyDOE3 (DOE / experiments helpers)
-    pip install 'process-improve[batch]'       # scikit-image + openpyxl
+    pip install 'process-improve[batch]'       # scikit-image + openpyxl + ruptures
     pip install 'process-improve[mcp]'         # mcp
     pip install 'process-improve[fast]'        # numba (JIT)
     pip install 'process-improve[ilp]'         # pulp (OMARS design generator)

--- a/src/process_improve/batch/__init__.py
+++ b/src/process_improve/batch/__init__.py
@@ -48,6 +48,7 @@ from process_improve.batch.features import (
     f_sum,
 )
 from process_improve.batch.preprocessing import (
+    BatchScaler,
     batch_dtw,
     determine_scaling,
     find_reference_batch,
@@ -59,6 +60,7 @@ __all__ = [
     "BatchMonitor",
     "BatchPCA",
     "BatchPLS",
+    "BatchScaler",
     "MidCourseCorrector",
     # Preprocessing/alignment
     "batch_dtw",

--- a/src/process_improve/batch/features.py
+++ b/src/process_improve/batch/features.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, NoReturn
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -9,6 +9,13 @@ from scipy.stats import iqr, median_abs_deviation
 
 if TYPE_CHECKING:
     from pandas.core.groupby import DataFrameGroupBy
+
+try:
+    import ruptures as rpt
+except ImportError:  # pragma: no cover - exercised via env-without-ruptures
+    from .._extras import _MissingExtra
+
+    rpt = _MissingExtra("ruptures", "batch")  # type: ignore[assignment]
 
 from ..bivariate.methods import find_elbow_point
 from ..regression.methods import repeated_median_slope
@@ -336,39 +343,144 @@ def f_area(
 # ------------------------------------------
 def f_rupture(
     data: pd.DataFrame,
-    columns: list[str] | None = None,
+    tags: list[str] | None = None,
     batch_col: str | None = None,
     phase_col: str | None = None,
-) -> NoReturn:
+    settings: dict | None = None,
+) -> pd.DataFrame:
     """
-    Feature:    rupture. Not implemented; always raises.
+    Feature:    rupture.
 
-    The intended feature is the breakpoint in a given tag in ``columns``
-    (usually it is 1 tag), for each unique batch in the ``batch_col``
-    indicator column, and within each unique phase, per batch, of the
+    The change points (breakpoints) of each tag in ``tags``, for each unique batch in the
+    ``batch_col`` indicator column, and within each unique phase, per batch, of the
     ``phase_col`` column.
 
-    This function has never had a working body. It previously raised
-    ``NotImplementedError`` only when given the wrong number of columns, and
-    returned ``None`` for a valid single-column call, which a caller cannot
-    distinguish from a successful empty result. It now raises in every case,
-    so the unimplemented state is visible at the call site.
+    A change point is a position where the statistical behaviour of the trajectory
+    shifts: the mean steps, the variance opens up, or the correlation structure changes.
+    In a batch context these usually mark the transitions between operating stages
+    (heat-up finishing, a feed starting, an agitator changing speed), which is why they
+    are worth extracting even when no phase column is recorded.
 
-    Implementation, including the change-point detection approach and the
-    ``ruptures`` dependency it needs, is tracked on
-    https://github.com/kgdunn/process-improve/issues/198.
+    Detection is done by the ``ruptures`` package, using PELT (Pruned Exact Linear Time),
+    an exact search whose cost is linear in the length of the signal. PELT does not need
+    to be told how many change points to look for; the ``penalty`` decides that instead.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        Batch data in the long (melted) format the other feature functions take.
+    tags : list[str], optional
+        Which tags to search. Defaults to every non-grouping column.
+    batch_col, phase_col : str, optional
+        The batch and phase indicator columns, as elsewhere in this module.
+    settings : dict, optional
+        Detector options::
+
+            {
+                "model": "rbf",     # cost function; see below
+                "penalty": None,    # cost of one more change point; None means log(n)
+                "min_size": 2,      # smallest number of samples in a segment
+                "jump": 5,          # only consider change points at multiples of this
+            }
+
+        ``model`` is the cost function ``ruptures`` minimises: ``"rbf"`` (the default)
+        detects any change in distribution through a kernel, ``"l2"`` detects a change in
+        the mean, ``"l1"`` is its outlier-resistant counterpart, and ``"normal"`` detects
+        a change in mean or variance.
+
+        The default is ``"rbf"`` because its kernel cost is bounded, which makes it
+        insensitive to the tag's units: multiplying a signal by 1000 leaves the detected
+        change points unchanged. ``"l2"`` is not, and on the same rescaled signal the same
+        penalty turned one true change point into 37 spurious ones. Scale the tag, or
+        scale the penalty with its variance, before choosing ``"l2"``.
+
+        ``penalty`` decides how many change points come back: larger values return fewer.
+        ``None`` (the default) uses ``log(n)`` for a signal of ``n`` samples, the
+        BIC-style choice, which adapts to the length of the batch. Measured on a single
+        step of five standard deviations, it recovers the change point exactly at 60, 200
+        and 1000 samples under both ``"rbf"`` and ``"l2"``, and on pure noise of those
+        lengths it reports at most one spurious change point.
+
+        ``jump`` trades resolution for speed; pass 1 to consider every sample.
+
+    Returns
+    -------
+    pd.DataFrame
+        Indexed like the other feature functions, with one ``<tag>_rupture`` column per
+        tag. **Unlike them, the cells are not numeric**: each holds a tuple of integer
+        positions into that batch's rows, which is the only faithful shape for a result
+        whose length varies from batch to batch. Position ``i`` means the change occurs
+        between row ``i - 1`` and row ``i``.
+
+        The trailing sentinel ``ruptures`` appends (the length of the signal, which is
+        not a change point) is removed, so an empty tuple means no change was detected.
+
+        For a numeric feature to put in a model matrix, take the count::
+
+            breaks = f_rupture(data, tags=["Temperature"], batch_col="batch_id")
+            counts = breaks.map(len)
 
     Raises
     ------
-    NotImplementedError
-        Always.
+    ImportError
+        If ``ruptures`` is not installed. It is part of the optional ``batch`` extra.
+    ValueError
+        If ``settings`` carries a key this function does not recognize.
+
+    Notes
+    -----
+    This function returns the change points rather than drawing them. ``ruptures`` has a
+    ``display`` helper that uses matplotlib; plotting belongs to the caller, and the rest
+    of this project plots with plotly.
+
+    See also: f_elbow, f_cross
     """
-    raise NotImplementedError(
-        "f_rupture is not implemented: it has no working body, and previously returned None for a "
-        "valid single-column call. Change-point detection for batch data is tracked on "
-        "https://github.com/kgdunn/process-improve/issues/198. To extract breakpoints today, run a "
-        "change-point library such as `ruptures` directly on the per-batch signal."
-    )
+    default_settings: dict = {"model": "rbf", "penalty": None, "min_size": 2, "jump": 5}
+    if settings:
+        unknown = set(settings) - set(default_settings)
+        if unknown:
+            raise ValueError(
+                f"f_rupture got unrecognized settings {sorted(unknown)}; expected any of {sorted(default_settings)}."
+            )
+        default_settings.update(settings)
+
+    settings = default_settings
+    base_name = "rupture"
+    prepared, tags, output, _ = _prepare_data(data, tags, batch_col, phase_col)
+    f_names = [(tag + "_" + base_name) for tag in tags]
+
+    # Build the output frame the way f_area does, so it carries the (batch, phase)
+    # MultiIndex that `prepared` iterates over. Object dtype, because every cell holds a
+    # tuple and the tuples differ in length.
+    output = (prepared.sum() * 0.0).astype(object)
+    for batch_id, this_batch in prepared:
+        for tag in tags:
+            output.loc[batch_id, tag] = _change_points(np.asarray(this_batch[tag].to_numpy(), dtype=float), settings)
+
+    return output.rename(columns=dict(zip(tags, f_names, strict=False)))
+
+
+def _change_points(signal: np.ndarray, settings: dict) -> tuple[int, ...]:
+    """
+    Run PELT on one signal and return its change points, without the trailing sentinel.
+
+    ``ruptures`` always ends its result with the length of the signal, which marks the
+    end of the last segment rather than a change, and it raises rather than returning
+    nothing when the signal is too short to hold two segments. Both are normalised here
+    to an empty tuple, so a caller can compare batches without special cases.
+
+    A ``penalty`` of ``None`` becomes ``log(n)``, which is why it is resolved per signal
+    rather than once for the whole frame: batches differ in length.
+    """
+    min_size = int(settings["min_size"])
+    if signal.size < 2 * min_size or not np.all(np.isfinite(signal)):
+        # Too short to split, or carrying missing data that the cost function cannot use.
+        return ()
+
+    penalty = float(np.log(signal.size)) if settings["penalty"] is None else float(settings["penalty"])
+    algorithm = rpt.Pelt(model=settings["model"], min_size=min_size, jump=int(settings["jump"])).fit(signal)
+    breakpoints = algorithm.predict(pen=penalty)
+    return tuple(int(position) for position in breakpoints if position < signal.size)
 
 
 # Extreme features

--- a/src/process_improve/batch/preprocessing.py
+++ b/src/process_improve/batch/preprocessing.py
@@ -16,6 +16,9 @@ except ImportError:  # pragma: no cover - exercised via env-without-plotly
 
     go = _MissingExtra("plotly", "plotting")  # type: ignore[assignment]
 
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils.validation import check_is_fitted
+
 from ..multivariate.methods import PCA, MCUVScaler
 from .alignment_helpers import backtrack_optimal_path, distance_matrix
 from .data_input import check_valid_batch_dict, dict_to_wide, melted_to_dict
@@ -165,9 +168,8 @@ def determine_scaling(
         the mean otherwise, but the per-batch minimum itself is always the
         raw ``batch.min(axis=0)``, not a quantile.
     """
-    # TODO(#199): reshape this trio of functions into a scikit-learn style estimator
-    # with .fit() / .transform(), the way MCUVScaler already works.
-    # This will be clumsy, until we have Python 3.9
+    # A fit / transform wrapper over this trio now exists as :class:`BatchScaler`, which
+    # also accepts the melted-DataFrame input these functions reject (#199).
     default_settings: dict = {"robust": True, "robust_range": "q98-q02"}
     if settings:
         default_settings.update(settings)
@@ -314,6 +316,113 @@ class DTWresult:
         self.normalized_distance = normalized_distance
 
 
+class BatchScaler(TransformerMixin, BaseEstimator):
+    """
+    Range-scale batch trajectories, as a fit / transform estimator.
+
+    Wraps the three functions :func:`determine_scaling`, :func:`apply_scaling` and
+    :func:`reverse_scaling` in the estimator shape the rest of this package uses, so
+    batch preprocessing composes with :class:`~sklearn.pipeline.Pipeline` and with
+    ``clone`` / ``get_params`` / ``set_params`` the way
+    :class:`~process_improve.multivariate.MCUVScaler` already does (#199). The three
+    functions remain public and unchanged; this adds a way to carry the fitted scaling
+    around as one object instead of threading a ``scale_df`` through every call.
+
+    Each tag is mapped to roughly ``[0, 1]`` by subtracting a per-tag minimum and
+    dividing by a per-tag range, both aggregated across the batches seen in
+    :meth:`fit`. That is a different normalisation from mean-centring to unit variance:
+    it preserves the shape of a trajectory within its own operating range, which is what
+    the alignment distance needs.
+
+    Parameters
+    ----------
+    columns_to_align : list or None, optional
+        The tags to scale. ``None`` (the default) takes the columns of the first batch,
+        matching :func:`determine_scaling`.
+    batch_col : str or None, optional
+        When set, :meth:`fit` and :meth:`transform` also accept a single melted
+        DataFrame holding every batch, and split it on this column. This is the
+        DataFrame input case #199 asked for: the functions reject a DataFrame outright
+        and tell the caller to split it themselves.
+    robust : bool, optional
+        Use a robust per-batch range (the default) rather than ``max - min``.
+    robust_range : str, optional
+        Which robust range: ``"q98-q02"`` (the default) or ``"iqr"``. See
+        :func:`determine_scaling` for what separates them.
+
+    Attributes
+    ----------
+    scale_df_ : pd.DataFrame
+        The fitted scaling, exactly as :func:`determine_scaling` returns it: a ``Range``
+        and a ``Minimum`` per tag.
+    columns_to_align_ : list
+        The tags actually scaled, resolved during :meth:`fit`.
+    n_features_in_ : int
+        Number of tags scaled, for the sklearn contract.
+
+    Examples
+    --------
+    >>> scaler = BatchScaler(columns_to_align=["Temperature"])       # doctest: +SKIP
+    >>> scaled = scaler.fit_transform(batches)                       # doctest: +SKIP
+    >>> original = scaler.inverse_transform(scaled)                  # doctest: +SKIP
+
+    A melted frame works when the batch column is named:
+
+    >>> scaler = BatchScaler(batch_col="batch_id")                   # doctest: +SKIP
+    >>> scaled = scaler.fit_transform(melted_frame)                  # doctest: +SKIP
+    """
+
+    def __init__(
+        self,
+        columns_to_align: list | None = None,
+        batch_col: str | None = None,
+        robust: bool = True,
+        robust_range: str = "q98-q02",
+    ) -> None:
+        self.columns_to_align = columns_to_align
+        self.batch_col = batch_col
+        self.robust = robust
+        self.robust_range = robust_range
+
+    def _as_batches(self, X: dict | pd.DataFrame) -> dict:
+        """Accept either the dict format or, when ``batch_col`` is set, a melted frame."""
+        if isinstance(X, pd.DataFrame):
+            if self.batch_col is None:
+                raise TypeError(
+                    f"{type(self).__name__} was given a single DataFrame but no `batch_col`, so it "
+                    "cannot tell which column identifies the batch. Pass "
+                    f"{type(self).__name__}(batch_col=...), or split the frame yourself with "
+                    "`dict(tuple(df.groupby(batch_col)))`."
+                )
+            return melted_to_dict(X, batch_id_col=self.batch_col)
+        return X
+
+    def fit(self, X: dict | pd.DataFrame, y: object = None) -> BatchScaler:  # noqa: ARG002
+        """
+        Determine the per-tag range and minimum from these batches.
+
+        ``y`` is accepted and ignored, per the sklearn transformer contract.
+        """
+        batches = self._as_batches(X)
+        settings = {"robust": self.robust, "robust_range": self.robust_range}
+        self.scale_df_ = determine_scaling(batches, columns_to_align=self.columns_to_align, settings=settings)
+        self.columns_to_align_ = list(
+            _resolve_columns_to_align(batches, self.columns_to_align, f"{type(self).__name__}.fit")
+        )
+        self.n_features_in_ = len(self.columns_to_align_)
+        return self
+
+    def transform(self, X: dict | pd.DataFrame) -> dict:
+        """Scale these batches with the fitted range and minimum."""
+        check_is_fitted(self, "scale_df_")
+        return apply_scaling(self._as_batches(X), self.scale_df_, columns_to_align=self.columns_to_align_)
+
+    def inverse_transform(self, X: dict | pd.DataFrame) -> dict:
+        """Undo :meth:`transform`, returning the batches to their original units."""
+        check_is_fitted(self, "scale_df_")
+        return reverse_scaling(self._as_batches(X), self.scale_df_, columns_to_align=self.columns_to_align_)
+
+
 def align_with_path(md_path: np.ndarray, batch: pd.DataFrame) -> pd.DataFrame:
     """Align a batch to the reference using the DTW path.
 
@@ -401,11 +510,82 @@ def dtw_core(
     )
 
 
+#: Huber's tuning constant, the value giving 95% efficiency at the Gaussian.
+_HUBER_CUTOFF = 1.345
+
+#: Smallest batch weight :func:`_batch_weights` will return, so no batch is ever silenced.
+_MIN_BATCH_WEIGHT = 1e-3
+
+
+def _batch_weights(aligned_batches: dict, batch_weighting: str) -> np.ndarray:
+    """
+    Weight each batch by how well it aligned, for the variable-weight update.
+
+    Every batch contributes equally to the variable weights under ``"equal"``, so one
+    badly aligned batch inflates the summed deviation of whichever variables it misfits
+    and depresses their weights for every other batch. ``"huber"`` downweights such a
+    batch in proportion to how far its alignment distance sits from the rest.
+
+    The distance used is each batch's ``normalized_distance``, which divides by the
+    summed path length and so compares across batches of unequal duration. It is turned
+    into a robust z-score against the median and the MAD of the batch set, then passed
+    through Huber's function: weight 1 inside the cutoff, falling off as ``1 / |z|``
+    outside it.
+
+    Huber rather than a redescending function (Tukey's bisquare, say) because it never
+    reaches zero. A batch that is downweighted pulls the average trajectory away from
+    itself, which makes it look worse on the next iteration; a weight that can reach
+    zero turns that feedback into a one-way door, where a batch excluded once can never
+    return. The weights are recomputed from scratch every iteration and floored at
+    ``_MIN_BATCH_WEIGHT`` for the same reason.
+
+    Parameters
+    ----------
+    aligned_batches : dict
+        The :class:`DTWresult` of each batch from the current iteration.
+    batch_weighting : str
+        ``"equal"`` (every batch weight 1.0) or ``"huber"``.
+
+    Returns
+    -------
+    np.ndarray
+        One weight per batch, in the iteration order of ``aligned_batches``, scaled so
+        they average 1.0. That scaling keeps the accumulated deviations on the magnitude
+        they had under equal weighting, so the existing relative floor on them, and the
+        convergence tolerance, keep their meaning.
+    """
+    n_batches = len(aligned_batches)
+    if batch_weighting == "equal" or n_batches == 0:
+        return np.ones(n_batches)
+
+    distances = np.array([result.normalized_distance for result in aligned_batches.values()], dtype=float)
+    finite = np.isfinite(distances)
+    if not finite.any():
+        return np.ones(n_batches)
+
+    median = float(np.median(distances[finite]))
+    # 1.4826 scales the MAD to estimate the standard deviation of a Gaussian.
+    mad = 1.4826 * float(np.median(np.abs(distances[finite] - median)))
+    if mad <= epsqrt:
+        # The batches are indistinguishable on this measure (or over half of them share
+        # one distance exactly), so there is nothing to tell apart. MAD can be zero on
+        # data that does vary, which is why this returns equal weights rather than
+        # dividing by a floored MAD and manufacturing a spread.
+        return np.ones(n_batches)
+
+    z_scores = np.abs(distances - median) / mad
+    weights = np.where(z_scores <= _HUBER_CUTOFF, 1.0, _HUBER_CUTOFF / np.maximum(z_scores, epsqrt))
+    weights = np.where(finite, weights, _MIN_BATCH_WEIGHT)
+    weights = np.maximum(weights, _MIN_BATCH_WEIGHT)
+    return weights / float(np.mean(weights))
+
+
 def _accumulate_deviations(
     aligned_batches: dict,
     average_batch: pd.DataFrame,
     weighting: str,
     n_columns: int,
+    batch_weighting: str = "equal",
 ) -> np.ndarray:
     """
     Sum each variable's deviation from the average trajectory, across all batches.
@@ -429,6 +609,10 @@ def _accumulate_deviations(
         both the fixed point and the number of iterations to reach it.
     n_columns : int
         Number of columns being aligned.
+    batch_weighting : str, optional
+        How much each batch contributes, resolved by :func:`_batch_weights`. The default
+        ``"equal"`` gives every batch a weight of exactly 1.0, which is the behaviour
+        this function had before batch weighting existed.
 
     Returns
     -------
@@ -437,10 +621,11 @@ def _accumulate_deviations(
     """
     accumulated = np.zeros((1, n_columns))
     square = weighting == "quadratic"
-    for result in aligned_batches.values():
+    batch_weights = _batch_weights(aligned_batches, batch_weighting)
+    for weight, result in zip(batch_weights, aligned_batches.values(), strict=True):
         deviation = result.synced - average_batch
         term = np.power(deviation, 2) if square else np.abs(deviation)
-        accumulated = accumulated + np.nansum(term, axis=0)
+        accumulated = accumulated + weight * np.nansum(term, axis=0)
 
     return accumulated
 
@@ -503,6 +688,33 @@ def _validate_time_axis(settings: dict) -> None:
         )
 
 
+def _validate_dtw_settings(settings: dict) -> None:
+    """
+    Reject an unusable ``batch_dtw`` setting once, before any alignment work is done.
+
+    Each of these would otherwise surface far from its cause: an unrecognized string
+    silently taking the other branch, or a band constraint failing once per batch.
+    """
+    if settings["weighting"] not in {"quadratic", "absolute"}:
+        raise ValueError(
+            f"settings['weighting']={settings['weighting']!r} is not recognized; expected "
+            "'quadratic' (the default, and the published method) or 'absolute'."
+        )
+    if settings["batch_weighting"] not in {"equal", "huber"}:
+        raise ValueError(
+            f"settings['batch_weighting']={settings['batch_weighting']!r} is not recognized; "
+            "expected 'equal' (the default) or 'huber'."
+        )
+    _validate_time_axis(settings)
+    band = settings["band"]
+    if not (band is None or callable(band) or isinstance(band, np.ndarray)):
+        raise TypeError(
+            f"settings['band']={band!r} is not a band constraint; expected None, an "
+            "(n_test, 2) array of row bounds, or a callable of (n_test, n_ref). See "
+            "`alignment_helpers.sakoe_chiba` and `alignment_helpers.itakura`."
+        )
+
+
 def batch_dtw(  # noqa: C901, PLR0915
     batches: dict[str, pd.DataFrame],
     columns_to_align: list,
@@ -533,6 +745,7 @@ def batch_dtw(  # noqa: C901, PLR0915
                 "show_progress": True,     # show progress
                 "subsample": 1,            # use every sample
                 "weighting": "quadratic",  # "quadratic" or "absolute"; see below
+                "batch_weighting": "equal",  # "equal" or "huber"; see below
                 "band": None,              # warping-path constraint; see below
                 "interpolate_time_axis_maximum": 100,  # resample time axis to this scale
                 "interpolate_time_axis_delta": 1,      # resolution of the resampled axis
@@ -563,6 +776,20 @@ def batch_dtw(  # noqa: C901, PLR0915
             the path to it differ. Offered for comparison; it is not the published
             method, and the effect on your own data should be measured rather than
             assumed.
+
+        ``batch_weighting`` decides how much each batch contributes to the variable
+        weights. Under ``"equal"`` (the default) every batch counts the same, so one badly
+        aligned batch inflates the summed deviation of whichever variables it misfits and
+        depresses their weights for every other batch. ``"huber"`` weights each batch by
+        Huber's function applied to the robust z-score of its ``normalized_distance``,
+        against the median and MAD of the batch set: weight 1 inside a cutoff of 1.345,
+        falling off as ``1 / |z|`` beyond it, then rescaled to average 1.0.
+
+        Huber rather than a redescending function because it never reaches zero. A
+        downweighted batch pulls the average trajectory away from itself, so it looks
+        worse on the next iteration; a weight that could reach zero would make that a
+        one-way door. The weights are recomputed from scratch each iteration and floored,
+        so a batch that recovers is counted again.
 
         ``band`` constrains the warping path: the reference rows each test sample may
         map to. ``None`` (the default) places no constraint. Pass an ``(n_test, 2)``
@@ -610,6 +837,7 @@ def batch_dtw(  # noqa: C901, PLR0915
         show_progress=True,  # show progress
         subsample=1,  # use every sample
         weighting="quadratic",  # how to accumulate deviations: "quadratic" or "absolute"
+        batch_weighting="equal",  # how much each batch contributes: "equal" or "huber"
         band=None,  # warping-path constraint; None places none. See `sakoe_chiba`, `itakura`.
         interpolate_time_axis_maximum=100,  # interpolates everything to be on this scale
         interpolate_time_axis_delta=1,
@@ -622,19 +850,7 @@ def batch_dtw(  # noqa: C901, PLR0915
         raise ValueError(
             f"At least 3 iterations are required; got maximum_iterations={settings['maximum_iterations']}."
         )
-    if settings["weighting"] not in {"quadratic", "absolute"}:
-        raise ValueError(
-            f"settings['weighting']={settings['weighting']!r} is not recognized; expected "
-            "'quadratic' (the default, and the published method) or 'absolute'."
-        )
-    _validate_time_axis(settings)
-    band = settings["band"]
-    if not (band is None or callable(band) or isinstance(band, np.ndarray)):
-        raise TypeError(
-            f"settings['band']={band!r} is not a band constraint; expected None, an "
-            "(n_test, 2) array of row bounds, or a callable of (n_test, n_ref). See "
-            "`alignment_helpers.sakoe_chiba` and `alignment_helpers.itakura`."
-        )
+    _validate_dtw_settings(settings)
     if reference_batch not in batches:
         raise KeyError(f"`reference_batch` was not found in the dict of batches; got {reference_batch!r}.")
 
@@ -678,15 +894,12 @@ def batch_dtw(  # noqa: C901, PLR0915
         )
 
         next_weights = _accumulate_deviations(
-            aligned_batches, average_batch, settings["weighting"], refbatch_sc.shape[1]
+            aligned_batches,
+            average_batch,
+            settings["weighting"],
+            refbatch_sc.shape[1],
+            settings["batch_weighting"],
         )
-
-        # TODO(#199): every batch contributes equally here. Downweighting the badly
-        # aligned ones continuously, rather than trimming a fixed quantile, is the open
-        # question; the `distances` output now returned makes the distribution visible
-        # so the weight function can be chosen from data. Note the feedback risk: a
-        # downweighted batch pulls the average away from itself and is then downweighted
-        # further, so any such weight must be recomputed per iteration and floored.
 
         # Kassidas: each variable's weight is inversely proportional to its
         # summed squared deviation from the average trajectory, so a variable

--- a/src/process_improve/batch/preprocessing.py
+++ b/src/process_improve/batch/preprocessing.py
@@ -196,7 +196,13 @@ def determine_scaling(
             collapsed[str(tag)] = collapsed.get(str(tag), 0) + 1
         rnge[is_zero] = 1.0
         collector_rnge.append(rnge)
-        collector_mins.append(batch.min(axis=0))
+        # Restricted to `columns_to_align`, as the range above is. Taking the minimum over
+        # every column raised `TypeError: Cannot convert [...] to numeric` the moment a
+        # batch carried a non-numeric column, which a batch identifier of string type
+        # always is (#197). With integer identifiers it did not raise, but it still put
+        # rows in the result for columns that were never scaled, leaving `Range` NaN
+        # against a real `Minimum` for each of them.
+        collector_mins.append(batch[columns_to_align].min(axis=0))
 
     _warn_about_collapsed_ranges(collapsed, len(batches))
 
@@ -319,25 +325,40 @@ def align_with_path(md_path: np.ndarray, batch: pd.DataFrame) -> pd.DataFrame:
     ``initial_row`` argument seeded it from the reference row (in one caller) or
     from an out-of-space batch index (in the other), which mixed an unrelated row
     into the row-0 average (#197).
+
+    Non-numeric columns are carried through rather than averaged. A batch frame from
+    :func:`~process_improve.batch.data_input.melted_to_dict` still holds its identifier
+    column, and averaging a label is meaningless even when it happens to be a number:
+    with string identifiers it raised ``TypeError: unsupported operand type(s) for /``,
+    and with integer ones it silently wrote the mean of the identifier into the aligned
+    frame. Such a column is constant within a batch, so the first value is taken (#197).
     """
+    numeric = batch.select_dtypes(include="number")
+    passthrough = batch.columns.difference(numeric.columns, sort=False)
+
     row = 0
     nr = md_path[:, 0].max() + 1  # to account for the zero-based indexing
-    synced = pd.DataFrame(np.zeros((nr, batch.shape[1])), columns=batch.columns)
-    synced.iloc[row, :] = batch.iloc[md_path[0, 1], :]
-    temp: pd.Series | np.ndarray = batch.iloc[md_path[0, 1], :]
+    synced = pd.DataFrame(np.zeros((nr, numeric.shape[1])), columns=numeric.columns)
+    synced.iloc[row, :] = numeric.iloc[md_path[0, 1], :]
+    temp: pd.Series | np.ndarray = numeric.iloc[md_path[0, 1], :]
     for idx in np.arange(1, md_path.shape[0]):
         if md_path[idx, 0] != md_path[idx - 1, 0]:
             row += 1
-            synced.iloc[row, :] = temp = batch.iloc[md_path[idx, 1], :]
+            synced.iloc[row, :] = temp = numeric.iloc[md_path[idx, 1], :]
 
         else:
             # More than one batch sample maps to this reference index (a compression in
             # the warping path), so the synced value is the average of those samples.
             # Pinned by tests/batch/test_dtw_align_with_path.py.
-            temp = np.vstack((temp, batch.iloc[md_path[idx, 1], :]))
+            temp = np.vstack((temp, numeric.iloc[md_path[idx, 1], :]))
             synced.iloc[row, :] = np.nanmean(temp, axis=0)
 
-    return pd.DataFrame(synced)
+    for column in passthrough:
+        # Constant within a batch, so every row gets the same value and the column keeps
+        # its own dtype instead of being coerced into the float frame.
+        synced[column] = batch[column].iloc[0]
+
+    return pd.DataFrame(synced[batch.columns])
 
 
 def dtw_core(
@@ -459,6 +480,29 @@ def one_iteration_dtw(
     return aligned_batches, average_batch
 
 
+def _validate_time_axis(settings: dict) -> None:
+    """
+    Check the resampled time axis is well formed, before any alignment work is done.
+
+    The axis has to hold more than one point for the interpolation to have anything to
+    interpolate along, and both values have to be positive for ``np.arange`` to produce
+    an increasing axis at all.
+    """
+    maximum = float(settings["interpolate_time_axis_maximum"])
+    delta = float(settings["interpolate_time_axis_delta"])
+    if delta <= 0 or maximum <= 0:
+        raise ValueError(
+            f"settings['interpolate_time_axis_maximum'] and ['interpolate_time_axis_delta'] must both "
+            f"be positive; got maximum={maximum} and delta={delta}."
+        )
+    if delta >= maximum:
+        raise ValueError(
+            f"settings['interpolate_time_axis_delta']={delta} must be smaller than "
+            f"['interpolate_time_axis_maximum']={maximum}, so that the resampled axis has more than "
+            "one point."
+        )
+
+
 def batch_dtw(  # noqa: C901, PLR0915
     batches: dict[str, pd.DataFrame],
     columns_to_align: list,
@@ -491,12 +535,16 @@ def batch_dtw(  # noqa: C901, PLR0915
                 "weighting": "quadratic",  # "quadratic" or "absolute"; see below
                 "band": None,              # warping-path constraint; see below
                 "interpolate_time_axis_maximum": 100,  # resample time axis to this scale
-                "interpolate_time_axis_delta": 1,      # resolution of resampled axis
+                "interpolate_time_axis_delta": 1,      # resolution of the resampled axis
                 "interpolate_method": "cubic",         # any scipy.interpolate.interp1d method
             }
 
-        The default settings resample the time axis to 100 data points, starting at 0 and
-        ending at 99. Adjust the delta for more points, or change the maximum.
+        The default settings resample the time axis to 100 points, starting at 0 and ending
+        at 99, so each point is one percent of the batch's duration however long the batch
+        actually ran. Lower the delta for a finer axis (``0.5`` gives 200 points, ``0.25``
+        gives 400) or change the maximum for a different scale. The delta no longer has to
+        divide the maximum exactly: values such as ``0.3`` or ``7`` used to fail an
+        assertion.
 
         ``weighting`` selects how a variable's deviation from the average trajectory is
         accumulated before the weight is taken as its reciprocal:
@@ -579,6 +627,7 @@ def batch_dtw(  # noqa: C901, PLR0915
             f"settings['weighting']={settings['weighting']!r} is not recognized; expected "
             "'quadratic' (the default, and the published method) or 'absolute'."
         )
+    _validate_time_axis(settings)
     band = settings["band"]
     if not (band is None or callable(band) or isinstance(band, np.ndarray)):
         raise TypeError(
@@ -673,15 +722,15 @@ def batch_dtw(  # noqa: C901, PLR0915
             result.md_path,
             batches[batch_id].iloc[:: int(settings["subsample"]), :],
         )
-        # Resample the trajectories of the aligned data now along this sequence.
-        sequence = np.linspace(
-            0,
-            settings["interpolate_time_axis_maximum"] - settings["interpolate_time_axis_delta"],
-            synced.shape[0],
-        )
-        # Internal invariants on the just-built axes; not user input.
-        assert new_time_axis.min() == sequence.min()  # post-construction invariant
-        assert new_time_axis.max() == sequence.max()  # post-construction invariant
+        # Resample the trajectories of the aligned data now along this sequence, whose
+        # endpoints are taken from the target axis rather than recomputed. Deriving them
+        # separately assumed the delta divided the maximum exactly: `np.arange` stops at
+        # the last multiple below the maximum, while `maximum - delta` does not, so a
+        # delta of 0.3 or 7 put the two axes' endpoints in different places. Two asserts
+        # caught that as a bare AssertionError, and `python -O` strips asserts, so under
+        # optimisation it silently extrapolated instead (#197). Sharing the endpoints
+        # makes any delta work and leaves nothing to assert.
+        sequence = np.linspace(new_time_axis[0], new_time_axis[-1], synced.shape[0])
 
         synced_interpolated = pd.DataFrame()
         for column in synced:

--- a/src/process_improve/batch/preprocessing.py
+++ b/src/process_improve/batch/preprocessing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import cast
 
 import numpy as np
@@ -86,6 +87,35 @@ def _resolve_columns_to_align(
     return batches[next(iter(batches))].columns
 
 
+#: Quantile pair behind each ``settings["robust_range"]`` choice in :func:`determine_scaling`.
+_ROBUST_RANGE_QUANTILES = {"q98-q02": (0.02, 0.98), "iqr": (0.25, 0.75)}
+
+
+def _warn_about_collapsed_ranges(collapsed: dict[str, int], n_batches: int) -> None:
+    """
+    Report tags whose range was zero and was replaced by 1.0, once for the whole call.
+
+    A zero range means the tag held a single value across the batch, so the substitution
+    leaves it unscaled. That is recoverable, but the caller should know: a constant tag
+    carries nothing for the alignment to work with, and an identifier column swept in by
+    the default ``columns_to_align`` shows up here too.
+    """
+    if not collapsed:
+        return
+
+    listed = ", ".join(
+        f"{tag!r} ({count} of {n_batches} batches)"
+        for tag, count in sorted(collapsed.items(), key=lambda item: (-item[1], item[0]))
+    )
+    warnings.warn(
+        f"determine_scaling found tags with a zero range and substituted 1.0, leaving them "
+        f"unscaled: {listed}. A tag that holds one value across a batch carries no information "
+        f"for alignment; exclude it with `columns_to_align`.",
+        category=UserWarning,
+        stacklevel=3,
+    )
+
+
 def determine_scaling(
     batches: dict[str, pd.DataFrame],
     columns_to_align: list | pd.Index | None = None,
@@ -102,9 +132,28 @@ def determine_scaling(
         The column names (tags) to be scaled. If ``None``, the columns of the
         first batch are used.
     settings : dict, optional
-        Optional overrides. Currently supports the key ``"robust"`` (bool,
-        default ``True``) which switches between a robust range (q98 - q02)
-        and the raw (max - min) range.
+        Optional overrides:
+
+        ``"robust"`` (bool, default ``True``)
+            Switches between a robust per-batch range and the raw ``max - min``.
+        ``"robust_range"`` (str, default ``"q98-q02"``)
+            Which robust range to use when ``robust`` is True, either
+            ``"q98-q02"`` or ``"iqr"`` (q75 - q25, the interquartile range that
+            :func:`~process_improve.batch.features.f_iqr` computes). Ignored when
+            ``robust`` is False.
+
+            The two are not interchangeable, which is the answer to the question the
+            old TODO here posed. The IQR spans the middle half of a batch; q98 - q02
+            spans nearly all of it. On a Gaussian tag the second is about 3.05 times
+            the first, but a batch trajectory is not Gaussian, so the ratio varies by
+            tag: measured per tag on the bundled data it runs from 1.02 to 4.23
+            (dryer) and 1.21 to 2.95 (nylon). Switching therefore re-weights the tags
+            against each other rather than rescaling them together. The IQR also
+            collapses to zero more often, because a tag that holds one value for more
+            than half of a batch has no interquartile spread at all:
+            ``DifferentialPressure`` collapses in 21 of the 71 dryer batches under the
+            IQR against 16 under q98 - q02. Prefer the IQR when the tags carry
+            excursions you want the scaling to ignore; the default otherwise.
 
     Returns
     -------
@@ -119,26 +168,37 @@ def determine_scaling(
     # TODO(#199): reshape this trio of functions into a scikit-learn style estimator
     # with .fit() / .transform(), the way MCUVScaler already works.
     # This will be clumsy, until we have Python 3.9
-    default_settings = {"robust": True}
+    default_settings: dict = {"robust": True, "robust_range": "q98-q02"}
     if settings:
         default_settings.update(settings)
 
     settings = default_settings
+    if settings["robust_range"] not in _ROBUST_RANGE_QUANTILES:
+        raise ValueError(
+            f"settings['robust_range']={settings['robust_range']!r} is not recognized; expected "
+            f"one of {sorted(_ROBUST_RANGE_QUANTILES)}."
+        )
     columns_to_align = _resolve_columns_to_align(batches, columns_to_align, "determine_scaling")
 
     collector_rnge = []
     collector_mins = []
+    collapsed: dict[str, int] = {}
     for batch in batches.values():
         if settings["robust"]:
-            # TODO(#198): consider the f_iqr feature here instead of q98 - q02. Would that work?
-            rnge = batch[columns_to_align].quantile(0.98) - batch[columns_to_align].quantile(0.02)
+            lower, upper = _ROBUST_RANGE_QUANTILES[settings["robust_range"]]
+            rnge = batch[columns_to_align].quantile(upper) - batch[columns_to_align].quantile(lower)
         else:
             rnge = batch[columns_to_align].max() - batch[columns_to_align].min()
 
         rnge = cast("pd.Series", rnge)
-        rnge[rnge.to_numpy() == 0] = 1.0
+        is_zero = rnge.to_numpy() == 0
+        for tag in rnge.index[is_zero]:
+            collapsed[str(tag)] = collapsed.get(str(tag), 0) + 1
+        rnge[is_zero] = 1.0
         collector_rnge.append(rnge)
         collector_mins.append(batch.min(axis=0))
+
+    _warn_about_collapsed_ranges(collapsed, len(batches))
 
     if settings["robust"]:
         scalings = pd.concat(

--- a/tests/batch/test_features.py
+++ b/tests/batch/test_features.py
@@ -291,27 +291,112 @@ def test_f_elbow_no_elbow_records_nan() -> None:
     assert np.isnan(value)
 
 
-class TestFRuptureNotImplemented:
-    """`f_rupture` has no working body and must say so. Regression test for #559.
-
-    It previously raised only for the wrong number of columns and returned ``None``
-    for a valid single-column call, which a caller cannot tell apart from a
-    successful empty result.
-    """
+class TestFRupture:
+    """Change-point detection via `ruptures` (#198)."""
 
     @staticmethod
-    def _frame() -> pd.DataFrame:
-        return pd.DataFrame({"batch_id": [1, 1, 1, 2, 2, 2], "temp": [10.0, 11, 12, 20, 21, 22]})
+    def _stepped(steps: dict[str, int], n_samples: int = 100) -> pd.DataFrame:
+        """One batch per entry, each with a single step at the given position."""
+        rng = np.random.default_rng(0)
+        frames = [
+            pd.DataFrame(
+                {
+                    "batch_id": batch_id,
+                    "Temperature": np.concatenate([rng.normal(0, 0.1, step), rng.normal(5, 0.1, n_samples - step)]),
+                    "Flat": 7.0,
+                }
+            )
+            for batch_id, step in steps.items()
+        ]
+        return pd.concat(frames, ignore_index=True)
 
-    def test_valid_single_column_call_raises_rather_than_returning_none(self) -> None:
-        with pytest.raises(NotImplementedError, match=r"f_rupture is not implemented"):
-            features.f_rupture(self._frame(), columns=["temp"], batch_col="batch_id")
+    def test_it_finds_a_known_step_exactly(self) -> None:
+        steps = {"A": 40, "B": 70, "C": 25}
+        found = features.f_rupture(
+            self._stepped(steps), tags=["Temperature"], batch_col="batch_id", settings={"jump": 1}
+        ).droplevel(-1)
 
-    def test_message_points_at_the_tracking_issue(self) -> None:
-        with pytest.raises(NotImplementedError, match=r"issues/198"):
-            features.f_rupture(self._frame(), columns=["temp"], batch_col="batch_id")
+        assert list(found.columns) == ["Temperature_rupture"]
+        for batch_id, step in steps.items():
+            assert found.loc[batch_id, "Temperature_rupture"] == (step,)
 
-    @pytest.mark.parametrize("columns", [None, [], ["temp", "batch_id"]])
-    def test_other_arities_also_raise(self, columns: list[str] | None) -> None:
-        with pytest.raises(NotImplementedError):
-            features.f_rupture(self._frame(), columns=columns, batch_col="batch_id")
+    def test_a_constant_tag_has_no_change_points(self) -> None:
+        found = features.f_rupture(self._stepped({"A": 40}), tags=["Flat"], batch_col="batch_id")
+
+        assert found.iloc[0, 0] == ()
+
+    def test_the_trailing_sentinel_is_removed(self) -> None:
+        """`ruptures` ends its result with the signal length, which is not a change point."""
+        found = features.f_rupture(
+            self._stepped({"A": 40}), tags=["Temperature"], batch_col="batch_id", settings={"jump": 1}
+        )
+
+        assert 100 not in found.iloc[0, 0]
+
+    def test_counts_give_a_numeric_feature(self) -> None:
+        """The documented way to get a column that fits in a model matrix."""
+        found = features.f_rupture(
+            self._stepped({"A": 40, "B": 70}), tags=["Temperature", "Flat"], batch_col="batch_id"
+        ).droplevel(-1)
+
+        counts = found.map(len)
+        assert counts.loc["A", "Temperature_rupture"] == 1
+        assert counts.loc["A", "Flat_rupture"] == 0
+
+    def test_a_larger_penalty_returns_no_more_change_points(self) -> None:
+        data = self._stepped({"A": 40})
+        found = [
+            len(
+                features.f_rupture(
+                    data, tags=["Temperature"], batch_col="batch_id", settings={"penalty": penalty, "jump": 1}
+                ).iloc[0, 0]
+            )
+            for penalty in (1.0, 10.0, 1000.0)
+        ]
+
+        assert found == sorted(found, reverse=True), f"expected monotone, got {found}"
+
+    def test_the_default_penalty_adapts_to_the_signal_length(self) -> None:
+        """`None` means log(n); a fixed 100.0 finds nothing under the bounded rbf cost."""
+        data = self._stepped({"A": 40}, n_samples=100)
+
+        adaptive = features.f_rupture(data, tags=["Temperature"], batch_col="batch_id", settings={"jump": 1})
+        fixed = features.f_rupture(
+            data, tags=["Temperature"], batch_col="batch_id", settings={"penalty": 100.0, "jump": 1}
+        )
+
+        assert adaptive.iloc[0, 0] == (40,)
+        assert fixed.iloc[0, 0] == ()
+
+    def test_a_signal_too_short_to_split_returns_empty(self) -> None:
+        tiny = pd.DataFrame({"batch_id": ["A", "A", "A"], "T": [1.0, 2.0, 3.0]})
+
+        assert features.f_rupture(tiny, tags=["T"], batch_col="batch_id").iloc[0, 0] == ()
+
+    def test_missing_data_returns_empty_rather_than_raising(self) -> None:
+        signal = np.concatenate([np.zeros(50), [np.nan], np.ones(49) * 5])
+        data = pd.DataFrame({"batch_id": "A", "T": signal})
+
+        assert features.f_rupture(data, tags=["T"], batch_col="batch_id").iloc[0, 0] == ()
+
+    def test_an_unrecognized_setting_is_rejected(self) -> None:
+        """`pen` is the ruptures spelling; this function takes `penalty`."""
+        with pytest.raises(ValueError, match=r"unrecognized settings \['pen'\]"):
+            features.f_rupture(
+                self._stepped({"A": 40}), tags=["Temperature"], batch_col="batch_id", settings={"pen": 1}
+            )
+
+    @pytest.mark.dataset
+    def test_it_runs_on_the_dryer_data(self) -> None:
+        folder = pathlib.Path(__file__).parents[2] / "src" / "process_improve" / "datasets" / "batch"
+        dryer = pd.read_csv(folder / "dryer.csv")
+        subset = dryer[dryer["batch_id"].isin(dryer["batch_id"].unique()[:3])]
+
+        found = features.f_rupture(subset, tags=["DryerTemp"], batch_col="batch_id").droplevel(-1)
+
+        assert len(found) == 3
+        # Every batch of this dryer run has structure to find, and the positions are
+        # inside the batch rather than at its ends.
+        for breaks in found["DryerTemp_rupture"]:
+            assert len(breaks) > 0
+            assert all(0 < position < len(subset) for position in breaks)

--- a/tests/batch/test_preprocessing.py
+++ b/tests/batch/test_preprocessing.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -798,3 +800,88 @@ class TestBatchDtwBandSetting:
         """The per-batch handler used to discard the cause, which is the actionable part."""
         with pytest.raises(ValueError, match=r"Failed on batch .*starting cell"):
             self._run(dryer_data, band=lambda n_test, n_ref: np.full((n_test, 2), [1, n_ref], dtype=np.int64))
+
+
+class TestDetermineScalingRobustRange:
+    """`settings["robust_range"]` chooses the robust per-batch range (#198).
+
+    The old TODO asked whether `f_iqr` would work here instead of q98 - q02. It does,
+    but it is not interchangeable, so it is offered rather than substituted.
+    """
+
+    def test_the_default_is_q98_minus_q02(self, dryer_data: dict) -> None:
+        implicit = determine_scaling(dryer_data, columns_to_align=_DRYER_ALIGN_COLUMNS)
+        explicit = determine_scaling(
+            dryer_data, columns_to_align=_DRYER_ALIGN_COLUMNS, settings={"robust_range": "q98-q02"}
+        )
+
+        assert np.array_equal(implicit.to_numpy(), explicit.to_numpy(), equal_nan=True)
+
+    def test_the_iqr_is_narrower_on_every_tag(self, dryer_data: dict) -> None:
+        """It spans the middle half of a batch, against nearly all of it."""
+        wide = determine_scaling(dryer_data, columns_to_align=_DRYER_ALIGN_COLUMNS)["Range"]
+        iqr = determine_scaling(dryer_data, columns_to_align=_DRYER_ALIGN_COLUMNS, settings={"robust_range": "iqr"})[
+            "Range"
+        ]
+
+        narrower = iqr.loc[_DRYER_ALIGN_COLUMNS] < wide.loc[_DRYER_ALIGN_COLUMNS]
+        assert narrower.all(), f"expected the IQR to be narrower everywhere, got {iqr / wide}"
+
+    def test_the_two_are_not_a_uniform_rescale(self, dryer_data: dict) -> None:
+        """The default is not simply switched because the tags move by different factors."""
+        wide = determine_scaling(dryer_data, columns_to_align=_DRYER_ALIGN_COLUMNS)["Range"]
+        iqr = determine_scaling(dryer_data, columns_to_align=_DRYER_ALIGN_COLUMNS, settings={"robust_range": "iqr"})[
+            "Range"
+        ]
+
+        ratio = (wide / iqr).loc[_DRYER_ALIGN_COLUMNS]
+        assert ratio.max() / ratio.min() > 1.5, f"expected tag-dependent ratios, got {ratio.to_dict()}"
+
+    def test_robust_false_ignores_the_setting(self, dryer_data: dict) -> None:
+        raw = determine_scaling(dryer_data, columns_to_align=_DRYER_ALIGN_COLUMNS, settings={"robust": False})
+        also_raw = determine_scaling(
+            dryer_data,
+            columns_to_align=_DRYER_ALIGN_COLUMNS,
+            settings={"robust": False, "robust_range": "iqr"},
+        )
+
+        assert np.array_equal(raw.to_numpy(), also_raw.to_numpy(), equal_nan=True)
+
+    def test_an_unrecognized_range_is_rejected(self, dryer_data: dict) -> None:
+        with pytest.raises(ValueError, match=r"robust_range'\]='mad' is not recognized"):
+            determine_scaling(dryer_data, columns_to_align=_DRYER_ALIGN_COLUMNS, settings={"robust_range": "mad"})
+
+
+class TestDetermineScalingZeroRangeWarning:
+    """A zero range is replaced by 1.0; that substitution is no longer silent (#198).
+
+    `docs/development/error_handling.rst` names a dropped constant column as a
+    `warnings.warn` case, and the IQR option makes it more likely: a tag holding one
+    value for over half a batch has no interquartile spread at all.
+    """
+
+    def test_a_constant_tag_is_reported_once_for_the_whole_call(self, dryer_data: dict) -> None:
+        with pytest.warns(UserWarning, match="zero range and substituted 1.0") as caught:
+            determine_scaling(dryer_data)  # every column, including the constant batch_id
+
+        assert len(caught) == 1, "one aggregated warning, not one per batch"
+        message = str(caught[0].message)
+        assert "'batch_id' (71 of 71 batches)" in message
+        assert "'DifferentialPressure' (16 of 71 batches)" in message
+
+    def test_tags_that_vary_produce_no_warning(self, dryer_data: dict) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            determine_scaling(dryer_data, columns_to_align=_DRYER_ALIGN_COLUMNS)
+
+    def test_the_iqr_collapses_more_often_than_q98_q02(self, dryer_data: dict) -> None:
+        """Measured on this fixture: the same tag, in more batches."""
+        columns = [*_DRYER_ALIGN_COLUMNS, "DifferentialPressure"]
+
+        def collapse_count(robust_range: str) -> int:
+            with pytest.warns(UserWarning, match="DifferentialPressure") as caught:
+                determine_scaling(dryer_data, columns_to_align=columns, settings={"robust_range": robust_range})
+            return int(str(caught[0].message).split("(")[1].split(" of ")[0])
+
+        assert collapse_count("q98-q02") == 16
+        assert collapse_count("iqr") == 21

--- a/tests/batch/test_preprocessing.py
+++ b/tests/batch/test_preprocessing.py
@@ -3,6 +3,8 @@ import warnings
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.base import clone
+from sklearn.exceptions import NotFittedError
 
 from process_improve.batch.alignment_helpers import (
     backtrack_optimal_path,
@@ -16,6 +18,8 @@ from process_improve.batch.alignment_helpers import (
     validate_band,
 )
 from process_improve.batch.preprocessing import (
+    BatchScaler,
+    _batch_weights,
     align_with_path,
     apply_scaling,
     batch_dtw,
@@ -1042,3 +1046,152 @@ class TestInterpolationAxisResolution:
     ) -> None:
         with pytest.raises(ValueError, match=message):
             self._rows(dryer_data, maximum, delta)
+
+
+class TestBatchWeighting:
+    """`settings["batch_weighting"]` downweights badly aligned batches (#199)."""
+
+    def _run(self, dryer_data: dict, batch_weighting: str) -> dict:
+        return batch_dtw(
+            dryer_data,
+            columns_to_align=_DRYER_ALIGN_COLUMNS,
+            reference_batch=2,
+            settings={
+                "robust": False,
+                "tolerance": 0.1,
+                "show_progress": False,
+                "batch_weighting": batch_weighting,
+            },
+        )
+
+    def test_equal_weighting_gives_every_batch_exactly_one(self, dryer_data: dict) -> None:
+        """Exactly 1.0, so multiplying by it is a no-op and the default cannot drift."""
+        aligned = self._run(dryer_data, "equal")["aligned_batch_objects"]
+
+        weights = _batch_weights(aligned, "equal")
+        assert weights.tolist() == [1.0] * len(aligned)
+
+    def test_the_default_is_equal_weighting(self, dryer_data: dict) -> None:
+        implicit = batch_dtw(
+            dryer_data,
+            columns_to_align=_DRYER_ALIGN_COLUMNS,
+            reference_batch=2,
+            settings={"robust": False, "tolerance": 0.1, "show_progress": False},
+        )["weight_history"]
+
+        assert implicit.iloc[-1].to_numpy() == pytest.approx(
+            self._run(dryer_data, "equal")["weight_history"].iloc[-1].to_numpy(), rel=1e-12
+        )
+
+    def test_huber_downweights_the_batches_the_distances_output_flags(self, dryer_data: dict) -> None:
+        """The diagnostic from #570 and the weighting must agree on which batches are worst."""
+        outputs = self._run(dryer_data, "huber")
+        aligned = outputs["aligned_batch_objects"]
+
+        weights = pd.Series(_batch_weights(aligned, "huber"), index=list(aligned))
+        worst_by_distance = set(outputs["distances"]["Normalized distance"].nlargest(3).index)
+
+        assert set(weights.nsmallest(3).index) == worst_by_distance
+
+    def test_huber_leaves_the_bulk_of_batches_at_full_weight(self, dryer_data: dict) -> None:
+        """A robust weight should touch the tail, not reshape the whole set."""
+        aligned = self._run(dryer_data, "huber")["aligned_batch_objects"]
+
+        weights = _batch_weights(aligned, "huber")
+        at_full_weight = int((weights >= weights.max() - 1e-12).sum())
+        assert at_full_weight > len(weights) / 2
+        assert at_full_weight < len(weights), "something must be downweighted on this fixture"
+
+    def test_no_batch_is_ever_silenced(self, dryer_data: dict) -> None:
+        """Huber never reaches zero, so a downweighted batch can recover next iteration."""
+        aligned = self._run(dryer_data, "huber")["aligned_batch_objects"]
+
+        assert _batch_weights(aligned, "huber").min() > 0.0
+
+    def test_the_weights_average_to_one(self, dryer_data: dict) -> None:
+        """Which keeps the accumulated deviations on the magnitude equal weighting gives."""
+        aligned = self._run(dryer_data, "huber")["aligned_batch_objects"]
+
+        assert float(np.mean(_batch_weights(aligned, "huber"))) == pytest.approx(1.0)
+
+    def test_huber_changes_the_variable_weights(self, dryer_data: dict) -> None:
+        equal = self._run(dryer_data, "equal")["weight_history"].iloc[-1].to_numpy()
+        huber = self._run(dryer_data, "huber")["weight_history"].iloc[-1].to_numpy()
+
+        assert huber != pytest.approx(equal, rel=1e-6)
+
+    def test_indistinguishable_batches_fall_back_to_equal_weights(self) -> None:
+        """A zero MAD means there is nothing to tell apart, not a reason to divide by zero."""
+
+        class _Result:
+            def __init__(self, distance: float) -> None:
+                self.normalized_distance = distance
+
+        identical = {index: _Result(0.5) for index in range(5)}
+        assert _batch_weights(identical, "huber").tolist() == [1.0] * 5
+
+    def test_an_unrecognized_batch_weighting_is_rejected(self, dryer_data: dict) -> None:
+        with pytest.raises(ValueError, match=r"batch_weighting'\]='tukey' is not recognized"):
+            self._run(dryer_data, "tukey")
+
+
+class TestBatchScaler:
+    """The fit / transform wrapper over the scaling functions (#199)."""
+
+    def test_it_matches_the_functions_it_wraps(self, dryer_data: dict) -> None:
+        scaler = BatchScaler(columns_to_align=_DRYER_ALIGN_COLUMNS)
+        scaled = scaler.fit_transform(dryer_data)
+
+        scale_df = determine_scaling(dryer_data, columns_to_align=_DRYER_ALIGN_COLUMNS)
+        expected = apply_scaling(dryer_data, scale_df, columns_to_align=_DRYER_ALIGN_COLUMNS)
+
+        assert np.array_equal(scaler.scale_df_.to_numpy(), scale_df.to_numpy(), equal_nan=True)
+        for batch_id, frame in expected.items():
+            assert np.array_equal(scaled[batch_id].to_numpy(), frame.to_numpy())
+
+    def test_it_round_trips(self, dryer_data: dict) -> None:
+        scaler = BatchScaler(columns_to_align=_DRYER_ALIGN_COLUMNS)
+        restored = scaler.inverse_transform(scaler.fit_transform(dryer_data))
+
+        for batch_id, frame in dryer_data.items():
+            assert restored[batch_id].to_numpy() == pytest.approx(frame[_DRYER_ALIGN_COLUMNS].to_numpy(), abs=1e-10)
+
+    def test_it_accepts_a_melted_frame_when_the_batch_column_is_named(self, dryer_data: dict) -> None:
+        """The DataFrame input case the functions reject outright."""
+        melted = pd.concat(dryer_data.values(), ignore_index=True)
+
+        from_frame = BatchScaler(columns_to_align=_DRYER_ALIGN_COLUMNS, batch_col="batch_id").fit_transform(melted)
+        from_dict = BatchScaler(columns_to_align=_DRYER_ALIGN_COLUMNS).fit_transform(dryer_data)
+
+        assert set(from_frame) == set(from_dict)
+        for batch_id, frame in from_dict.items():
+            assert np.array_equal(from_frame[batch_id].to_numpy(), frame.to_numpy())
+
+    def test_a_frame_without_a_batch_column_says_what_to_do(self, dryer_data: dict) -> None:
+        melted = pd.concat(dryer_data.values(), ignore_index=True)
+
+        with pytest.raises(TypeError, match="no `batch_col`"):
+            BatchScaler(columns_to_align=_DRYER_ALIGN_COLUMNS).fit(melted)
+
+    def test_transform_before_fit_raises(self, dryer_data: dict) -> None:
+        with pytest.raises(NotFittedError):
+            BatchScaler().transform(dryer_data)
+
+    def test_it_follows_the_sklearn_estimator_contract(self, dryer_data: dict) -> None:
+        scaler = BatchScaler(columns_to_align=_DRYER_ALIGN_COLUMNS).fit(dryer_data)
+
+        assert sorted(BatchScaler().get_params()) == ["batch_col", "columns_to_align", "robust", "robust_range"]
+        assert scaler.n_features_in_ == len(_DRYER_ALIGN_COLUMNS)
+        assert scaler.columns_to_align_ == _DRYER_ALIGN_COLUMNS
+        # `clone` must give back an unfitted estimator with the same parameters.
+        cloned = clone(scaler)
+        assert not hasattr(cloned, "scale_df_")
+        assert cloned.get_params() == scaler.get_params()
+
+    def test_the_settings_reach_determine_scaling(self, dryer_data: dict) -> None:
+        wide = BatchScaler(columns_to_align=_DRYER_ALIGN_COLUMNS).fit(dryer_data)
+        iqr = BatchScaler(columns_to_align=_DRYER_ALIGN_COLUMNS, robust_range="iqr").fit(dryer_data)
+        raw = BatchScaler(columns_to_align=_DRYER_ALIGN_COLUMNS, robust=False).fit(dryer_data)
+
+        assert (iqr.scale_df_["Range"] < wide.scale_df_["Range"]).all()
+        assert not np.array_equal(raw.scale_df_["Range"].to_numpy(), wide.scale_df_["Range"].to_numpy())

--- a/tests/batch/test_preprocessing.py
+++ b/tests/batch/test_preprocessing.py
@@ -16,6 +16,7 @@ from process_improve.batch.alignment_helpers import (
     validate_band,
 )
 from process_improve.batch.preprocessing import (
+    align_with_path,
     apply_scaling,
     batch_dtw,
     determine_scaling,
@@ -226,10 +227,22 @@ def test_alignment(dryer_data: dict) -> None:
         settings={"robust": False, "tolerance": 0.06, "show_progress": True},
     )
     assert outputs["weight_history"].shape == (3, 5)
-    # TODO(#197): restore this assertion once DTW termination is settled.
-    # assert [0.43702525, 1.33206459, 0.98298667, 0.93599197, 1.31193153] == pytest.approx(
-    #     outputs["weight_history"][4, :], abs=1e-7
-    # )
+    # Restored (#197). The assertion was commented out while DTW termination was in flux;
+    # it indexed `weight_history[4, :]`, a row that does not exist in a 3-row history, and
+    # positional indexing no longer works on what is now a DataFrame. These are the values
+    # this tolerance actually converges to, captured from a run rather than transcribed.
+    assert outputs["weight_history"].iloc[-1].to_numpy() == pytest.approx(
+        [
+            0.4436887267921799,
+            1.3462170688939308,
+            0.971991318132117,
+            0.9288826144452699,
+            1.3092202717365031,
+        ],
+        rel=1e-6,
+    )
+    # The first iteration always starts from unit weights, whatever the tolerance.
+    assert outputs["weight_history"].iloc[0].to_numpy() == pytest.approx([1, 1, 1, 1, 1])
 
 
 def test_reference_batch_selection_dryer(dryer_data: dict) -> None:
@@ -885,3 +898,147 @@ class TestDetermineScalingZeroRangeWarning:
 
         assert collapse_count("q98-q02") == 16
         assert collapse_count("iqr") == 21
+
+
+class TestBatchDtwTermination:
+    """A tighter tolerance runs more iterations, and the weights settle (#197)."""
+
+    def _history(self, dryer_data: dict, tolerance: float) -> pd.DataFrame:
+        return batch_dtw(
+            dryer_data,
+            columns_to_align=_DRYER_ALIGN_COLUMNS,
+            reference_batch=2,
+            settings={"robust": False, "tolerance": tolerance, "show_progress": False},
+        )["weight_history"]
+
+    @pytest.mark.slow
+    def test_a_tighter_tolerance_runs_more_iterations(self, dryer_data: dict) -> None:
+        counts = [self._history(dryer_data, tolerance).shape[0] for tolerance in (1.0, 0.06, 0.01)]
+
+        assert counts == [1, 3, 11]
+
+    @pytest.mark.slow
+    def test_every_run_starts_from_unit_weights(self, dryer_data: dict) -> None:
+        for tolerance in (1.0, 0.06, 0.01):
+            history = self._history(dryer_data, tolerance)
+            assert history.iloc[0].to_numpy() == pytest.approx([1, 1, 1, 1, 1])
+
+    @pytest.mark.slow
+    def test_the_iterations_are_a_prefix_of_the_tighter_run(self, dryer_data: dict) -> None:
+        """The same fixed-point iteration, stopped earlier: tolerance only decides when."""
+        loose = self._history(dryer_data, 0.06).to_numpy()
+        tight = self._history(dryer_data, 0.01).to_numpy()
+
+        assert loose == pytest.approx(tight[: loose.shape[0], :], rel=1e-9)
+
+
+class TestNonNumericBatchIdentifiers:
+    """Batch identifiers need not be numbers, and the identifier column is not a tag (#197)."""
+
+    @staticmethod
+    def _with_string_ids(dryer_data: dict) -> dict:
+        """Relabel the bundled batches with string identifiers, changing nothing else."""
+        relabelled = {}
+        for batch_id, batch in dryer_data.items():
+            frame = batch.copy()
+            frame["batch_id"] = f"B{batch_id}"
+            relabelled[f"B{batch_id}"] = frame
+        return relabelled
+
+    def _run(self, batches: dict, reference: object) -> dict:
+        return batch_dtw(
+            batches,
+            columns_to_align=_DRYER_ALIGN_COLUMNS,
+            reference_batch=reference,
+            settings={"show_progress": False, "maximum_iterations": 4, "tolerance": 0.1, "robust": False},
+        )
+
+    @pytest.mark.slow
+    def test_string_identifiers_align_to_the_same_numbers_as_integer_ones(self, dryer_data: dict) -> None:
+        """Two failures used to sit on this path: a TypeError in each of two functions."""
+        integers = self._run(dryer_data, 2)
+        strings = self._run(self._with_string_ids(dryer_data), "B2")
+
+        assert integers["weight_history"].iloc[-1].to_numpy() == pytest.approx(
+            strings["weight_history"].iloc[-1].to_numpy(), rel=1e-12
+        )
+        # Compared as sets: string keys order differently from integer ones, and the
+        # ordering of the output dict is not what this test is about.
+        assert set(strings["aligned_batch_dfdict"]) == {f"B{key}" for key in integers["aligned_batch_dfdict"]}
+        for key, aligned in integers["aligned_batch_dfdict"].items():
+            assert strings["aligned_batch_dfdict"][f"B{key}"][_DRYER_ALIGN_COLUMNS].to_numpy() == pytest.approx(
+                aligned[_DRYER_ALIGN_COLUMNS].to_numpy(), rel=1e-12
+            )
+
+    def test_determine_scaling_takes_the_minimum_only_over_the_aligned_columns(self, dryer_data: dict) -> None:
+        """Over every column it raised on a string identifier, and reported rows never scaled."""
+        scale_df = determine_scaling(
+            self._with_string_ids(dryer_data), columns_to_align=_DRYER_ALIGN_COLUMNS, settings={"robust": False}
+        )
+
+        assert list(scale_df.index) == _DRYER_ALIGN_COLUMNS
+        assert not scale_df.isna().to_numpy().any(), "no row should carry a Minimum without a Range"
+
+    def test_align_with_path_carries_a_label_column_through_unaveraged(self) -> None:
+        """Averaging an identifier is meaningless even when it happens to be a number."""
+        batch = pd.DataFrame({"batch_id": ["B7"] * 4, "temp": [10.0, 20.0, 30.0, 40.0]})
+        # Rows 1 and 2 of the batch both map to reference index 1, so they are averaged.
+        md_path = np.array([[0, 0], [1, 1], [1, 2], [2, 3]])
+
+        synced = align_with_path(md_path, batch)
+
+        assert list(synced.columns) == ["batch_id", "temp"]
+        assert list(synced["batch_id"]) == ["B7", "B7", "B7"]
+        assert synced["temp"].tolist() == [10.0, 25.0, 40.0]
+
+
+class TestInterpolationAxisResolution:
+    """The resampled percentage axis takes any resolution (#197)."""
+
+    def _rows(self, dryer_data: dict, maximum: float, delta: float) -> int:
+        subset = {key: dryer_data[key] for key in list(dryer_data)[:4]}
+        outputs = batch_dtw(
+            subset,
+            columns_to_align=_DRYER_ALIGN_COLUMNS,
+            reference_batch=next(iter(subset)),
+            settings={
+                "show_progress": False,
+                "maximum_iterations": 3,
+                "interpolate_time_axis_maximum": maximum,
+                "interpolate_time_axis_delta": delta,
+            },
+        )
+        return len(next(iter(outputs["aligned_batch_dfdict"].values())))
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize(
+        ("maximum", "delta", "expected"), [(100, 1, 100), (100, 0.5, 200), (100, 2, 50), (50, 1, 50)]
+    )
+    def test_a_delta_that_divides_the_maximum(
+        self, dryer_data: dict, maximum: float, delta: float, expected: int
+    ) -> None:
+        assert self._rows(dryer_data, maximum, delta) == expected
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize(("maximum", "delta", "expected"), [(100, 0.3, 334), (100, 7, 15)])
+    def test_a_delta_that_does_not_divide_the_maximum(
+        self, dryer_data: dict, maximum: float, delta: float, expected: int
+    ) -> None:
+        """These raised a bare AssertionError, and under `python -O` extrapolated silently."""
+        assert self._rows(dryer_data, maximum, delta) == expected
+
+    @pytest.mark.parametrize(
+        ("maximum", "delta", "message"),
+        [
+            (100, 0, "must both be positive"),
+            (0, 1, "must both be positive"),
+            (100, -1, "must both be positive"),
+            (10, 10, "must be smaller than"),
+            (10, 20, "must be smaller than"),
+        ],
+    )
+    def test_an_axis_that_cannot_be_built_is_rejected_up_front(
+        self, dryer_data: dict, maximum: float, delta: float, message: str
+    ) -> None:
+        with pytest.raises(ValueError, match=message):
+            self._rows(dryer_data, maximum, delta)

--- a/tests/batch/test_preprocessing.py
+++ b/tests/batch/test_preprocessing.py
@@ -1120,15 +1120,36 @@ class TestBatchWeighting:
 
         assert huber != pytest.approx(equal, rel=1e-6)
 
-    def test_indistinguishable_batches_fall_back_to_equal_weights(self) -> None:
-        """A zero MAD means there is nothing to tell apart, not a reason to divide by zero."""
+    @staticmethod
+    def _results(distances: list[float]) -> dict:
+        """Build the minimal stand-ins: one attribute is all `_batch_weights` reads."""
 
         class _Result:
             def __init__(self, distance: float) -> None:
                 self.normalized_distance = distance
 
-        identical = {index: _Result(0.5) for index in range(5)}
-        assert _batch_weights(identical, "huber").tolist() == [1.0] * 5
+        return {index: _Result(distance) for index, distance in enumerate(distances)}
+
+    def test_indistinguishable_batches_fall_back_to_equal_weights(self) -> None:
+        """A zero MAD means there is nothing to tell apart, not a reason to divide by zero."""
+        assert _batch_weights(self._results([0.5] * 5), "huber").tolist() == [1.0] * 5
+
+    def test_all_non_finite_distances_fall_back_to_equal_weights(self) -> None:
+        """With no usable distance there is no basis to rank batches, so none is penalised."""
+        assert _batch_weights(self._results([float("nan")] * 4), "huber").tolist() == [1.0] * 4
+
+    def test_a_single_non_finite_distance_is_floored_not_dropped(self) -> None:
+        """That batch still counts, at the floor, rather than vanishing from the sum."""
+        weights = _batch_weights(self._results([0.01, 0.011, 0.012, 0.013, float("nan")]), "huber")
+
+        assert len(weights) == 5
+        assert weights[-1] > 0.0
+        assert weights[-1] == weights.min()
+
+    def test_no_batches_gives_no_weights(self) -> None:
+        """`zip(..., strict=True)` in the caller needs the lengths to agree even at zero."""
+        for batch_weighting in ("equal", "huber"):
+            assert _batch_weights({}, batch_weighting).tolist() == []
 
     def test_an_unrecognized_batch_weighting_is_rejected(self, dryer_data: dict) -> None:
         with pytest.raises(ValueError, match=r"batch_weighting'\]='tukey' is not recognized"):


### PR DESCRIPTION
## Summary

Closes **#198**, the **three remaining items of #197**, and **#199**. All three land here because this session works on one branch; happy to split if you prefer.

**No default behaviour changes.** The scaling default is byte-for-byte what it was, the integer-identifier alignment path is verified bit-identical, and the new batch weighting defaults to exactly 1.0 per batch. The only new signals on existing call paths are a warning that was previously a silent substitution, and a `ValueError` where there was a bare `assert`.

---

# #199

## Downweighting badly aligned batches

Every batch contributed equally to the variable weights, so one badly aligned batch inflated the summed deviation of whichever variables it misfit and depressed their weights for every other batch. `settings["batch_weighting"]` is now `"equal"` (default) or `"huber"`.

Huber weights each batch by its `normalized_distance` turned into a robust z-score against the median and MAD of the batch set: weight 1 inside the 1.345 cutoff, falling off as `1/|z|` beyond it, rescaled to average 1.0.

**Huber rather than a redescending function (Tukey's bisquare) because it never reaches zero.** That is the feedback risk the old TODO recorded: a downweighted batch pulls the average trajectory away from itself, so it looks worse next iteration. A weight that could reach zero makes that a one-way door. Weights are recomputed from scratch each iteration and floored, so a batch that recovers is counted again.

Measured on the dryer fixture:

| | equal | huber |
|---|---|---|
| batches at full weight | 71 of 71 | 53 of 71 |
| hardest downweighted | n/a | 23, 48, 34 |
| variable-weight spread | 2.819 | 3.289 |
| iterations | 2 | 3 |

Those three batches are **exactly** the ones the `distances` output added in #570 reports as worst, so the diagnostic and the weighting agree without being wired together.

**One result that looks wrong and is not:** the worst normalized distance *rises* under Huber, 0.0714 to 0.0759. That is the feedback working as described and staying bounded, because the average moves away from the batch being downweighted. The aim is not to fit the worst batch better; it is to stop that batch setting the variable weights for the other seventy.

## `BatchScaler`

A fit / transform wrapper over `determine_scaling`, `apply_scaling` and `reverse_scaling`, following the estimator contract the rest of the package uses, so batch scaling composes with `Pipeline` and survives `clone`. The three functions are unchanged and still public.

```python
scaler = BatchScaler(columns_to_align=["Temperature"])
scaled = scaler.fit_transform(batches)
original = scaler.inverse_transform(scaled)

BatchScaler(batch_col="batch_id").fit_transform(melted_frame)   # the DataFrame input case
```

## The "thesis page 181" item was stale

It referred to `align_with_path`: averaging the batch samples that compress onto one reference index. The original marker read *"where more than 1 point in the target trajectory is aligned with the reference: compute the average"*. That is implemented (`np.nanmean` over those samples), pinned by `tests/batch/test_dtw_align_with_path.py`, and the marker was already replaced with a plain comment in #563. Nothing to do; the issue's list had not caught up.

---

# #197

## Batch identifiers may be of any type

A string identifier raised in **two** places, not the one the TODO predicted:

1. `determine_scaling` took its per-batch minimum over **every** column rather than over `columns_to_align`: `TypeError: Cannot convert [...] to numeric`. With integer identifiers it did not raise, but it still returned rows for columns never scaled, each with a real `Minimum` against a NaN `Range`.
2. `align_with_path` then averaged whole rows, so a compression in the warping path hit `TypeError: unsupported operand type(s) for /: 'str' and 'int'`. That is the predicted crash. With integer identifiers it wrote the *mean of the identifier* into the aligned frame, and pandas had already begun warning the string case would become a hard error.

Non-numeric columns are now carried through unaveraged, keeping their dtype. Integer path verified bit-identical; string identifiers give the same numbers per batch to 1e-12.

## The resampled percentage axis accepts any resolution

| maximum | delta | before | now |
|---|---|---|---|
| 100 | 1 | 100 rows | 100 rows |
| 100 | 0.3 | `AssertionError` | 334 rows |
| 100 | 7 | `AssertionError` | 15 rows |

Worse than the bare assert: **`python -O` strips asserts**, and this repo runs a `test-under-dash-O` job, so under optimisation it extrapolated silently. The source axis now takes its endpoints from the target axis, so any delta works and there is nothing left to assert.

## The parked termination assertion is restored

It had drifted twice: it indexed `weight_history[4, :]`, a row that does not exist in the 3-row history, and positional indexing no longer works now the history is a DataFrame. New tests pin termination: tolerances 1.0 / 0.06 / 0.01 give **1, 3 and 11** iterations, every run starts from unit weights, and the looser run is a prefix of the tighter one.

---

# #198

## `f_rupture` now works

Never had a working body: it returned `None`, then raised `NotImplementedError` after #563. Now PELT from `ruptures`.

**The default penalty is `log(n)`, not the `100.0` in the old sketch.** The `rbf` cost is bounded, so on a 100-sample signal a penalty of 100 is unreachable and the function finds *nothing*: a five-sigma step went undetected. `log(n)` recovers the step exactly at 60, 200 and 1000 samples under both `rbf` and `l2`, with at most one spurious point on pure noise.

**The default model is `rbf` because its cost is scale-free.** Multiplying a signal by 1000 leaves the points unchanged under `rbf`; under `l2` at the same penalty one true change point became **37** spurious ones.

**The first keyword is now `tags`, not `columns`,** matching every other feature function. No working caller can be affected, but it is a signature change.

`ruptures>=1.1.9` joins the optional `batch` extra via the `_MissingExtra` idiom.

## q98 - q02 versus IQR

The IQR works but is not interchangeable: the ratio varies **by tag** (1.02 to 4.23 on dryer, 1.21 to 2.95 on nylon), so switching re-weights tags against each other rather than rescaling them together. Offered as `settings["robust_range"]`, not substituted. It also collapses to zero more often (`DifferentialPressure`: 21 of 71 batches against 16).

## The collapsed range was silent

`rnge[rnge == 0] = 1.0` said nothing, which `docs/development/error_handling.rst` names as a `warnings.warn` case. One aggregated `UserWarning` per call now names each tag and its batch count.

**Worth its own decision:** it reports `batch_id` in 71 of 71 batches. With `columns_to_align` left `None`, the identifier column is swept in and scaled as though it were a tag. Pre-existing, unchanged here, but the warning is how you would notice.

---

## Test plan

- [x] `uv run pytest` full suite: **3343 passed, 41 skipped**, coverage **94.37%** (3261 before, plus 82 new tests).
- [x] CI green on this head: all 14 checks, including the test matrix over Python 3.10-3.13 on ubuntu / windows / macOS, `test-under-dash-O`, lint, typecheck, CodeQL, build and codecov.
- [x] `ruff check .`, `ruff format --check .`, `mypy src/process_improve` all clean locally.
- [x] Scaling default identical; integer-identifier alignment bit-identical; `"equal"` batch weighting returns exactly 1.0.

Codecov first flagged two unreached lines in `_batch_weights`, both guards for distances that carry no information. Covered with three tests (every distance non-finite, one non-finite among usable ones, no batches at all) rather than suppressed; codecov is green again.

A note on one number, in case it shows up in a log: an intermediate full-suite run reported 40% coverage. That was my own doing, from running targeted `pytest` commands concurrently with the full suite, which clobbers the shared `.coverage` data. The clean serial runs read 94.37%.

## Checklist

- [x] Version bumped (MINOR: 1.89.0 to 1.92.0; `CITATION.cff` in step in the same commit). 1.90.0 and 1.91.0 were never released, so their entries are folded into one section in Keep a Changelog order.
- [x] Tests added
- [x] `ruff check .` passes
- [x] `CHANGELOG.md` updated

## After this merges

#198, #197 and #199 should all be closable. Their remaining list items are either delivered here or verified already done (`f_robust_mad`, the bare TODO markers cleared in #563, `f_cross` / `f_elbow` / the `age` column, and the thesis page 181 item above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123j56Hk6jRz9zy91Doc1og